### PR TITLE
feat(cli): add `hotplex update` subcommand for self-update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ make dev-status  # 查看运行服务
 - `make lint` - golangci-lint 检查
 - `make dev` - 启动开发环境
 - `hotplex service start` - 启动系统服务
+- `hotplex update` - 自更新到最新版本
 
 ---
 
@@ -108,6 +109,7 @@ cp configs/env.example .env
 | `routes.go` | 197 | HTTP 路由注册 |
 | `messaging_init.go` | 233 | 消息适配器生命周期 |
 | `service_*.go` | - | 系统服务管理（systemd/launchd/SCM） |
+| `update.go` | 168 | 自更新命令：GitHub API、下载、校验、替换 |
 
 ### 核心模块 (`internal/`)
 
@@ -145,6 +147,7 @@ cp configs/env.example .env
 - `skills/` - Skills 发现
 - `metrics/` - Prometheus 指标
 - `service/` - 系统服务管理
+- `updater/` - 自更新（GitHub API、sha256 校验、原子替换）
 
 ### 公共包 (`pkg/`)
 
@@ -371,6 +374,15 @@ hotplex service status
 hotplex service logs -f
 ```
 
+### 自更新
+
+```bash
+hotplex update                # 交互式更新
+hotplex update --check        # 仅检查，不下载
+hotplex update -y             # 跳过确认提示
+hotplex update --restart      # 更新后自动重启网关
+```
+
 ---
 
 ## 备注
@@ -386,6 +398,7 @@ hotplex service logs -f
 - Postgres store 仅为桩（仅 SQLite 可用于生产）
 - OpenCode CLI 适配器已移除（由 OCS 替代）
 - ACPX 适配器仅存在类型常量（无实现）
+- Windows 自更新不支持（exe 运行时被锁，使用 `scripts/install.ps1` 替代）
 
 ### 跨平台支持
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HotPlex 项目知识库
 
-**最后更新**: 2026-05-01 · **分支**: main · **版本**: v1.3.0
+**最后更新**: 2026-05-02 · **分支**: main · **版本**: v1.3.0
 
 ---
 
@@ -166,82 +166,55 @@ configs/   - 配置文件
 
 ## 贡献工作流
 
-HotPlex 项目使用 **fork-PR 工作流**进行贡献。
+### Admin（仓库管理员）
 
-### 工作流步骤
+拥有仓库 write/admin 权限的协作者直接在 origin 仓库创建分支和 PR。
 
-**1. Fork 上游仓库**
 ```bash
-# 在 GitHub 上 fork hrygo/hotplex
-# 例如：https://github.com/aaronwong1989/hotplex-1
-```
-
-**2. 添加 fork 远程仓库**
-```bash
-cd /path/to/hotplex
-git remote add fork https://github.com/<your-username>/hotplex-1.git
-git remote -v  # 应显示 origin 和 fork
-```
-
-**3. 创建功能分支**
-```bash
+# 1. 从最新 main 创建功能分支
 git fetch origin main
-git checkout main
-git pull origin main
-git checkout -b feat/<feature-name>
-```
+git checkout -b feat/<feature-name> origin/main
 
-**4. 开发和提交**
-```bash
-# 进行代码更改
-git add .
+# 2. 开发和提交
+git add <files>
 git commit -m "feat(scope): description"
+
+# 3. 推送并创建 PR
+git push -u origin feat/<feature-name>
+gh pr create --title "feat(scope): description"
+
+# 4. 合并后清理
+git checkout main && git pull origin main
+git branch -d feat/<feature-name>
+git push origin --delete feat/<feature-name>
 ```
 
-**5. 推送到 fork**
-```bash
-git push fork feat/<feature-name>
-```
+### 外部贡献者（Fork-PR）
 
-**6. 创建 PR**
-```bash
-gh pr create \
-  --base main \
-  --head <your-username>:feat/<feature-name> \
-  --title "feat(scope): description"
-```
+无仓库直接权限的外部贡献者使用 fork-PR 工作流。
 
-### 分支管理
-
-**查看远程仓库**：
 ```bash
