### PR TITLE
fix(feishu): decouple Write/Flush with background timer loop

### DIFF
--- a/.github/actions/setup-go-webchat/action.yml
+++ b/.github/actions/setup-go-webchat/action.yml
@@ -35,7 +35,7 @@ runs:
     # which compiles internal/webchat even if we don't test it.
     - name: Restore webchat build output
       id: webchat-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: internal/webchat/out
         key: webchat-${{ hashFiles('webchat/src/**', 'webchat/next.config.*', 'webchat/package.json', 'webchat/pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         if: always()
         run: go tool cover -func=coverage.out 2>/dev/null | tail -1 || true
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage
@@ -222,7 +222,7 @@ jobs:
           cache: false
 
       - name: Download coverage
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: coverage
           path: coverage-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build webchat
         run: make webchat-embed
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: webchat-out
           path: internal/webchat/out
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Restore webchat
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: webchat-out
           path: internal/webchat/out
@@ -115,7 +115,7 @@ jobs:
           NAME="hotplex-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
           sha256sum "dist/${NAME}" >> dist/checksums.txt
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all binaries
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: dist-*
           path: dist

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -381,12 +381,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			}
 			b.log.Warn("bridge: turn timeout exceeded, terminating worker",
 				"session_id", sessionID, "worker_type", workerType, "turn_timeout", b.turnTimeout)
-			timeoutEvt := events.NewEnvelope(aep.NewID(), sessionID,
-				b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
-					Code:    "TURN_TIMEOUT",
-					Message: fmt.Sprintf("Turn exceeded %v time limit and was terminated.", b.turnTimeout),
-				})
-			_ = b.hub.SendToSession(context.Background(), timeoutEvt)
+			b.sendError(sessionID, events.ErrCodeTurnTimeout, "Turn exceeded %v time limit and was terminated.", b.turnTimeout)
 			_ = w.Terminate(context.Background())
 		})
 		defer turnTimer.Stop()
@@ -655,24 +650,14 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			"session_id", sessionID, "worker_type", workerType, "exit_code", exitCode,
 			"duration", time.Since(startTime).Round(time.Millisecond), "turn_count", acc.TurnCount)
 		metrics.WorkerCrashesTotal.WithLabelValues(string(workerType), fmt.Sprintf("%d", exitCode)).Inc()
-		crashErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
-			Code:    events.ErrCodeWorkerCrash,
-			Message: fmt.Sprintf("worker crashed (exit code %d)", exitCode),
-		})
-		_ = b.hub.SendToSession(context.Background(), crashErr)
-	} else if exitCode == 143 || exitCode == -1 {
-		termErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
-			Code:    events.ErrCodeSessionTerminated,
-			Message: fmt.Sprintf("worker terminated (signal %d)", -exitCode),
-		})
-		_ = b.hub.SendToSession(context.Background(), termErr)
+		b.sendError(sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
+	} else if exitCode == 143 {
+		b.sendError(sessionID, events.ErrCodeSessionTerminated, "worker terminated (SIGTERM)")
+	} else if exitCode == -1 {
+		b.sendError(sessionID, events.ErrCodeSessionTerminated, "worker terminated (killed)")
 	} else if !doneReceived {
 		b.log.Debug("bridge: sending error for platform cleanup (no done received)", "session_id", sessionID, "worker_type", workerType)
-		exitErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
-			Code:    events.ErrCodeWorkerCrash,
-			Message: "worker exited without sending done",
-		})
-		_ = b.hub.SendToSession(context.Background(), exitErr)
+		b.sendError(sessionID, events.ErrCodeWorkerCrash, "worker exited without sending done")
 	}
 
 	// Record partial assistant response on crash/timeout (Path 3).
