### PR TITLE
fix(worker/ocs): resolve SSE timeout and server startup issues

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -349,7 +349,10 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 
 	serverErr := make(chan error, 1)
 	go func() {
-		serverErr <- server.ListenAndServe()
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Error("gateway: server failed to start", "err", err)
+			serverErr <- err
+		}
 	}()
 
 	adminAddr := cfg.Admin.Addr
@@ -371,8 +374,23 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		RetryDelay:      cfg.Worker.AutoRetry.BaseDelay.String(),
 	}, configPath)
 
-	sig := waitForSignal(stopCh)
-	log.Info("gateway: shutdown", "signal", sig)
+	// Wait for either signal or server error
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case s := <-sig:
+		log.Info("gateway: shutdown", "signal", s)
+	case err := <-serverErr:
+		if err != nil {
+			log.Error("gateway: server failed, exiting", "err", err)
+			return err
+		}
+		// Server closed cleanly (should not happen here)
+		return nil
+	case <-stopCh:
+		log.Info("gateway: shutdown", "signal", "stopCh")
+	}
 
 	cancel()
 
@@ -487,16 +505,5 @@ func loadEnvFile(dir string) {
 	}
 	if loaded > 0 {
 		fmt.Fprintf(os.Stderr, "  env loaded %d vars from %s\n", loaded, envPath)
-	}
-}
-
-func waitForSignal(stopCh <-chan struct{}) os.Signal {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	select {
-	case s := <-sig:
-		return s
-	case <-stopCh:
-		return syscall.SIGTERM
 	}
 }

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -33,9 +33,10 @@ import (
 // All methods are safe for concurrent use. Acquire serializes process startup
 // via mutex so only the first caller starts the process.
 type SingletonProcessManager struct {
-	log    *slog.Logger
-	client *http.Client
-	cfg    config.OpenCodeServerConfig
+	log       *slog.Logger
+	client    *http.Client // with Timeout for API calls
+	sseClient *http.Client // without Timeout for long-lived SSE streams
+	cfg       config.OpenCodeServerConfig
 
 	mu       sync.Mutex
 	proc     *proc.Manager
@@ -61,24 +62,31 @@ var portRegex = regexp.MustCompile(`listening on http://[\d.]+:(\d+)`)
 
 // NewSingletonProcessManager creates a new singleton process manager.
 func NewSingletonProcessManager(log *slog.Logger, cfg config.OpenCodeServerConfig) *SingletonProcessManager {
+	transport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
 	return &SingletonProcessManager{
-		log:     log.With("component", "opencode-server-singleton"),
-		client:  &http.Client{Timeout: cfg.HTTPTimeout},
-		cfg:     cfg,
-		crashCh: make(chan struct{}),
+		log:       log.With("component", "opencode-server-singleton"),
+		client:    &http.Client{Timeout: cfg.HTTPTimeout, Transport: transport},
+		sseClient: &http.Client{Transport: transport}, // no Timeout for SSE
+		cfg:       cfg,
+		crashCh:   make(chan struct{}),
 	}
 }
 
 // Acquire increments the reference count and starts the process if needed.
-// Returns the server HTTP address, HTTP client, and a crash notification channel.
+// Returns the server HTTP address, HTTP client for API calls, HTTP client for SSE (no timeout),
+// and a crash notification channel.
 // The crash channel is closed when the process exits unexpectedly; workers should
 // check it in their Wait() implementation to report the correct exit code.
-func (s *SingletonProcessManager) Acquire(ctx context.Context) (httpAddr string, client *http.Client, crashCh <-chan struct{}, err error) {
+func (s *SingletonProcessManager) Acquire(ctx context.Context) (httpAddr string, client, sseClient *http.Client, crashCh <-chan struct{}, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.state == stateStopped {
-		return "", nil, nil, fmt.Errorf("opencode-server-singleton: stopped")
+		return "", nil, nil, nil, fmt.Errorf("opencode-server-singleton: stopped")
 	}
 
 	// Cancel idle drain timer if one is pending.
@@ -90,17 +98,17 @@ func (s *SingletonProcessManager) Acquire(ctx context.Context) (httpAddr string,
 	// Start process on first reference.
 	if s.state == stateIdle {
 		if err := s.startProcessLocked(ctx); err != nil {
-			return "", nil, nil, err
+			return "", nil, nil, nil, err
 		}
 	}
 
 	if s.state != stateRunning {
-		return "", nil, nil, fmt.Errorf("opencode-server-singleton: unexpected state %d", s.state)
+		return "", nil, nil, nil, fmt.Errorf("opencode-server-singleton: unexpected state %d", s.state)
 	}
 
 	s.refs++
 	s.log.Debug("opencode-server-singleton: acquire", "refs", s.refs)
-	return s.httpAddr, s.client, s.crashCh, nil
+	return s.httpAddr, s.client, s.sseClient, s.crashCh, nil
 }
 
 // Release decrements the reference count. When refs reach zero, an idle drain

--- a/internal/worker/opencodeserver/singleton_test.go
+++ b/internal/worker/opencodeserver/singleton_test.go
@@ -209,10 +209,11 @@ func TestSingletonProcessManager_Acquire_StoppedState(t *testing.T) {
 	mgr.state = stateStopped
 	mgr.mu.Unlock()
 
-	addr, client, crash, err := mgr.Acquire(context.Background())
+	addr, client, sseClient, crash, err := mgr.Acquire(context.Background())
 	require.Error(t, err)
 	require.Empty(t, addr)
 	require.Nil(t, client)
+	require.Nil(t, sseClient)
 	require.Nil(t, crash)
 }
 

--- a/internal/worker/opencodeserver/singleton_test.go
+++ b/internal/worker/opencodeserver/singleton_test.go
@@ -27,6 +27,7 @@ func TestNewSingletonProcessManager(t *testing.T) {
 	require.Equal(t, stateIdle, mgr.state)
 	require.Equal(t, 0, mgr.refs)
 	require.NotNil(t, mgr.client)
+	require.NotNil(t, mgr.sseClient)
 	require.NotNil(t, mgr.crashCh)
 }
 
@@ -233,4 +234,43 @@ func TestShutdownSingleton_Real(t *testing.T) {
 
 	ShutdownSingleton(context.Background())
 	require.Nil(t, singleton.Load())
+}
+
+func TestNewSingletonProcessManager_SSEClient(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := config.OpenCodeServerConfig{
+		HTTPTimeout: 30 * time.Second,
+	}
+	mgr := NewSingletonProcessManager(log, cfg)
+
+	// Verify sseClient is created without timeout
+	require.NotNil(t, mgr.sseClient)
+	require.Zero(t, mgr.sseClient.Timeout, "sseClient should have no timeout")
+
+	// Verify regular client has timeout
+	require.NotNil(t, mgr.client)
+	require.Equal(t, cfg.HTTPTimeout, mgr.client.Timeout)
+}
+
+func TestSingletonProcessManager_Acquire_ReturnsSSEClient(t *testing.T) {
+	t.Parallel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := config.OpenCodeServerConfig{}
+	mgr := NewSingletonProcessManager(log, cfg)
+
+	// Simulate running state
+	mgr.mu.Lock()
+	mgr.state = stateRunning
+	mgr.httpAddr = "http://127.0.0.1:8080"
+	mgr.mu.Unlock()
+
+	addr, client, sseClient, crashCh, err := mgr.Acquire(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, addr)
+	require.NotNil(t, client)
+	require.NotNil(t, sseClient, "sseClient should be returned")
+	require.NotNil(t, crashCh)
 }

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -110,8 +110,12 @@ type Worker struct {
 	httpConn  *conn
 	httpAddr  string
 	client    *http.Client
+	sseClient *http.Client // separate client without Timeout for SSE
 	cmd       *ServerCommander
 	crashSub  <-chan struct{} // closed when singleton process crashes
+
+	// sseCancel is used to cancel the SSE request context on Terminate/Kill.
+	sseCancel context.CancelFunc
 
 	// releaseOnce ensures singleton.Release() is called exactly once,
 	// regardless of which method triggers it (Terminate, Kill, or Wait).
@@ -191,12 +195,13 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	w.Mu.Unlock()
 
 	// Acquire ref from singleton (starts process if first session)
-	httpAddr, client, crashSub, err := w.singleton.Acquire(ctx)
+	httpAddr, client, sseClient, crashSub, err := w.singleton.Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("opencodeserver: acquire server: %w", err)
 	}
 	w.httpAddr = httpAddr
 	w.client = client
+	w.sseClient = sseClient
 	w.crashSub = crashSub
 
 	// Create new session via HTTP API
@@ -208,7 +213,13 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	w.initSessionConn(ctx, sessionID, session)
 
-	go w.readSSE(sessionID)
+	// Create cancellable context for SSE request
+	sseCtx, sseCancel := context.WithCancel(context.Background())
+	w.Mu.Lock()
+	w.sseCancel = sseCancel
+	w.Mu.Unlock()
+
+	go w.readSSE(sseCtx, sessionID)
 	return nil
 }
 
@@ -273,23 +284,39 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 	}
 	w.Mu.Unlock()
 
-	httpAddr, client, crashSub, err := w.singleton.Acquire(ctx)
+	httpAddr, client, sseClient, crashSub, err := w.singleton.Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("opencodeserver: acquire server: %w", err)
 	}
 	w.httpAddr = httpAddr
 	w.client = client
+	w.sseClient = sseClient
 	w.crashSub = crashSub
 
 	w.initSessionConn(ctx, session.SessionID, session)
 
-	go w.readSSE(session.SessionID)
+	// Create cancellable context for SSE request
+	sseCtx, sseCancel := context.WithCancel(context.Background())
+	w.Mu.Lock()
+	w.sseCancel = sseCancel
+	w.Mu.Unlock()
+
+	go w.readSSE(sseCtx, session.SessionID)
 	return nil
 }
 
 // Terminate closes the SSE connection and releases the singleton ref.
 // Does NOT kill the shared server process.
 func (w *Worker) Terminate(_ context.Context) error {
+	w.Mu.Lock()
+	sseCancel := w.sseCancel
+	w.Mu.Unlock()
+
+	// Cancel SSE request to unblock readSSE goroutine
+	if sseCancel != nil {
+		sseCancel()
+	}
+
 	w.releaseOnce.Do(func() {
 		if w.singleton != nil {
 			w.singleton.Release()
@@ -310,6 +337,15 @@ func (w *Worker) Terminate(_ context.Context) error {
 // Kill closes the SSE connection and releases the singleton ref.
 // Does NOT kill the shared server process.
 func (w *Worker) Kill() error {
+	w.Mu.Lock()
+	sseCancel := w.sseCancel
+	w.Mu.Unlock()
+
+	// Cancel SSE request to unblock readSSE goroutine
+	if sseCancel != nil {
+		sseCancel()
+	}
+
 	w.releaseOnce.Do(func() {
 		if w.singleton != nil {
 			w.singleton.Release()
@@ -523,7 +559,7 @@ func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, se
 	w.Mu.Unlock()
 }
 
-func (w *Worker) readSSE(sessionID string) {
+func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 	defer func() {
 		if r := recover(); r != nil {
 			w.Log.Error("opencodeserver: readSSE panic", "session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
@@ -531,7 +567,7 @@ func (w *Worker) readSSE(sessionID string) {
 	}()
 
 	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, sessionID)
-	req, err := http.NewRequest("GET", url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		w.Log.Error("opencodeserver: create SSE request", "session_id", sessionID, "err", err)
 		return
@@ -539,7 +575,7 @@ func (w *Worker) readSSE(sessionID string) {
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	resp, err := w.client.Do(req)
+	resp, err := w.sseClient.Do(req)
 	if err != nil {
 		w.Log.Error("opencodeserver: SSE connect", "session_id", sessionID, "err", err)
 		return

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -170,6 +170,35 @@ func TestOpenCodeServerWorker_Kill_NilSSECancel(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestOpenCodeServerWorker_Terminate_ReleasesSingleton(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+	ctx := context.Background()
+
+	// Terminate should call releaseOnce
+	err := w.Terminate(ctx)
+	require.NoError(t, err)
+
+	// Call Terminate again - should not call release twice
+	err = w.Terminate(ctx)
+	require.NoError(t, err)
+}
+
+func TestOpenCodeServerWorker_Kill_ReleasesSingleton(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+
+	// Kill should call releaseOnce
+	err := w.Kill()
+	require.NoError(t, err)
+
+	// Call Kill again - should not call release twice
+	err = w.Kill()
+	require.NoError(t, err)
+}
+
 func TestOpenCodeServerWorker_WaitWithoutStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -29,6 +29,21 @@ func TestOpenCodeServerWorker_Capabilities(t *testing.T) {
 	require.Equal(t, []string{"text", "code"}, w.Modalities())
 }
 
+func TestOpenCodeServerWorker_New(t *testing.T) {
+	t.Parallel()
+	w := New()
+
+	// Verify worker is properly initialized
+	require.NotNil(t, w)
+	require.NotNil(t, w.BaseWorker)
+	// singleton may be nil if not initialized, so just check it exists (could be nil)
+	// require.NotNil(t, w.singleton)
+	require.NotNil(t, w.client)
+	require.Nil(t, w.sseClient, "sseClient should be nil until Start/Resume")
+	require.Nil(t, w.sseCancel, "sseCancel should be nil until Start/Resume")
+	require.Nil(t, w.httpConn)
+}
+
 func TestOpenCodeServerWorker_EnvWhitelist(t *testing.T) {
 	t.Parallel()
 	w := New()
@@ -79,6 +94,78 @@ func TestOpenCodeServerWorker_KillWithoutStart(t *testing.T) {
 	t.Parallel()
 
 	w := New()
+	err := w.Kill()
+	require.NoError(t, err)
+}
+
+func TestOpenCodeServerWorker_Terminate_CallsSSECancel(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+	ctx := context.Background()
+
+	// Set sseCancel
+	sseCtx, sseCancel := context.WithCancel(context.Background())
+	w.Mu.Lock()
+	w.sseCancel = sseCancel
+	w.Mu.Unlock()
+
+	// Terminate should call sseCancel
+	err := w.Terminate(ctx)
+	require.NoError(t, err)
+
+	// Verify context was cancelled
+	select {
+	case <-sseCtx.Done():
+		// Context was cancelled as expected
+	default:
+		t.Fatal("sseCancel was not called by Terminate")
+	}
+}
+
+func TestOpenCodeServerWorker_Kill_CallsSSECancel(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+
+	// Set sseCancel
+	sseCtx, sseCancel := context.WithCancel(context.Background())
+	w.Mu.Lock()
+	w.sseCancel = sseCancel
+	w.Mu.Unlock()
+
+	// Kill should call sseCancel
+	err := w.Kill()
+	require.NoError(t, err)
+
+	// Verify context was cancelled
+	select {
+	case <-sseCtx.Done():
+		// Context was cancelled as expected
+	default:
+		t.Fatal("sseCancel was not called by Kill")
+	}
+}
+
+func TestOpenCodeServerWorker_Terminate_NilSSECancel(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+	ctx := context.Background()
+
+	// Don't set sseCancel (it's nil)
+	// Terminate should not panic
+	err := w.Terminate(ctx)
+	require.NoError(t, err)
+}
+
+func TestOpenCodeServerWorker_Kill_NilSSECancel(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+
+	// Don't set sseCancel (it's nil)
+	// Kill should not panic
 	err := w.Kill()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

This PR fixes two high-priority issues affecting OpenCode Server worker stability and observability:

### Issue #85: SSE Client Timeout Breaks Long-lived Streaming
**Problem**: `SingletonProcessManager` created an `http.Client` with 30s Timeout. The `readSSE()` goroutine reused this client for SSE requests, causing the long-lived streaming connection to be interrupted after 30s. Additionally, `Terminate()`/`Kill()` did not cancel the in-flight SSE HTTP request, leaving the `readSSE` goroutine blocked.

**Solution**:
- Add separate `sseClient` field without Timeout for SSE connections
- Use cancellable context in `readSSE()` for clean shutdown
- Store `sseCancel` in Worker and call it in `Terminate()`/`Kill()`

### Issue #79 Finding 1: Silent HTTP Server Startup Failure
**Problem**: `serverErr` channel was created but never read. If HTTP server failed to bind (port in use, permission denied), the error was silently lost. The gateway appeared to start successfully but was actually non-functional.

**Solution**:
- Use `select` to race signal against `serverErr`
- Log error and exit if `ListenAndServe` fails
- Prevents silent startup failure

## Changes

- `internal/worker/opencodeserver/singleton.go`: Add `sseClient` field, update `Acquire()` signature
- `internal/worker/opencodeserver/worker.go`: Use `sseClient`, add context cancellation
- `cmd/hotplex/gateway_run.go`: Handle `serverErr` channel, remove unused `waitForSignal()`
- `internal/worker/opencodeserver/singleton_test.go`: Update for new `Acquire()` signature

## Test Plan

- [x] `make test` - All tests pass
- [x] `make lint` - Zero issues
- [x] Manual test: SSE connection remains responsive beyond 30s timeout
- [x] Manual test: Terminate/Kill unblocks readSSE goroutine promptly
- [x] Manual test: Port conflict triggers error log and clean exit

## Related Issues

- Fixes #85 (SSE timeout)
- Fixes #79 Finding 1 (silent startup failure)
- Closes #91 (verified as already fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)