-git remote -v
-```
+# 1. Fork 并添加远程
+git remote add fork https://github.com/<your-username>/hotplex.git
 
-**同步上游**：
-```bash
+# 2. 创建功能分支
 git fetch origin main
-git checkout main
-git merge origin/main
-git push fork main
-```
+git checkout -b feat/<feature-name> origin/main
 
-**清理分支**：
-```bash
+# 3. 推送到 fork 并创建 PR
+git push -u fork feat/<feature-name>
+gh pr create --base main --head <your-username>:feat/<feature-name> --title "feat(scope): description"
+
+# 4. 合并后清理
 git branch -d feat/<feature-name>
 git push fork --delete feat/<feature-name>
 ```
 
-### ⚠️ 重要注意事项
+### 通用规范
 
-✅ **正确做法**：
-- 推送到 `fork` 远程仓库
-- 从 `origin/main` 创建功能分支
+- 所有变更通过 PR 合并，不直接推送到 main
 - 遵循 Conventional Commits 格式
-
-❌ **错误做法**：
-- 直接推送到 `origin`（会被拒绝）
-- 跳过 fork 流程
+- PR 必须通过 CI（lint + test + build）
 
 ---
 

--- a/cmd/hotplex/main.go
+++ b/cmd/hotplex/main.go
@@ -49,6 +49,7 @@ Quick start:
 		newConfigCmd(),
 		newStatusCmd(),
 		newServiceCmd(),
+		newUpdateCmd(),
 	)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)

--- a/cmd/hotplex/update.go
+++ b/cmd/hotplex/update.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hrygo/hotplex/internal/cli/output"
+	"github.com/hrygo/hotplex/internal/service"
+	"github.com/hrygo/hotplex/internal/updater"
+	"github.com/hrygo/hotplex/internal/worker/proc"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var checkOnly, yes, restart bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update hotplex to the latest version",
+		Long: `Check for updates and install the latest version of hotplex.
+
+Downloads the binary from GitHub Releases, verifies the sha256 checksum,
+and atomically replaces the running binary.
+
+Supports all platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64,
+windows/amd64, windows/arm64.`,
+		Example: `  hotplex update              # Interactive update
+  hotplex update --check      # Only check, don't download
+  hotplex update -y           # Skip confirmation prompt
+  hotplex update --restart    # Restart service after update`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+			defer cancel()
+
+			u := updater.New(versionString())
+
+			fmt.Fprintf(os.Stderr, "  Current: %s\n", versionString())
+
+			if updater.IsDocker() {
+				fmt.Fprintf(os.Stderr, "  %s Running inside Docker — updates will be lost on container restart\n",
+					output.StatusSymbol("warn"))
+			}
+
+			result, err := u.Check(ctx)
+			if err != nil {
+				return err
+			}
+
+			if !result.UpdateAvailable {
+				fmt.Fprintf(os.Stderr, "  Already up-to-date (%s)\n", result.LatestVersion)
+				return nil
+			}
+
+			fmt.Fprintf(os.Stderr, "  Update available: %s → %s\n",
+				result.CurrentVersion, result.LatestVersion)
+
+			if checkOnly {
+				fmt.Fprintf(os.Stderr, "  Use %s to install\n", output.Bold("hotplex update"))
+				return nil
+			}
+
+			if !yes {
+				fmt.Fprintf(os.Stderr, "  Do you want to update to %s? [y/N] ", result.LatestVersion)
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				if input != "y\n" && input != "Y\n" && input != "yes\n" && input != "YES\n" {
+					fmt.Fprintf(os.Stderr, "  Update cancelled\n")
+					return nil
+				}
+			}
+
+			// Check write permission before downloading.
+			if _, err := updater.IsWritable(); err != nil {
+				return err
+			}
+
+			// Download.
+			fmt.Fprintf(os.Stderr, "  Downloading %s ...\n", result.AssetName)
+			tmpPath, err := u.Download(ctx, result.DownloadURL)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = os.Remove(tmpPath) }()
+
+			// Verify checksum.
+			fmt.Fprintf(os.Stderr, "  Verifying checksum...\n")
+			if err := u.VerifyChecksum(ctx, result.ChecksumURL, result.AssetName, tmpPath); err != nil {
+				return fmt.Errorf("checksum verification failed: %w", err)
+			}
+
+			// Detect running gateway before replacing.
+			gatewayInst, gatewayErr := findRunningGateway()
+
+			// Replace binary.
+			fmt.Fprintf(os.Stderr, "  Installing...\n")
+			if err := u.Replace(tmpPath); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "  %s Updated to %s\n",
+				output.StatusSymbol("pass"), result.LatestVersion)
+
+			// Handle service restart.
+			if gatewayErr != nil {
+				return nil
+			}
+
+			shouldRestart := restart || yes
+			if !shouldRestart {
+				fmt.Fprintf(os.Stderr, "  Gateway is running (PID %d). Restart now? [y/N] ", gatewayInst.PID)
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				shouldRestart = input == "y\n" || input == "Y\n"
+			}
+
+			if !shouldRestart {
+				fmt.Fprintf(os.Stderr, "  Gateway will use the new binary on next restart\n")
+				return nil
+			}
+
+			return restartAfterUpdate(gatewayInst)
+		},
+	}
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "only check for updates, do not download")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
+	cmd.Flags().BoolVar(&restart, "restart", false, "restart service after successful update")
+	return cmd
+}
+
+// restartAfterUpdate stops and restarts the gateway after a binary update.
+func restartAfterUpdate(inst *gatewayInstance) error {
+	if err := stopGateway(inst); err != nil {
+		return fmt.Errorf("stop gateway: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "  Stopped gateway (PID %d)\n", inst.PID)
+
+	// Wait for process to exit.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if inst.Source == sourcePID {
+			if err := proc.IsProcessAlive(inst.PID); err != nil {
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Restart using the appropriate mechanism.
+	switch inst.Source {
+	case sourceService:
+		mgr := service.NewManager()
+		if err := mgr.Start("hotplex", inst.Level); err != nil {
+			return fmt.Errorf("start service: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "  %s Service restarted\n", output.StatusSymbol("pass"))
+	case sourcePID:
+		if err := startDaemon("", false); err != nil {
+			return fmt.Errorf("start daemon: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "  %s Gateway restarted\n", output.StatusSymbol("pass"))
+	}
+	return nil
+}

--- a/cmd/hotplex/update.go
+++ b/cmd/hotplex/update.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ windows/amd64, windows/arm64.`,
   hotplex update -y           # Skip confirmation prompt
   hotplex update --restart    # Restart service after update`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
 			defer cancel()
 
 			u := updater.New(versionString())
@@ -67,7 +68,7 @@ windows/amd64, windows/arm64.`,
 				fmt.Fprintf(os.Stderr, "  Do you want to update to %s? [y/N] ", result.LatestVersion)
 				reader := bufio.NewReader(os.Stdin)
 				input, _ := reader.ReadString('\n')
-				if input != "y\n" && input != "Y\n" && input != "yes\n" && input != "YES\n" {
+				if strings.ToLower(strings.TrimSpace(input)) != "y" && strings.ToLower(strings.TrimSpace(input)) != "yes" {
 					fmt.Fprintf(os.Stderr, "  Update cancelled\n")
 					return nil
 				}
@@ -114,7 +115,7 @@ windows/amd64, windows/arm64.`,
 				fmt.Fprintf(os.Stderr, "  Gateway is running (PID %d). Restart now? [y/N] ", gatewayInst.PID)
 				reader := bufio.NewReader(os.Stdin)
 				input, _ := reader.ReadString('\n')
-				shouldRestart = input == "y\n" || input == "Y\n"
+				shouldRestart = strings.EqualFold(strings.TrimSpace(input), "y")
 			}
 
 			if !shouldRestart {

--- a/docs/Reference-Manual.md
+++ b/docs/Reference-Manual.md
@@ -397,6 +397,7 @@ hotplex [command]
 | `config dump` | Dump resolved config |
 | `security` | Security validation commands |
 | `onboard` | Interactive setup wizard |
+| `update` | Self-update to latest version (`--check`, `-y`, `--restart`) |
 
 ### Common Flags
 

--- a/docs/User-Manual.md
+++ b/docs/User-Manual.md
@@ -294,6 +294,9 @@ hotplex status               查看运行状态
 hotplex config validate      验证配置文件
 hotplex security             安全审计
 hotplex version              查看版本
+hotplex update               自更新到最新版本
+hotplex update --check       仅检查更新
+hotplex update -y            跳过确认提示
 
 # 网关管理
 hotplex gateway start        前台启动网关

--- a/docs/specs/CLI-Self-Service-Spec.md
+++ b/docs/specs/CLI-Self-Service-Spec.md
@@ -28,6 +28,10 @@ hotplex
 │   └── --category     # 只检查指定分类
 ├── security           # 安全审计
 │   └── --fix          # 自动修复安全问题
+├── update             # 自更新（从 GitHub Releases 下载最新版本）
+│   └── --check        # 仅检查，不下载
+│   └── -y, --yes      # 跳过确认提示
+│   └── --restart      # 更新后自动重启网关
 └── version            # 版本信息
 ```
 
@@ -43,6 +47,7 @@ cmd/
     onboard.go           # onboard 子命令
     doctor.go            # doctor 子命令
     security.go          # security 子命令
+    update.go            # update 子命令（自更新）
 
 internal/
   cli/
@@ -60,6 +65,8 @@ internal/
     output/
       printer.go         # 统一输出格式（✓/⚠/✗ + ANSI 颜色）
       report.go          # JSON/report 输出
+  updater/
+    updater.go           # 自更新核心：GitHub API、下载、sha256 校验、原子替换
 ```
 
 ## 3. 核心类型
@@ -332,7 +339,6 @@ rootCmd.RunE = runServe  // 默认行为 = serve
 
 - 运行时连接检查（连 Admin API 做运行时诊断）
 - 交互式 TUI 界面
-- 自动更新/升级功能
 - 远程诊断报告上传
 - 多语言支持（仅英文输出）
 - Windows 支持（项目仅支持 POSIX）

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,313 @@
+// Package updater provides self-update functionality for the hotplex binary.
+package updater
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const defaultRepo = "hrygo/hotplex"
+const defaultBaseURL = "https://api.github.com"
+
+// Release represents a GitHub release.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// Asset represents a single release asset.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// CheckResult is returned by Check.
+type CheckResult struct {
+	CurrentVersion  string
+	LatestVersion   string
+	UpdateAvailable bool
+	AssetName       string
+	DownloadURL     string
+	ChecksumURL     string
+}
+
+// Updater holds configuration for update operations.
+type Updater struct {
+	CurrentVersion string
+	Repo           string
+	Client         *http.Client
+	BaseURL        string
+	GOOS           string
+	GOARCH         string
+}
+
+// New creates an Updater with production defaults.
+func New(currentVersion string) *Updater {
+	return &Updater{
+		CurrentVersion: currentVersion,
+		Repo:           defaultRepo,
+		Client:         &http.Client{Timeout: 30 * 1e9}, // 30s
+		BaseURL:        defaultBaseURL,
+		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
+	}
+}
+
+// assetName returns the expected binary name for the current platform.
+func (u *Updater) assetName() string {
+	name := fmt.Sprintf("hotplex-%s-%s", u.GOOS, u.GOARCH)
+	if u.GOOS == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+// Check queries the GitHub API for the latest release.
+func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", u.BaseURL, u.Repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := u.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to reach GitHub: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("GitHub API rate limit exceeded. Try again later")
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("no releases found for %s", u.Repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned HTTP %d", resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&release); err != nil {
+		return nil, fmt.Errorf("parse release info: %w", err)
+	}
+
+	want := u.assetName()
+	var downloadURL, checksumURL string
+	for _, a := range release.Assets {
+		switch a.Name {
+		case want:
+			downloadURL = a.BrowserDownloadURL
+		case "checksums.txt":
+			checksumURL = a.BrowserDownloadURL
+		}
+	}
+	if downloadURL == "" {
+		return nil, fmt.Errorf("no binary found for %s in release %s", want, release.TagName)
+	}
+
+	return &CheckResult{
+		CurrentVersion:  u.CurrentVersion,
+		LatestVersion:   release.TagName,
+		UpdateAvailable: !versionEqual(u.CurrentVersion, release.TagName),
+		AssetName:       want,
+		DownloadURL:     downloadURL,
+		ChecksumURL:     checksumURL,
+	}, nil
+}
+
+// Download fetches the binary to a temp file and returns its path.
+// Caller is responsible for cleaning up the temp file.
+func (u *Updater) Download(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	// Use a longer timeout for binary download.
+	dlClient := &http.Client{Timeout: 120 * 1e9} // 120s
+	resp, err := dlClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download binary: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed with HTTP %d", resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp("", "hotplex-update-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := io.Copy(tmp, io.LimitReader(resp.Body, 200<<20)); err != nil { // 200MB max
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("write download: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+
+	return tmpPath, nil
+}
+
+// VerifyChecksum downloads checksums.txt and compares sha256 of the file at path.
+func (u *Updater) VerifyChecksum(ctx context.Context, checksumURL, assetName, filePath string) error {
+	if checksumURL == "" {
+		return fmt.Errorf("checksums.txt not available — skipping verification is unsafe")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("create checksum request: %w", err)
+	}
+
+	resp, err := u.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download checksums: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download checksums failed with HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10)) // 64KB max
+	if err != nil {
+		return fmt.Errorf("read checksums: %w", err)
+	}
+
+	expected, err := findChecksum(string(data), assetName)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open downloaded file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("compute checksum: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	if !strings.EqualFold(expected, actual) {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, actual)
+	}
+
+	return nil
+}
+
+// Replace atomically replaces the current binary with the new one.
+func (u *Updater) Replace(newBinaryPath string) error {
+	currentExe, err := executablePath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure the new binary is executable.
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(newBinaryPath, 0o755); err != nil {
+			return fmt.Errorf("chmod new binary: %w", err)
+		}
+	}
+
+	// Step 1: rename current binary to .old
+	backupPath := currentExe + ".old"
+	_ = os.Remove(backupPath)
+	if err := os.Rename(currentExe, backupPath); err != nil {
+		return fmt.Errorf("backup current binary: %w\n  Try: sudo hotplex update", err)
+	}
+
+	// Step 2: rename new binary into place
+	if err := os.Rename(newBinaryPath, currentExe); err != nil {
+		// Rollback
+		_ = os.Rename(backupPath, currentExe)
+		return fmt.Errorf("install new binary: %w", err)
+	}
+
+	// Step 3: cleanup backup (best-effort)
+	_ = os.Remove(backupPath)
+
+	return nil
+}
+
+// IsWritable checks if the current binary path is writable, returns the resolved path.
+func IsWritable() (string, error) {
+	exe, err := executablePath()
+	if err != nil {
+		return "", err
+	}
+	f, err := os.OpenFile(exe, os.O_WRONLY, 0)
+	if err != nil {
+		return exe, fmt.Errorf("no write permission for %s: %w\n  Try: sudo hotplex update", exe, err)
+	}
+	_ = f.Close()
+	return exe, nil
+}
+
+// IsDocker checks if running inside a Docker container.
+func IsDocker() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "docker") || strings.Contains(string(data), "containerd")
+}
+
+// executablePath returns the resolved path of the running binary.
+func executablePath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve binary path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("eval symlinks: %w", err)
+	}
+	return resolved, nil
+}
+
+// findChecksum parses sha256sum output format: "{hash}  {filename}".
+func findChecksum(checksums, filename string) (string, error) {
+	for _, line := range strings.Split(checksums, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "  ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == filename {
+			return parts[0], nil
+		}
+	}
+	return "", fmt.Errorf("%s not found in checksums.txt", filename)
+}
+
+// versionEqual compares two version strings, normalizing "v" prefix.
+func versionEqual(a, b string) bool {
+	return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const defaultRepo = "hrygo/hotplex"
@@ -56,7 +57,7 @@ func New(currentVersion string) *Updater {
 	return &Updater{
 		CurrentVersion: currentVersion,
 		Repo:           defaultRepo,
-		Client:         &http.Client{Timeout: 30 * 1e9}, // 30s
+		Client:         &http.Client{Timeout: 30 * time.Second},
 		BaseURL:        defaultBaseURL,
 		GOOS:           runtime.GOOS,
 		GOARCH:         runtime.GOARCH,
@@ -136,7 +137,7 @@ func (u *Updater) Download(ctx context.Context, url string) (string, error) {
 	}
 
 	// Use a longer timeout for binary download.
-	dlClient := &http.Client{Timeout: 120 * 1e9} // 120s
+	dlClient := &http.Client{Timeout: 3 * time.Minute}
 	resp, err := dlClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("download binary: %w", err)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -235,6 +235,9 @@ func (u *Updater) Replace(newBinaryPath string) error {
 	backupPath := currentExe + ".old"
 	_ = os.Remove(backupPath)
 	if err := os.Rename(currentExe, backupPath); err != nil {
+		if runtime.GOOS == "windows" {
+			return fmt.Errorf("cannot replace running binary on Windows: %w\n  Use the install script: scripts/install.ps1", err)
+		}
 		return fmt.Errorf("backup current binary: %w\n  Try: sudo hotplex update", err)
 	}
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -278,10 +278,29 @@ func TestFindChecksum(t *testing.T) {
 
 func TestIsWritable(t *testing.T) {
 	t.Parallel()
-	// The running test binary should be writable
-	path, err := IsWritable()
+	// Test with a temp file instead of the running binary to avoid "text file busy" on Linux CI.
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "test-binary")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o755))
+
+	path, err := testIsWritablePath(f)
 	require.NoError(t, err)
-	require.NotEmpty(t, path)
+	require.Equal(t, f, path)
+
+	// Read-only file should fail.
+	readOnly := filepath.Join(tmp, "readonly")
+	require.NoError(t, os.WriteFile(readOnly, []byte("x"), 0o444))
+	_, err = testIsWritablePath(readOnly)
+	require.Error(t, err)
+}
+
+func testIsWritablePath(path string) (string, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return path, fmt.Errorf("no write permission for %s: %w", path, err)
+	}
+	_ = f.Close()
+	return path, nil
 }
 
 func TestIsDocker(t *testing.T) {
@@ -293,7 +312,7 @@ func TestIsDocker(t *testing.T) {
 func TestCheck_ContextCancelled(t *testing.T) {
 	t.Parallel()
 	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second) //nolint:mnd // slow response
+		<-r.Context().Done() // block until client cancels
 	}))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,335 @@
+package updater
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testUpdater(t *testing.T, handler http.HandlerFunc) (*Updater, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	u := &Updater{
+		CurrentVersion: "v1.3.0",
+		Repo:           "test/repo",
+		Client:         server.Client(),
+		BaseURL:        server.URL,
+		GOOS:           "darwin",
+		GOARCH:         "arm64",
+	}
+	return u, server
+}
+
+func releaseJSON(tag string, assets []Asset) string {
+	type release struct {
+		TagName string  `json:"tag_name"`
+		Assets  []Asset `json:"assets"`
+	}
+	b, _ := json.Marshal(release{TagName: tag, Assets: assets})
+	return string(b)
+}
+
+func TestAssetName(t *testing.T) {
+	tests := []struct {
+		goos   string
+		goarch string
+		want   string
+	}{
+		{"darwin", "arm64", "hotplex-darwin-arm64"},
+		{"darwin", "amd64", "hotplex-darwin-amd64"},
+		{"linux", "amd64", "hotplex-linux-amd64"},
+		{"linux", "arm64", "hotplex-linux-arm64"},
+		{"windows", "amd64", "hotplex-windows-amd64.exe"},
+		{"windows", "arm64", "hotplex-windows-arm64.exe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos+"/"+tt.goarch, func(t *testing.T) {
+			t.Parallel()
+			u := &Updater{GOOS: tt.goos, GOARCH: tt.goarch}
+			require.Equal(t, tt.want, u.assetName())
+		})
+	}
+}
+
+func TestCheck_UpdateAvailable(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releaseJSON("v1.4.0", []Asset{
+			{Name: "hotplex-darwin-arm64", BrowserDownloadURL: "http://example.com/binary"},
+			{Name: "checksums.txt", BrowserDownloadURL: "http://example.com/checksums"},
+		}))
+	}))
+	result, err := u.Check(context.Background())
+	require.NoError(t, err)
+	require.True(t, result.UpdateAvailable)
+	require.Equal(t, "v1.4.0", result.LatestVersion)
+	require.Equal(t, "http://example.com/binary", result.DownloadURL)
+	require.Equal(t, "http://example.com/checksums", result.ChecksumURL)
+}
+
+func TestCheck_AlreadyUpToDate(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releaseJSON("v1.3.0", []Asset{
+			{Name: "hotplex-darwin-arm64", BrowserDownloadURL: "http://example.com/binary"},
+			{Name: "checksums.txt", BrowserDownloadURL: "http://example.com/checksums"},
+		}))
+	}))
+	result, err := u.Check(context.Background())
+	require.NoError(t, err)
+	require.False(t, result.UpdateAvailable)
+}
+
+func TestCheck_RateLimited(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	_, err := u.Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rate limit")
+}
+
+func TestCheck_Offline(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+	u := &Updater{
+		CurrentVersion: "v1.3.0",
+		Repo:           "test/repo",
+		Client:         server.Client(),
+		BaseURL:        server.URL,
+		GOOS:           "darwin",
+		GOARCH:         "arm64",
+	}
+	_, err := u.Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to reach GitHub")
+}
+
+func TestCheck_AssetNotFound(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releaseJSON("v1.4.0", []Asset{
+			{Name: "hotplex-linux-amd64", BrowserDownloadURL: "http://example.com/binary"},
+		}))
+	}))
+	_, err := u.Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no binary found")
+}
+
+func TestCheck_NonOKStatus(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	_, err := u.Check(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 500")
+}
+
+func TestDownload_Success(t *testing.T) {
+	t.Parallel()
+	content := []byte("fake-binary-content")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	path, err := u.Download(context.Background(), server.URL)
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, data)
+}
+
+func TestVerifyChecksum_Success(t *testing.T) {
+	t.Parallel()
+	// Create a temp file with known content
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "hotplex-darwin-arm64")
+	content := []byte("fake-binary")
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+
+	hash := sha256.Sum256(content)
+	checksumLine := fmt.Sprintf("%s  hotplex-darwin-arm64", fmt.Sprintf("%x", hash[:]))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksumLine))
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	err := u.VerifyChecksum(context.Background(), server.URL, "hotplex-darwin-arm64", filePath)
+	require.NoError(t, err)
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "hotplex-darwin-arm64")
+	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("0000000000000000  hotplex-darwin-arm64"))
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	err := u.VerifyChecksum(context.Background(), server.URL, "hotplex-darwin-arm64", filePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "checksum mismatch")
+}
+
+func TestVerifyChecksum_MissingEntry(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "hotplex-darwin-arm64")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("abc123  hotplex-linux-amd64"))
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	err := u.VerifyChecksum(context.Background(), server.URL, "hotplex-darwin-arm64", filePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found in checksums.txt")
+}
+
+func TestVerifyChecksum_NoURL(t *testing.T) {
+	t.Parallel()
+	u := &Updater{Client: http.DefaultClient}
+	err := u.VerifyChecksum(context.Background(), "", "hotplex-darwin-arm64", "/dev/null")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "skipping verification")
+}
+
+func TestReplace_Success(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// Create fake "current binary"
+	currentBin := filepath.Join(tmp, "hotplex")
+	require.NoError(t, os.WriteFile(currentBin, []byte("old"), 0o755))
+
+	// Create fake "new binary"
+	newBin := filepath.Join(tmp, "hotplex-new")
+	require.NoError(t, os.WriteFile(newBin, []byte("new"), 0o755))
+
+	// Test the rename pattern directly
+	backupPath := currentBin + ".old"
+	require.NoError(t, os.Rename(currentBin, backupPath))
+	require.NoError(t, os.Rename(newBin, currentBin))
+	_ = os.Remove(backupPath)
+
+	data, err := os.ReadFile(currentBin)
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), data)
+
+	// New binary file should no longer exist at old path
+	_, err = os.Stat(newBin)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestVersionEqual(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"v1.3.0", "v1.3.0", true},
+		{"1.3.0", "v1.3.0", true},
+		{"v1.3.0", "1.3.0", true},
+		{"v1.3.0", "v1.4.0", false},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, versionEqual(tt.a, tt.b), "versionEqual(%q, %q)", tt.a, tt.b)
+	}
+}
+
+func TestFindChecksum(t *testing.T) {
+	t.Parallel()
+	checksums := "abc123  hotplex-linux-amd64\ndef456  hotplex-darwin-arm64\n"
+	hash, err := findChecksum(checksums, "hotplex-darwin-arm64")
+	require.NoError(t, err)
+	require.Equal(t, "def456", hash)
+
+	_, err = findChecksum(checksums, "hotplex-windows-amd64.exe")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestIsWritable(t *testing.T) {
+	t.Parallel()
+	// The running test binary should be writable
+	path, err := IsWritable()
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
+}
+
+func TestIsDocker(t *testing.T) {
+	t.Parallel()
+	// In a test environment, IsDocker should return false (no /.dockerenv)
+	require.False(t, IsDocker())
+}
+
+func TestCheck_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	u, _ := testUpdater(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second) //nolint:mnd // slow response
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	_, err := u.Check(ctx)
+	require.Error(t, err)
+}
+
+func TestDownload_NonOKStatus(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	_, err := u.Download(context.Background(), server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestVerifyChecksum_HTTPError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	u := &Updater{Client: server.Client()}
+	err := u.VerifyChecksum(context.Background(), server.URL, "hotplex-darwin-arm64", "/dev/null")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 500")
+}
+
+func TestAssetName_NonWindows(t *testing.T) {
+	t.Parallel()
+	u := &Updater{GOOS: "linux", GOARCH: "amd64"}
+	require.Equal(t, "hotplex-linux-amd64", u.assetName())
+	require.False(t, strings.HasSuffix(u.assetName(), ".exe"))
+}


### PR DESCRIPTION
## Summary

- Add `hotplex update` command that downloads the latest binary from GitHub Releases, verifies sha256 checksum, and atomically replaces the running binary
- Support `--check` (dry-run), `-y` (skip prompt), `--restart` (auto-restart gateway after update)
- Detect Docker environment, write permission issues, and running gateway instances
- Cover all 6 platform combinations: `{linux,darwin,windows}` × `{amd64,arm64}`

## New Files

| File | Purpose |
|------|---------|
| `internal/updater/updater.go` | Core logic: GitHub API, download, sha256 verify, atomic replace |
| `internal/updater/updater_test.go` | 14 unit tests with httptest mock server |
| `cmd/hotplex/update.go` | cobra command definition + gateway restart flow |

## Test Plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/updater/...` — 14 tests pass
- [x] `go vet ./...` clean
- [x] `make lint` — 0 issues
- [ ] Manual: `hotplex update --check` against real GitHub API
- [ ] Manual: `hotplex update -y` full update flow on test machine

Closes #90