@@ -733,11 +718,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	if b.recordCrashLoop(p.sessionID) {
 		b.log.Error("bridge: crash loop detected, aborting retry to protect gateway",
 			"session_id", p.sessionID, "worker_type", p.workerType, "max", crashLoopMax, "window", crashLoopWindow)
-		errEvt := events.NewEnvelope(aep.NewID(), p.sessionID, b.hub.NextSeq(p.sessionID), events.Error, events.ErrorData{
-			Code:    events.ErrCodeWorkerCrash,
-			Message: fmt.Sprintf("Worker crashed %d times in %v. Stopping retry to protect gateway stability.", crashLoopMax, crashLoopWindow),
-		})
-		_ = b.hub.SendToSession(context.Background(), errEvt)
+		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "Worker crashed %d times in %v. Stopping retry to protect gateway stability.", crashLoopMax, crashLoopWindow)
 		return false
 	}
 
@@ -751,11 +732,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 			// Synchronous failure — fall through to fresh start below.
 		} else {
 			b.log.Info("bridge: resume retry succeeded", "session_id", p.sessionID, "worker_type", p.workerType)
-			warnEvt := events.NewEnvelope(aep.NewID(), p.sessionID, b.hub.NextSeq(p.sessionID), events.Error, events.ErrorData{
-				Code:    events.ErrCodeResumeRetry,
-				Message: fmt.Sprintf("Worker crashed after resume (exit %d), retried resume to preserve conversation.", p.exitCode),
-			})
-			_ = b.hub.SendToSession(context.Background(), warnEvt)
+			b.sendError(p.sessionID, events.ErrCodeResumeRetry, "Worker crashed after resume (exit %d), retried resume to preserve conversation.", p.exitCode)
 			return true
 		}
 	}
@@ -1263,6 +1240,14 @@ func (b *Bridge) resetCrashLoop(sessionID string) {
 	b.crashTrackerMu.Lock()
 	defer b.crashTrackerMu.Unlock()
 	delete(b.crashTracker, sessionID)
+}
+
+func (b *Bridge) sendError(sessionID string, code events.ErrorCode, format string, args ...any) {
+	env := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
+		Code:    code,
+		Message: fmt.Sprintf(format, args...),
+	})
+	_ = b.hub.SendToSession(context.Background(), env)
 }
 
 // gitAvailable is checked once via sync.Once. If git is not on PATH,

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -633,12 +633,12 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 	}
 
 	// If session is already TERMINATED (e.g., handler client_kill), the handler
-	// already sends error + done events. Skip sending redundant crash/synthetic
-	// done — only detach and clean up.
+	// already sent an error event. Skip sending redundant crash error — only
+	// detach and clean up.
 	if b.sm != nil {
 		si, smErr := b.sm.Get(sessionID)
 		if smErr == nil && si.State == events.StateTerminated {
-			b.log.Debug("bridge: session already terminated, skipping done for handler-killed worker", "session_id", sessionID, "worker_type", workerType)
+			b.log.Debug("bridge: session already terminated, skipping error for handler-killed worker", "session_id", sessionID, "worker_type", workerType)
 			if !fallbackAttempted {
 				b.cleanupCrashedWorker(sessionID, w)
 			}
@@ -646,37 +646,33 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		}
 	}
 
-	// SIGTERM (143) and Kill (-1) are intentional, not crashes.
+	// Send Error events for cleanup — platform adapters handle Error the same as Done
+	// (clear indicators, cancel interactions, close streaming cards) but without
+	// triggering turn summary, which requires _session data from a real worker Done.
 	if exitCode != 0 && exitCode != 143 && exitCode != -1 {
 		acc := b.getOrInitAccum(sessionID, "")
-		b.log.Warn("bridge: worker exited with non-zero code, sending crash done",
+		b.log.Warn("bridge: worker exited with non-zero code, sending crash error",
 			"session_id", sessionID, "worker_type", workerType, "exit_code", exitCode,
 			"duration", time.Since(startTime).Round(time.Millisecond), "turn_count", acc.TurnCount)
 		metrics.WorkerCrashesTotal.WithLabelValues(string(workerType), fmt.Sprintf("%d", exitCode)).Inc()
-		crashDone := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Done, events.DoneData{
-			Success: false,
-			Stats:   map[string]any{"crash_exit_code": exitCode},
+		crashErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
+			Code:    events.ErrCodeWorkerCrash,
+			Message: fmt.Sprintf("worker crashed (exit code %d)", exitCode),
 		})
-		_ = b.hub.SendToSession(context.Background(), crashDone)
+		_ = b.hub.SendToSession(context.Background(), crashErr)
 	} else if exitCode == 143 || exitCode == -1 {
-		// Worker was intentionally terminated (SIGTERM) or killed — not a crash.
-		// Send a clean done so platform connections (Slack/Feishu) clean up
-		// typing indicators and streaming UI.
-		syntheticDone := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Done, events.DoneData{
-			Success: false,
-			Stats:   map[string]any{"exit_code": exitCode},
+		termErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
+			Code:    events.ErrCodeSessionTerminated,
+			Message: fmt.Sprintf("worker terminated (signal %d)", -exitCode),
 		})
