### PR TITLE
feat(messaging): send turn summary on Done event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [1.4.0] - 2026-05-02
+
+### Summary
+
+v1.4.0 是一次 minor 版本更新，聚焦于 **运维自服务能力、Gateway 稳定性与并发安全、SQLite OOM 韧性、Messaging 层架构治理**。新增 CLI 自更新命令（GitHub Releases API + SHA256 校验 + 原子替换）、智能目录切换安全策略、config-driven Worker 环境变量注入、SQLite CGo 双驱动自动降级。Gateway 全面加固并发安全（pcEntry race condition、Session panic recovery、WriteBufferFull 信号化），Messaging 层提取 BaseAdapter 消除 connPool 重复、统一 `$context` 命令输出。CI 流水线并行化和缓存优化显著缩短构建时间。
+
+### Added
+
+- **CLI**: `hotplex update` 自更新命令 — GitHub Releases API 集成、SHA256 校验验证、原子二进制替换、服务自动重启支持（`--check`、`-y`、`--restart` 标志）。(#115)
+- **Security**: 智能目录切换安全策略 — 支持用户主目录和 `/usr/local` 约定优于配置的智能判断，跨平台路径验证。(#110 相关)
+- **Configuration**: Worker 环境变量注入 — `worker.environment` 配置驱动，支持 `${VAR}` 展开和 `env_whitelist` 过滤，默认注入 `BUN_RUNTIME_NV=disable_avx512`。
+- **Configuration**: `db.events_path` 可配置 — events.db 路径支持自定义，脱离默认数据目录。
+- **SQLite**: CGo 双驱动自动降级 — CGo 构建使用 mattn/go-sqlite3（性能优先），纯 Go 构建使用 modernc.org/sqlite（OOM 韧性），build tag 自动选择。
+- **Messaging**: `$context` 命令输出美化 — 共享格式化层（severity 级别、进度条、友好 token 计数、操作建议），Slack/飞书/WebChat 统一输出。WebChat 新增 ContextUsageCard 玻璃态组件。(#110)
+- **Messaging**: events.Message 处理 — 飞书和 Slack 适配器新增 handler/bridge 发起的独立消息处理（cd 确认、命令反馈）。
+- **Messaging**: 控制命令详细错误消息 — 用户友好的错误提示替代静默失败。
+
+### Changed
+
+- **Messaging**: 提取 BaseAdapter[C] 泛型结构体 — 消除 Slack/飞书适配器约 30 行 connPool 重复代码，提供 `InitConnPool`/`GetOrCreateConn`/`DrainConns`/`DeleteConn` 统一生命周期管理。(#114)
+- **Gateway**: 模块拆分 — 从 hub.go 提取 SeqGen 和 pcEntry 到独立文件，提取 `createAndLaunchWorker`、`requireActiveOwner` 辅助函数，Handler 改用 SessionManager 接口替代具体类型。
+- **Session**: 提取 `audit_store.go`（审计追踪方法）、`stores.go`（store 工厂）、`updateSession` 辅助函数，store.go 减少 182 行。
+- **SQLite**: 提取 `sqlutil` 包统一 DB 初始化和 PRAGMA 调优，消除冗余零值回退。
+- **Security**: 提取 `resolveSigningKey` 辅助函数，移除无用的 `DevAllowedTools`。
+- **Admin**: 提取 CORS 处理到中间件。
+- **Metrics**: 移除 `session_id` label 防止 delta 指标基数无限增长。
+- **CI**: 流水线优化 — 移除 Gate 阶段、步骤并行化、Go/WebChat 缓存。
+- **Messaging**: 关闭 turn_timeout 默认值（原 15m 过于激进，execution_timeout 30m 已足够捕获僵尸会话）。
+- **Service**: systemd WorkingDirectory 对齐 worker.default_work_dir 而非硬编码 `$HOME`。(#109)
+
+### Fixed
+
+- **Service**: ExecStart 路径解析 — `ResolveBinaryPath()` 优先使用 PATH 查找（`exec.LookPath`），修复 build 目录路径写入 systemd unit 的问题。(#113)
+- **Configuration**: `${VAR}` 环境变量展开 — ExpandEnv 已定义但未在加载路径中调用，worker.environment 值注入为字面量而非展开值。(#111)
+- **Gateway**: pcEntry WriteCtx/Close race condition — 并发写入和关闭导致 panic，新增错误分类辅助函数。关闭 data channel 解除 writeLoop 阻塞。
+- **Session**: 并发安全加固 — UpdateWorkDir/ClearContext 添加 RLock 保护早期返回字段读取；回调函数添加 panic recovery；级联删除包裹在事务中；WriteBuffer 满时返回 `ErrWriteBufferFull` 替代静默丢弃。
+- **Worker**: RLIMIT_AS 自限 bug 修复 — 网关进程被自身内存限制崩溃；禁用 RLIMIT_AS 修复 Bun 运行时崩溃。(#112 相关)
+- **Worker**: OCS SSE 超时和启动问题修复；releaseOnce 行为测试覆盖。(#112 相关)
+- **Messaging**: watchTimeout panic recovery 和 idleMonitor context race 修复。
+- **Messaging/Feishu**: ChatQueue `wg.Add` 移入 mutex lock 内防止 race；非用户流式卡片清理路径用 Close() 替代 Abort()；控制命令错误静默失败修复。
+- **Agent Config**: `readFile` 区分 IsNotExist 和其他错误类型。
+- **CLI**: wizard stepAgentConfig 写入和关闭错误处理。
+
+### Security
+
+- **Configuration**: GH_TOKEN/GITHUB_TOKEN 重命名为 HOTPLEX_WORKER_GH_TOKEN/HOTPLEX_WORKER_GITHUB_TOKEN 前缀，防止 shell 环境污染影响 `gh` CLI keyring 认证。(#111)
+
 ## [1.3.0] - 2026-04-30
 
 ### Summary

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ARG BUILD_TIME
 
 # Labels for metadata
 LABEL maintainer="HotPlex Team <support@hotplex.dev>"
-LABEL version="1.3.0"
+LABEL version="1.4.0"
 LABEL git.sha="${GIT_SHA}"
 LABEL build.time="${BUILD_TIME}"
 LABEL description="HotPlex Worker Gateway - AI Coding Agent access layer"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOOS         := $(shell go env GOOS)
 GOARCH       := $(shell go env GOARCH)
 GIT_SHA      := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME   := $(shell date '+%Y-%m-%dT%H:%M:%S%z')
-LDFLAGS      := -s -w -X main.version=v1.3.0 -X main.buildTime=$(BUILD_TIME)
+LDFLAGS      := -s -w -X main.version=v1.4.0 -X main.buildTime=$(BUILD_TIME)
 BUILD_OPTS   := -trimpath
 
 GATEWAY_PID   := $(HOME)/.hotplex/.pids/gateway.pid

--- a/cmd/hotplex/main.go
+++ b/cmd/hotplex/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	version   = "v1.3.0"
+	version   = "v1.4.0"
 	buildTime = "unknown"
 )
 

--- a/docs/specs/Turn-Summary-Spec.md
+++ b/docs/specs/Turn-Summary-Spec.md
@@ -1,0 +1,343 @@
+# Turn Summary Spec — Issue #117
+
+每轮 Done 时，向用户发送本轮摘要信息。
+
+---
+
+## 1. 数据源
+
+### 1.1 `_session` 快照扩展
+
+在 `sessionAccumulator.snapshot()` 输出中新增以下 key：
+
+| Key | 类型 | 来源 | 说明 |
+|-----|------|------|------|
+| `turn_duration_ms` | int64 | `time.Since(turnStartTime)` | 本轮耗时（毫秒） |
+| `turn_input_tok` | int64 | `PerTurnInput` | 本轮输入 token（delta） |
+| `turn_output_tok` | int64 | `PerTurnOutput` | 本轮输出 token（delta） |
+| `turn_cost_usd` | float64 | `PerTurnCost` | 本轮花费（delta） |
+| `tool_names` | map[string]int | `ToolNames` | 工具名 → 调用次数 |
+
+已有字段不变：
+
+| Key | 类型 | 说明 |
+|-----|------|------|
+| `turn_count` | int | 累计轮次 |
+| `tool_call_count` | int | 本轮工具调用总数 |
+| `total_input_tok` | int64 | 累计输入 token |
+| `total_output_tok` | int64 | 累计输出 token |
+| `context_window` | int64 | context 窗口大小（0 = 未知） |
+| `context_pct` | float64 | context 使用率 0-100 |
+| `total_cost_usd` | float64 | 累计花费 |
+| `model_name` | string | 模型短名 |
+| `duration` | string | session 累计耗时 |
+| `duration_seconds` | float64 | session 累计耗时（秒） |
+
+### 1.2 提取函数
+
+```go
+// ExtractTurnSummary 从 Done envelope 提取 _session 数据。
+// 处理 events.Clone JSON round-trip 后的 map[string]any 类型。
+func ExtractTurnSummary(env *events.Envelope) TurnSummaryData
+```
+
+Envelope 经 `events.Clone` 后，`Event.Data` 为 `map[string]any`。
+提取路径：`env.Event.Data.(map[string]any)["stats"].(map[string]any)["_session"].(map[string]any)`。
+
+数值类型统一用 `toInt64` / `toFloat64` 辅助函数转换（JSON 反序列化后为 float64）。
+
+### 1.3 Worker 兼容性
+
+| Worker | `context_pct` | `model_name` | `tool_call_count` | `turn_duration_ms` |
+|--------|---------------|--------------|-------------------|---------------------|
+| Claude Code | ✅ 完整 | ✅ "Sonnet"/"Opus"/"Haiku" | ✅ | ✅ |
+| OCS | ⚠️ 0（无 contextWindow） | ⚠️ 可能为空 | ✅ | ✅ |
+| Pi | ❌ noop worker | — | — | — |
+
+字段缺失时格式化函数跳过该段，不显示占位符。
+
+---
+
+## 2. 格式化规则
+
+### 2.1 统一格式（Slack / 飞书）
+
+```
+{icon} Context {pct}% ({used}/{max}) | {model} | 🛠 {count} tools | ⏱ {duration} | ${cost}
+```
+
+**示例输出**：
+
+```
+🟢 Context 24% (48K/200K) | Sonnet | 🛠 12 tools | ⏱ 42s | $0.04
+```
+
+**Severity icon 映射**（复用 `context_format.go`）：
+
+| Context % | Icon | 级别 |
+|-----------|------|------|
+| 0-49% | 🟢 | Comfortable |
+| 50-75% | 🟡 | Moderate |
+| 76-90% | 🟠 | High |
+| 91-100% | 🔴 | Critical |
+| 无数据 | ⚪ | — |
+
+**各段格式规则**：
+
+| 段 | 条件 | 格式 |
+|----|------|------|
+| Context | `context_window > 0` | `{icon} Context {pct}% ({used}/{max})` |
+| Context（无 window） | `total_input_tok > 0 && context_window == 0` | `{icon} Context {used} tokens` |
+| Model | `model_name != ""` | `{model_name}` |
+| Tools | `tool_call_count > 0` | `🛠 {count} tools` |
+| Duration | `turn_duration_ms > 0` | `⏱ {human_duration}` |
+| Cost | `turn_cost_usd >= 0.01` | `${cost}` |
+
+**时长格式化**：
+
+| 范围 | 格式 | 示例 |
+|------|------|------|
+| < 1s | `{ms}ms` | `420ms` |
+| < 60s | `{s}s` | `42s` |
+| < 60m | `{m}m{s}s` | `3m42s` |
+| ≥ 60m | `{h}h{m}m` | `1h23m` |
+
+**Token 格式化**（复用 `context_format.go.FormatTokenCount`）：
+
+| 值 | 格式 |
+|----|------|
+| < 1000 | `999` |
+| 整千 | `48K` |
+| 非整千 | `~48.4K` |
+
+**Cost 格式化**：
+
+| 值 | 格式 |
+|----|------|
+| < 0.01 | 不显示 |
+| < 1 | `$0.04` |
+| ≥ 1 | `$1.23` |
+
+### 2.2 降级场景
+
+**OCS（无 context window）**：
+```
+⚪ Context ~48K tokens | Sonnet | 🛠 5 tools | ⏱ 12s
+```
+
+**无 context 数据、有 model**：
+```
+Sonnet | 🛠 3 tools | ⏱ 8s
+```
+
+**全部无数据（Pi noop）**：
+```
+（空字符串，不发送消息）
+```
+
+---
+
+## 3. 后端变更
+
+### 3.1 session_stats.go
+
+**新增字段**：
+
+```go
+type sessionAccumulator struct {
+    // ... existing fields ...
+    TurnDurationMs int64  // 本轮耗时（毫秒）
+}
+```
+
+**snapshot() 新增 key**：
+
+```go
+func (a *sessionAccumulator) snapshot() map[string]any {
+    // ... existing ...
+    "turn_duration_ms": a.TurnDurationMs,
+    "turn_input_tok":   a.PerTurnInput,
+    "turn_output_tok":  a.PerTurnOutput,
+    "turn_cost_usd":    a.PerTurnCost,
+    "tool_names":       a.ToolNames,
+}
+```
+
+### 3.2 bridge.go
+
+**Done case 内，提前计算 per-turn 数据**：
+
+```go
+case events.Done:
+    if turnTimer != nil {
+        turnTimer.Stop()
+    }
+    acc := b.getOrInitAccum(sessionID)
+    if dd, ok := asDoneData(env.Event.Data); ok {
+        acc.mergePerTurnStats(dd)
+    }
+    acc.TurnCount++
+    acc.TurnDurationMs = time.Since(turnStartTime).Milliseconds()  // ← 新增
+    acc.computePerTurnDeltas()                                       // ← 提前调用
+    b.injectSessionStats(env, acc)                                   // snapshot 包含完整数据
+    // ... rest unchanged ...
+```
+
+`resetPerTurn()` 保持不变（在 conversation store 写入后调用）。
+`computePerTurnDeltas()` 是纯计算，提前调用安全。
+
+### 3.3 turn_summary.go
+
+**新建** `internal/messaging/turn_summary.go`。
+
+```go
+package messaging
+
+type TurnSummaryData struct {
+    ContextPct     float64
+    ContextWindow  int64
+    TotalInputTok  int64
+    ModelName      string
+    ToolCallCount  int
+    ToolNames      map[string]int
+    TurnDurationMs int64
+    TurnCount      int
+    TurnInputTok   int64
+    TurnOutputTok  int64
+    TurnCostUSD    float64
+    TotalCostUSD   float64
+}
+
+func ExtractTurnSummary(env *events.Envelope) TurnSummaryData { ... }
+func FormatTurnSummary(d TurnSummaryData) string { ... }
+```
+
+**复用已有工具**（`context_format.go`）：
+- `SeverityLevel(pct)` → severity
+- `SeverityIcon(severity)` → emoji
+- `FormatTokenCount(tokens)` → "48K"
+
+### 3.4 Slack adapter
+
+**WriteCtx Done case**：
+
+```go
+case events.Done, events.Error:
+    c.clearStatus(ctx)
+    c.adapter.Interactions.CancelAll(env.SessionID)
+    c.closeStreamWriter()
+    if env.Event.Type == events.Done {
+        go c.sendTurnSummary(ctx, env)
+    }
+    if env.Event.Type == events.Error {
+        // ... existing error handling ...
+    }
+    return nil
+```
+
+**sendTurnSummary 方法**（遵循 `sendContextUsage` 模式）：
+
+```go
+func (c *SlackConn) sendTurnSummary(ctx context.Context, env *events.Envelope) {
+    d := messaging.ExtractTurnSummary(env)
+    text := messaging.FormatTurnSummary(d)
+    if text == "" {
+        return
+    }
+    opts := []slack.MsgOption{slack.MsgOptionText(text, false)}
+    if c.threadTS != "" {
+        opts = append(opts, slack.MsgOptionTS(c.threadTS))
+    }
+    _, _, _ = c.adapter.client.PostMessageContext(ctx, c.channelID, opts...)
+}
+```
+
+### 3.5 Feishu adapter
+
+**WriteCtx Done case**（重构，保留 Close 错误传播）：
+
+```go
+case events.Done:
+    streamCtrl := c.clearActiveIndicators(ctx)
+    c.adapter.Interactions.CancelAll(env.SessionID)
+    var closeErr error
+    if streamCtrl != nil && streamCtrl.IsCreated() {
+        closeErr = streamCtrl.Close(ctx)
+    }
+    go c.sendTurnSummary(ctx, env)
+    return closeErr
+```
+
+**sendTurnSummary 方法**（遵循 `sendContextUsage` 模式）：
+
+```go
+func (c *FeishuConn) sendTurnSummary(ctx context.Context, env *events.Envelope) {
+    d := messaging.ExtractTurnSummary(env)
+    text := messaging.FormatTurnSummary(d)
+    if text == "" {
+        return
+    }
+    c.mu.RLock()
+    replyToMsgID := c.replyToMsgID
+    chatID := c.chatID
+    c.mu.RUnlock()
+    if replyToMsgID != "" {
+        _ = c.adapter.replyMessage(ctx, replyToMsgID, text, false)
+    } else {
+        _ = c.adapter.sendTextMessage(ctx, chatID, text)
+    }
+}
+```
+
+---
+
+## 4. WebChat 前端
+
+无需后端改动。前端从 `DoneData.Stats["_session"]` 渲染。
+
+扩展后的 `_session` 数据供前端展示：
+
+```
+Context: 🟢 24% [██████░░░░] 48K/200K
+Model: Sonnet 4 | Turn: 3
+Input: ~12K tokens | Output: ~2K tokens
+Tools: Read × 5, Bash × 3, Edit × 2, Grep × 2
+Duration: 42s | Cost: $0.04 (Total: $0.12)
+```
+
+前端可自行决定渲染粒度和展示风格。
+
+---
+
+## 5. 测试覆盖
+
+### 5.1 turn_summary_test.go
+
+| 测试 | 场景 |
+|------|------|
+| `TestExtractTurnSummary_Full` | 全部字段有值，验证每个字段正确提取 |
+| `TestExtractTurnSummary_NilSession` | `_session` 不存在，返回零值 |
+| `TestExtractTurnSummary_NilStats` | `Stats` 为 nil |
+| `TestFormatTurnSummary_Full` | 完整输出：`🟢 Context 24% (48K/200K) \| Sonnet \| 🛠 12 tools \| ⏱ 42s \| $0.04` |
+| `TestFormatTurnSummary_NoContext` | 无 context window：`Sonnet \| 🛠 5 tools \| ⏱ 12s` |
+| `TestFormatTurnSummary_NoModel` | 有 context 无 model |
+| `TestFormatTurnSummary_NoTools` | 零工具调用，tools 段不显示 |
+| `TestFormatTurnSummary_Minimal` | 仅 duration |
+| `TestFormatTurnSummary_Empty` | 全部无数据，返回空字符串 |
+| `TestFormatTurnSummary_DurationFormats` | 覆盖 ms/s/m+s/h+m 格式 |
+| `TestFormatTurnSummary_CostThreshold` | cost < $0.01 不显示 |
+
+### 5.2 session_stats 验证
+
+`snapshot()` 包含新增 key，`computePerTurnDeltas` 提前调用结果一致。
+
+---
+
+## 6. 实施顺序
+
+1. `session_stats.go` — 新增字段 + 扩展 snapshot
+2. `bridge.go` — 提前计算 turnDuration + perTurnDeltas
+3. `turn_summary.go` + `turn_summary_test.go` — 提取 + 格式化 + 测试
+4. `slack/adapter.go` — Done case + sendTurnSummary
+5. `feishu/adapter.go` — Done case + sendTurnSummary
+6. `make lint && make test` 验证

--- a/examples/java-client/pom.xml
+++ b/examples/java-client/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>dev.hotplex</groupId>
     <artifactId>hotplex-client</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>HotPlex Client</name>

--- a/examples/python-client/hotplex_client/__init__.py
+++ b/examples/python-client/hotplex_client/__init__.py
@@ -4,7 +4,7 @@ HotPlex Python Client
 A Python client library for interacting with HotPlex Gateway via AEP v1 protocol.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __author__ = "HotPlex Team"
 
 # 导出公共 API

--- a/examples/python-client/pyproject.toml
+++ b/examples/python-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hotplex-client"
-version = "1.3.0"
+version = "1.4.0"
 description = "Python client example for HotPlex Gateway (AEP v1)"
 requires-python = ">=3.10"
 dependencies = [

--- a/examples/typescript-client/package.json
+++ b/examples/typescript-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotplex-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TypeScript client SDK for HotPlex Gateway (AEP v1)",
   "type": "module",
   "main": "./dist/index.js",

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -60,7 +60,7 @@ func Init(ctx context.Context, log *slog.Logger, serviceName string) {
 		res, err := resource.New(ctx,
 			resource.WithAttributes(
 				semconv.ServiceName(serviceName),
-				semconv.ServiceVersion("1.3.0"),
+				semconv.ServiceVersion("1.4.0"),
 			),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

每轮 Done 时，向用户发送本轮 context 摘要信息（使用率、模型名称、工具调用次数、本轮耗时）。Slack/飞书体验一致，WebChat 前端从扩展后的 `_session` 快照渲染更全面的信息。

### Changes

- 详细设计规格文档 `docs/specs/Turn-Summary-Spec.md`

**架构影响**：
- Channel: Slack / 飞书 / WebChat
- Worker: CC / OCS / Pi（graceful degradation）

## Test Plan

- [x] Spec 文档审阅
- [ ] 后续 PR 实现代码（遵循 spec）

## Related Issues

- Refs #117