### PR TITLE
refactor(messaging): extract shared adapter logic + test coverage

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -553,7 +553,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 				ToolCallCount: acc.ToolCallCount,
 				TokensIn:      acc.PerTurnInput,
 				TokensOut:     acc.PerTurnOutput,
-				DurationMs:    time.Since(turnStartTime).Milliseconds(),
+				DurationMs:    acc.TurnDurationMs,
 				CostUSD:       acc.PerTurnCost,
 			})
 			acc.resetPerTurn()

--- a/internal/messaging/command_executor.go
+++ b/internal/messaging/command_executor.go
@@ -1,0 +1,65 @@
+package messaging
+
+import (
+	"github.com/hrygo/hotplex/pkg/aep"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// BuildControlEnvelope creates a control event envelope from a parsed command result.
+func BuildControlEnvelope(result *ControlCommandResult, sessionID, userID string) *events.Envelope {
+	ctrlData := events.ControlData{Action: result.Action}
+	if result.Arg != "" {
+		ctrlData.Details = map[string]any{"path": result.Arg}
+	}
+	return &events.Envelope{
+		Version:   events.Version,
+		ID:        aep.NewID(),
+		SessionID: sessionID,
+		Event: events.Event{
+			Type: events.Control,
+			Data: ctrlData,
+		},
+		OwnerID: userID,
+	}
+}
+
+// BuildWorkerCommandEnvelope creates a worker command envelope from a parsed command result.
+func BuildWorkerCommandEnvelope(result *WorkerCommandResult, sessionID, userID string) *events.Envelope {
+	return &events.Envelope{
+		Version:   events.Version,
+		ID:        aep.NewID(),
+		SessionID: sessionID,
+		Event: events.Event{
+			Type: events.WorkerCmd,
+			Data: events.WorkerCommandData{
+				Command: result.Command,
+				Args:    result.Args,
+				Extra:   result.Extra,
+			},
+		},
+		OwnerID: userID,
+	}
+}
+
+// ControlFeedbackCN maps control actions to Chinese feedback messages.
+var ControlFeedbackCN = map[events.ControlAction]string{
+	events.ControlActionGC:    "✅ 会话已休眠，发消息即可恢复。",
+	events.ControlActionReset: "✅ 上下文已重置。",
+	events.ControlActionCD:    "📁 正在切换工作目录...",
+}
+
+// ControlFeedbackEN maps control actions to English feedback messages.
+var ControlFeedbackEN = map[events.ControlAction]string{
+	events.ControlActionGC:    "🗑️ Session parked. Send a message to resume.",
+	events.ControlActionReset: "🔄 Context reset.",
+	events.ControlActionCD:    "📁 Switching work directory...",
+}
+
+// ControlFeedbackMessage returns the feedback message for a control action,
+// using the provided locale map. Returns fallback if action is not in the map.
+func ControlFeedbackMessage(action events.ControlAction, msgs map[events.ControlAction]string, fallback string) string {
+	if msg, ok := msgs[action]; ok {
+		return msg
+	}
+	return fallback
+}

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/stt"
-	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -885,25 +884,15 @@ func (c *FeishuConn) sendContextUsage(ctx context.Context, env *events.Envelope)
 }
 
 func (c *FeishuConn) sendMCPStatus(ctx context.Context, env *events.Envelope) error {
-	var d events.MCPStatusData
-	switch v := env.Event.Data.(type) {
-	case events.MCPStatusData:
-		d = v
-	case map[string]any:
-		raw, _ := json.Marshal(v)
-		_ = json.Unmarshal(raw, &d)
-	default:
+	d, ok := messaging.ExtractMCPStatusData(env)
+	if !ok {
 		return nil
 	}
 
 	var sb strings.Builder
 	sb.WriteString("🔌 MCP Server Status")
 	for _, s := range d.Servers {
-		icon := "✅"
-		if s.Status != "connected" && s.Status != "ok" {
-			icon = "❌"
-		}
-		fmt.Fprintf(&sb, "\n%s %s — %s", icon, s.Name, s.Status)
+		fmt.Fprintf(&sb, "\n%s %s — %s", messaging.MCPServerIcon(s.Status), s.Name, s.Status)
 	}
 
 	c.mu.RLock()
@@ -929,21 +918,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, 
 		return
 	}
 
-	ctrlData := events.ControlData{Action: result.Action}
-	if result.Arg != "" {
-		ctrlData.Details = map[string]any{"path": result.Arg}
-	}
-
-	ctrlEnv := &events.Envelope{
-		Version:   events.Version,
-		ID:        aep.NewID(),
-		SessionID: envelope.SessionID,
-		Event: events.Event{
-			Type: events.Control,
-			Data: ctrlData,
-		},
-		OwnerID: userID,
-	}
+	ctrlEnv := messaging.BuildControlEnvelope(result, envelope.SessionID, userID)
 
 	// CD sends progress feedback before execution; other actions send completion feedback after.
 	if result.Action == events.ControlActionCD {
@@ -1008,20 +983,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, chatID, chatType,
 		return
 	}
 
-	cmdEnv := &events.Envelope{
-		Version:   events.Version,
-		ID:        aep.NewID(),
-		SessionID: envelope.SessionID,
-		Event: events.Event{
-			Type: events.WorkerCmd,
-			Data: events.WorkerCommandData{
-				Command: result.Command,
-				Args:    result.Args,
-				Extra:   result.Extra,
-			},
-		},
-		OwnerID: userID,
-	}
+	cmdEnv := messaging.BuildWorkerCommandEnvelope(result, envelope.SessionID, userID)
 
 	// Set conn fields for async response delivery.
 	conn.mu.Lock()
@@ -1045,16 +1007,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, chatID, chatType,
 }
 
 func controlFeedbackMessageCN(action events.ControlAction) string {
-	switch action {
-	case events.ControlActionGC:
-		return "✅ 会话已休眠，发消息即可恢复。"
-	case events.ControlActionReset:
-		return "✅ 上下文已重置。"
-	case events.ControlActionCD:
-		return "📁 正在切换工作目录..."
-	default:
-		return "✅ 已完成。"
-	}
+	return messaging.ControlFeedbackMessage(action, messaging.ControlFeedbackCN, "✅ 已完成。")
 }
 
 func (a *Adapter) sendTextMessage(ctx context.Context, chatID, text string) error {
@@ -1278,60 +1231,7 @@ func buildCardContent(text string) string {
 
 // formatSecurityError converts technical security errors into user-friendly messages.
 func formatSecurityError(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	errMsg := err.Error()
-
-	// Security-related errors
-	if strings.Contains(errMsg, "security: work dir") {
-		if strings.Contains(errMsg, "forbidden system directory") {
-			return "🚫 禁止访问系统目录"
-		}
-		if strings.Contains(errMsg, "under forbidden directory") {
-			return "🚫 目录被安全策略禁止（系统关键目录）"
-		}
-		if strings.Contains(errMsg, "not in whitelist") {
-			return "🚫 目录未在允许列表中（需在 config.yaml 中配置 security.work_dir_allowed_base_patterns）"
-		}
-		if strings.Contains(errMsg, "must be absolute") {
-			return "🚫 路径必须是绝对路径（以 / 开头）"
-		}
-		if strings.Contains(errMsg, "must not be empty") {
-			return "🚫 工作目录不能为空"
-		}
-		return "🚫 安全策略拒绝"
-	}
-
-	// Session-related errors
-	if strings.Contains(errMsg, "session not active") {
-		return "⚠️ 会话未激活（请先发送消息启动会话）"
-	}
-	if strings.Contains(errMsg, "get session") {
-		return "⚠️ 会话不存在"
-	}
-
-	// Work directory errors
-	if strings.Contains(errMsg, "expand work dir") {
-		return "📁 路径展开失败（请检查路径格式）"
-	}
-	if strings.Contains(errMsg, "worker terminate failed") {
-		return "⚠️ 停止原工作进程失败"
-	}
-	if strings.Contains(errMsg, "start session") {
-		return "⚠️ 启动新会话失败"
-	}
-
-	// Generic error (return original message for non-security errors)
-	if strings.Contains(errMsg, "switch-workdir") {
-		// Remove technical prefix for cleaner output
-		cleanMsg := strings.ReplaceAll(errMsg, "switch-workdir-inplace: ", "")
-		cleanMsg = strings.ReplaceAll(cleanMsg, "switch-workdir: ", "")
-		return cleanMsg
-	}
-
-	return errMsg
+	return messaging.FormatSecurityError(err, messaging.SecurityMessagesCN)
 }
 
 func extractTextFromContent(content string) string {

--- a/internal/messaging/security_errors.go
+++ b/internal/messaging/security_errors.go
@@ -54,6 +54,29 @@ var SecurityMessagesEN = map[SecurityErrorCode]string{
 	SecErrStartSession:     ":warning: Failed to start new session",
 }
 
+// Pre-compiled pattern tables to avoid per-call allocation.
+var securityChecks = []struct {
+	substr string
+	code   SecurityErrorCode
+}{
+	{"forbidden system directory", SecErrForbiddenDir},
+	{"under forbidden directory", SecErrUnderDir},
+	{"not in whitelist", SecErrNotInWhitelist},
+	{"must be absolute", SecErrMustBeAbsolute},
+	{"must not be empty", SecErrMustNotBeEmpty},
+}
+
+var errorChecks = []struct {
+	substr string
+	code   SecurityErrorCode
+}{
+	{"session not active", SecErrSessionNotActive},
+	{"get session", SecErrSessionNotFound},
+	{"expand work dir", SecErrExpandWorkDir},
+	{"worker terminate failed", SecErrWorkerTerminate},
+	{"start session", SecErrStartSession},
+}
+
 // FormatSecurityError converts a technical error into a user-friendly message
 // using the provided locale message map. Returns the original error message
 // as fallback when no known pattern matches.
@@ -63,18 +86,7 @@ func FormatSecurityError(err error, msgs map[SecurityErrorCode]string) string {
 	}
 	errMsg := err.Error()
 
-	// Security-related errors (nested pattern matching)
 	if strings.Contains(errMsg, "security: work dir") {
-		securityChecks := []struct {
-			substr string
-			code   SecurityErrorCode
-		}{
-			{"forbidden system directory", SecErrForbiddenDir},
-			{"under forbidden directory", SecErrUnderDir},
-			{"not in whitelist", SecErrNotInWhitelist},
-			{"must be absolute", SecErrMustBeAbsolute},
-			{"must not be empty", SecErrMustNotBeEmpty},
-		}
 		for _, check := range securityChecks {
 			if strings.Contains(errMsg, check.substr) {
 				return msgs[check.code]
@@ -83,17 +95,6 @@ func FormatSecurityError(err error, msgs map[SecurityErrorCode]string) string {
 		return msgs[SecErrPolicyRejected]
 	}
 
-	// Session and work directory errors
-	errorChecks := []struct {
-		substr string
-		code   SecurityErrorCode
-	}{
-		{"session not active", SecErrSessionNotActive},
-		{"get session", SecErrSessionNotFound},
-		{"expand work dir", SecErrExpandWorkDir},
-		{"worker terminate failed", SecErrWorkerTerminate},
-		{"start session", SecErrStartSession},
-	}
 	for _, check := range errorChecks {
 		if strings.Contains(errMsg, check.substr) {
 			return msgs[check.code]

--- a/internal/messaging/security_errors.go
+++ b/internal/messaging/security_errors.go
@@ -1,0 +1,134 @@
+package messaging
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// SecurityErrorCode identifies a category of security or session error.
+type SecurityErrorCode int
+
+const (
+	SecErrForbiddenDir SecurityErrorCode = iota
+	SecErrUnderDir
+	SecErrNotInWhitelist
+	SecErrMustBeAbsolute
+	SecErrMustNotBeEmpty
+	SecErrPolicyRejected
+	SecErrSessionNotActive
+	SecErrSessionNotFound
+	SecErrExpandWorkDir
+	SecErrWorkerTerminate
+	SecErrStartSession
+)
+
+// SecurityMessagesCN maps security error codes to Chinese user-facing messages.
+var SecurityMessagesCN = map[SecurityErrorCode]string{
+	SecErrForbiddenDir:     "🚫 禁止访问系统目录",
+	SecErrUnderDir:         "🚫 目录被安全策略禁止（系统关键目录）",
+	SecErrNotInWhitelist:   "🚫 目录未在允许列表中（需在 config.yaml 中配置 security.work_dir_allowed_base_patterns）",
+	SecErrMustBeAbsolute:   "🚫 路径必须是绝对路径（以 / 开头）",
+	SecErrMustNotBeEmpty:   "🚫 工作目录不能为空",
+	SecErrPolicyRejected:   "🚫 安全策略拒绝",
+	SecErrSessionNotActive: "⚠️ 会话未激活（请先发送消息启动会话）",
+	SecErrSessionNotFound:  "⚠️ 会话不存在",
+	SecErrExpandWorkDir:    "📁 路径展开失败（请检查路径格式）",
+	SecErrWorkerTerminate:  "⚠️ 停止原工作进程失败",
+	SecErrStartSession:     "⚠️ 启动新会话失败",
+}
+
+// SecurityMessagesEN maps security error codes to English user-facing messages.
+var SecurityMessagesEN = map[SecurityErrorCode]string{
+	SecErrForbiddenDir:     ":no_entry_sign: Forbidden system directory",
+	SecErrUnderDir:         ":no_entry_sign: Directory blocked by security policy (system directory)",
+	SecErrNotInWhitelist:   ":no_entry_sign: Directory not allowed (configure `security.work_dir_allowed_base_patterns` in config.yaml)",
+	SecErrMustBeAbsolute:   ":no_entry_sign: Path must be absolute (start with /)",
+	SecErrMustNotBeEmpty:   ":no_entry_sign: Work directory cannot be empty",
+	SecErrPolicyRejected:   ":no_entry_sign: Security policy rejected",
+	SecErrSessionNotActive: ":warning: Session not active (send a message first to start)",
+	SecErrSessionNotFound:  ":warning: Session not found",
+	SecErrExpandWorkDir:    ":file_folder: Path expansion failed (check path format)",
+	SecErrWorkerTerminate:  ":warning: Failed to stop previous worker",
+	SecErrStartSession:     ":warning: Failed to start new session",
+}
+
+// FormatSecurityError converts a technical error into a user-friendly message
+// using the provided locale message map. Returns the original error message
+// as fallback when no known pattern matches.
+func FormatSecurityError(err error, msgs map[SecurityErrorCode]string) string {
+	if err == nil {
+		return ""
+	}
+	errMsg := err.Error()
+
+	// Security-related errors (nested pattern matching)
+	if strings.Contains(errMsg, "security: work dir") {
+		securityChecks := []struct {
+			substr string
+			code   SecurityErrorCode
+		}{
+			{"forbidden system directory", SecErrForbiddenDir},
+			{"under forbidden directory", SecErrUnderDir},
+			{"not in whitelist", SecErrNotInWhitelist},
+			{"must be absolute", SecErrMustBeAbsolute},
+			{"must not be empty", SecErrMustNotBeEmpty},
+		}
+		for _, check := range securityChecks {
+			if strings.Contains(errMsg, check.substr) {
+				return msgs[check.code]
+			}
+		}
+		return msgs[SecErrPolicyRejected]
+	}
+
+	// Session and work directory errors
+	errorChecks := []struct {
+		substr string
+		code   SecurityErrorCode
+	}{
+		{"session not active", SecErrSessionNotActive},
+		{"get session", SecErrSessionNotFound},
+		{"expand work dir", SecErrExpandWorkDir},
+		{"worker terminate failed", SecErrWorkerTerminate},
+		{"start session", SecErrStartSession},
+	}
+	for _, check := range errorChecks {
+		if strings.Contains(errMsg, check.substr) {
+			return msgs[check.code]
+		}
+	}
+
+	// Clean switch-workdir technical prefix for clearer output.
+	if strings.Contains(errMsg, "switch-workdir") {
+		cleanMsg := strings.ReplaceAll(errMsg, "switch-workdir-inplace: ", "")
+		cleanMsg = strings.ReplaceAll(cleanMsg, "switch-workdir: ", "")
+		return cleanMsg
+	}
+
+	return errMsg
+}
+
+// ExtractMCPStatusData extracts MCP status data from an event envelope.
+func ExtractMCPStatusData(env *events.Envelope) (events.MCPStatusData, bool) {
+	var d events.MCPStatusData
+	switch v := env.Event.Data.(type) {
+	case events.MCPStatusData:
+		d = v
+	case map[string]any:
+		raw, _ := json.Marshal(v)
+		_ = json.Unmarshal(raw, &d)
+	default:
+		return d, false
+	}
+	return d, true
+}
+
+// MCPServerIcon returns the status icon for an MCP server.
+func MCPServerIcon(status string) string {
+	if status == "connected" || status == "ok" {
+		return "✅"
+	}
+	return "❌"
+}

--- a/internal/messaging/security_errors_test.go
+++ b/internal/messaging/security_errors_test.go
@@ -1,0 +1,147 @@
+package messaging
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestFormatSecurityError_Nil(t *testing.T) {
+	got := FormatSecurityError(nil, SecurityMessagesCN)
+	if got != "" {
+		t.Fatalf("expected empty string for nil error, got %q", got)
+	}
+}
+
+func TestFormatSecurityError_CN(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"forbidden dir", errors.New("security: work dir is a forbidden system directory"), "🚫 禁止访问系统目录"},
+		{"under dir", errors.New("security: work dir under forbidden directory"), "🚫 目录被安全策略禁止（系统关键目录）"},
+		{"not in whitelist", errors.New("security: work dir not in whitelist"), "🚫 目录未在允许列表中（需在 config.yaml 中配置 security.work_dir_allowed_base_patterns）"},
+		{"must be absolute", errors.New("security: work dir must be absolute"), "🚫 路径必须是绝对路径（以 / 开头）"},
+		{"must not be empty", errors.New("security: work dir must not be empty"), "🚫 工作目录不能为空"},
+		{"policy rejected fallback", errors.New("security: work dir unknown issue"), "🚫 安全策略拒绝"},
+		{"session not active", errors.New("session not active"), "⚠️ 会话未激活（请先发送消息启动会话）"},
+		{"get session", errors.New("get session failed"), "⚠️ 会话不存在"},
+		{"expand work dir", errors.New("expand work dir failed"), "📁 路径展开失败（请检查路径格式）"},
+		{"worker terminate", errors.New("worker terminate failed"), "⚠️ 停止原工作进程失败"},
+		{"start session", errors.New("start session error"), "⚠️ 启动新会话失败"},
+		{"switch-workdir", errors.New("switch-workdir: no such file"), "no such file"},
+		{"switch-workdir-inplace", errors.New("switch-workdir-inplace: permission denied"), "permission denied"},
+		{"unknown error", errors.New("something unexpected"), "something unexpected"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatSecurityError(tt.err, SecurityMessagesCN)
+			if got != tt.want {
+				t.Errorf("FormatSecurityError(CN) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSecurityError_EN(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"forbidden dir", errors.New("security: work dir is a forbidden system directory"), ":no_entry_sign: Forbidden system directory"},
+		{"policy rejected fallback", errors.New("security: work dir unknown issue"), ":no_entry_sign: Security policy rejected"},
+		{"session not active", errors.New("session not active"), ":warning: Session not active (send a message first to start)"},
+		{"switch-workdir", errors.New("switch-workdir: no such file"), "no such file"},
+		{"unknown error", errors.New("something unexpected"), "something unexpected"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatSecurityError(tt.err, SecurityMessagesEN)
+			if got != tt.want {
+				t.Errorf("FormatSecurityError(EN) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMCPServerIcon(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"connected", "✅"},
+		{"ok", "✅"},
+		{"disconnected", "❌"},
+		{"error", "❌"},
+		{"", "❌"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := MCPServerIcon(tt.status); got != tt.want {
+				t.Errorf("MCPServerIcon(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractMCPStatusData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("typed data", func(t *testing.T) {
+		env := &events.Envelope{Event: events.Event{Data: events.MCPStatusData{
+			Servers: []events.MCPServerInfo{{Name: "test", Status: "connected"}},
+		}}}
+		d, ok := ExtractMCPStatusData(env)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if len(d.Servers) != 1 || d.Servers[0].Name != "test" {
+			t.Fatalf("unexpected data: %+v", d)
+		}
+	})
+
+	t.Run("map data", func(t *testing.T) {
+		env := &events.Envelope{Event: events.Event{Data: map[string]any{
+			"servers": []any{map[string]any{"name": "srv", "status": "ok"}},
+		}}}
+		d, ok := ExtractMCPStatusData(env)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if len(d.Servers) != 1 || d.Servers[0].Name != "srv" {
+			t.Fatalf("unexpected data: %+v", d)
+		}
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		env := &events.Envelope{Event: events.Event{Data: "string"}}
+		_, ok := ExtractMCPStatusData(env)
+		if ok {
+			t.Fatal("expected ok=false for string data")
+		}
+	})
+}
+
+func TestControlFeedbackMessage(t *testing.T) {
+	tests := []struct {
+		action   events.ControlAction
+		msgs     map[events.ControlAction]string
+		fallback string
+		want     string
+	}{
+		{events.ControlActionGC, ControlFeedbackCN, "fallback", "✅ 会话已休眠，发消息即可恢复。"},
+		{events.ControlActionReset, ControlFeedbackEN, "fallback", "🔄 Context reset."},
+		{events.ControlAction("unknown"), ControlFeedbackCN, "✅ 已完成。", "✅ 已完成。"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			got := ControlFeedbackMessage(tt.action, tt.msgs, tt.fallback)
+			if got != tt.want {
+				t.Errorf("ControlFeedbackMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/messaging/security_errors_test.go
+++ b/internal/messaging/security_errors_test.go
@@ -4,17 +4,18 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
 func TestFormatSecurityError_Nil(t *testing.T) {
-	got := FormatSecurityError(nil, SecurityMessagesCN)
-	if got != "" {
-		t.Fatalf("expected empty string for nil error, got %q", got)
-	}
+	t.Parallel()
+	require.Empty(t, FormatSecurityError(nil, SecurityMessagesCN))
 }
 
 func TestFormatSecurityError_CN(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		err  error
@@ -37,15 +38,14 @@ func TestFormatSecurityError_CN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatSecurityError(tt.err, SecurityMessagesCN)
-			if got != tt.want {
-				t.Errorf("FormatSecurityError(CN) = %q, want %q", got, tt.want)
-			}
+			t.Parallel()
+			require.Equal(t, tt.want, FormatSecurityError(tt.err, SecurityMessagesCN))
 		})
 	}
 }
 
 func TestFormatSecurityError_EN(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		err  error
@@ -59,15 +59,14 @@ func TestFormatSecurityError_EN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatSecurityError(tt.err, SecurityMessagesEN)
-			if got != tt.want {
-				t.Errorf("FormatSecurityError(EN) = %q, want %q", got, tt.want)
-			}
+			t.Parallel()
+			require.Equal(t, tt.want, FormatSecurityError(tt.err, SecurityMessagesEN))
 		})
 	}
 }
 
 func TestMCPServerIcon(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		status string
 		want   string
@@ -80,9 +79,8 @@ func TestMCPServerIcon(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
-			if got := MCPServerIcon(tt.status); got != tt.want {
-				t.Errorf("MCPServerIcon(%q) = %q, want %q", tt.status, got, tt.want)
-			}
+			t.Parallel()
+			require.Equal(t, tt.want, MCPServerIcon(tt.status))
 		})
 	}
 }
@@ -91,41 +89,37 @@ func TestExtractMCPStatusData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("typed data", func(t *testing.T) {
+		t.Parallel()
 		env := &events.Envelope{Event: events.Event{Data: events.MCPStatusData{
 			Servers: []events.MCPServerInfo{{Name: "test", Status: "connected"}},
 		}}}
 		d, ok := ExtractMCPStatusData(env)
-		if !ok {
-			t.Fatal("expected ok=true")
-		}
-		if len(d.Servers) != 1 || d.Servers[0].Name != "test" {
-			t.Fatalf("unexpected data: %+v", d)
-		}
+		require.True(t, ok)
+		require.Len(t, d.Servers, 1)
+		require.Equal(t, "test", d.Servers[0].Name)
 	})
 
 	t.Run("map data", func(t *testing.T) {
+		t.Parallel()
 		env := &events.Envelope{Event: events.Event{Data: map[string]any{
 			"servers": []any{map[string]any{"name": "srv", "status": "ok"}},
 		}}}
 		d, ok := ExtractMCPStatusData(env)
-		if !ok {
-			t.Fatal("expected ok=true")
-		}
-		if len(d.Servers) != 1 || d.Servers[0].Name != "srv" {
-			t.Fatalf("unexpected data: %+v", d)
-		}
+		require.True(t, ok)
+		require.Len(t, d.Servers, 1)
+		require.Equal(t, "srv", d.Servers[0].Name)
 	})
 
 	t.Run("unsupported type", func(t *testing.T) {
+		t.Parallel()
 		env := &events.Envelope{Event: events.Event{Data: "string"}}
 		_, ok := ExtractMCPStatusData(env)
-		if ok {
-			t.Fatal("expected ok=false for string data")
-		}
+		require.False(t, ok)
 	})
 }
 
 func TestControlFeedbackMessage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		action   events.ControlAction
 		msgs     map[events.ControlAction]string
@@ -138,10 +132,8 @@ func TestControlFeedbackMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.action), func(t *testing.T) {
-			got := ControlFeedbackMessage(tt.action, tt.msgs, tt.fallback)
-			if got != tt.want {
-				t.Errorf("ControlFeedbackMessage() = %q, want %q", got, tt.want)
-			}
+			t.Parallel()
+			require.Equal(t, tt.want, ControlFeedbackMessage(tt.action, tt.msgs, tt.fallback))
 		})
 	}
 }

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -3,7 +3,6 @@ package slack
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/stt"
-	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 
 	"runtime/debug"
@@ -556,21 +554,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelI
 		return
 	}
 
-	ctrlData := events.ControlData{Action: result.Action}
-	if result.Arg != "" {
-		ctrlData.Details = map[string]any{"path": result.Arg}
-	}
-
-	ctrlEnv := &events.Envelope{
-		Version:   events.Version,
-		ID:        aep.NewID(),
-		SessionID: env.SessionID,
-		Event: events.Event{
-			Type: events.Control,
-			Data: ctrlData,
-		},
-		OwnerID: userID,
-	}
+	ctrlEnv := messaging.BuildControlEnvelope(result, env.SessionID, userID)
 
 	// CD sends progress feedback before execution; other actions send completion feedback after.
 	if result.Action == events.ControlActionCD {
@@ -626,20 +610,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, teamID, channelID
 		return
 	}
 
-	cmdEnv := &events.Envelope{
-		Version:   events.Version,
-		ID:        aep.NewID(),
-		SessionID: envelope.SessionID,
-		Event: events.Event{
-			Type: events.WorkerCmd,
-			Data: events.WorkerCommandData{
-				Command: result.Command,
-				Args:    result.Args,
-				Extra:   result.Extra,
-			},
-		},
-		OwnerID: userID,
-	}
+	cmdEnv := messaging.BuildWorkerCommandEnvelope(result, envelope.SessionID, userID)
 
 	if err := a.Bridge().Handle(ctx, cmdEnv, conn); err != nil {
 		a.Log.Warn("slack: worker command failed", "command", result.Label, "err", err)
@@ -651,16 +622,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, teamID, channelID
 }
 
 func controlFeedbackMessage(action events.ControlAction) string {
-	switch action {
-	case events.ControlActionGC:
-		return "🗑️ Session parked. Send a message to resume."
-	case events.ControlActionReset:
-		return "🔄 Context reset."
-	case events.ControlActionCD:
-		return "📁 Switching work directory..."
-	default:
-		return "✅ Done."
-	}
+	return messaging.ControlFeedbackMessage(action, messaging.ControlFeedbackEN, "✅ Done.")
 }
 
 // SlackConn wraps the adapter with channel/thread routing info
@@ -1127,34 +1089,20 @@ func richTextCell(text string) *slack.RichTextBlock {
 	return slack.NewRichTextBlock("", section)
 }
 
-// mcpServerIcon returns the status icon for an MCP server.
-func mcpServerIcon(status string) string {
-	if status == "connected" || status == "ok" {
-		return "✅"
-	}
-	return "❌"
-}
-
 func (c *SlackConn) sendMCPStatus(ctx context.Context, env *events.Envelope) error {
 	if c.adapter == nil || c.adapter.client == nil {
 		return fmt.Errorf("slack: client not initialized")
 	}
 
-	var d events.MCPStatusData
-	switch v := env.Event.Data.(type) {
-	case events.MCPStatusData:
-		d = v
-	case map[string]any:
-		raw, _ := json.Marshal(v)
-		_ = json.Unmarshal(raw, &d)
-	default:
+	d, ok := messaging.ExtractMCPStatusData(env)
+	if !ok {
 		return nil
 	}
 
 	var sb strings.Builder
 	sb.WriteString("🔌 MCP Server Status\n")
 	for _, s := range d.Servers {
-		fmt.Fprintf(&sb, "%s %s — %s\n", mcpServerIcon(s.Status), s.Name, s.Status)
+		fmt.Fprintf(&sb, "%s %s — %s\n", messaging.MCPServerIcon(s.Status), s.Name, s.Status)
 	}
 	plainText := sb.String()
 
@@ -1165,7 +1113,7 @@ func (c *SlackConn) sendMCPStatus(ctx context.Context, env *events.Envelope) err
 	)
 	table.AddRow(richTextCell("🔌 MCP Status"), richTextCell(fmt.Sprintf("%d servers", len(d.Servers))))
 	for _, s := range d.Servers {
-		table.AddRow(richTextCell(mcpServerIcon(s.Status)+" "+s.Name), richTextCell(s.Status))
+		table.AddRow(richTextCell(messaging.MCPServerIcon(s.Status)+" "+s.Name), richTextCell(s.Status))
 	}
 
 	blocks := []slack.Block{table}
@@ -1193,60 +1141,7 @@ func (c *SlackConn) sendMCPStatus(ctx context.Context, env *events.Envelope) err
 
 // formatSecurityErrorSlack converts technical security errors into user-friendly messages for Slack.
 func formatSecurityErrorSlack(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	errMsg := err.Error()
-
-	// Security-related errors
-	if strings.Contains(errMsg, "security: work dir") {
-		if strings.Contains(errMsg, "forbidden system directory") {
-			return ":no_entry_sign: Forbidden system directory"
-		}
-		if strings.Contains(errMsg, "under forbidden directory") {
-			return ":no_entry_sign: Directory blocked by security policy (system directory)"
-		}
-		if strings.Contains(errMsg, "not in whitelist") {
-			return ":no_entry_sign: Directory not allowed (configure `security.work_dir_allowed_base_patterns` in config.yaml)"
-		}
-		if strings.Contains(errMsg, "must be absolute") {
-			return ":no_entry_sign: Path must be absolute (start with /)"
-		}
-		if strings.Contains(errMsg, "must not be empty") {
-			return ":no_entry_sign: Work directory cannot be empty"
-		}
-		return ":no_entry_sign: Security policy rejected"
-	}
-
-	// Session-related errors
-	if strings.Contains(errMsg, "session not active") {
-		return ":warning: Session not active (send a message first to start)"
-	}
-	if strings.Contains(errMsg, "get session") {
-		return ":warning: Session not found"
-	}
-
-	// Work directory errors
-	if strings.Contains(errMsg, "expand work dir") {
-		return ":file_folder: Path expansion failed (check path format)"
-	}
-	if strings.Contains(errMsg, "worker terminate failed") {
-		return ":warning: Failed to stop previous worker"
-	}
-	if strings.Contains(errMsg, "start session") {
-		return ":warning: Failed to start new session"
-	}
-
-	// Generic error (return original message for non-security errors)
-	if strings.Contains(errMsg, "switch-workdir") {
-		// Remove technical prefix for cleaner output
-		cleanMsg := strings.ReplaceAll(errMsg, "switch-workdir-inplace: ", "")
-		cleanMsg = strings.ReplaceAll(cleanMsg, "switch-workdir: ", "")
-		return cleanMsg
-	}
-
-	return errMsg
+	return messaging.FormatSecurityError(err, messaging.SecurityMessagesEN)
 }
 
 var _ messaging.PlatformConn = (*SlackConn)(nil)

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -14,7 +14,6 @@ type TurnSummaryData struct {
 	TotalInputTok  int64
 	ModelName      string
 	ToolCallCount  int
-	ToolNames      map[string]int
 	TurnDurationMs int64
 	TurnCount      int
 	TurnInputTok   int64
@@ -50,18 +49,17 @@ func ExtractTurnSummary(env *events.Envelope) TurnSummaryData {
 	}
 
 	return TurnSummaryData{
-		ContextPct:     toFloat64Msg(m["context_pct"]),
-		ContextWindow:  toInt64Msg(m["context_window"]),
-		TotalInputTok:  toInt64Msg(m["total_input_tok"]),
-		ModelName:      toString(m["model_name"]),
-		ToolCallCount:  int(toInt64Msg(m["tool_call_count"])),
-		ToolNames:      toToolNames(m["tool_names"]),
-		TurnDurationMs: toInt64Msg(m["turn_duration_ms"]),
-		TurnCount:      int(toInt64Msg(m["turn_count"])),
-		TurnInputTok:   toInt64Msg(m["turn_input_tok"]),
-		TurnOutputTok:  toInt64Msg(m["turn_output_tok"]),
-		TurnCostUSD:    toFloat64Msg(m["turn_cost_usd"]),
-		TotalCostUSD:   toFloat64Msg(m["total_cost_usd"]),
+		ContextPct:     events.ToFloat64(m["context_pct"]),
+		ContextWindow:  events.ToInt64(m["context_window"]),
+		TotalInputTok:  events.ToInt64(m["total_input_tok"]),
+		ModelName:      events.StrVal(m["model_name"]),
+		ToolCallCount:  int(events.ToInt64(m["tool_call_count"])),
+		TurnDurationMs: events.ToInt64(m["turn_duration_ms"]),
+		TurnCount:      int(events.ToInt64(m["turn_count"])),
+		TurnInputTok:   events.ToInt64(m["turn_input_tok"]),
+		TurnOutputTok:  events.ToInt64(m["turn_output_tok"]),
+		TurnCostUSD:    events.ToFloat64(m["turn_cost_usd"]),
+		TotalCostUSD:   events.ToFloat64(m["total_cost_usd"]),
 	}
 }
 
@@ -93,7 +91,7 @@ func FormatTurnSummary(d TurnSummaryData) string {
 
 	// Tools segment
 	if d.ToolCallCount > 0 {
-		parts = append(parts, fmt.Sprintf("\U0001f6e0 %d tools", d.ToolCallCount))
+		parts = append(parts, fmt.Sprintf("🛠 %d tools", d.ToolCallCount))
 	}
 
 	// Duration segment
@@ -124,47 +122,4 @@ func formatDuration(ms int64) string {
 
 func formatCost(usd float64) string {
 	return fmt.Sprintf("$%.2f", usd)
-}
-
-func toInt64Msg(v any) int64 {
-	switch n := v.(type) {
-	case float64:
-		return int64(n)
-	case int:
-		return int64(n)
-	case int64:
-		return n
-	default:
-		return 0
-	}
-}
-
-func toFloat64Msg(v any) float64 {
-	switch n := v.(type) {
-	case float64:
-		return n
-	case int:
-		return float64(n)
-	case int64:
-		return float64(n)
-	default:
-		return 0
-	}
-}
-
-func toString(v any) string {
-	s, _ := v.(string)
-	return s
-}
-
-func toToolNames(v any) map[string]int {
-	m, ok := v.(map[string]any)
-	if !ok {
-		return nil
-	}
-	result := make(map[string]int, len(m))
-	for k, val := range m {
-		result[k] = int(toInt64Msg(val))
-	}
-	return result
 }

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -16,17 +16,11 @@ func TestExtractTurnSummary_Full(t *testing.T) {
 			Data: events.DoneData{
 				Stats: map[string]any{
 					"_session": map[string]any{
-						"context_pct":     24.2,
-						"context_window":  float64(200000),
-						"total_input_tok": float64(48434),
-						"model_name":      "Sonnet",
-						"tool_call_count": float64(12),
-						"tool_names": map[string]any{
-							"Read": float64(5),
-							"Bash": float64(3),
-							"Edit": float64(2),
-							"Grep": float64(2),
-						},
+						"context_pct":      24.2,
+						"context_window":   float64(200000),
+						"total_input_tok":  float64(48434),
+						"model_name":       "Sonnet",
+						"tool_call_count":  float64(12),
 						"turn_duration_ms": float64(42000),
 						"turn_count":       float64(3),
 						"turn_input_tok":   float64(12000),
@@ -50,7 +44,6 @@ func TestExtractTurnSummary_Full(t *testing.T) {
 	require.Equal(t, int64(2000), d.TurnOutputTok)
 	require.InDelta(t, 0.04, d.TurnCostUSD, 0.001)
 	require.InDelta(t, 0.12, d.TotalCostUSD, 0.001)
-	require.Equal(t, map[string]int{"Read": 5, "Bash": 3, "Edit": 2, "Grep": 2}, d.ToolNames)
 }
 
 func TestExtractTurnSummary_NilSession(t *testing.T) {
@@ -91,7 +84,7 @@ func TestFormatTurnSummary_Full(t *testing.T) {
 		TurnCostUSD:    0.04,
 	}
 	got := FormatTurnSummary(d)
-	require.Equal(t, "🟢 Context 24% (~48.4K/200K) | Sonnet | \U0001f6e0 12 tools | ⏱ 42s | $0.04", got)
+	require.Equal(t, "🟢 Context 24% (~48.4K/200K) | Sonnet | 🛠 12 tools | ⏱ 42s | $0.04", got)
 }
 
 func TestFormatTurnSummary_NoContext(t *testing.T) {
@@ -102,7 +95,7 @@ func TestFormatTurnSummary_NoContext(t *testing.T) {
 		TurnDurationMs: 12000,
 	}
 	got := FormatTurnSummary(d)
-	require.Equal(t, "Sonnet | \U0001f6e0 5 tools | ⏱ 12s", got)
+	require.Equal(t, "Sonnet | 🛠 5 tools | ⏱ 12s", got)
 }
 
 func TestFormatTurnSummary_NoModel(t *testing.T) {

--- a/pkg/events/helpers.go
+++ b/pkg/events/helpers.go
@@ -1,8 +1,46 @@
 package events
 
+import "encoding/json"
+
 func IntFloat(v any) int {
 	f, _ := v.(float64)
 	return int(f)
+}
+
+// ToInt64 converts any numeric value to int64.
+// Handles float64, int, int64, and json.Number.
+func ToInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	default:
+		return 0
+	}
+}
+
+// ToFloat64 converts any numeric value to float64.
+// Handles float64, int, int64, and json.Number.
+func ToFloat64(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case json.Number:
+		f, _ := n.Float64()
+		return f
+	default:
+		return 0
+	}
 }
 
 func StrVal(v any) string {


### PR DESCRIPTION
## Summary

- Extract shared messaging adapter logic from feishu/slack into `internal/messaging/` helpers (security errors, command envelopes, MCP status, control feedback)
- Add comprehensive test coverage for admin API (middleware, rate limiter, log buffer, handlers, integration) and eventstore (CRUD, cursor pagination, transactions, collector)
- Deduplicate type-conversion helpers into `pkg/events/helpers.go`, remove dead code, fix test conventions

## Changes

### #119 — Extract shared messaging adapter logic
**Problem**: Feishu and Slack adapters had ~200 lines of duplicated logic for security error formatting, control command envelope building, MCP status extraction, and feedback messages.

**Solution**: Extracted 4 shared helpers into `internal/messaging/`:
- `security_errors.go` — `FormatSecurityError()`, `ExtractMCPStatusData()`, `MCPServerIcon()` with locale-aware messages (CN/EN)
- `command_executor.go` — `BuildControlEnvelope()`, `BuildWorkerCommandEnvelope()`, `ControlFeedbackMessage()`

### #120 — Add admin API and eventstore test coverage
**Problem**: `internal/admin` and `internal/eventstore` had zero test coverage.

**Solution**: Added 5 test files with 1000+ lines of coverage using httptest + mock providers (admin) and real SQLite on `t.TempDir()` (eventstore).

### Cleanup
- Add `ToInt64`/`ToFloat64` to `pkg/events/helpers.go` (with `json.Number` support)
- Remove unused `ToolNames` field and private helper copies from `turn_summary.go` (net -50 lines)
- Hoist `FormatSecurityError` pattern-matching slices to package-level vars
- Use `acc.TurnDurationMs` instead of recomputing `time.Since()` in bridge.go Done path
- Fix test conventions: `require` instead of `t.Fatalf`, add `t.Parallel()`

## Test plan

- [x] `make check` passes (lint + test + build)
- [x] All new tests pass with `-race` flag
- [x] No behavior changes — pure refactoring + new tests

Fixes #119
Fixes #120