-		_ = b.hub.SendToSession(context.Background(), syntheticDone)
+		_ = b.hub.SendToSession(context.Background(), termErr)
 	} else if !doneReceived {
-		// Worker exited without sending a done event (e.g., ResetContext consumed
-		// the exit code). Send a synthetic done so platform connections clean up
-		// typing indicators, streaming cards, and tool reactions.
-		b.log.Debug("bridge: sending synthetic done for platform cleanup", "session_id", sessionID, "worker_type", workerType)
-		syntheticDone := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Done, events.DoneData{
-			Success: false,
-			Stats:   map[string]any{"synthetic": true},
+		b.log.Debug("bridge: sending error for platform cleanup (no done received)", "session_id", sessionID, "worker_type", workerType)
+		exitErr := events.NewEnvelope(aep.NewID(), sessionID, b.hub.NextSeq(sessionID), events.Error, events.ErrorData{
+			Code:    events.ErrCodeWorkerCrash,
+			Message: "worker exited without sending done",
 		})
-		_ = b.hub.SendToSession(context.Background(), syntheticDone)
+		_ = b.hub.SendToSession(context.Background(), exitErr)
 	}
 
 	// Record partial assistant response on crash/timeout (Path 3).

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -1209,13 +1209,13 @@ func TestBridge_ForwardEvents_CrashExitCode(t *testing.T) {
 		close(done)
 	}()
 
-	// Read the crash done event.
+	// Read the crash error event.
 	_ = server.SetReadDeadline(time.Now().Add(3 * time.Second))
 	_, data, err := server.ReadMessage()
-	require.NoError(t, err, "forwardEvents should have sent crash done after Wait()")
-	require.Contains(t, string(data), `"type":"done"`)
-	require.Contains(t, string(data), `"success":false`)
-	require.Contains(t, string(data), `"crash_exit_code":1`)
+	require.NoError(t, err, "forwardEvents should have sent crash error after Wait()")
+	require.Contains(t, string(data), `"type":"error"`)
+	require.Contains(t, string(data), `"code":"WORKER_CRASH"`)
+	require.Contains(t, string(data), "exit code 1")
 
 	<-done
 }

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -276,16 +276,7 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 			}
 			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "terminate failed: %v", err)
 		}
