### PR TITLE
fix(service): resolve ExecStart to PATH deployment path, not build dir

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -52,6 +53,20 @@ type Manager interface {
 }
 
 func ResolveBinaryPath() (string, error) {
+	// Prefer the binary found in PATH (standard deployment location).
+	// This avoids capturing a build-directory path when the user runs
+	// ./bin/hotplex-linux-amd64 service install.
+	if p, err := exec.LookPath("hotplex"); err == nil {
+		if abs, err := filepath.Abs(p); err == nil {
+			if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+				return resolved, nil
+			}
+			return abs, nil
+		}
+		return p, nil
+	}
+
+	// Fallback: resolve the currently running executable.
 	exe, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve binary: %w", err)


### PR DESCRIPTION
## Summary

- `ResolveBinaryPath()` now uses `exec.LookPath("hotplex")` to find the canonical deployment binary in `PATH` before falling back to `os.Executable()`
- Prevents `hotplex service install` from writing the build directory path (e.g. `~/workspace/hotplex/bin/hotplex-linux-amd64`) into the systemd/launchd unit's `ExecStart` directive
- Cross-platform compatible: `exec.LookPath` handles Linux, macOS, and Windows (auto-appends `.exe`) without platform-specific code

## Root Cause

When running `./bin/hotplex-linux-amd64 service install`, `os.Executable()` returns the build output path. The service unit then references that path, which diverges from the standard deployment location (`~/.local/bin/hotplex`) used by the update workflow. Updates appeared to succeed but the service was always running from the build directory.

## Test plan

- [x] `make build && make test-short` — all tests pass
- [x] Reinstalled service with `hotplex service uninstall && hotplex service install --level user`
- [x] Verified `ExecStart` now points to `/home/hotplex/.local/bin/hotplex`
- [x] Service starts and runs normally with Feishu adapter connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)