### PR TITLE
fix(config): expand ${VAR} in worker.environment and isolate GH_TOKEN

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -39,13 +40,14 @@ func ExpandEnv(s string) string {
 	})
 }
 
-// expandEnvEntry expands ${VAR} references in a KEY=VALUE environment entry.
+// expandEnvEntry expands ${VAR} references in an environment entry.
 // Entries that reference unset variables without a default clause are excluded
 // (returned as false) so the entry is omitted from the worker environment.
+// A variable set to empty string is treated as unset; use ${VAR:-default} to preserve such entries.
 func expandEnvEntry(entry string) (string, bool) {
 	for _, m := range envVarRe.FindAllStringSubmatch(entry, -1) {
 		if strings.Contains(m[0], ":-") {
-			continue // has :-default clause, always included
+			continue // has :-default clause, skip exclusion check
 		}
 		if len(m) >= 2 && os.Getenv(m[1]) == "" {
 			return "", false // unset var, no default → exclude
@@ -663,10 +665,13 @@ func loadRecursive(filePath string, opts LoadOptions, visited []string) (*Config
 	// Messaging platform env var overrides.
 	applyMessagingEnv(cfg)
 
+	// Expand env entries and drop those referencing unset vars without defaults.
 	expanded := make([]string, 0, len(cfg.Worker.Environment))
 	for _, e := range cfg.Worker.Environment {
 		if entry, ok := expandEnvEntry(e); ok {
 			expanded = append(expanded, entry)
+		} else {
+			slog.Warn("excluding env entry: references unset variable", "entry", e)
 		}
 	}
 	cfg.Worker.Environment = expanded

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,21 @@ func ExpandEnv(s string) string {
 	})
 }
 
+// expandEnvEntry expands ${VAR} references in a KEY=VALUE environment entry.
+// Entries that reference unset variables without a default clause are excluded
+// (returned as false) so the entry is omitted from the worker environment.
+func expandEnvEntry(entry string) (string, bool) {
+	for _, m := range envVarRe.FindAllStringSubmatch(entry, -1) {
+		if strings.Contains(m[0], ":-") {
+			continue // has :-default clause, always included
+		}
+		if len(m) >= 2 && os.Getenv(m[1]) == "" {
+			return "", false // unset var, no default → exclude
+		}
+	}
+	return ExpandEnv(entry), true
+}
+
 // SecretsProvider abstracts how secrets are retrieved.
 type SecretsProvider interface {
 	// Get returns the secret value for the given key, or "" if not found.
@@ -648,9 +663,13 @@ func loadRecursive(filePath string, opts LoadOptions, visited []string) (*Config
 	// Messaging platform env var overrides.
 	applyMessagingEnv(cfg)
 
-	for i, e := range cfg.Worker.Environment {
-		cfg.Worker.Environment[i] = ExpandEnv(e)
+	expanded := make([]string, 0, len(cfg.Worker.Environment))
+	for _, e := range cfg.Worker.Environment {
+		if entry, ok := expandEnvEntry(e); ok {
+			expanded = append(expanded, entry)
+		}
 	}
+	cfg.Worker.Environment = expanded
 
 	// Post-process: normalize allowed_envs into env_whitelist.
 	if len(cfg.Worker.AllowedEnvs) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -177,6 +177,78 @@ func TestExpandEnv(t *testing.T) {
 	}
 }
 
+func TestExpandEnvEntry(t *testing.T) {
+	// NOT parallel — mutates global env vars
+	tests := []struct {
+		name     string
+		input    string
+		setup    func()
+		want     string
+		included bool
+	}{
+		{
+			name:     "set variable",
+			input:    "GH_TOKEN=${TEST_GH_TOKEN}",
+			setup:    func() { os.Setenv("TEST_GH_TOKEN", "gho_abc123") },
+			want:     "GH_TOKEN=gho_abc123",
+			included: true,
+		},
+		{
+			name:     "unset variable without default",
+			input:    "GH_TOKEN=${TEST_UNSET_TOKEN}",
+			setup:    func() {},
+			want:     "",
+			included: false,
+		},
+		{
+			name:     "unset variable with default",
+			input:    "PATH=${TEST_MISSING_PATH:-/usr/bin}",
+			setup:    func() {},
+			want:     "PATH=/usr/bin",
+			included: true,
+		},
+		{
+			name:     "unset variable with empty default",
+			input:    "DEBUG=${TEST_MISSING_DEBUG:-}",
+			setup:    func() {},
+			want:     "DEBUG=",
+			included: true,
+		},
+		{
+			name:     "plain value without references",
+			input:    "BUN_JSC_useJIT=0",
+			setup:    func() {},
+			want:     "BUN_JSC_useJIT=0",
+			included: true,
+		},
+		{
+			name:     "multiple vars one unset",
+			input:    "KEY=${TEST_SET_VAR}+${TEST_UNSET_VAR}",
+			setup:    func() { os.Setenv("TEST_SET_VAR", "hello") },
+			want:     "",
+			included: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("TEST_GH_TOKEN")
+			os.Unsetenv("TEST_UNSET_TOKEN")
+			os.Unsetenv("TEST_MISSING_PATH")
+			os.Unsetenv("TEST_MISSING_DEBUG")
+			os.Unsetenv("TEST_SET_VAR")
+			os.Unsetenv("TEST_UNSET_VAR")
+			tt.setup()
+			got, ok := expandEnvEntry(tt.input)
+			require.Equal(t, tt.included, ok)
+			if ok {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestEnvSecretsProvider(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -228,6 +228,20 @@ func TestExpandEnvEntry(t *testing.T) {
 			want:     "",
 			included: false,
 		},
+		{
+			name:     "set variable with default uses actual value",
+			input:    "KEY=${TEST_HAS_DEFAULT:-fallback}",
+			setup:    func() { os.Setenv("TEST_HAS_DEFAULT", "real_value") },
+			want:     "KEY=real_value",
+			included: true,
+		},
+		{
+			name:     "multiple vars all set expands all",
+			input:    "PATH=${TEST_A}:${TEST_B}",
+			setup:    func() { os.Setenv("TEST_A", "/usr/bin"); os.Setenv("TEST_B", "/usr/local/bin") },
+			want:     "PATH=/usr/bin:/usr/local/bin",
+			included: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -239,6 +253,9 @@ func TestExpandEnvEntry(t *testing.T) {
 			os.Unsetenv("TEST_MISSING_DEBUG")
 			os.Unsetenv("TEST_SET_VAR")
 			os.Unsetenv("TEST_UNSET_VAR")
+			os.Unsetenv("TEST_HAS_DEFAULT")
+			os.Unsetenv("TEST_A")
+			os.Unsetenv("TEST_B")
 			tt.setup()
 			got, ok := expandEnvEntry(tt.input)
 			require.Equal(t, tt.included, ok)


### PR DESCRIPTION
## Summary

- **Fix latent bug**: `ExpandEnv()` was defined but never called in the config loading path (`loadRecursive`), causing `${VAR}` references in `worker.environment` to be injected as literal strings into worker processes
- **Add `expandEnvEntry()`**: entries referencing unset environment variables without a `:-default` clause are now **excluded entirely** (not injected as empty strings or literals)
- **Rename `GH_TOKEN`/`GITHUB_TOKEN`** to `HOTPLEX_WORKER_GH_TOKEN`/`HOTPLEX_WORKER_GITHUB_TOKEN` prefix in `config.yaml` and `env.example` to prevent conflict with `gh` CLI keyring auth

## Root Cause

The regex `envVarRe` captures optional `:-default` as group 2. Go's `FindAllStringSubmatch` always returns all groups (even non-participating ones as empty strings), so `len(m) >= 3` was always true. Fixed by checking `strings.Contains(m[0], ":-")` instead.

## Test plan

- [x] `TestExpandEnvEntry` — 6 table-driven cases covering: set var, unset without default (excluded), unset with default, empty default, plain value, mixed set/unset
- [x] `make quality` — fmt + lint + test (with -race) all pass
- [x] Pre-push hooks pass