-		// Send error + done to client.
-		errEnv := events.NewEnvelope(aep.NewID(), env.SessionID, h.hub.NextSeq(env.SessionID), events.Error, events.ErrorData{
-			Code:    events.ErrCodeSessionTerminated,
-			Message: "session terminated by client",
-		})
-		doneEnv := events.NewEnvelope(aep.NewID(), env.SessionID, h.hub.NextSeq(env.SessionID), events.Done, events.DoneData{
-			Success: false,
-		})
-		_ = h.hub.SendToSession(ctx, errEnv)
-		_ = h.hub.SendToSession(ctx, doneEnv)
+		_ = h.sendErrorf(ctx, env, events.ErrCodeSessionTerminated, "session terminated by client")
 		return nil
 
 	case events.ControlActionDelete:

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -844,7 +844,7 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 				return nil
 			}
 		} else {
-			// Subsequent content: write + flush.
+			// Subsequent content: write to buffer; background flush loop handles delivery.
 			if err := streamCtrl.Write(text); err != nil {
 				// Streaming failed — flush buffered content and fall back to static delivery.
 				c.adapter.Log.Warn("feishu: streaming write failed, falling back to static", "err", err)
@@ -852,9 +852,8 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 				c.mu.Lock()
 				c.streamCtrl = nil
 				c.mu.Unlock()
-			} else {
-				return streamCtrl.Flush(ctx)
 			}
+			return nil
 		}
 	}
 

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -844,7 +844,7 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 				return nil
 			}
 		} else {
-			// Subsequent content: write to buffer; background flush loop handles delivery.
+			// Background flush loop handles delivery.
 			if err := streamCtrl.Write(text); err != nil {
 				// Streaming failed — flush buffered content and fall back to static delivery.
 				c.adapter.Log.Warn("feishu: streaming write failed, falling back to static", "err", err)

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcardkit "github.com/larksuite/oapi-sdk-go/v3/service/cardkit/v1"
@@ -85,7 +86,6 @@ type StreamingCardController struct {
 	streamStartTime time.Time
 	streamExpired   bool
 	bytesWritten    int64
-	bytesFlushed    int64
 	failedFlushes   int
 
 	chatType     string
@@ -93,6 +93,12 @@ type StreamingCardController struct {
 	limiter      *FeishuRateLimiter
 	client       *lark.Client
 	log          *slog.Logger
+
+	// Background flush loop (decoupled from Write, like Slack NativeStreamingWriter).
+	flushDone    chan struct{}
+	flushStop    sync.Once
+	flushWg      sync.WaitGroup
+	flushTrigger chan struct{} // buffered 1: coalesces rapid signals
 }
 
 const streamingElementID = "streaming_content"
@@ -101,6 +107,11 @@ const streamingElementID = "streaming_content"
 // Feishu server auto-closes streaming after 10 minutes; we rotate at 6 minutes
 // to proactively create a new card and avoid hitting the server limit.
 const StreamTTL = 6 * time.Minute
+
+const (
+	flushInterval = 150 * time.Millisecond // CardKit allows 100ms; 150ms gives margin
+	flushSize     = 30                     // rune count threshold for immediate flush trigger
+)
 
 func NewStreamingCardController(client *lark.Client, limiter *FeishuRateLimiter, log *slog.Logger) *StreamingCardController {
 	var p atomic.Int32
@@ -111,6 +122,8 @@ func NewStreamingCardController(client *lark.Client, limiter *FeishuRateLimiter,
 		log:             log,
 		cardKitOK:       true,
 		elementID:       streamingElementID,
+		flushDone:       make(chan struct{}),
+		flushTrigger:    make(chan struct{}, 1),
 		streamStartTime: time.Now(),
 	}
 }
@@ -205,6 +218,7 @@ func (c *StreamingCardController) EnsureCard(ctx context.Context, chatID, chatTy
 	if !c.transition(PhaseStreaming) {
 		return fmt.Errorf("feishu: cannot transition to streaming")
 	}
+	c.startFlushLoop()
 	return nil
 }
 
@@ -227,7 +241,16 @@ func (c *StreamingCardController) Write(text string) error {
 	}
 	c.buf.WriteString(text)
 	c.bytesWritten += int64(len(text))
+	bufLen := utf8.RuneCountInString(c.buf.String())
 	c.mu.Unlock()
+
+	// Trigger immediate flush when buffer exceeds rune threshold.
+	if bufLen >= flushSize {
+		select {
+		case c.flushTrigger <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -254,9 +277,6 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 
 	if c.cardKitOK && c.cardID != "" && c.limiter.AllowCardKit(c.cardID) {
 		if err := c.flushCardKitWithRetry(ctx, content, seq); err != nil {
-			// failedFlushes tracks all CardKit failures including rate-limit silent drops.
-			// It is used for integrity checks and logging; rate-limit drops do NOT
-			// count toward bytesFlushed, so content may appear incomplete to users.
 			c.mu.Lock()
 			c.failedFlushes++
 			switch {
@@ -280,7 +300,6 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 		} else {
 			c.mu.Lock()
 			c.lastFlushed = content
-			c.bytesFlushed += int64(len(content))
 			c.mu.Unlock()
 			return nil
 		}
@@ -296,11 +315,42 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 		}
 		c.mu.Lock()
 		c.lastFlushed = content
-		c.bytesFlushed += int64(len(content))
 		c.mu.Unlock()
 	}
 
 	return nil
+}
+
+// startFlushLoop launches the background flush goroutine.
+// Called once after successful transition to PhaseStreaming.
+func (c *StreamingCardController) startFlushLoop() {
+	c.flushWg.Add(1)
+	go c.flushLoop()
+}
+
+func (c *StreamingCardController) flushLoop() {
+	defer c.flushWg.Done()
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.flushDone:
+			return
+		case <-c.flushTrigger:
+			_ = c.Flush(context.Background())
+		case <-ticker.C:
+			_ = c.Flush(context.Background())
+		}
+	}
+}
+
+// stopFlushLoop cleanly terminates the background flush goroutine.
+func (c *StreamingCardController) stopFlushLoop() {
+	c.flushStop.Do(func() {
+		close(c.flushDone)
+	})
+	c.flushWg.Wait()
 }
 
 // Expired reports whether the streaming session has exceeded its TTL.
@@ -326,27 +376,15 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		return nil
 	}
 
+	// Stop background flush loop first so it doesn't race with final flush.
+	c.stopFlushLoop()
+
 	c.mu.Lock()
 	content := c.buf.String()
 	c.mu.Unlock()
 
 	// Final content: sanitize then optimize for best rendering.
-	// Order matters: SanitizeForCard first (wraps excess tables in code blocks),
-	// then OptimizeMarkdownStyle (extracts code blocks, processes tables, restores).
 	content = OptimizeMarkdownStyle(SanitizeForCard(content))
-
-	// Integrity check: if bytesWritten >> bytesFlushed, the stream lost content.
-	c.mu.Lock()
-	integrityOK := (c.bytesWritten == 0 && c.bytesFlushed == 0) ||
-		c.bytesFlushed >= c.bytesWritten*9/10
-	if !integrityOK {
-		c.log.Warn("feishu: streaming integrity check failed",
-			"bytes_written", c.bytesWritten,
-			"bytes_flushed", c.bytesFlushed,
-			"failed_flushes", c.failedFlushes)
-		content += "\n\n> ⚠️ _部分输出可能因速率限制而丢失。_"
-	}
-	c.mu.Unlock()
 
 	c.log.Debug("feishu: streaming card close",
 		"card_kit_ok", c.cardKitOK,
@@ -355,25 +393,43 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		"content_len", len(content),
 		"last_flushed_len", len(c.lastFlushed))
 
+	// Final flush: push complete content to the card.
+	finalFlushOK := false
 	if c.cardKitOK && c.cardID != "" {
 		seq := int(c.sequence.Add(1))
-
 		if err := c.flushCardKit(ctx, content, seq); err != nil {
 			c.log.Warn("feishu: final cardkit flush failed, attempting IM patch fallback",
 				"err", err)
-			// Only attempt IM patch fallback if we have a msgID.
-			// This avoids a double-write when both CardKit and IM patch are attempted.
 			if c.msgID != "" {
-				_ = c.flushIMPatchWithConfig(ctx, content)
+				if err := c.flushIMPatchWithConfig(ctx, content); err == nil {
+					finalFlushOK = true
+				}
 			}
+		} else {
+			finalFlushOK = true
 		}
 	} else if c.msgID != "" {
-		// CardKit never available or permanently degraded: use IM Patch with final
-		// config (streaming_mode=false + summary) to ensure the card renders
-		// correctly without stale streaming state.
 		c.log.Debug("feishu: cardkit degraded, using IM patch with final config")
-		_ = c.flushIMPatchWithConfig(ctx, content)
+		if err := c.flushIMPatchWithConfig(ctx, content); err == nil {
+			finalFlushOK = true
+		}
 	}
+
+	// Integrity check: compare last successfully flushed content against final buffer.
+	// Only warn if the final flush itself failed to deliver full content.
+	c.mu.Lock()
+	if !finalFlushOK || len(c.lastFlushed) < len(SanitizeForCard(c.buf.String()))*9/10 {
+		if c.bytesWritten > 0 {
+			c.log.Warn("feishu: streaming integrity check failed",
+				"bytes_written", c.bytesWritten,
+				"last_flushed_len", len(c.lastFlushed),
+				"buffer_len", len(c.buf.String()),
+				"failed_flushes", c.failedFlushes,
+				"final_flush_ok", finalFlushOK)
+			content += "\n\n> ⚠️ _部分输出可能因速率限制而丢失。_"
+		}
+	}
+	c.mu.Unlock()
 
 	// Update lastFlushed so disableStreaming can use it for the summary preview.
 	c.mu.Lock()
@@ -409,6 +465,8 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 	if !c.transition(PhaseAborted) {
 		return nil
 	}
+
+	c.stopFlushLoop()
 
 	c.mu.Lock()
 	cardID := c.cardID

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -82,10 +82,11 @@ type StreamingCardController struct {
 	cardKitOK       bool
 	streamingActive bool // true once enableStreaming succeeds; disables on disableStreaming
 
-	// Reliability tracking (mirrors Slack NativeStreamingWriter).
+	// Reliability tracking.
 	streamStartTime time.Time
 	streamExpired   bool
 	bytesWritten    int64
+	bufRunes        int // running rune count for flush threshold
 	failedFlushes   int
 
 	chatType     string
@@ -94,7 +95,6 @@ type StreamingCardController struct {
 	client       *lark.Client
 	log          *slog.Logger
 
-	// Background flush loop (decoupled from Write, like Slack NativeStreamingWriter).
 	flushDone    chan struct{}
 	flushStop    sync.Once
 	flushWg      sync.WaitGroup
@@ -241,11 +241,11 @@ func (c *StreamingCardController) Write(text string) error {
 	}
 	c.buf.WriteString(text)
 	c.bytesWritten += int64(len(text))
-	bufLen := utf8.RuneCountInString(c.buf.String())
+	c.bufRunes += utf8.RuneCountInString(text)
+	needFlush := c.bufRunes >= flushSize
 	c.mu.Unlock()
 
-	// Trigger immediate flush when buffer exceeds rune threshold.
-	if bufLen >= flushSize {
+	if needFlush {
 		select {
 		case c.flushTrigger <- struct{}{}:
 		default:
@@ -259,7 +259,10 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 	content := c.buf.String()
 	c.mu.Unlock()
 
-	// Proactively sanitize to prevent CardKit table-limit errors.
+	if content == c.lastFlushed {
+		return nil
+	}
+
 	content = SanitizeForCard(content)
 
 	if content == c.lastFlushed {
@@ -371,19 +374,16 @@ func (c *StreamingCardController) MsgID() string {
 }
 
 func (c *StreamingCardController) Close(ctx context.Context) error {
-	// Idempotency: if already in a terminal state, skip.
 	if !c.transition(PhaseCompleted) {
 		return nil
 	}
 
-	// Stop background flush loop first so it doesn't race with final flush.
 	c.stopFlushLoop()
 
 	c.mu.Lock()
 	content := c.buf.String()
 	c.mu.Unlock()
 
-	// Final content: sanitize then optimize for best rendering.
 	content = OptimizeMarkdownStyle(SanitizeForCard(content))
 
 	c.log.Debug("feishu: streaming card close",
@@ -393,7 +393,6 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		"content_len", len(content),
 		"last_flushed_len", len(c.lastFlushed))
 
-	// Final flush: push complete content to the card.
 	finalFlushOK := false
 	if c.cardKitOK && c.cardID != "" {
 		seq := int(c.sequence.Add(1))
@@ -415,34 +414,22 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		}
 	}
 
-	// Integrity check: compare last successfully flushed content against final buffer.
-	// Only warn if the final flush itself failed to deliver full content.
 	c.mu.Lock()
-	if !finalFlushOK || len(c.lastFlushed) < len(SanitizeForCard(c.buf.String()))*9/10 {
-		if c.bytesWritten > 0 {
-			c.log.Warn("feishu: streaming integrity check failed",
-				"bytes_written", c.bytesWritten,
-				"last_flushed_len", len(c.lastFlushed),
-				"buffer_len", len(c.buf.String()),
-				"failed_flushes", c.failedFlushes,
-				"final_flush_ok", finalFlushOK)
-			content += "\n\n> ⚠️ _部分输出可能因速率限制而丢失。_"
-		}
+	integrityFailed := !finalFlushOK || len(c.lastFlushed) < len(content)*9/10
+	if integrityFailed && c.bytesWritten > 0 {
+		c.log.Warn("feishu: streaming integrity check failed",
+			"bytes_written", c.bytesWritten,
+			"last_flushed_len", len(c.lastFlushed),
+			"content_len", len(content),
+			"failed_flushes", c.failedFlushes,
+			"final_flush_ok", finalFlushOK)
+		content += "\n\n> ⚠️ _部分输出可能因速率限制而丢失。_"
 	}
-	c.mu.Unlock()
-
-	// Update lastFlushed so disableStreaming can use it for the summary preview.
-	c.mu.Lock()
 	c.lastFlushed = content
+	cardID := c.cardID
 	c.mu.Unlock()
 
-	// Always disable streaming if it was enabled, even after cardKitOK degraded.
-	// Without this, the card stays in "generating" state permanently.
 	if c.streamingActive {
-		c.mu.Lock()
-		cardID := c.cardID
-		c.mu.Unlock()
-
 		if cardID != "" {
 			if err := c.disableStreaming(ctx); err != nil {
 				c.log.Warn("feishu: disable streaming failed", "err", err)

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -84,7 +84,7 @@ type StreamingCardController struct {
 
 	// Reliability tracking.
 	streamStartTime time.Time
-	streamExpired   bool
+	ttlWarnOnce     sync.Once
 	bytesWritten    int64
 	bufRunes        int // running rune count for flush threshold
 	failedFlushes   int
@@ -231,11 +231,10 @@ func (c *StreamingCardController) Write(text string) error {
 	}
 	elapsed := time.Since(c.streamStartTime)
 	if elapsed > StreamTTL {
-		if !c.streamExpired {
-			c.streamExpired = true
+		c.ttlWarnOnce.Do(func() {
 			c.log.Warn("feishu: streaming TTL exceeded, rejecting further writes",
 				"elapsed", elapsed.Round(time.Second))
-		}
+		})
 		c.mu.Unlock()
 		return fmt.Errorf("feishu: streaming expired after %v", StreamTTL)
 	}

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -302,6 +302,7 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 		} else {
 			c.mu.Lock()
 			c.lastFlushed = content
+			c.bufRunes = 0
 			c.mu.Unlock()
 			return nil
 		}
@@ -317,6 +318,7 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 		}
 		c.mu.Lock()
 		c.lastFlushed = content
+		c.bufRunes = 0
 		c.mu.Unlock()
 	}
 

--- a/internal/messaging/feishu/streaming_card_test.go
+++ b/internal/messaging/feishu/streaming_card_test.go
@@ -215,10 +215,12 @@ func TestStreamingCardController_Close_IntegrityFail(t *testing.T) {
 	require.True(t, c.transition(PhaseCreating))
 	require.True(t, c.transition(PhaseStreaming))
 
-	// Simulate: many bytes written, very few flushed → integrity check fails.
+	// Simulate: many bytes written, nothing flushed → integrity check fails.
 	c.mu.Lock()
 	c.bytesWritten = 10000
-	c.bytesFlushed = 100 // only 1% flushed
+	c.lastFlushed = "" // nothing was flushed
+	c.msgID = ""       // no msgID → final flush will fail
+	c.cardKitOK = false
 	c.buf.WriteString("test content")
 	c.mu.Unlock()
 
@@ -233,10 +235,11 @@ func TestStreamingCardController_Close_IntegrityPass(t *testing.T) {
 	require.True(t, c.transition(PhaseCreating))
 	require.True(t, c.transition(PhaseStreaming))
 
-	// Simulate: bytes written ≈ bytes flushed → integrity OK.
+	// Simulate: lastFlushed covers buffer content → integrity OK.
 	c.mu.Lock()
 	c.bytesWritten = 1000
-	c.bytesFlushed = 950 // 95% flushed → passes 90% threshold
+	c.lastFlushed = "content" // matches buf content
+	c.streamingActive = false
 	c.buf.WriteString("content")
 	c.mu.Unlock()
 

--- a/internal/messaging/feishu/streaming_test.go
+++ b/internal/messaging/feishu/streaming_test.go
@@ -381,7 +381,7 @@ func TestStreamingCardController_IntegrityCheck(t *testing.T) {
 	require.True(t, c.transition(PhaseCreating))
 	c.mu.Lock()
 	c.bytesWritten = 0
-	c.bytesFlushed = 0
+	// bytesFlushed removed; integrity now based on lastFlushed vs buf
 	c.mu.Unlock()
 
 	// Close should not panic with zero bytes.

--- a/internal/messaging/feishu/streaming_test.go
+++ b/internal/messaging/feishu/streaming_test.go
@@ -381,7 +381,6 @@ func TestStreamingCardController_IntegrityCheck(t *testing.T) {
 	require.True(t, c.transition(PhaseCreating))
 	c.mu.Lock()
 	c.bytesWritten = 0
-	// bytesFlushed removed; integrity now based on lastFlushed vs buf
 	c.mu.Unlock()
 
 	// Close should not panic with zero bytes.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -78,6 +78,7 @@ const (
 	ErrCodeWorkerOutputLimit  ErrorCode = "WORKER_OUTPUT_LIMIT"
 	ErrCodeResumeRetry        ErrorCode = "RESUME_RETRY"
 	ErrCodeNotSupported       ErrorCode = "NOT_SUPPORTED"
+	ErrCodeTurnTimeout        ErrorCode = "TURN_TIMEOUT"
 )
 
 // Envelope is the unified AEP v1 message envelope, shared by both client→gateway and gateway→client.


### PR DESCRIPTION
## Summary

Closes #126

- **Background flush loop**: Add 150ms timer-driven flush goroutine to `StreamingCardController`, decoupling `Write()` from `Flush()` (mirrors Slack's proven `NativeStreamingWriter` pattern)
- **Integrity check fix**: Replace cumulative `bytesFlushed`/`bytesWritten` comparison with `lastFlushed` vs buffer content length check, eliminating false-positive `⚠️ 部分输出可能因速率限制而丢失` warnings
- **Abolish synthetic Done events**: Replace all fake Done events (crash, SIGTERM, no-done) with Error events. Platform adapters already handle Error with full cleanup (clear indicators, cancel interactions, close streaming cards). Only real worker Done events now trigger turn summary.
- **Code quality**: Remove write-only `streamExpired` field (replaced with `sync.Once`), reset `bufRunes` counter on successful flush, consolidate lock cycles in `Close()`, use existing `sendErrorf` helper in handler

### Changes

- `internal/messaging/feishu/streaming.go` — Background flush loop, bufRunes threshold, integrity check refactor, sync.Once for TTL warning, lock consolidation
- `internal/messaging/feishu/adapter.go` — Remove synchronous Flush from writeContent
- `internal/gateway/bridge.go` — Replace 3 synthetic Done events with Error events
- `internal/gateway/handler.go` — Remove redundant Done from client-kill, use sendErrorf
- `internal/messaging/feishu/streaming_card_test.go` — Update integrity tests for new lastFlushed-based check
- `internal/gateway/conn_test.go` — Update crash test to expect Error event

**架构影响**：
- Channel: 飞书 (streaming), Slack/飞书 (Done→Error cleanup)
- Worker: CC/OCS (synthetic Done removal affects all worker types)
- 平台: 跨平台

## Test Plan

- [x] make test (含 -race，三平台)
- [x] make lint (golangci-lint, 0 issues)

## Related Issues

- Fixes #126