### PR TITLE
fix(gateway): deduplicate PlatformConn to prevent content multiplication

### DIFF
--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -203,6 +203,7 @@ func (h *Hub) LeaveSession(sessionID string, conn *Conn) {
 // JoinPlatformSession subscribes a PlatformConn to receive events for a session.
 // Unlike JoinSession, it does not register the connection in h.conns (no WS tracking)
 // and does not remove stale connections (platform SDK handles its own lifecycle).
+// Deduplicates: if the same PlatformConn is already subscribed, this is a no-op.
 func (h *Hub) JoinPlatformSession(sessionID string, pc messaging.PlatformConn) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -210,6 +211,15 @@ func (h *Hub) JoinPlatformSession(sessionID string, pc messaging.PlatformConn) {
 	if h.sessions[sessionID] == nil {
 		h.sessions[sessionID] = make(map[SessionWriter]bool)
 	}
+
+	// Deduplicate: avoid wrapping the same PlatformConn in multiple pcEntries,
+	// which would cause each event to be routed N times (content duplication).
+	for sw := range h.sessions[sessionID] {
+		if pce, ok := sw.(*pcEntry); ok && pce.pc == pc {
+			return
+		}
+	}
+
 	h.sessions[sessionID][&pcEntry{pc: pc}] = true
 }
 

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -29,7 +29,7 @@ const (
 
 var phaseTransitions = map[CardPhase]map[CardPhase]bool{
 	PhaseIdle:           {PhaseCreating: true},
-	PhaseCreating:       {PhaseStreaming: true, PhaseCreationFailed: true, PhaseTerminated: true},
+	PhaseCreating:       {PhaseStreaming: true, PhaseCreationFailed: true, PhaseTerminated: true, PhaseCompleted: true},
 	PhaseStreaming:      {PhaseCompleted: true, PhaseAborted: true, PhaseTerminated: true},
 	PhaseCompleted:      {},
 	PhaseAborted:        {},
@@ -143,6 +143,18 @@ func (c *StreamingCardController) EnsureCard(ctx context.Context, chatID, chatTy
 	c.msgID = msgID
 	c.lastFlushed = initialContent
 	c.mu.Unlock()
+
+	// Check if Close() was called while the card was being created.
+	// This can happen when the worker finishes before the card creation
+	// HTTP round-trip completes. In that case, finalize immediately.
+	if c.getPhase() == PhaseCompleted {
+		c.log.Debug("feishu: card created but Close() already called, finalizing")
+		content := OptimizeMarkdownStyle(SanitizeForCard(initialContent))
+		if c.cardKitOK && c.msgID != "" {
+			_ = c.flushIMPatch(ctx, content)
+		}
+		return nil
+	}
 
 	// Step 2: Convert msg_id → card_id so streaming updates target the message's card.
 	cardID, err := c.idConvert(ctx, msgID)


### PR DESCRIPTION
## Summary

Fixes #11 — Feishu streaming card content duplication bug where responses appear 2x, 4x, 8x... multiplied after N messages.

### Root Causes

1. **`JoinPlatformSession` creates duplicate `pcEntry` wrappers** — `Bridge.Handle` calls `JoinPlatformSession` on every incoming message, but each call creates a new `&pcEntry{pc: pc}` map entry. Since each `pcEntry` is a distinct pointer (map key), N messages result in N event routing entries, causing N-fold content duplication.

2. **`Close()` silently dropped during `PhaseCreating`** — When a worker finishes quickly, the `done` event arrives while `EnsureCard` is still in `PhaseCreating` (doing HTTP round-trips). `Close()` tries to transition to `PhaseCompleted`, but this transition was not allowed from `PhaseCreating`, so the final content flush was lost.

### Changes

- **`internal/gateway/hub.go`**: Added deduplication check in `JoinPlatformSession` — iterates existing session entries to find an existing `pcEntry` wrapping the same `PlatformConn`, returning early if found.
  
- **`internal/messaging/feishu/streaming.go`**: 
  - Added `PhaseCompleted` to `PhaseCreating`'s allowed transitions in the phase state machine
  - Added defensive check in `EnsureCard`: after the card message is sent, if `Close()` was already called (phase is `PhaseCompleted`), immediately flush optimized content via IM patch and return

### Test Plan

- [x] `make test-short` — all packages pass
- [x] `make lint` — 0 issues
- [ ] Manual verification: send multiple Feishu messages, confirm no content duplication
- [ ] Manual verification: send a message that triggers a very fast response, confirm content renders correctly