### PR TITLE
feat(messaging): add turn summary with per-turn stats on Done

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -460,6 +460,8 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 				acc.mergePerTurnStats(dd)
 			}
 			acc.TurnCount++
+			acc.TurnDurationMs = time.Since(turnStartTime).Milliseconds()
+			acc.computePerTurnDeltas()
 			b.injectSessionStats(env, acc)
 			if b.log.Enabled(context.Background(), slog.LevelDebug) {
 				b.log.Debug("bridge: turn completed",
@@ -536,7 +538,6 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		if env.Event.Type == events.Done && b.convStore != nil {
 			dd, _ := asDoneData(env.Event.Data)
 			acc := b.getOrInitAccum(sessionID)
-			acc.computePerTurnDeltas()
 			success := dd.Success
 			_ = b.convStore.Append(context.Background(), &session.ConversationRecord{
 				SessionID:     sessionID,

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -22,10 +22,11 @@ type sessionAccumulator struct {
 	StartedAt     time.Time
 
 	// Per-turn tracking (reset after each done).
-	ToolNames     map[string]int // tool name -> call count this turn
-	PerTurnInput  int64
-	PerTurnOutput int64
-	PerTurnCost   float64
+	ToolNames      map[string]int // tool name -> call count this turn
+	PerTurnInput   int64
+	PerTurnOutput  int64
+	PerTurnCost    float64
+	TurnDurationMs int64 // current turn duration in milliseconds
 
 	// Cumulative totals at the end of the previous turn (for delta computation).
 	PrevTotalIn   int64
@@ -136,6 +137,11 @@ func (a *sessionAccumulator) snapshot() map[string]any {
 		"context_pct":      ctxPct,
 		"total_cost_usd":   a.TotalCostUSD,
 		"model_name":       a.ModelName,
+		"turn_duration_ms": a.TurnDurationMs,
+		"turn_input_tok":   a.PerTurnInput,
+		"turn_output_tok":  a.PerTurnOutput,
+		"turn_cost_usd":    a.PerTurnCost,
+		"tool_names":       a.ToolNames,
 	}
 }
 

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -127,6 +127,13 @@ func (a *sessionAccumulator) computeContextPct() float64 {
 // snapshot returns the current accumulator state as a map for injection into DoneData.Stats["_session"].
 func (a *sessionAccumulator) snapshot() map[string]any {
 	ctxPct := a.computeContextPct()
+	var toolNames map[string]int
+	if len(a.ToolNames) > 0 {
+		toolNames = make(map[string]int, len(a.ToolNames))
+		for k, v := range a.ToolNames {
+			toolNames[k] = v
+		}
+	}
 	return map[string]any{
 		"turn_count":       a.TurnCount,
 		"tool_call_count":  a.ToolCallCount,
@@ -142,7 +149,7 @@ func (a *sessionAccumulator) snapshot() map[string]any {
 		"turn_input_tok":   a.PerTurnInput,
 		"turn_output_tok":  a.PerTurnOutput,
 		"turn_cost_usd":    a.PerTurnCost,
-		"tool_names":       a.ToolNames,
+		"tool_names":       toolNames,
 	}
 }
 

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -105,6 +105,7 @@ func (a *sessionAccumulator) resetPerTurn() {
 	a.PerTurnInput = 0
 	a.PerTurnOutput = 0
 	a.PerTurnCost = 0
+	a.TurnDurationMs = 0
 }
 
 // computeContextPct calculates context window usage percentage.

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -633,10 +633,12 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 	case events.Done:
 		streamCtrl := c.clearActiveIndicators(ctx)
 		c.adapter.Interactions.CancelAll(env.SessionID)
+		var closeErr error
 		if streamCtrl != nil && streamCtrl.IsCreated() {
-			return streamCtrl.Close(ctx)
+			closeErr = streamCtrl.Close(ctx)
 		}
-		return nil
+		go c.sendTurnSummary(ctx, env)
+		return closeErr
 	case events.Error:
 		streamCtrl := c.clearActiveIndicators(ctx)
 		c.adapter.Interactions.CancelAll(env.SessionID)
@@ -844,6 +846,23 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 		return c.adapter.replyMessage(ctx, replyToMsgID, OptimizeMarkdownStyle(SanitizeForCard(text)), false)
 	}
 	return c.adapter.sendTextMessage(ctx, chatID, OptimizeMarkdownStyle(SanitizeForCard(text)))
+}
+
+func (c *FeishuConn) sendTurnSummary(ctx context.Context, env *events.Envelope) {
+	d := messaging.ExtractTurnSummary(env)
+	text := messaging.FormatTurnSummary(d)
+	if text == "" {
+		return
+	}
+	c.mu.RLock()
+	replyToMsgID := c.replyToMsgID
+	chatID := c.chatID
+	c.mu.RUnlock()
+	if replyToMsgID != "" {
+		_ = c.adapter.replyMessage(ctx, replyToMsgID, text, false)
+	} else {
+		_ = c.adapter.sendTextMessage(ctx, chatID, text)
+	}
 }
 
 func (c *FeishuConn) sendContextUsage(ctx context.Context, env *events.Envelope) error {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -1027,6 +1027,9 @@ func (a *Adapter) cleanupMediaInDir(dir string) {
 }
 
 func (c *SlackConn) sendTurnSummary(ctx context.Context, env *events.Envelope) {
+	if c.adapter == nil || c.adapter.client == nil {
+		return
+	}
 	d := messaging.ExtractTurnSummary(env)
 	text := messaging.FormatTurnSummary(d)
 	if text == "" {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -725,6 +725,9 @@ func (c *SlackConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.clearStatus(ctx)
 		c.adapter.Interactions.CancelAll(env.SessionID)
 		c.closeStreamWriter()
+		if env.Event.Type == events.Done {
+			go c.sendTurnSummary(ctx, env)
+		}
 		if env.Event.Type == events.Error {
 			if errMsg := messaging.ExtractErrorMessage(env); errMsg != "" {
 				// Async: PostMessage is synchronous HTTP and must not block Hub broadcast.
@@ -1021,6 +1024,19 @@ func (a *Adapter) cleanupMediaInDir(dir string) {
 		}
 		return nil
 	})
+}
+
+func (c *SlackConn) sendTurnSummary(ctx context.Context, env *events.Envelope) {
+	d := messaging.ExtractTurnSummary(env)
+	text := messaging.FormatTurnSummary(d)
+	if text == "" {
+		return
+	}
+	opts := []slack.MsgOption{slack.MsgOptionText(text, false)}
+	if c.threadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(c.threadTS))
+	}
+	_, _, _ = c.adapter.client.PostMessageContext(ctx, c.channelID, opts...)
 }
 
 func (c *SlackConn) sendContextUsage(ctx context.Context, env *events.Envelope) error {

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -1,0 +1,173 @@
+package messaging
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TurnSummaryData holds per-turn summary fields extracted from a Done envelope.
+type TurnSummaryData struct {
+	ContextPct     float64
+	ContextWindow  int64
+	TotalInputTok  int64
+	ModelName      string
+	ToolCallCount  int
+	ToolNames      map[string]int
+	TurnDurationMs int64
+	TurnCount      int
+	TurnInputTok   int64
+	TurnOutputTok  int64
+	TurnCostUSD    float64
+	TotalCostUSD   float64
+}
+
+// ExtractTurnSummary extracts TurnSummaryData from a Done envelope.
+// Handles events.Clone JSON round-trip where Event.Data becomes map[string]any.
+func ExtractTurnSummary(env *events.Envelope) TurnSummaryData {
+	var dataMap map[string]any
+	switch v := env.Event.Data.(type) {
+	case events.DoneData:
+		dataMap = v.Stats
+	case map[string]any:
+		if s, ok := v["stats"].(map[string]any); ok {
+			dataMap = s
+		}
+	}
+
+	if dataMap == nil {
+		return TurnSummaryData{}
+	}
+
+	ss, ok := dataMap["_session"]
+	if !ok {
+		return TurnSummaryData{}
+	}
+	m, ok := ss.(map[string]any)
+	if !ok {
+		return TurnSummaryData{}
+	}
+
+	return TurnSummaryData{
+		ContextPct:     toFloat64Msg(m["context_pct"]),
+		ContextWindow:  toInt64Msg(m["context_window"]),
+		TotalInputTok:  toInt64Msg(m["total_input_tok"]),
+		ModelName:      toString(m["model_name"]),
+		ToolCallCount:  int(toInt64Msg(m["tool_call_count"])),
+		ToolNames:      toToolNames(m["tool_names"]),
+		TurnDurationMs: toInt64Msg(m["turn_duration_ms"]),
+		TurnCount:      int(toInt64Msg(m["turn_count"])),
+		TurnInputTok:   toInt64Msg(m["turn_input_tok"]),
+		TurnOutputTok:  toInt64Msg(m["turn_output_tok"]),
+		TurnCostUSD:    toFloat64Msg(m["turn_cost_usd"]),
+		TotalCostUSD:   toFloat64Msg(m["total_cost_usd"]),
+	}
+}
+
+// FormatTurnSummary produces a single-line turn summary for messaging platforms.
+// Returns empty string if no meaningful data is available.
+func FormatTurnSummary(d TurnSummaryData) string {
+	var parts []string
+
+	// Context segment
+	if d.ContextWindow > 0 && d.TotalInputTok > 0 {
+		pct := int(d.ContextPct + 0.5)
+		if pct > 100 {
+			pct = 100
+		}
+		severity := SeverityLevel(pct)
+		icon := SeverityIcon(severity)
+		used := FormatTokenCount(int(d.TotalInputTok))
+		max := FormatTokenCount(int(d.ContextWindow))
+		parts = append(parts, fmt.Sprintf("%s Context %d%% (%s/%s)", icon, pct, used, max))
+	} else if d.TotalInputTok > 0 {
+		used := FormatTokenCount(int(d.TotalInputTok))
+		parts = append(parts, fmt.Sprintf("%s Context %s tokens", SeverityIcon(SeverityComfortable), used))
+	}
+
+	// Model segment
+	if d.ModelName != "" {
+		parts = append(parts, d.ModelName)
+	}
+
+	// Tools segment
+	if d.ToolCallCount > 0 {
+		parts = append(parts, fmt.Sprintf("\U0001f6e0 %d tools", d.ToolCallCount))
+	}
+
+	// Duration segment
+	if d.TurnDurationMs > 0 {
+		parts = append(parts, "⏱ "+formatDuration(d.TurnDurationMs))
+	}
+
+	// Cost segment (skip if < $0.01)
+	if d.TurnCostUSD >= 0.01 {
+		parts = append(parts, formatCost(d.TurnCostUSD))
+	}
+
+	return strings.Join(parts, " | ")
+}
+
+func formatDuration(ms int64) string {
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%dms", ms)
+	case ms < 60_000:
+		return fmt.Sprintf("%ds", ms/1000)
+	case ms < 3_600_000:
+		return fmt.Sprintf("%dm%ds", ms/60_000, (ms%60_000)/1000)
+	default:
+		return fmt.Sprintf("%dh%dm", ms/3_600_000, (ms%3_600_000)/60_000)
+	}
+}
+
+func formatCost(usd float64) string {
+	if usd < 1 {
+		return fmt.Sprintf("$%.2f", usd)
+	}
+	return fmt.Sprintf("$%.2f", usd)
+}
+
+func toInt64Msg(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	default:
+		return 0
+	}
+}
+
+func toFloat64Msg(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	default:
+		return 0
+	}
+}
+
+func toString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func toToolNames(v any) map[string]int {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	result := make(map[string]int, len(m))
+	for k, val := range m {
+		result[k] = int(toInt64Msg(val))
+	}
+	return result
+}

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -123,9 +123,6 @@ func formatDuration(ms int64) string {
 }
 
 func formatCost(usd float64) string {
-	if usd < 1 {
-		return fmt.Sprintf("$%.2f", usd)
-	}
 	return fmt.Sprintf("$%.2f", usd)
 }
 

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -169,6 +169,36 @@ func TestFormatTurnSummary_DurationFormats(t *testing.T) {
 	}
 }
 
+func TestExtractTurnSummary_CloneRoundTrip(t *testing.T) {
+	t.Parallel()
+	original := &events.Envelope{
+		Event: events.Event{
+			Type: events.Done,
+			Data: events.DoneData{
+				Stats: map[string]any{
+					"_session": map[string]any{
+						"context_pct":      50.0,
+						"context_window":   float64(200000),
+						"total_input_tok":  float64(100000),
+						"model_name":       "Opus",
+						"tool_call_count":  float64(5),
+						"turn_duration_ms": float64(8000),
+						"turn_cost_usd":    0.12,
+					},
+				},
+			},
+		},
+	}
+	cloned := events.Clone(original)
+	d := ExtractTurnSummary(cloned)
+	require.InDelta(t, 50.0, d.ContextPct, 0.01)
+	require.Equal(t, int64(200000), d.ContextWindow)
+	require.Equal(t, "Opus", d.ModelName)
+	require.Equal(t, 5, d.ToolCallCount)
+	require.Equal(t, int64(8000), d.TurnDurationMs)
+	require.InDelta(t, 0.12, d.TurnCostUSD, 0.001)
+}
+
 func TestFormatTurnSummary_CostThreshold(t *testing.T) {
 	t.Parallel()
 	t.Run("below threshold", func(t *testing.T) {

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -1,0 +1,193 @@
+package messaging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestExtractTurnSummary_Full(t *testing.T) {
+	t.Parallel()
+	env := &events.Envelope{
+		Event: events.Event{
+			Type: events.Done,
+			Data: events.DoneData{
+				Stats: map[string]any{
+					"_session": map[string]any{
+						"context_pct":     24.2,
+						"context_window":  float64(200000),
+						"total_input_tok": float64(48434),
+						"model_name":      "Sonnet",
+						"tool_call_count": float64(12),
+						"tool_names": map[string]any{
+							"Read": float64(5),
+							"Bash": float64(3),
+							"Edit": float64(2),
+							"Grep": float64(2),
+						},
+						"turn_duration_ms": float64(42000),
+						"turn_count":       float64(3),
+						"turn_input_tok":   float64(12000),
+						"turn_output_tok":  float64(2000),
+						"turn_cost_usd":    0.04,
+						"total_cost_usd":   0.12,
+					},
+				},
+			},
+		},
+	}
+	d := ExtractTurnSummary(env)
+	require.InDelta(t, 24.2, d.ContextPct, 0.01)
+	require.Equal(t, int64(200000), d.ContextWindow)
+	require.Equal(t, int64(48434), d.TotalInputTok)
+	require.Equal(t, "Sonnet", d.ModelName)
+	require.Equal(t, 12, d.ToolCallCount)
+	require.Equal(t, int64(42000), d.TurnDurationMs)
+	require.Equal(t, 3, d.TurnCount)
+	require.Equal(t, int64(12000), d.TurnInputTok)
+	require.Equal(t, int64(2000), d.TurnOutputTok)
+	require.InDelta(t, 0.04, d.TurnCostUSD, 0.001)
+	require.InDelta(t, 0.12, d.TotalCostUSD, 0.001)
+	require.Equal(t, map[string]int{"Read": 5, "Bash": 3, "Edit": 2, "Grep": 2}, d.ToolNames)
+}
+
+func TestExtractTurnSummary_NilSession(t *testing.T) {
+	t.Parallel()
+	env := &events.Envelope{
+		Event: events.Event{
+			Type: events.Done,
+			Data: events.DoneData{
+				Stats: map[string]any{},
+			},
+		},
+	}
+	d := ExtractTurnSummary(env)
+	require.Equal(t, TurnSummaryData{}, d)
+}
+
+func TestExtractTurnSummary_NilStats(t *testing.T) {
+	t.Parallel()
+	env := &events.Envelope{
+		Event: events.Event{
+			Type: events.Done,
+			Data: events.DoneData{},
+		},
+	}
+	d := ExtractTurnSummary(env)
+	require.Equal(t, TurnSummaryData{}, d)
+}
+
+func TestFormatTurnSummary_Full(t *testing.T) {
+	t.Parallel()
+	d := TurnSummaryData{
+		ContextPct:     24.2,
+		ContextWindow:  200000,
+		TotalInputTok:  48434,
+		ModelName:      "Sonnet",
+		ToolCallCount:  12,
+		TurnDurationMs: 42000,
+		TurnCostUSD:    0.04,
+	}
+	got := FormatTurnSummary(d)
+	require.Equal(t, "🟢 Context 24% (~48.4K/200K) | Sonnet | \U0001f6e0 12 tools | ⏱ 42s | $0.04", got)
+}
+
+func TestFormatTurnSummary_NoContext(t *testing.T) {
+	t.Parallel()
+	d := TurnSummaryData{
+		ModelName:      "Sonnet",
+		ToolCallCount:  5,
+		TurnDurationMs: 12000,
+	}
+	got := FormatTurnSummary(d)
+	require.Equal(t, "Sonnet | \U0001f6e0 5 tools | ⏱ 12s", got)
+}
+
+func TestFormatTurnSummary_NoModel(t *testing.T) {
+	t.Parallel()
+	d := TurnSummaryData{
+		ContextPct:     50.0,
+		ContextWindow:  200000,
+		TotalInputTok:  100000,
+		ToolCallCount:  3,
+		TurnDurationMs: 8000,
+	}
+	got := FormatTurnSummary(d)
+	require.Contains(t, got, "🟡 Context 50% (100K/200K)")
+	require.NotContains(t, got, "Sonnet")
+}
+
+func TestFormatTurnSummary_NoTools(t *testing.T) {
+	t.Parallel()
+	d := TurnSummaryData{
+		ContextPct:     24.0,
+		ContextWindow:  200000,
+		TotalInputTok:  48000,
+		ModelName:      "Sonnet",
+		TurnDurationMs: 5000,
+	}
+	got := FormatTurnSummary(d)
+	require.NotContains(t, got, "tools")
+	require.Contains(t, got, "🟢 Context 24% (48K/200K) | Sonnet | ⏱ 5s")
+}
+
+func TestFormatTurnSummary_Minimal(t *testing.T) {
+	t.Parallel()
+	d := TurnSummaryData{
+		TurnDurationMs: 3000,
+	}
+	got := FormatTurnSummary(d)
+	require.Equal(t, "⏱ 3s", got)
+}
+
+func TestFormatTurnSummary_Empty(t *testing.T) {
+	t.Parallel()
+	got := FormatTurnSummary(TurnSummaryData{})
+	require.Equal(t, "", got)
+}
+
+func TestFormatTurnSummary_DurationFormats(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ms   int64
+		want string
+	}{
+		{"milliseconds", 420, "420ms"},
+		{"seconds", 42000, "42s"},
+		{"minutes and seconds", 222000, "3m42s"},
+		{"hours and minutes", 4980000, "1h23m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatDuration(tt.ms)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatTurnSummary_CostThreshold(t *testing.T) {
+	t.Parallel()
+	t.Run("below threshold", func(t *testing.T) {
+		t.Parallel()
+		d := TurnSummaryData{
+			TurnDurationMs: 1000,
+			TurnCostUSD:    0.009,
+		}
+		got := FormatTurnSummary(d)
+		require.NotContains(t, got, "$")
+	})
+
+	t.Run("at threshold", func(t *testing.T) {
+		t.Parallel()
+		d := TurnSummaryData{
+			TurnDurationMs: 1000,
+			TurnCostUSD:    0.01,
+		}
+		got := FormatTurnSummary(d)
+		require.Contains(t, got, "$0.01")
+	})
+}


### PR DESCRIPTION
## Summary

- Extend `sessionAccumulator` with `TurnDurationMs` field and 5 new snapshot keys (`turn_duration_ms`, `turn_input_tok`, `turn_output_tok`, `turn_cost_usd`, `tool_names`)
- Move `computePerTurnDeltas()` and turn duration calculation earlier in the Done handler so snapshot data is complete before envelope injection
- New `internal/messaging/turn_summary.go`: `ExtractTurnSummary` + `FormatTurnSummary` with severity icon, token/cost/duration formatting, and graceful degradation for partial data
- Slack and Feishu adapters: async `sendTurnSummary` on Done event, following existing `sendContextUsage` pattern

Closes #117

## Test plan

- [x] 11 unit tests in `turn_summary_test.go` (full extraction, nil stats, format variants, duration formats, cost threshold)
- [x] `make lint` — 0 issues
- [x] `go test -race ./internal/messaging/... ./internal/gateway/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)