### PR TITLE
fix(agentconfig): distinguish IsNotExist from other errors + chore(aep): remove dead code

### DIFF
--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -29,7 +29,7 @@ const MaxTotalChars = 40_000
 // Load reads all config files from dir, appending platform-specific variants.
 // Returns AgentConfigs with frontmatter stripped and size limits enforced.
 // Platform can be "slack", "feishu", or "" (websocket/gateway direct).
-// Missing files are silently skipped. A non-existent dir is not an error.
+// Missing files are silently skipped. Non-NotExist errors (permission denied, I/O errors) are returned.
 func Load(dir, platform string) (*AgentConfigs, error) {
 	if dir == "" {
 		return &AgentConfigs{}, nil
@@ -38,40 +38,73 @@ func Load(dir, platform string) (*AgentConfigs, error) {
 	c := &AgentConfigs{}
 	var total int
 
-	load := func(baseName string, target *string) {
-		content, n := loadFile(dir, baseName, platform)
+	load := func(baseName string, target *string) error {
+		content, n, err := loadFileWithErrorCount(dir, baseName, platform)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			return nil // missing file is expected
+		}
 		if n == 0 {
-			return
+			return nil
 		}
 		if total+n > MaxTotalChars {
 			n = MaxTotalChars - total
 			if n <= 0 {
-				return
+				return nil
 			}
 			content = content[:n]
 		}
 		total += n
 		*target = content
+		return nil
 	}
 
-	load("SOUL.md", &c.Soul)
-	load("AGENTS.md", &c.Agents)
-	load("SKILLS.md", &c.Skills)
-	load("USER.md", &c.User)
-	load("MEMORY.md", &c.Memory)
+	if err := load("SOUL.md", &c.Soul); err != nil {
+		return nil, err
+	}
+	if err := load("AGENTS.md", &c.Agents); err != nil {
+		return nil, err
+	}
+	if err := load("SKILLS.md", &c.Skills); err != nil {
+		return nil, err
+	}
+	if err := load("USER.md", &c.User); err != nil {
+		return nil, err
+	}
+	if err := load("MEMORY.md", &c.Memory); err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }
 
+// loadFileWithErrorCount is a helper that wraps loadFile and returns character count.
+func loadFileWithErrorCount(dir, baseName, platform string) (string, int, error) {
+	content, err := loadFile(dir, baseName, platform)
+	if err != nil {
+		return "", 0, err
+	}
+	return content, len(content), nil
+}
+
 // loadFile reads a base file and appends its platform variant.
 // Returns the combined content and total character count.
-func loadFile(dir, baseName, platform string) (string, int) {
-	content := readFile(dir, baseName)
+// Propagates non-NotExist errors from readFile (permission denied, I/O errors).
+func loadFile(dir, baseName, platform string) (string, error) {
+	content, err := readFile(dir, baseName)
+	if err != nil {
+		return "", err
+	}
 	if platform != "" {
 		ext := filepath.Ext(baseName)
 		prefix := strings.TrimSuffix(baseName, ext)
 		variantName := prefix + "." + platform + ext
-		variant := readFile(dir, variantName)
+		variant, err := readFile(dir, variantName)
+		if err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
 		if variant != "" {
 			if content != "" {
 				content += "\n\n" + variant
@@ -80,22 +113,25 @@ func loadFile(dir, baseName, platform string) (string, int) {
 			}
 		}
 	}
-	return content, len(content)
+	return content, nil
 }
 
 // readFile reads a file, strips YAML frontmatter, and enforces per-file size limit.
-// Returns empty string if the file does not exist.
-func readFile(dir, name string) string {
+// Returns ("", nil) if the file does not exist (expected), ("", error) for other errors.
+func readFile(dir, name string) (string, error) {
 	path := filepath.Join(dir, name)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return ""
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("agentconfig: read %s: %w", name, err)
 	}
 	s := stripFrontmatter(string(data))
 	if len(s) > MaxFileChars {
 		s = s[:MaxFileChars]
 	}
-	return s
+	return s, nil
 }
 
 // stripFrontmatter removes YAML frontmatter (--- blocks) from markdown content.

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -105,6 +105,19 @@ func TestLoad(t *testing.T) {
 		require.Equal(t, "Rules.", cfg.Agents)
 		require.Empty(t, cfg.User)
 	})
+
+	t.Run("permission denied returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// Create a file with no read permissions
+		filePath := filepath.Join(dir, "SOUL.md")
+		err := os.WriteFile(filePath, []byte("Content"), 0o000)
+		require.NoError(t, err)
+
+		_, err = Load(dir, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "agentconfig: read")
+	})
 }
 
 func TestSizeLimits(t *testing.T) {

--- a/pkg/aep/codec.go
+++ b/pkg/aep/codec.go
@@ -38,23 +38,6 @@ func Encode(w io.Writer, env *events.Envelope) error {
 	return err
 }
 
-// EncodeChunk is like Encode but for streaming deltas where you want to avoid
-// re-allocating the encoder on each call. Caller must call w.Flush() when done.
-func EncodeChunk(w io.Writer, env *events.Envelope) error {
-	env.Version = events.Version
-	if env.Timestamp == 0 {
-		env.Timestamp = nowMillis()
-	}
-	data, err := json.Marshal(env)
-	if err != nil {
-		return fmt.Errorf("aep: marshal envelope: %w", err)
-	}
-	data = escapeJSTerminators(data)
-	data = append(data, '\n')
-	_, err = w.Write(data)
-	return err
-}
-
 // NDJSONSpec: https://datatracker.ietf.org/doc/html/rfc7464
 // JS JSON.parse accepts U+2028/U+2029 as valid JSON, but they are NOT valid
 // inside JavaScript string literals. A NDJSON consumer that evaluates lines as JS

--- a/pkg/aep/codec_test.go
+++ b/pkg/aep/codec_test.go
@@ -59,28 +59,6 @@ func TestEncodeDecode(t *testing.T) {
 	require.Equal(t, env.Event.Type, decoded.Event.Type)
 }
 
-func TestEncodeChunk(t *testing.T) {
-	t.Parallel()
-
-	env := NewEnvelope(
-		NewID(),
-		"sess_chunk",
-		1,
-		events.Input,
-		events.InputData{Content: "hello"},
-	)
-
-	var sb strings.Builder
-	err := EncodeChunk(&sb, env)
-	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(sb.String(), "\n"))
-
-	// Decode and verify
-	decoded, err := Decode(strings.NewReader(sb.String()))
-	require.NoError(t, err)
-	require.Equal(t, env.SessionID, decoded.SessionID)
-}
-
 func TestDecode_InvalidJSON(t *testing.T) {
 	t.Parallel()
 
@@ -397,30 +375,6 @@ func TestEncode_NDJSONSafe(t *testing.T) {
 	require.Contains(t, output, `\u2028`, "U+2028 must be escaped as \\u2028")
 
 	// Must still decode correctly.
-	decoded, err := Decode(strings.NewReader(output))
-	require.NoError(t, err)
-	require.Equal(t, env.SessionID, decoded.SessionID)
-}
-
-func TestEncodeChunk_NDJSONSafe(t *testing.T) {
-	t.Parallel()
-
-	env := NewEnvelope(
-		NewID(),
-		"sess_chunk_ndjson",
-		1,
-		events.MessageDelta,
-		map[string]any{"content": "para1\u2029para2"}, // U+2029 embedded
-	)
-
-	var sb strings.Builder
-	err := EncodeChunk(&sb, env)
-	require.NoError(t, err)
-
-	output := sb.String()
-	require.NotContains(t, output, "\xe2\x80\xa9", "raw U+2029 must not appear in output")
-	require.Contains(t, output, `\u2029`, "U+2029 must be escaped as \\u2029")
-
 	decoded, err := Decode(strings.NewReader(output))
 	require.NoError(t, err)
 	require.Equal(t, env.SessionID, decoded.SessionID)


### PR DESCRIPTION
## Summary

This PR implements two architecture improvements from the selected issues:

1. **fix(agentconfig)**: `readFile` error handling (#80)
   - Modified `readFile` to return `(string, error)` instead of `string`
   - Properly distinguishes between `IsNotExist` errors (silent skip) and other errors like permission denied (propagate to caller)
   - Updated `loadFile` and `Load` to handle errors via new `loadFileWithErrorCount` helper
   - Added test case `TestLoad_PermissionError` to verify error propagation

2. **chore(aep)**: remove dead `EncodeChunk` function (#75)
   - Removed `EncodeChunk` function (duplicate of `Encode`)
   - Removed test cases `TestEncodeChunk` and `TestEncodeChunk_NDJSONSafe`
   - The function was only used in tests and provided no value

## Verified Already Implemented

The following issues were verified as already implemented in the codebase:

- **fix(session)**: concurrent worker termination (#84) - Already uses `errgroup` in `TerminateAllWorkers()`
- **fix(worker/ocs)**: SSE race condition (#83) - Already has `sseCancel` field and proper mutex protection

## Skipped

- **chore(config)**: `applyMessagingEnv` DRY violation (#72) - Skipped due to complexity and risk of introducing bugs

## Test Plan

- [x] All existing tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Formatting passes (`make fmt`)
- [x] New test case added for permission error handling
- [x] Quality checks pass (`make quality`)

## Architecture Impact

- **agentconfig**: Improved error visibility and debugging capability
- **aep**: Reduced code surface by removing unused function

## Related Issues

Closes #80 (partially - error handling only)
Closes #75

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>