### PR TITLE
feat(agentconfig): per-bot 3-level directory fallback + session key botID + context fill fix

### DIFF
--- a/.agent/rules/agentconfig.md
+++ b/.agent/rules/agentconfig.md
@@ -8,16 +8,33 @@ paths:
 > 加载 personality/context 配置，构建统一 system prompt
 > 参考：`internal/agentconfig/loader.go`、`internal/agentconfig/prompt.go`
 
-## B/C 双通道架构
+## 三级目录 Fallback 架构
+
+每个配置文件独立解析，按以下优先级查找：
 
 ```
-~/.hotplex/agent-configs/           配置文件根目录
-├── SOUL.md                         B 通道：身份定义（高优先级、无hedging）
-├── SOUL.slack.md                   B 通道平台变体（自动追加到 SOUL.md）
-├── AGENTS.md                       B 通道：Agent 行为规范
-├── SKILLS.md                       B 通道：可用技能列表
-├── USER.md                         C 通道：用户个人信息（背景参考）
-└── MEMORY.md                       C 通道：记忆/上下文（背景参考）
+1. dir/{platform}/{botID}/{file}    — Bot 级（最高优先级）
+2. dir/{platform}/{file}            — 平台级
+3. dir/{file}                       — 全局级（兜底）
+```
+
+```
+~/.hotplex/agent-configs/
+├── SOUL.md                         ← 全局默认
+├── AGENTS.md
+├── SKILLS.md
+├── USER.md
+├── MEMORY.md
+├── slack/                          ← Slack 平台级
+│   ├── SOUL.md
+│   └── U12345/                     ← Slack Bot 级（UserID from auth.test）
+│       └── SOUL.md
+├── feishu/                         ← 飞书平台级
+│   └── ou_abc123/                  ← 飞书 Bot 级（OpenID from Bot API）
+│       └── SOUL.md
+└── webchat/                        ← WebChat 平台级
+    └── my-bot/                     ← WebChat Bot 级（JWT bot_id）
+        └── SOUL.md
 ```
 
 ### B 通道（`<directives>`）— 高优先级指令
@@ -30,6 +47,17 @@ paths:
 - **USER.md**：用户角色、偏好、背景（降低幻觉）
 - **MEMORY.md**：长期记忆、会话历史摘要
 - 注入位置：`<context>` XML 组内，作为参考信息
+
+## 加载逻辑
+
+```go
+// loader.go — Load(dir, platform, botID)
+// resolveFile: 按优先级查找文件，找到第一个非空文件即返回
+// 空 frontmatter-only 文件视为"未找到"，继续 fallthrough
+// botID 安全校验：filepath.Base(botID) == botID（防路径穿越）
+```
+
+**旧后缀格式已废弃**：`SOUL.slack.md` 不再加载。启动时扫描并输出 deprecation warning。
 
 ## META-COGNITION.md（Agent 自画像）
 
@@ -46,12 +74,10 @@ paths:
 
 ## 统一 System Prompt 构建
 
-```go
-// prompt.go — BuildSystemPrompt
-// B 通道 + C 通道合并为单一 prompt，统一注入 CC 和 OCS
+```xml
 <agent-configuration>
   <directives>
-    <soul>        ← SOUL.md（+ SOUL.<platform>.md）
+    <soul>        ← SOUL.md
     <agents>      ← AGENTS.md
     <skills>      ← SKILLS.md
   </directives>
@@ -66,22 +92,14 @@ paths:
 **CC 注入**：`--append-system-prompt` flag
 **OCS 注入**：`system` 字段（HTTP 请求体）
 
-## 平台变体
+## BotID 传播路径
 
-配置加载时自动追加平台特定文件（无平台文件时跳过）：
-
-```go
-// loader.go — Load
-platformVariants := []string{"SOUL." + platform + ".md"}
-for _, name := range platformVariants {
-    path := filepath.Join(dir, name)
-    if data, err := os.ReadFile(path); err == nil {
-        content += "\n" + stripFrontmatter(string(data))
-    }
-}
 ```
-
-**示例**：Slack 平台 → `SOUL.slack.md` 追加到 `SOUL.md` 后；其他平台同理。
+Adapter.Start() → adapter.botID / adapter.botOpenID
+  → GetBotID() → Bridge.Handle() → StartPlatformSession(..., botID)
+    → gateway.Bridge → injectAgentConfig(info, platform, botID)
+      → agentconfig.Load(dir, platform, botID) → resolveFile per file
+```
 
 ## 大小限制
 
@@ -89,7 +107,6 @@ for _, name := range platformVariants {
 |------|-----|------|
 | 单文件上限 | 8KB | 防止 prompt 爆炸 |
 | 总量上限 | 40KB | Gateway 内存 + Token 成本 |
-| 数量限制 | 6 个文件 | SOUL + AGENTS + SKILLS + USER + MEMORY + 变体 |
 
 超限 → `ErrConfigFileTooLarge` / `ErrTotalConfigTooLarge`。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,7 +419,7 @@ hotplex update --restart      # 更新后自动重启网关
 - Agent 配置目录：`~/.hotplex/agent-configs/`
 - B 通道：SOUL.md、AGENTS.md、SKILLS.md
 - C 通道：USER.md、MEMORY.md
-- 平台变体：SOUL.slack.md（自动追加）
+- 三级 fallback：全局 → 平台（slack/）→ Bot（slack/U12345/），每文件独立解析
 
 ### 最大文件
 

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -249,6 +249,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	agentConfigDir := ""
 	if cfg.AgentConfig.Enabled {
 		agentConfigDir = cfg.AgentConfig.ConfigDir
+		warnDeprecatedSuffixFiles(agentConfigDir, log)
 	}
 
 	bridge := gateway.NewBridge(gateway.BridgeDeps{
@@ -506,5 +507,25 @@ func loadEnvFile(dir string) {
 	}
 	if loaded > 0 {
 		fmt.Fprintf(os.Stderr, "  env loaded %d vars from %s\n", loaded, envPath)
+	}
+}
+
+// warnDeprecatedSuffixFiles checks for old-style SOUL.<platform>.md files
+// that are no longer loaded by the 3-level directory fallback system.
+func warnDeprecatedSuffixFiles(dir string, log *slog.Logger) {
+	if dir == "" {
+		return
+	}
+	platforms := []string{"slack", "feishu", "webchat"}
+	bases := []string{"SOUL", "AGENTS", "SKILLS", "USER", "MEMORY"}
+	for _, p := range platforms {
+		for _, b := range bases {
+			suffix := b + "." + p + ".md"
+			if _, err := os.Stat(filepath.Join(dir, suffix)); err == nil {
+				log.Warn("agent-config: deprecated suffix file found; use directory-based layout instead",
+					"file", suffix,
+					"migration", "move to "+p+"/"+b+".md")
+			}
+		}
 	}
 }

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -128,6 +128,7 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 			statuses = append(statuses, AdapterStatus{Name: string(pt), Started: false})
 			continue
 		}
+		msgBridge.SetAdapter(adapter)
 		adapters = append(adapters, adapter)
 		statuses = append(statuses, AdapterStatus{Name: string(pt), Started: true})
 		log.Info("messaging: adapter started", "platform", pt)

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -128,7 +128,9 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 			statuses = append(statuses, AdapterStatus{Name: string(pt), Started: false})
 			continue
 		}
-		msgBridge.SetAdapter(adapter)
+		if err := msgBridge.SetAdapter(adapter); err != nil {
+			log.Error("messaging: adapter platform mismatch", "platform", pt, "err", err)
+		}
 		adapters = append(adapters, adapter)
 		statuses = append(statuses, AdapterStatus{Name: string(pt), Started: true})
 		log.Info("messaging: adapter started", "platform", pt)

--- a/cmd/hotplex/onboard.go
+++ b/cmd/hotplex/onboard.go
@@ -152,5 +152,6 @@ func displayAgentConfigPanel(created []string) {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "  %s\n", output.Dim("根据需要编辑这些文件来定制 Agent 行为。"))
-	fmt.Fprintf(os.Stderr, "  %s\n\n", output.Dim("修改后自动生效（支持热重载），无需重启网关。"))
+	fmt.Fprintf(os.Stderr, "  %s\n", output.Dim("修改后自动生效（支持热重载），无需重启网关。"))
+	fmt.Fprintf(os.Stderr, "  %s\n\n", output.Dim("支持平台和 Bot 级覆盖：slack/SOUL.md、slack/U12345/SOUL.md"))
 }

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -359,7 +359,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 - Update `cmd/hotplex/onboard.go` `displayAgentConfigPanel()`: update guidance text
 - Update `.agent/skills/hotplex-setup/SKILL.md`: directory structure, bot subdirectories, env vars
 - Add deprecation warning in `cmd/hotplex/gateway_run.go`: one-time scan for `*.{platform}.md` suffix files at startup
-- Add `AgentConfigChecker` to `internal/cli/checkers/`: detect old suffix files, validate directory structure
+- Add `agentConfigSuffixChecker` to `internal/cli/checkers/`: detect old suffix files and suggest migration
 
 ### Phase 6: Documentation & Rules — Use Section 7 as Checklist
 - Update all files listed in Section 7 below
@@ -422,7 +422,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 | `internal/cli/onboard/wizard.go` | `stepAgentConfig()` 更新：说明目录结构（平台子目录、bot 子目录） |
 | `internal/cli/onboard/agentconfig_templates.go` | 保持不变（全局模板仍在根目录生成） |
 | `cmd/hotplex/onboard.go` | `displayAgentConfigPanel()` 更新说明文案，引导用户了解目录结构 |
-| `internal/cli/checkers/` **新增** | `AgentConfigChecker` — 检测旧 suffix 文件并提示迁移，验证目录结构合法性 |
+| `internal/cli/checkers/` **新增** | `agentConfigSuffixChecker` — 检测旧 suffix 文件并提示迁移 |
 
 ### 7.3 Skills Changes
 
@@ -438,7 +438,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 |------|--------|
 | `.agent/rules/agentconfig.md` | **核心更新**: 替换 suffix-append 文档为目录 fallback 文档，更新目录结构图、加载逻辑说明、大小限制 |
 | `.agent/rules/golang.md` | 更新 cross-reference |
-| `.agent/rules/cli.md` | 更新 checker 列表（新增 AgentConfigChecker） |
+| `.agent/rules/cli.md` | 更新 checker 列表（新增 agentConfigSuffixChecker） |
 | `.agent/rules/session.md` | 更新 session key 派生说明（+botID） |
 
 ### 7.5 Embedded Content Changes
@@ -498,7 +498,7 @@ vim ~/.hotplex/agent-configs/slack/U12345/SOUL.md
 ### Step 3: Verify with doctor
 
 ```bash
-hotplex doctor  # AgentConfigChecker detects old suffix files and suggests migration
+hotplex doctor  # agentConfigSuffixChecker detects old suffix files and suggests migration
 ```
 
 ### Session ID Impact

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -1,0 +1,322 @@
+# Per-Bot Agent Config Specification
+
+> Issue: #127
+> Status: Draft
+> Created: 2026-05-03
+
+## 1. Overview
+
+Replace the existing platform-suffix agent config mechanism (`SOUL.slack.md`) with a directory-based 3-level fallback system supporting per-bot configuration granularity.
+
+## 2. Requirements
+
+### 2.1 Per-File Granularity Fallback
+
+Each config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md) resolves independently through:
+
+```
+1. dir/{platform}/{botID}/{file}    ← bot-level (highest priority)
+2. dir/{platform}/{file}            ← platform-level
+3. dir/{file}                       ← global-level (fallback)
+```
+
+If a file exists at a higher priority level, it is used; lower levels are **not** appended (no merge/overlay).
+
+### 2.2 Four Configuration Dimensions
+
+| Dimension | Example | Directory |
+|-----------|---------|-----------|
+| Global (system default) | All platforms | `agent-configs/SOUL.md` |
+| Platform | Slack | `agent-configs/slack/SOUL.md` |
+| Bot | Slack bot U12345 | `agent-configs/slack/U12345/SOUL.md` |
+| WebChat | JWT bot_id | `agent-configs/webchat/my-bot/SOUL.md` |
+
+### 2.3 Bot Identity — Direct botID as Directory Name
+
+BotID is used **directly** as the subdirectory name. No config mapping needed.
+
+```
+~/.hotplex/agent-configs/
+├── SOUL.md / AGENTS.md / ...          ← 全局默认
+├── slack/                             ← Slack 平台默认
+│   ├── SOUL.md / ...
+│   ├── U12345/                        ← Slack bot (UserID from auth.test)
+│   │   └── SOUL.md / ...
+│   └── U67890/                        ← 另一个 Slack bot
+│       └── SOUL.md / ...
+├── feishu/                            ← 飞书平台默认
+│   ├── ou_abc123/                     ← 飞书 bot (OpenID from Bot API)
+│   │   └── SOUL.md / ...
+└── webchat/                           ← WebChat 默认
+    └── SOUL.md / ...
+```
+
+Platform bot IDs:
+- **Slack**: `auth.test` → `UserID` (e.g., `U12345`)
+- **Feishu**: Bot API → `OpenID` (e.g., `ou_abc123`)
+- **WebChat**: JWT claim `bot_id` (e.g., `webchat-premium`)
+
+### 2.4 Breaking Change
+
+The existing `SOUL.<platform>.md` suffix-append mechanism is **removed**. Users must migrate:
+
+| Before | After |
+|--------|-------|
+| `SOUL.slack.md` | `slack/SOUL.md` |
+| `AGENTS.feishu.md` | `feishu/AGENTS.md` |
+
+## 3. API Changes
+
+### 3.1 agentconfig.Load
+
+```go
+// Before
+func Load(dir, platform string) (*AgentConfigs, error)
+
+// After — botID is used directly as directory name
+func Load(dir, platform, botID string) (*AgentConfigs, error)
+```
+
+### 3.2 config.AgentConfig — No Changes
+
+`AgentConfig` remains unchanged — no `bots` mapping needed since botID is used directly as directory name.
+
+```go
+type AgentConfig struct {
+    Enabled   bool   `mapstructure:"enabled"`
+    ConfigDir string `mapstructure:"config_dir"`
+}
+```
+
+### 3.3 PlatformAdapterInterface
+
+```go
+// Added method
+type PlatformAdapterInterface interface {
+    // ... existing ...
+    GetBotID() string
+}
+```
+
+### 3.4 messaging.SessionStarter
+
+```go
+// Before
+StartPlatformSession(ctx, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string) error
+
+// After
+StartPlatformSession(ctx, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
+```
+
+### 3.5 gateway.BridgeDeps — No Changes
+
+No `AgentBotMap` needed — botID flows directly from adapter to `agentconfig.Load`.
+
+### 3.6 bridge.injectAgentConfig
+
+```go
+// Before
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform string)
+
+// After — botID passed directly to Load, no mapping step
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string)
+```
+
+## 4. Data Flow
+
+### 4.1 Slack/Feishu Path
+
+```
+Adapter.Start()
+  └─> auth.test / Bot API → adapter.botID / adapter.botOpenID
+
+messaging.Bridge.Handle()
+  └─> adapter.GetBotID() → botID
+  └─> starter.StartPlatformSession(..., botID)
+        └─> gateway.Bridge.StartPlatformSession(..., botID)
+              └─> startOrResumeOnInUse(..., botID)
+                    └─> StartSession(..., botID, ...)
+                          └─> sm.CreateWithBot(..., botID, ...)
+                          └─> createAndLaunchWorker(params{botID})
+                                └─> injectAgentConfig(info, platform, botID)
+                                      └─> agentconfig.Load(dir, platform, botID)
+                                            └─> resolveFile per file:
+                                                  dir/platform/botID/SOUL.md
+                                                  dir/platform/SOUL.md
+                                                  dir/SOUL.md
+```
+
+### 4.2 WebChat Path
+
+```
+JWT token → claims.BotID → conn.botID
+  └─> starter.StartSession(..., c.botID, ...)
+        └─> (same as above from StartSession)
+```
+
+### 4.3 Resume Path
+
+```
+si.BotID (from DB) → used in workerLaunchParams.botID
+  └─> injectAgentConfig(info, platform, botID)
+```
+
+## 5. Implementation Phases
+
+### Phase 1: Core Fallback Logic
+- Modify `agentconfig/loader.go`: new `Load` signature, `resolveFile` function, remove suffix-append
+- Update `agentconfig/loader_test.go`: replace suffix-append tests with 3-level fallback tests
+- Tests: 3-level fallback, per-file independence, backward compatibility
+
+### Phase 2: BotID Propagation
+- Add `GetBotID()` to `PlatformAdapterInterface` and implementations (Slack, Feishu)
+- Extend `messaging.SessionStarter` with `botID` parameter
+- Update `messaging.Bridge.Handle()` to extract and pass botID
+- Wire adapter reference in `messaging_init.go`
+
+### Phase 3: Gateway Bridge Integration
+- Update `StartPlatformSession`, `startOrResumeOnInUse`, `injectAgentConfig` signatures
+- Add `botID` to `workerLaunchParams`
+- Wire in `gateway_run.go` (no new BridgeDeps fields needed)
+
+### Phase 4: CLI & Skills Updates
+- Update onboard wizard (`internal/cli/onboard/wizard.go`)
+- Update onboard display panel (`cmd/hotplex/onboard.go`)
+- Update hotplex-setup skill
+- Add migration deprecation warning in gateway startup
+- Add agent-config doctor checker
+
+### Phase 5: Documentation & Rules Updates
+- Update all rule files, design docs, user-facing docs
+- Full test suite pass
+
+## 6. Acceptance Criteria
+
+| ID | Criterion | Validation |
+|----|-----------|------------|
+| PBAC-001 | `Load(dir, "slack", "U12345")` resolves SOUL.md from `slack/U12345/` first | Unit test |
+| PBAC-002 | Missing bot-level file falls back to platform-level | Unit test |
+| PBAC-003 | Missing platform-level file falls back to global | Unit test |
+| PBAC-004 | Each file resolves independently (SOUL from bot-level, AGENTS from platform-level) | Unit test |
+| PBAC-005 | Flat directory (no subdirs) produces identical results to current behavior | Unit test |
+| PBAC-006 | `SOUL.slack.md` suffix files are no longer loaded | Unit test |
+| PBAC-007 | Slack adapter exposes botID via `GetBotID()` | Unit test |
+| PBAC-008 | Feishu adapter exposes botID via `GetBotID()` | Unit test |
+| PBAC-009 | `StartPlatformSession` receives botID from adapter | Integration test |
+| PBAC-010 | `injectAgentConfig` passes botID directly to `agentconfig.Load` | Unit test |
+| PBAC-011 | WebChat JWT bot_id resolves to correct directory | Integration test |
+| PBAC-012 | Resume sessions reuse persisted botID for config resolution | Integration test |
+| PBAC-013 | `make check` passes (lint + test + build) | CI |
+| PBAC-014 | Cross-platform build passes (linux/macOS/windows) | CI |
+
+## 7. Full Impact Map — Files Requiring Changes
+
+### 7.1 Core Code Changes
+
+| File | Change |
+|------|--------|
+| `internal/agentconfig/loader.go` | **核心改动**: `Load` 签名变更, `resolveFile` 3级 fallback, 删除 suffix-append |
+| `internal/agentconfig/loader_test.go` | 替换 suffix-append 测试为 3级 fallback 测试 |
+| `internal/messaging/platform_adapter.go` | `PlatformAdapterInterface` +`GetBotID()`, `SessionStarter` +botID |
+| `internal/messaging/slack/adapter.go` | 实现 `GetBotID()` 返回 `a.botID` |
+| `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()` 返回 `a.botOpenID` |
+| `internal/messaging/bridge.go` | `Handle()` 提取 botID, 传递到 `StartPlatformSession` |
+| `internal/gateway/bridge.go` | `injectAgentConfig` +botID, `startOrResumeOnInUse` 使用 botID, `workerLaunchParams` +botID |
+| `cmd/hotplex/messaging_init.go` | 注入 adapter 引用到 messaging.Bridge |
+| `cmd/hotplex/gateway_run.go` | 无新字段，但需确认 botID 流转正确 |
+
+### 7.2 CLI & Wizard Changes
+
+| File | Change |
+|------|--------|
+| `internal/cli/onboard/wizard.go` | `stepAgentConfig()` 更新：说明目录结构（平台子目录、bot 子目录） |
+| `internal/cli/onboard/agentconfig_templates.go` | 保持不变（全局模板仍在根目录生成） |
+| `cmd/hotplex/onboard.go` | `displayAgentConfigPanel()` 更新说明文案，引导用户了解目录结构 |
+| `internal/cli/checkers/` | **新增**: `AgentConfigChecker` — 检测旧 suffix 文件并提示迁移，验证目录结构合法性 |
+| `cmd/hotplex/gateway_run.go` | **新增**: 启动时检测旧 `*.{platform}.md` suffix 文件，日志 deprecation warning |
+
+### 7.3 Skills Changes
+
+| File | Change |
+|------|--------|
+| `.agent/skills/hotplex-setup/SKILL.md` | 更新 agent-config 配置说明：目录结构、bot 子目录用法、环境变量 |
+| `.agent/skills/hotplex-release/SKILL.md` | 更新 config area 列表描述 |
+| `.agent/skills/hotplex-arch-analyzer/SKILL.md` | 更新 agentconfig 模块描述 |
+
+### 7.4 Rule Files Changes
+
+| File | Change |
+|------|--------|
+| `.agent/rules/agentconfig.md` | **核心更新**: 替换 suffix-append 文档为目录 fallback 文档，更新目录结构图、加载逻辑说明、大小限制 |
+| `.agent/rules/golang.md` | 更新 cross-reference: "Agent Config -> see agentconfig.md" |
+| `.agent/rules/cli.md` | 更新 checker 列表（新增 AgentConfigChecker） |
+
+### 7.5 Embedded Content Changes
+
+| File | Change |
+|------|--------|
+| `internal/agentconfig/META-COGNITION.md` | **必须更新**: "Agent Config 架构" 段落 — 删除 "平台变体：SOUL.slack.md"，改为 "三级目录 fallback：全局 → 平台 → bot" |
+
+### 7.6 Documentation Changes
+
+| File | Change |
+|------|--------|
+| `docs/architecture/Agent-Config-Design.md` | **主要设计文档更新**: 替换 suffix-append 架构为目录 fallback 架构，更新示例、文件树、迁移说明 |
+| `docs/Reference-Manual.md` | 更新 B/C 通道描述、平台变体说明、config 示例 |
+| `docs/User-Manual.md` | 更新目录位置、文件描述、平台变体用法（删除 suffix 说明，改为目录说明） |
+| `docs/management/Config-Reference.md` | 更新 B/C 通道文件列表、目录结构、环境变量说明 |
+| `docs/Architecture-Design.md` | 更新 B/C 双通道概述 |
+| `docs/specs/Per-Bot-Agent-Config-Spec.md` | 本 spec 文件（实施后标记为 Final） |
+
+### 7.7 Root-Level Docs Changes
+
+| File | Change |
+|------|--------|
+| `AGENTS.md` (→ `CLAUDE.md`) | 更新 agentconfig 模块描述、Agent Config section、文件加载说明、平台变体段落 |
+| `README.md` | 更新 agent_config 配置表说明 |
+| `README_zh.md` | 同步中文版更新 |
+| `INSTALL.md` | 更新 `~/.hotplex/agent-configs/` 目录描述 |
+
+### 7.8 Config Files Changes
+
+| File | Change |
+|------|--------|
+| `configs/config.yaml` | agent_config 段新增注释说明目录结构 |
+| `configs/env.example` | 更新 `HOTPLEX_AGENT_CONFIG_DIR` 注释说明 |
+| `configs/README.md` | 更新 agent_config section 文档 |
+
+## 8. Migration Guide
+
+### Step 1: Move platform suffix files to directories
+
+```bash
+mkdir -p ~/.hotplex/agent-configs/slack
+mv ~/.hotplex/agent-configs/SOUL.slack.md ~/.hotplex/agent-configs/slack/SOUL.md
+mv ~/.hotplex/agent-configs/AGENTS.slack.md ~/.hotplex/agent-configs/slack/AGENTS.md
+# ... same for other files and platforms
+```
+
+### Step 2: Create bot-specific configs (optional)
+
+```bash
+# Use botID (from Slack auth.test / Feishu Bot API) as directory name
+mkdir -p ~/.hotplex/agent-configs/slack/U12345
+# Only create files that differ from platform-level defaults
+vim ~/.hotplex/agent-configs/slack/U12345/SOUL.md
+```
+
+### Step 3: Verify with doctor
+
+```bash
+hotplex doctor  # New AgentConfigChecker detects old suffix files and suggests migration
+```
+
+## 9. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking change for `SOUL.<platform>.md` users | Clear migration guide + startup deprecation warning + doctor checker |
+| Performance: 3x stat calls per file | Negligible — runs once per session creation, not per message |
+| BotID not yet available at adapter creation time | Lazy resolution: `GetBotID()` called in `Handle()`, after `Start()` |
+| BotID may contain special chars | Slack UserID (`U[0-9A-Z]+`) and Feishu OpenID (`ou_[a-z0-9]+`) are safe for directory names |
+| Doc drift across 30+ files | Systematic impact map (Section 7) + checklist in release skill |

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -3,10 +3,11 @@
 > Issue: #127
 > Status: Draft
 > Created: 2026-05-03
+> Reviewed: 2026-05-03
 
 ## 1. Overview
 
-Replace the existing platform-suffix agent config mechanism (`SOUL.slack.md`) with a directory-based 3-level fallback system supporting per-bot configuration granularity.
+Replace the existing platform-suffix agent config mechanism (`SOUL.slack.md`) with a directory-based 3-level fallback system supporting per-bot configuration granularity. Additionally, include botID in the session key derivation to ensure different bots in the same channel produce separate sessions.
 
 ## 2. Requirements
 
@@ -20,7 +21,7 @@ Each config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md) resolves in
 3. dir/{file}                       ← global-level (fallback)
 ```
 
-If a file exists at a higher priority level, it is used; lower levels are **not** appended (no merge/overlay).
+If a file exists at a higher priority level, it is used; lower levels are **not** appended (no merge/overlay). An empty file (content is empty after frontmatter stripping) is treated as "not found" and falls through to the next level — this is consistent with current behavior.
 
 ### 2.2 Four Configuration Dimensions
 
@@ -56,14 +57,46 @@ Platform bot IDs:
 - **Feishu**: Bot API → `OpenID` (e.g., `ou_abc123`)
 - **WebChat**: JWT claim `bot_id` (e.g., `webchat-premium`)
 
-### 2.4 Breaking Change
+### 2.4 BotID in Session Key Derivation
 
-The existing `SOUL.<platform>.md` suffix-append mechanism is **removed**. Users must migrate:
+**Current**: `DerivePlatformSessionKey(ownerID, wt, PlatformContext{Platform, TeamID, ChannelID, ThreadTS, ChatID, UserID, WorkDir})` — no botID. Two bots in the same Slack channel responding to the same user **collide on the same session ID**.
 
-| Before | After |
-|--------|-------|
-| `SOUL.slack.md` | `slack/SOUL.md` |
-| `AGENTS.feishu.md` | `feishu/AGENTS.md` |
+**After**: `PlatformContext` gains a `BotID` field. It participates in the UUIDv5 hash so each bot gets its own session. This is critical for multi-bot deployments.
+
+```go
+// PlatformContext — 新增 BotID
+type PlatformContext struct {
+    Platform string
+    TeamID    string
+    ChannelID string
+    ThreadTS  string
+    ChatID    string
+    UserID    string
+    WorkDir   string
+    BotID     string  // NEW
+}
+```
+
+Session key derivation includes botID (after platform, before platform-specific fields):
+
+```
+// Before: owner|wt|slack|teamID|channelID|threadTS|userID|workDir
+// After:  owner|wt|slack|botID|teamID|channelID|threadTS|userID|workDir
+```
+
+**Impact**: This is a **breaking change for session ID stability**. Existing platform sessions will get different IDs after upgrade. Sessions in TERMINATED state will not resume — users will start fresh sessions automatically (existing crash recovery handles this). This is acceptable for a minor version bump.
+
+### 2.5 Breaking Changes Summary
+
+| Change | Impact | Migration |
+|--------|--------|-----------|
+| `SOUL.<platform>.md` suffix removed | Platform-specific configs not loaded | Move to `slack/SOUL.md` directory |
+| `PlatformContext.BotID` added to session key | Existing session IDs change | Automatic — fresh sessions created on next message |
+| Size limits unchanged | `MaxFileChars = 8,000`, `MaxTotalChars = 40,000` | N/A |
+
+### 2.6 Versioning
+
+Target: next minor version (e.g., v1.5.0). Both changes (suffix removal + session key) are breaking but have automatic fallback behavior. Document in CHANGELOG as **BREAKING** section.
 
 ## 3. API Changes
 
@@ -73,13 +106,40 @@ The existing `SOUL.<platform>.md` suffix-append mechanism is **removed**. Users 
 // Before
 func Load(dir, platform string) (*AgentConfigs, error)
 
-// After — botID is used directly as directory name
+// After
 func Load(dir, platform, botID string) (*AgentConfigs, error)
 ```
 
-### 3.2 config.AgentConfig — No Changes
+**Path safety**: `botID` is validated at entry — must satisfy `filepath.Base(botID) == botID` (no path separators or `..`). This prevents path traversal even with user-controlled WebChat JWT bot_id values.
 
-`AgentConfig` remains unchanged — no `bots` mapping needed since botID is used directly as directory name.
+**Internal changes**: `loadFile` and `loadFileWithErrorCount` are replaced by `resolveFile`. The `Load` function's total-size tracking logic remains unchanged.
+
+### 3.2 agentconfig.resolveFile (NEW)
+
+```go
+// resolveFile implements the 3-level fallback for a single config file.
+// Returns the content of the first found file, or ("", nil) if none exist.
+func resolveFile(dir, platform, botID, fileName string) (string, error) {
+    // 1. Bot-level: dir/platform/botID/fileName
+    if botID != "" && platform != "" {
+        content, err := readFile(filepath.Join(dir, platform, botID), fileName)
+        if err != nil || content != "" {
+            return content, err
+        }
+    }
+    // 2. Platform-level: dir/platform/fileName
+    if platform != "" {
+        content, err := readFile(filepath.Join(dir, platform), fileName)
+        if err != nil || content != "" {
+            return content, err
+        }
+    }
+    // 3. Global: dir/fileName
+    return readFile(dir, fileName)
+}
+```
+
+### 3.3 config.AgentConfig — No Changes
 
 ```go
 type AgentConfig struct {
@@ -88,7 +148,36 @@ type AgentConfig struct {
 }
 ```
 
-### 3.3 PlatformAdapterInterface
+### 3.4 session.PlatformContext — BotID Added
+
+```go
+type PlatformContext struct {
+    Platform  string
+    TeamID    string
+    ChannelID string
+    ThreadTS  string
+    ChatID    string
+    UserID    string
+    WorkDir   string
+    BotID     string  // NEW: included in session key derivation
+}
+
+// FromMap — add bot_id parsing
+func (pc *PlatformContext) FromMap(m map[string]string) {
+    // ... existing fields ...
+    pc.BotID = m["bot_id"]  // NEW
+}
+```
+
+### 3.5 session.DerivePlatformSessionKey
+
+```go
+// BotID is included after Platform in the hash input
+// Before: owner|wt|slack|teamID|channelID|...
+// After:  owner|wt|slack|botID|teamID|channelID|...
+```
+
+### 3.6 PlatformAdapterInterface
 
 ```go
 // Added method
@@ -98,7 +187,7 @@ type PlatformAdapterInterface interface {
 }
 ```
 
-### 3.4 messaging.SessionStarter
+### 3.7 messaging.SessionStarter
 
 ```go
 // Before
@@ -108,19 +197,66 @@ StartPlatformSession(ctx, sessionID, ownerID, workerType, workDir, platform stri
 StartPlatformSession(ctx, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
 ```
 
-### 3.5 gateway.BridgeDeps — No Changes
+### 3.8 messaging.Bridge
+
+```go
+// Bridge gains an adapter reference for lazy botID resolution
+type Bridge struct {
+    // ... existing fields ...
+    adapter PlatformAdapterInterface  // NEW: set after adapter.Start()
+}
+
+func (b *Bridge) SetAdapter(a PlatformAdapterInterface)
+```
+
+### 3.9 gateway.BridgeDeps — No Changes
 
 No `AgentBotMap` needed — botID flows directly from adapter to `agentconfig.Load`.
 
-### 3.6 bridge.injectAgentConfig
+### 3.10 bridge.injectAgentConfig
 
 ```go
 // Before
 func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform string)
 
-// After — botID passed directly to Load, no mapping step
+// After
 func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string)
 ```
+
+### 3.11 messaging.Bridge.MakeSlackEnvelope / MakeFeishuEnvelope
+
+```go
+// Before
+func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope
+
+// After — botID parameter added
+func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope
+```
+
+`PlatformContext` in both methods now includes `BotID` field, which flows into `DerivePlatformSessionKey` and envelope metadata.
+
+### 3.12 messaging.Bridge.MakeEnvelope
+
+```go
+func (b *Bridge) MakeEnvelope(userID, text string, pctx session.PlatformContext) *events.Envelope {
+    // ... existing ...
+    if pctx.BotID != "" {
+        md["bot_id"] = pctx.BotID
+    }
+    // ...
+}
+```
+
+### 3.13 ExtractPlatformKeys — bot_id Extraction
+
+```go
+// Both Slack and Feishu cases must extract bot_id:
+if v, ok := md["bot_id"].(string); ok && v != "" {
+    pk["bot_id"] = v
+}
+```
+
+This ensures the `platformKey` map persisted to DB includes `bot_id`, enabling `FromMap` to reconstruct `PlatformContext.BotID` on resume.
 
 ## 4. Data Flow
 
@@ -129,6 +265,12 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID str
 ```
 Adapter.Start()
   └─> auth.test / Bot API → adapter.botID / adapter.botOpenID
+
+Adapter.HandleTextMessage()
+  └─> a.Bridge().MakeSlackEnvelope(teamID, ch, threadTS, userID, text, workDir, a.botID)
+        └─> MakeEnvelope(userID, text, PlatformContext{..., BotID: botID})
+              └─> DerivePlatformSessionKey(userID, wt, pctx)  ← botID in hash
+              └─> metadata["bot_id"] = botID
 
 messaging.Bridge.Handle()
   └─> adapter.GetBotID() → botID
@@ -152,43 +294,77 @@ messaging.Bridge.Handle()
 JWT token → claims.BotID → conn.botID
   └─> starter.StartSession(..., c.botID, ...)
         └─> (same as above from StartSession)
+
+WebChat without botID (c.botID == ""):
+  └─> Load(dir, "webchat", "") → resolves from webchat/ directory (platform-level)
 ```
 
 ### 4.3 Resume Path
 
 ```
 si.BotID (from DB) → used in workerLaunchParams.botID
-  └─> injectAgentConfig(info, platform, botID)
+  └─> injectAgentConfig(info, platform, si.BotID)
 ```
+
+Three `createAndLaunchWorker` call sites must pass botID:
+1. `StartSession` (bridge.go:120) — botID from parameter
+2. `resumeWithOpts` (bridge.go:254) — `botID: si.BotID` from DB
+3. `attemptResumeFallback` (bridge.go:787) — `botID: si.BotID` from DB
 
 ## 5. Implementation Phases
 
 ### Phase 1: Core Fallback Logic
-- Modify `agentconfig/loader.go`: new `Load` signature, `resolveFile` function, remove suffix-append
-- Update `agentconfig/loader_test.go`: replace suffix-append tests with 3-level fallback tests
-- Tests: 3-level fallback, per-file independence, backward compatibility
+- Modify `agentconfig/loader.go`:
+  - New `Load(dir, platform, botID)` signature
+  - New `resolveFile` function implementing 3-level per-file fallback
+  - Add botID path safety validation (`filepath.Base(botID) == botID`)
+  - Remove `loadFile` / `loadFileWithErrorCount` (replaced by `resolveFile`)
+  - Remove suffix-append logic (`SOUL.<platform>.md`)
+- Update `agentconfig/loader_test.go`:
+  - Replace suffix-append tests with 3-level fallback tests
+  - Add path traversal test for botID
+  - Add empty-file-equals-missing test
+  - Add flat-directory backward-compatibility test
 
-### Phase 2: BotID Propagation
-- Add `GetBotID()` to `PlatformAdapterInterface` and implementations (Slack, Feishu)
-- Extend `messaging.SessionStarter` with `botID` parameter
-- Update `messaging.Bridge.Handle()` to extract and pass botID
-- Wire adapter reference in `messaging_init.go`
+### Phase 2: BotID Propagation — Adapter Layer
+- Add `GetBotID()` to `PlatformAdapterInterface` (`messaging/platform_adapter.go`)
+- Implement in Slack adapter: `return a.botID`
+- Implement in Feishu adapter: `return a.botOpenID`
+- Add `adapter` field + `SetAdapter()` to `messaging.Bridge`
+- Wire `SetAdapter()` in `messaging_init.go` after `adapter.Start()`
+- Update `messaging.SessionStarter` interface: +botID parameter
+- Update `messaging.Bridge.Handle()`: extract botID from adapter, pass to `StartPlatformSession`
 
-### Phase 3: Gateway Bridge Integration
-- Update `StartPlatformSession`, `startOrResumeOnInUse`, `injectAgentConfig` signatures
+### Phase 3: Session Key Derivation
+- Add `BotID` field to `session.PlatformContext`
+- Update `FromMap()`: parse `m["bot_id"]`
+- Update `DerivePlatformSessionKey()`: include botID in hash input
+- Update `MakeSlackEnvelope` / `MakeFeishuEnvelope`: +botID parameter
+- Update all callers of `MakeSlackEnvelope` / `MakeFeishuEnvelope` in adapter files
+- Update `MakeEnvelope()`: include botID in metadata as `"bot_id"`
+- Update `ExtractPlatformKeys`: extract `bot_id` from metadata for both Slack and Feishu cases
+
+### Phase 4: Gateway Bridge Integration
+- Update `StartPlatformSession`: +botID parameter
+- Update `startOrResumeOnInUse`: use botID instead of hardcoded `""`
+- Update `injectAgentConfig`: +botID parameter, pass to `agentconfig.Load`
 - Add `botID` to `workerLaunchParams`
-- Wire in `gateway_run.go` (no new BridgeDeps fields needed)
+- Update all 3 `createAndLaunchWorker` call sites to pass botID:
+  - `StartSession` (bridge.go:120): from parameter
+  - `resumeWithOpts` (bridge.go:254): `si.BotID` from DB
+  - `attemptResumeFallback` (bridge.go:787): `si.BotID` from DB
 
-### Phase 4: CLI & Skills Updates
-- Update onboard wizard (`internal/cli/onboard/wizard.go`)
-- Update onboard display panel (`cmd/hotplex/onboard.go`)
-- Update hotplex-setup skill
-- Add migration deprecation warning in gateway startup
-- Add agent-config doctor checker
+### Phase 5: CLI & Skills Updates
+- Update `internal/cli/onboard/wizard.go` `stepAgentConfig()`: mention directory structure
+- Update `cmd/hotplex/onboard.go` `displayAgentConfigPanel()`: update guidance text
+- Update `.agent/skills/hotplex-setup/SKILL.md`: directory structure, bot subdirectories, env vars
+- Add deprecation warning in `cmd/hotplex/gateway_run.go`: one-time scan for `*.{platform}.md` suffix files at startup
+- Add `AgentConfigChecker` to `internal/cli/checkers/`: detect old suffix files, validate directory structure
 
-### Phase 5: Documentation & Rules Updates
-- Update all rule files, design docs, user-facing docs
-- Full test suite pass
+### Phase 6: Documentation & Rules — Use Section 7 as Checklist
+- Update all files listed in Section 7 below
+- Full test suite pass (`make check`)
+- Cross-platform build pass
 
 ## 6. Acceptance Criteria
 
@@ -200,14 +376,27 @@ si.BotID (from DB) → used in workerLaunchParams.botID
 | PBAC-004 | Each file resolves independently (SOUL from bot-level, AGENTS from platform-level) | Unit test |
 | PBAC-005 | Flat directory (no subdirs) produces identical results to current behavior | Unit test |
 | PBAC-006 | `SOUL.slack.md` suffix files are no longer loaded | Unit test |
-| PBAC-007 | Slack adapter exposes botID via `GetBotID()` | Unit test |
-| PBAC-008 | Feishu adapter exposes botID via `GetBotID()` | Unit test |
-| PBAC-009 | `StartPlatformSession` receives botID from adapter | Integration test |
-| PBAC-010 | `injectAgentConfig` passes botID directly to `agentconfig.Load` | Unit test |
-| PBAC-011 | WebChat JWT bot_id resolves to correct directory | Integration test |
-| PBAC-012 | Resume sessions reuse persisted botID for config resolution | Integration test |
-| PBAC-013 | `make check` passes (lint + test + build) | CI |
-| PBAC-014 | Cross-platform build passes (linux/macOS/windows) | CI |
+| PBAC-007 | `Load(dir, "slack", "../etc")` returns error (path traversal blocked) | Unit test |
+| PBAC-008 | Empty file (frontmatter only) falls through to next level | Unit test |
+| PBAC-009 | Slack adapter exposes botID via `GetBotID()` | Unit test |
+| PBAC-010 | Feishu adapter exposes botID via `GetBotID()` | Unit test |
+| PBAC-011 | `MakeSlackEnvelope` includes botID in PlatformContext | Unit test |
+| PBAC-012 | `DerivePlatformSessionKey` with different botIDs produces different session IDs | Unit test |
+| PBAC-013 | `StartPlatformSession` receives botID from adapter | Integration test |
+| PBAC-014 | `injectAgentConfig` passes botID directly to `agentconfig.Load` | Unit test |
+| PBAC-015 | WebChat JWT bot_id resolves to correct directory; empty bot_id uses platform-level | Integration test |
+| PBAC-016 | Resume sessions reuse persisted botID for config resolution | Integration test |
+| PBAC-017 | All 3 `createAndLaunchWorker` call sites pass botID | Unit test |
+| PBAC-018 | Gateway startup logs deprecation warning when `*.{platform}.md` suffix files exist | Unit test |
+| PBAC-019 | `hotplex doctor` detects old suffix files and suggests migration | Unit test |
+| PBAC-020 | `make check` passes (lint + test + build) | CI |
+| PBAC-021 | Cross-platform build passes (linux/macOS/windows) | CI |
+| PBAC-022 | `MakeFeishuEnvelope` includes botID in PlatformContext and metadata | Unit test |
+| PBAC-023 | `MakeEnvelope` includes `bot_id` in metadata map | Unit test |
+| PBAC-024 | `ExtractPlatformKeys` extracts `bot_id` from metadata for both Slack and Feishu | Unit test |
+| PBAC-025 | `messaging.Bridge.Handle()` extracts botID from adapter via `GetBotID()`, passes to `StartPlatformSession` | Unit test |
+| PBAC-026 | `messaging_init.go` calls `SetAdapter(adapter)` after `adapter.Start()` | Integration test |
+| PBAC-027 | `FromMap` reconstructs `BotID` from persisted `platformKey["bot_id"]` | Unit test |
 
 ## 7. Full Impact Map — Files Requiring Changes
 
@@ -215,15 +404,16 @@ si.BotID (from DB) → used in workerLaunchParams.botID
 
 | File | Change |
 |------|--------|
-| `internal/agentconfig/loader.go` | **核心改动**: `Load` 签名变更, `resolveFile` 3级 fallback, 删除 suffix-append |
-| `internal/agentconfig/loader_test.go` | 替换 suffix-append 测试为 3级 fallback 测试 |
-| `internal/messaging/platform_adapter.go` | `PlatformAdapterInterface` +`GetBotID()`, `SessionStarter` +botID |
-| `internal/messaging/slack/adapter.go` | 实现 `GetBotID()` 返回 `a.botID` |
-| `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()` 返回 `a.botOpenID` |
-| `internal/messaging/bridge.go` | `Handle()` 提取 botID, 传递到 `StartPlatformSession` |
-| `internal/gateway/bridge.go` | `injectAgentConfig` +botID, `startOrResumeOnInUse` 使用 botID, `workerLaunchParams` +botID |
-| `cmd/hotplex/messaging_init.go` | 注入 adapter 引用到 messaging.Bridge |
-| `cmd/hotplex/gateway_run.go` | 无新字段，但需确认 botID 流转正确 |
+| `internal/agentconfig/loader.go` | **核心改动**: `Load` +botID, `resolveFile` 3级 fallback, path safety check, 删除 `loadFile`/`loadFileWithErrorCount`/suffix-append |
+| `internal/agentconfig/loader_test.go` | 替换 suffix-append 测试为 3级 fallback 测试, +path traversal +empty file tests |
+| `internal/session/key.go` | `PlatformContext` +BotID, `FromMap` +bot_id, `DerivePlatformSessionKey` hash input +botID |
+| `internal/messaging/platform_adapter.go` | `PlatformAdapterInterface` +`GetBotID()`, `SessionStarter` +botID, `ExtractPlatformKeys` +`bot_id` extraction |
+| `internal/messaging/slack/adapter.go` | 实现 `GetBotID()`, 更新 `MakeSlackEnvelope` 调用 +botID 参数 |
+| `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()`, 更新 `MakeFeishuEnvelope` 调用 +botID 参数 |
+| `internal/messaging/bridge.go` | `Bridge` +adapter field +`SetAdapter()`, `MakeSlackEnvelope`/`MakeFeishuEnvelope` +botID, `MakeEnvelope` metadata +bot_id, `Handle()` 提取 botID |
+| `internal/gateway/bridge.go` | `injectAgentConfig` +botID, `startOrResumeOnInUse` 使用 botID, `workerLaunchParams` +botID, 3个 `createAndLaunchWorker` 调用点 +botID |
+| `cmd/hotplex/messaging_init.go` | `adapter.Start()` 后调用 `msgBridge.SetAdapter(adapter)` |
+| `cmd/hotplex/gateway_run.go` | 启动时扫描旧 suffix 文件, 日志 deprecation warning |
 
 ### 7.2 CLI & Wizard Changes
 
@@ -232,8 +422,7 @@ si.BotID (from DB) → used in workerLaunchParams.botID
 | `internal/cli/onboard/wizard.go` | `stepAgentConfig()` 更新：说明目录结构（平台子目录、bot 子目录） |
 | `internal/cli/onboard/agentconfig_templates.go` | 保持不变（全局模板仍在根目录生成） |
 | `cmd/hotplex/onboard.go` | `displayAgentConfigPanel()` 更新说明文案，引导用户了解目录结构 |
-| `internal/cli/checkers/` | **新增**: `AgentConfigChecker` — 检测旧 suffix 文件并提示迁移，验证目录结构合法性 |
-| `cmd/hotplex/gateway_run.go` | **新增**: 启动时检测旧 `*.{platform}.md` suffix 文件，日志 deprecation warning |
+| `internal/cli/checkers/` **新增** | `AgentConfigChecker` — 检测旧 suffix 文件并提示迁移，验证目录结构合法性 |
 
 ### 7.3 Skills Changes
 
@@ -248,8 +437,9 @@ si.BotID (from DB) → used in workerLaunchParams.botID
 | File | Change |
 |------|--------|
 | `.agent/rules/agentconfig.md` | **核心更新**: 替换 suffix-append 文档为目录 fallback 文档，更新目录结构图、加载逻辑说明、大小限制 |
-| `.agent/rules/golang.md` | 更新 cross-reference: "Agent Config -> see agentconfig.md" |
+| `.agent/rules/golang.md` | 更新 cross-reference |
 | `.agent/rules/cli.md` | 更新 checker 列表（新增 AgentConfigChecker） |
+| `.agent/rules/session.md` | 更新 session key 派生说明（+botID） |
 
 ### 7.5 Embedded Content Changes
 
@@ -261,29 +451,29 @@ si.BotID (from DB) → used in workerLaunchParams.botID
 
 | File | Change |
 |------|--------|
-| `docs/architecture/Agent-Config-Design.md` | **主要设计文档更新**: 替换 suffix-append 架构为目录 fallback 架构，更新示例、文件树、迁移说明 |
-| `docs/Reference-Manual.md` | 更新 B/C 通道描述、平台变体说明、config 示例 |
-| `docs/User-Manual.md` | 更新目录位置、文件描述、平台变体用法（删除 suffix 说明，改为目录说明） |
-| `docs/management/Config-Reference.md` | 更新 B/C 通道文件列表、目录结构、环境变量说明 |
+| `docs/architecture/Agent-Config-Design.md` | **主要设计文档更新**: 替换 suffix-append 架构为目录 fallback 架构 |
+| `docs/Reference-Manual.md` | 更新 B/C 通道描述、平台变体说明 |
+| `docs/User-Manual.md` | 更新文件描述、目录用法 |
+| `docs/management/Config-Reference.md` | 更新文件列表、目录结构 |
 | `docs/Architecture-Design.md` | 更新 B/C 双通道概述 |
-| `docs/specs/Per-Bot-Agent-Config-Spec.md` | 本 spec 文件（实施后标记为 Final） |
+| `docs/specs/Per-Bot-Agent-Config-Spec.md` | 本 spec（实施后标记 Final） |
 
 ### 7.7 Root-Level Docs Changes
 
 | File | Change |
 |------|--------|
-| `AGENTS.md` (→ `CLAUDE.md`) | 更新 agentconfig 模块描述、Agent Config section、文件加载说明、平台变体段落 |
-| `README.md` | 更新 agent_config 配置表说明 |
-| `README_zh.md` | 同步中文版更新 |
-| `INSTALL.md` | 更新 `~/.hotplex/agent-configs/` 目录描述 |
+| `AGENTS.md` (→ `CLAUDE.md`) | 更新 agentconfig 模块描述、Agent Config section、session key 派生 |
+| `README.md` | 更新 agent_config 配置表 |
+| `README_zh.md` | 同步中文版 |
+| `INSTALL.md` | 更新目录描述 |
 
 ### 7.8 Config Files Changes
 
 | File | Change |
 |------|--------|
 | `configs/config.yaml` | agent_config 段新增注释说明目录结构 |
-| `configs/env.example` | 更新 `HOTPLEX_AGENT_CONFIG_DIR` 注释说明 |
-| `configs/README.md` | 更新 agent_config section 文档 |
+| `configs/env.example` | 更新注释说明 |
+| `configs/README.md` | 更新 agent_config section |
 
 ## 8. Migration Guide
 
@@ -308,15 +498,21 @@ vim ~/.hotplex/agent-configs/slack/U12345/SOUL.md
 ### Step 3: Verify with doctor
 
 ```bash
-hotplex doctor  # New AgentConfigChecker detects old suffix files and suggests migration
+hotplex doctor  # AgentConfigChecker detects old suffix files and suggests migration
 ```
+
+### Session ID Impact
+
+Existing sessions will get new IDs (botID included in derivation). Terminated sessions will not resume — fresh sessions are created automatically on next message. No data loss; only conversation history continuity for active sessions is affected.
 
 ## 9. Risks
 
 | Risk | Mitigation |
 |------|------------|
-| Breaking change for `SOUL.<platform>.md` users | Clear migration guide + startup deprecation warning + doctor checker |
+| Breaking: `SOUL.<platform>.md` users | Migration guide + startup deprecation warning + doctor checker |
+| Breaking: session IDs change (botID in key) | Automatic recovery via orphan resume path; documented in CHANGELOG |
 | Performance: 3x stat calls per file | Negligible — runs once per session creation, not per message |
-| BotID not yet available at adapter creation time | Lazy resolution: `GetBotID()` called in `Handle()`, after `Start()` |
-| BotID may contain special chars | Slack UserID (`U[0-9A-Z]+`) and Feishu OpenID (`ou_[a-z0-9]+`) are safe for directory names |
-| Doc drift across 30+ files | Systematic impact map (Section 7) + checklist in release skill |
+| BotID not yet available at adapter creation time | Lazy: `GetBotID()` called in `Handle()` after `Start()` |
+| BotID path traversal (WebChat JWT) | `filepath.Base(botID) == botID` validation at `Load` entry |
+| BotID special chars | Slack (`U[0-9A-Z]+`) and Feishu (`ou_[a-z0-9]+`) safe; WebChat validated |
+| Doc drift across 30+ files | Systematic impact map (Section 7) used as implementation checklist |

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -1,7 +1,7 @@
 # Per-Bot Agent Config Specification
 
 > Issue: #127
-> Status: Draft
+> Status: Final
 > Created: 2026-05-03
 > Reviewed: 2026-05-03
 

--- a/docs/specs/Session-Stats-Spec.md
+++ b/docs/specs/Session-Stats-Spec.md
@@ -427,8 +427,10 @@ var defaultContextWindows = map[string]int64{
 
 使用 `DoneData.Stats` 中的约定 key `_session` 注入聚合统计。不需要新增事件类型。
 
+> **实际实现**: `internal/gateway/session_stats.go:sessionAccumulator.snapshot()`
+
 ```go
-// DoneData.Stats["_session"] 的值结构
+// DoneData.Stats["_session"] 的值结构（实际 snapshot 输出）
 type SessionStatsSnapshot struct {
     // 会话元信息
     TurnCount     int     `json:"turn_count"`
@@ -436,11 +438,12 @@ type SessionStatsSnapshot struct {
     Duration      string  `json:"duration"`          // "3m42s"
     DurationSecs  float64 `json:"duration_seconds"`  // 222.5
 
-    // Token 统计
-    TotalInputTokens  int64 `json:"total_input_tokens"`
-    TotalOutputTokens int64 `json:"total_output_tokens"`
+    // Token 统计（累计）
+    TotalInputTok  int64 `json:"total_input_tok"`
+    TotalOutputTok int64 `json:"total_output_tok"`
 
-    // Context Window（精确值，来自 modelUsage.contextWindow）
+    // Context Window
+    ContextFill   int64   `json:"context_fill"`     // 本轮 input tokens
     ContextWindow int64   `json:"context_window"`   // 200000
     ContextPct    float64 `json:"context_pct"`      // 24.1
 
@@ -448,7 +451,18 @@ type SessionStatsSnapshot struct {
     TotalCostUSD float64 `json:"total_cost_usd"`
 
     // 模型
-    ModelName string `json:"model_name"` // "Sonnet 4.6"
+    ModelName string `json:"model_name"` // "Sonnet"
+
+    // 每轮增量（Turn Summary Spec 扩展）
+    TurnDurationMs int64            `json:"turn_duration_ms"`
+    TurnInputTok   int64            `json:"turn_input_tok"`
+    TurnOutputTok  int64            `json:"turn_output_tok"`
+    TurnCostUSD    float64          `json:"turn_cost_usd"`
+    ToolNames      map[string]int   `json:"tool_names"`     // tool → count
+
+    // 环境
+    WorkDir   string `json:"work_dir"`
+    GitBranch string `json:"git_branch"`
 }
 ```
 
@@ -718,112 +732,42 @@ func (b *Bridge) deleteAccum(sessionID string) {
 }
 ```
 
-### 4.3 Phase 3: Feishu 渲染
+### 4.3 Phase 3: Feishu 渲染 ✅ Implemented (evolved)
 
 **文件**: `internal/messaging/feishu/adapter.go`
 
-#### 4.3.1 Done 事件处理增强
+实际实现使用统一的 `messaging.ExtractTurnSummary` + `messaging.FormatTurnSummary`（来自 `internal/messaging/turn_summary.go`），而非 spec 原始设计的独立 `formatFeishuStatsFooter` 函数。
 
-当前 `WriteCtx` (`adapter.go:488-508`) 在 done 时只清理资源。改为先追加 stats 再关闭：
+#### 实际实现逻辑
 
-```go
-if env.Event.Type == events.Done {
-    // ...existing typing/reaction cleanup...
+Done 事件时，提取 turn summary 并渲染：
 
-    // 追加 stats footer 到流式卡片
-    if streamCtrl != nil && streamCtrl.IsCreated() {
-        if ss := extractSessionStats(env); ss != nil {
-            footer := formatFeishuStatsFooter(ss)
-            _ = streamCtrl.AppendContent(footer)
-        }
-        return streamCtrl.Close(ctx)
-    }
-    return nil
-}
+1. **流式卡片存在**：通过 `streamCtrl.Write("\n\n---\n_" + summaryText + "_")` 追加到卡片内
+2. **无流式卡片**：通过 `go c.sendTurnSummaryText(summaryText)` 以独立消息发送（reply 或 sendText，10s 超时）
+
+格式化统一使用 `FormatTurnSummary(TurnSummaryData)` 生成单行紧凑格式：
+
+```
+Sonnet · 24% · 42s · 🛠 12 tools · $0.04
 ```
 
-#### 4.3.2 Stats Footer 格式化
+severity icon 映射复用 `context_format.go` 的 `SeverityLevel` + `SeverityIcon`。
 
-```go
-func formatFeishuStatsFooter(ss map[string]any) string {
-    modelName, _ := ss["model_name"].(string)
-    duration, _ := ss["duration"].(string)
-    turnCount := toInt(ss["turn_count"])
-    toolCount := toInt(ss["tool_call_count"])
-    inputTok := toInt64(ss["total_input_tok"])
-    outputTok := toInt64(ss["total_output_tok"])
-    ctxPct, _ := ss["context_pct"].(float64)
-    cost, _ := ss["total_cost_usd"].(float64)
-
-    return fmt.Sprintf("\n\n---\n📊 **%s** · 🕐 %s · 🔄 %d轮 · 🔧 %d次工具\n"+
-        "🪙 %s in / %s out (%.0f%% ctx) · 💰 $%.4f",
-        modelName, duration, turnCount, toolCount,
-        formatTokenCount(inputTok), formatTokenCount(outputTok),
-        ctxPct, cost)
-}
-```
-
-#### 4.3.3 Streaming Controller 扩展
-
-**文件**: `internal/messaging/feishu/streaming.go`
-
-需确认 `streamCtrl` 是否已有追加内容的方法。若没有，需新增 `AppendContent(content string) error`，在关闭前向卡片 markdown element 追加内容。
-
-### 4.4 Phase 4: Slack 渲染
+### 4.4 Phase 4: Slack 渲染 ✅ Implemented (evolved)
 
 **文件**: `internal/messaging/slack/adapter.go`
 
-#### 4.4.1 Done 事件处理增强
+实际实现使用 `sendTurnSummary` + `buildTurnSummaryTable`，超出 spec 原始设计的 `postStatsBlock` + `ContextBlock` 方案。
 
-当前 `WriteCtx` (`adapter.go:460-466`) 在 done 时只清除 status。改为追加 stats 消息：
+#### 实际实现逻辑
 
-```go
-case events.Done, events.Error:
-    _ = c.adapter.statusMgr.Clear(ctx, c.channelID, c.threadTS)
-    c.adapter.activeIndicators.Stop(ctx, c.channelID, c.messageTS)
+Done 事件时，`go c.sendTurnSummary(ctx, env)` 异步发送：
 
-    // done 时追加 stats block
-    if env.Event.Type == events.Done {
-        if ss := extractSessionStats(env); ss != nil {
-            _ = c.postStatsBlock(ctx, ss)
-        }
-    }
-    return nil
-```
+1. **首选 TableBlock**：`buildTurnSummaryTable(d)` 构建富表格，包含 Turn#、Model、Context（含进度条）、Duration、Tools（含分类明细）、Tokens、WorkDir、GitBranch、Session duration
+2. **Fallback**：TableBlock 被拒绝时降级为 `FormatTurnSummaryRich(d)` 多行纯文本格式
+3. **最终 fallback**：rich text 也失败时 `log.Warn` 记录
 
-#### 4.4.2 Stats Block 消息
-
-```go
-func (c *SlackConn) postStatsBlock(ctx context.Context, ss map[string]any) error {
-    duration, _ := ss["duration"].(string)
-    turnCount := toInt(ss["turn_count"])
-    toolCount := toInt(ss["tool_call_count"])
-    inputTok := toInt64(ss["total_input_tok"])
-    outputTok := toInt64(ss["total_output_tok"])
-    ctxPct, _ := ss["context_pct"].(float64)
-    cost, _ := ss["total_cost_usd"].(float64)
-
-    text := fmt.Sprintf(
-        "🕐 %s · 🔄 %d turns · 🔧 %d tools · 🪙 %s/%s tok (%.0f%% ctx) · 💰 $%.4f",
-        duration, turnCount, toolCount,
-        formatTokenCount(inputTok), formatTokenCount(outputTok),
-        ctxPct, cost,
-    )
-
-    blocks := []slack.Block{
-        slack.NewContextBlock(
-            "stats",
-            slack.NewTextBlockObject("mrkdwn", text, false, nil),
-        ),
-    }
-
-    _, _, err := c.adapter.client.PostMessageContext(ctx, c.channelID,
-        slack.MsgOptionBlocks(blocks...),
-        slack.MsgOptionTS(c.threadTS),
-    )
-    return err
-}
-```
+数据提取使用 `messaging.ExtractTurnSummary(env)`，格式化使用 `FormatTurnSummary` / `FormatTurnSummaryRich`。
 
 ### 4.5 辅助函数
 

--- a/docs/specs/Turn-Summary-Spec.md
+++ b/docs/specs/Turn-Summary-Spec.md
@@ -186,14 +186,15 @@ case events.Done:
 `resetPerTurn()` 保持不变（在 conversation store 写入后调用）。
 `computePerTurnDeltas()` 是纯计算，提前调用安全。
 
-### 3.3 turn_summary.go
+### 3.3 turn_summary.go ✅ Implemented
 
-**新建** `internal/messaging/turn_summary.go`。
+**文件**: `internal/messaging/turn_summary.go`
+
+实际 `TurnSummaryData` 包含比 spec 更多的字段：
 
 ```go
-package messaging
-
 type TurnSummaryData struct {
+    // Spec 定义字段
     ContextPct     float64
     ContextWindow  int64
     TotalInputTok  int64
@@ -206,10 +207,20 @@ type TurnSummaryData struct {
     TurnOutputTok  int64
     TurnCostUSD    float64
     TotalCostUSD   float64
+
+    // 额外实现字段
+    ContextFill     int64
+    TotalOutputTok  int64
+    SessionDuration string
+    WorkDir         string
+    GitBranch       string
 }
 
 func ExtractTurnSummary(env *events.Envelope) TurnSummaryData { ... }
-func FormatTurnSummary(d TurnSummaryData) string { ... }
+func FormatTurnSummary(d TurnSummaryData) string { ... }      // 紧凑单行
+func FormatTurnSummaryRich(d TurnSummaryData) string { ... }  // 多行（Slack fallback）
+func TruncatePath(p string) string { ... }
+func FormatSessionDuration(d string) string { ... }
 ```
 
 **复用已有工具**（`context_format.go`）：
@@ -291,21 +302,90 @@ func (c *FeishuConn) sendTurnSummary(ctx context.Context, env *events.Envelope) 
 
 ---
 
-## 4. WebChat 前端
+## 4. WebChat 前端 ✅ Implemented
 
-无需后端改动。前端从 `DoneData.Stats["_session"]` 渲染。
+### 4.1 数据流
 
-扩展后的 `_session` 数据供前端展示：
+后端无需额外改动。`_session` 数据通过 AEP `done` 事件到达前端：
 
 ```
-Context: 🟢 24% [██████░░░░] 48K/200K
-Model: Sonnet 4 | Turn: 3
-Input: ~12K tokens | Output: ~2K tokens
-Tools: Read × 5, Bash × 3, Edit × 2, Grep × 2
-Duration: 42s | Cost: $0.04 (Total: $0.12)
+Gateway → done envelope → BrowserHotPlexClient._routeEvent()
+  → handleDone(data) → data.stats._session → TurnSummaryCard
 ```
 
-前端可自行决定渲染粒度和展示风格。
+### 4.2 类型定义
+
+`webchat/lib/ai-sdk-transport/client/types.ts` 扩展 `DoneStats`：
+
+```typescript
+export interface DoneStats {
+  // ... existing fields ...
+  _session?: TurnSessionStats;
+}
+
+export interface TurnSessionStats {
+  turn_count: number;
+  tool_call_count: number;
+  model_name: string;
+  context_pct: number;
+  context_window: number;
+  context_fill: number;
+  total_input_tok: number;
+  total_output_tok: number;
+  total_cost_usd: number;
+  turn_duration_ms: number;
+  turn_input_tok: number;
+  turn_output_tok: number;
+  turn_cost_usd: number;
+  tool_names: Record<string, number> | null;
+  duration: string;
+  duration_seconds: number;
+  work_dir: string;
+  git_branch: string;
+}
+```
+
+### 4.3 Adapter 注入
+
+`webchat/lib/adapters/hotplex-runtime-adapter.ts`：
+- `MessagePart` union 包含 `TurnSummaryPart`（type: `turn-summary`, data: `TurnSessionStats`）
+- `handleDone` 中提取 `_session` 数据，追加 `turn-summary` part 到最后一条 assistant message
+- `adapterMessages` filter 过滤 `turn-summary` 类型（同 `context-usage` 逻辑）
+- `convertToThreadMessage` 通过 `metadata.turnSummary` 传递数据
+
+### 4.4 TurnSummaryCard 组件
+
+`webchat/components/assistant-ui/TurnSummaryCard.tsx`：
+- 遵循 `ContextUsageCard.tsx` 的动画和样式模式
+- severity coloring（复用 context-format severity 逻辑）
+- 紧凑布局：Model · Context bar · Tools · Duration · Cost
+
+### 4.5 渲染集成
+
+`webchat/components/assistant-ui/thread.tsx` `AssistantMessage` 中，在 `ContextUsageCard` 之后渲染 `TurnSummaryCard`。
+
+---
+
+## 5. WebChat Dedup & Filtering
+
+`webchat/lib/adapters/hotplex-runtime-adapter.ts` 中存在三层去重/过滤机制：
+
+### 5.1 Server History Merge Dedup
+
+加载服务端历史消息时，与本地 live 消息进行双层去重：
+
+- **ID-based**：以服务端消息 ID 集合为准，丢弃匹配的本地消息
+- **Content-signature-based**：对 `role:text` 内容签名匹配的本地消息丢弃（处理本地 `user-${Date.now()}` ID 与服务端 ID 不一致的场景）
+
+合并顺序：`[...serverMessages, ...liveOnly]`，服务端消息优先。
+
+### 5.2 Output Dedup for assistant-ui
+
+`adapterMessages` 使用 `useMemo` + `Set<string>` 过滤重复 ID 消息，防止 assistant-ui `MessageRepository` "same id already exists" 错误。`handleMessage` 和 `handleDelta+handleDone` 可为同一逻辑内容创建消息，此去重层确保不重复。
+
+### 5.3 Context-usage Message Filtering
+
+纯 `context-usage` 类型 part 的消息从 adapter 输出中过滤。`context_usage` 事件通过 `handleContextUsage` 创建独立消息，`ContextUsageCard` 通过 `metadata.contextUsage` 渲染（不作为可见对话消息）。不过滤会导致空 assistant 消息出现。
 
 ---
 

--- a/internal/agentconfig/META-COGNITION.md
+++ b/internal/agentconfig/META-COGNITION.md
@@ -47,8 +47,7 @@ HotPlex Gateway 元认知。
 
 ## 控制命令
 
-  /gc, $gc：         清理 Session（→ TERMINATED，释放 Worker）
-  /reset, $reset：   重置（Terminate + fresh Worker，保留 Session）
-  /park, $park：     休眠（→ IDLE，Worker 暂停）
-  /new, $new：       新建 Session（不同 Session Key）
+  /gc：              清理 Session（→ TERMINATED，释放 Worker）
+  /reset：           重置（Terminate + fresh Worker，复用 Session ID）
   /cd <路径>：       SwitchWorkDir（新 workDir 推导新 Session Key）
+  自然语言前缀 $：    $gc, $休眠, $挂起 → gc；$reset, $重置 → reset

--- a/internal/agentconfig/META-COGNITION.md
+++ b/internal/agentconfig/META-COGNITION.md
@@ -41,7 +41,8 @@ HotPlex Gateway 元认知。
 
 - B 通道（SOUL/AGENTS/SKILLS）：合并注入 system prompt（S3 尾部 for CC，body.system for OCS），无 hedging，优先级高
 - C 通道（USER/MEMORY）：注入 <context> section
-- 平台变体：SOUL.slack.md / SOUL.feishu.md 追加到基础文件（追加模式，非替换）
+- 三级目录 fallback：每个文件独立解析，bot 级 > 平台级 > 全局级（替换模式，非追加）
+  - 全局：SOUL.md / 平台：slack/SOUL.md / Bot：slack/U12345/SOUL.md
 - frontmatter（--- 包裹的 YAML 元数据）自动剥离；每文件最大 8K，全部最大 40K
 
 ## 控制命令

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -91,6 +91,9 @@ func Load(dir, platform, botID string) (*AgentConfigs, error) {
 
 // resolveFile implements the 3-level per-file fallback.
 // Returns the content of the first non-empty file found, or ("", nil) if none exist.
+// Non-NotExist I/O errors (e.g., permission denied) are propagated immediately
+// rather than falling through — a file that exists but is unreadable indicates
+// a real configuration problem that should not be silently masked.
 func resolveFile(dir, platform, botID, fileName string) (string, error) {
 	// 1. Bot-level: dir/platform/botID/fileName
 	if botID != "" && platform != "" {

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -13,11 +13,11 @@ import (
 
 // AgentConfigs holds loaded content for all agent config files.
 type AgentConfigs struct {
-	Soul   string // SOUL.md + SOUL.<platform>.md  (B channel)
-	Agents string // AGENTS.md + AGENTS.<platform>.md (B channel)
-	Skills string // SKILLS.md + SKILLS.<platform>.md (B channel)
-	User   string // USER.md + USER.<platform>.md  (C channel)
-	Memory string // MEMORY.md + MEMORY.<platform>.md (C channel)
+	Soul   string // SOUL.md   (B channel)
+	Agents string // AGENTS.md (B channel)
+	Skills string // SKILLS.md (B channel)
+	User   string // USER.md   (C channel)
+	Memory string // MEMORY.md (C channel)
 }
 
 // MaxFileChars is the maximum character limit per file.
@@ -26,26 +26,35 @@ const MaxFileChars = 8_000
 // MaxTotalChars is the maximum combined character limit across all files.
 const MaxTotalChars = 40_000
 
-// Load reads all config files from dir, appending platform-specific variants.
+// Load reads all config files from dir using 3-level per-file fallback:
+//
+//  1. dir/{platform}/{botID}/{file}    — bot-level (highest priority)
+//  2. dir/{platform}/{file}            — platform-level
+//  3. dir/{file}                       — global-level
+//
+// Each file resolves independently. Missing files fall through to the next level.
+// Platform can be "slack", "feishu", "webchat", or "" (no platform-level lookup).
+// botID is used directly as directory name (e.g., Slack UserID, Feishu OpenID).
 // Returns AgentConfigs with frontmatter stripped and size limits enforced.
-// Platform can be "slack", "feishu", or "" (websocket/gateway direct).
-// Missing files are silently skipped. Non-NotExist errors (permission denied, I/O errors) are returned.
-func Load(dir, platform string) (*AgentConfigs, error) {
+func Load(dir, platform, botID string) (*AgentConfigs, error) {
 	if dir == "" {
 		return &AgentConfigs{}, nil
+	}
+
+	// Path safety: botID must not contain path traversal components.
+	if botID != "" && filepath.Base(botID) != botID {
+		return nil, fmt.Errorf("agentconfig: invalid botID %q: path separators not allowed", botID)
 	}
 
 	c := &AgentConfigs{}
 	var total int
 
 	load := func(baseName string, target *string) error {
-		content, n, err := loadFileWithErrorCount(dir, baseName, platform)
+		content, err := resolveFile(dir, platform, botID, baseName)
 		if err != nil {
-			if !os.IsNotExist(err) {
-				return err
-			}
-			return nil // missing file is expected
+			return err
 		}
+		n := len(content)
 		if n == 0 {
 			return nil
 		}
@@ -80,40 +89,31 @@ func Load(dir, platform string) (*AgentConfigs, error) {
 	return c, nil
 }
 
-// loadFileWithErrorCount is a helper that wraps loadFile and returns character count.
-func loadFileWithErrorCount(dir, baseName, platform string) (string, int, error) {
-	content, err := loadFile(dir, baseName, platform)
-	if err != nil {
-		return "", 0, err
-	}
-	return content, len(content), nil
-}
-
-// loadFile reads a base file and appends its platform variant.
-// Returns the combined content and total character count.
-// Propagates non-NotExist errors from readFile (permission denied, I/O errors).
-func loadFile(dir, baseName, platform string) (string, error) {
-	content, err := readFile(dir, baseName)
-	if err != nil {
-		return "", err
-	}
-	if platform != "" {
-		ext := filepath.Ext(baseName)
-		prefix := strings.TrimSuffix(baseName, ext)
-		variantName := prefix + "." + platform + ext
-		variant, err := readFile(dir, variantName)
-		if err != nil && !os.IsNotExist(err) {
+// resolveFile implements the 3-level per-file fallback.
+// Returns the content of the first non-empty file found, or ("", nil) if none exist.
+func resolveFile(dir, platform, botID, fileName string) (string, error) {
+	// 1. Bot-level: dir/platform/botID/fileName
+	if botID != "" && platform != "" {
+		content, err := readFile(filepath.Join(dir, platform, botID), fileName)
+		if err != nil {
 			return "", err
 		}
-		if variant != "" {
-			if content != "" {
-				content += "\n\n" + variant
-			} else {
-				content = variant
-			}
+		if content != "" {
+			return content, nil
 		}
 	}
-	return content, nil
+	// 2. Platform-level: dir/platform/fileName
+	if platform != "" {
+		content, err := readFile(filepath.Join(dir, platform), fileName)
+		if err != nil {
+			return "", err
+		}
+		if content != "" {
+			return content, nil
+		}
+	}
+	// 3. Global-level: dir/fileName
+	return readFile(dir, fileName)
 }
 
 // readFile reads a file, strips YAML frontmatter, and enforces per-file size limit.

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -182,6 +182,31 @@ func TestLoad(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "agentconfig: read")
 	})
+
+	t.Run("permission denied at bot-level returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "slack/U12345/SOUL.md", "Bot soul.")
+		writeFile(t, dir, "slack/SOUL.md", "Platform soul.")
+
+		botFile := filepath.Join(dir, "slack", "U12345", "SOUL.md")
+		require.NoError(t, os.Chmod(botFile, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(botFile, 0o644) })
+
+		_, err := Load(dir, "slack", "U12345")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "agentconfig: read")
+	})
+
+	t.Run("botID ignored when platform is empty", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+
+		cfg, err := Load(dir, "", "U12345")
+		require.NoError(t, err)
+		require.Equal(t, "Global soul.", cfg.Soul)
+	})
 }
 
 func TestSizeLimits(t *testing.T) {

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -15,21 +15,21 @@ func TestLoad(t *testing.T) {
 	t.Run("empty dir returns empty configs", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		require.True(t, cfg.IsEmpty())
 	})
 
 	t.Run("nonexistent dir returns empty configs", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := Load("/nonexistent/path", "")
+		cfg, err := Load("/nonexistent/path", "", "")
 		require.NoError(t, err)
 		require.True(t, cfg.IsEmpty())
 	})
 
 	t.Run("empty dir string returns empty configs", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := Load("", "")
+		cfg, err := Load("", "", "")
 		require.NoError(t, err)
 		require.True(t, cfg.IsEmpty())
 	})
@@ -41,7 +41,7 @@ func TestLoad(t *testing.T) {
 		writeFile(t, dir, "AGENTS.md", "Workspace rules here.")
 		writeFile(t, dir, "USER.md", "User profile data.")
 
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		require.False(t, cfg.IsEmpty())
 		require.Equal(t, "I am an AI assistant.", cfg.Soul)
@@ -56,42 +56,107 @@ func TestLoad(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "SOUL.md", "---\nversion: 1\ndescription: test\n---\nActual content.")
 
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		require.Equal(t, "Actual content.", cfg.Soul)
 	})
 
-	t.Run("appends platform variant", func(t *testing.T) {
+	t.Run("platform directory overrides global", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+		writeFile(t, dir, "slack/SOUL.md", "Slack soul.")
+
+		cfg, err := Load(dir, "slack", "")
+		require.NoError(t, err)
+		require.Equal(t, "Slack soul.", cfg.Soul)
+	})
+
+	t.Run("bot-level overrides platform-level", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+		writeFile(t, dir, "slack/SOUL.md", "Platform soul.")
+		writeFile(t, dir, "slack/U12345/SOUL.md", "Bot soul.")
+
+		cfg, err := Load(dir, "slack", "U12345")
+		require.NoError(t, err)
+		require.Equal(t, "Bot soul.", cfg.Soul)
+	})
+
+	t.Run("falls back to global when platform dir missing", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+
+		cfg, err := Load(dir, "slack", "")
+		require.NoError(t, err)
+		require.Equal(t, "Global soul.", cfg.Soul)
+	})
+
+	t.Run("each file resolves independently", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+		writeFile(t, dir, "AGENTS.md", "Global agents.")
+		writeFile(t, dir, "slack/SOUL.md", "Slack soul.")
+		// AGENTS.md not in slack/ — should use global.
+
+		cfg, err := Load(dir, "slack", "")
+		require.NoError(t, err)
+		require.Equal(t, "Slack soul.", cfg.Soul)
+		require.Equal(t, "Global agents.", cfg.Agents)
+	})
+
+	t.Run("suffix files are not loaded", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		writeFile(t, dir, "SOUL.md", "Base soul.")
-		writeFile(t, dir, "SOUL.slack.md", "Slack specifics.")
+		writeFile(t, dir, "SOUL.slack.md", "Old-style variant.")
 
-		cfg, err := Load(dir, "slack")
-		require.NoError(t, err)
-		require.Contains(t, cfg.Soul, "Base soul.")
-		require.Contains(t, cfg.Soul, "Slack specifics.")
-	})
-
-	t.Run("platform variant only without base", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeFile(t, dir, "SOUL.slack.md", "Slack only.")
-
-		cfg, err := Load(dir, "slack")
-		require.NoError(t, err)
-		require.Equal(t, "Slack only.", cfg.Soul)
-	})
-
-	t.Run("no platform variant when empty", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeFile(t, dir, "SOUL.md", "Base soul.")
-		writeFile(t, dir, "SOUL.slack.md", "Slack specifics.")
-
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "slack", "")
 		require.NoError(t, err)
 		require.Equal(t, "Base soul.", cfg.Soul)
+		// SOUL.slack.md is NOT loaded — old suffix mechanism removed.
+	})
+
+	t.Run("path traversal botID rejected", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		_, err := Load(dir, "slack", "../etc")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid botID")
+	})
+
+	t.Run("path traversal with dots rejected", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		_, err := Load(dir, "slack", "foo/bar")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid botID")
+	})
+
+	t.Run("empty file falls through to next level", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+		writeFile(t, dir, "slack/SOUL.md", "---\n---\n") // frontmatter only = empty content
+
+		cfg, err := Load(dir, "slack", "")
+		require.NoError(t, err)
+		require.Equal(t, "Global soul.", cfg.Soul)
+	})
+
+	t.Run("flat directory backward compatible", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Soul content.")
+		writeFile(t, dir, "AGENTS.md", "Agents content.")
+
+		cfg, err := Load(dir, "", "")
+		require.NoError(t, err)
+		require.Equal(t, "Soul content.", cfg.Soul)
+		require.Equal(t, "Agents content.", cfg.Agents)
 	})
 
 	t.Run("missing files are skipped", func(t *testing.T) {
@@ -99,7 +164,7 @@ func TestLoad(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "AGENTS.md", "Rules.")
 
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		require.Empty(t, cfg.Soul)
 		require.Equal(t, "Rules.", cfg.Agents)
@@ -109,12 +174,11 @@ func TestLoad(t *testing.T) {
 	t.Run("permission denied returns error", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		// Create a file with no read permissions
 		filePath := filepath.Join(dir, "SOUL.md")
 		err := os.WriteFile(filePath, []byte("Content"), 0o000)
 		require.NoError(t, err)
 
-		_, err = Load(dir, "")
+		_, err = Load(dir, "", "")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "agentconfig: read")
 	})
@@ -129,7 +193,7 @@ func TestSizeLimits(t *testing.T) {
 		longContent := strings.Repeat("x", MaxFileChars+1000)
 		writeFile(t, dir, "SOUL.md", longContent)
 
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		require.Equal(t, MaxFileChars, len(cfg.Soul))
 	})
@@ -137,12 +201,11 @@ func TestSizeLimits(t *testing.T) {
 	t.Run("total limit enforced", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		// Write files that individually are under limit but combined exceed total.
 		content := strings.Repeat("a", MaxTotalChars/2+1)
 		writeFile(t, dir, "SOUL.md", content)
 		writeFile(t, dir, "AGENTS.md", content)
 
-		cfg, err := Load(dir, "")
+		cfg, err := Load(dir, "", "")
 		require.NoError(t, err)
 		total := len(cfg.Soul) + len(cfg.Agents) + len(cfg.Skills) + len(cfg.User) + len(cfg.Memory)
 		require.LessOrEqual(t, total, MaxTotalChars)
@@ -210,7 +273,6 @@ func TestBuildSystemPrompt(t *testing.T) {
 		require.Contains(t, prompt, "<directives>")
 		require.Contains(t, prompt, "<rules>")
 		require.NotContains(t, prompt, "<persona>")
-		// hotplex metacognition is always injected into <context> regardless of user config
 		require.Contains(t, prompt, "<context>")
 		require.Contains(t, prompt, "<hotplex>")
 		require.NotContains(t, prompt, "<user>")
@@ -251,6 +313,8 @@ func TestBuildSystemPrompt(t *testing.T) {
 
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
-	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644)
+	fullPath := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	err := os.WriteFile(fullPath, []byte(content), 0o644)
 	require.NoError(t, err)
 }

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -14,12 +14,22 @@ import (
 // agentConfigSuffixChecker detects deprecated platform-suffix files
 // (e.g., SOUL.slack.md) in the agent-configs directory and suggests
 // migration to the new directory-based layout.
-type agentConfigSuffixChecker struct{}
+type agentConfigSuffixChecker struct {
+	dir string // override for testing; defaults to config.HotplexHome()/agent-configs
+}
 
 func (c agentConfigSuffixChecker) Name() string     { return "agent.suffix_deprecated" }
 func (c agentConfigSuffixChecker) Category() string { return "agent_config" }
+
+func (c agentConfigSuffixChecker) scanDir() string {
+	if c.dir != "" {
+		return c.dir
+	}
+	return filepath.Join(config.HotplexHome(), "agent-configs")
+}
+
 func (c agentConfigSuffixChecker) Check(_ context.Context) cli.Diagnostic {
-	dir := filepath.Join(config.HotplexHome(), "agent-configs")
+	dir := c.scanDir()
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -1,0 +1,79 @@
+package checkers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// agentConfigSuffixChecker detects deprecated platform-suffix files
+// (e.g., SOUL.slack.md) in the agent-configs directory and suggests
+// migration to the new directory-based layout.
+type agentConfigSuffixChecker struct{}
+
+func (c agentConfigSuffixChecker) Name() string     { return "agent.suffix_deprecated" }
+func (c agentConfigSuffixChecker) Category() string { return "agent_config" }
+func (c agentConfigSuffixChecker) Check(_ context.Context) cli.Diagnostic {
+	dir := filepath.Join(config.HotplexHome(), "agent-configs")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cli.Diagnostic{
+				Name:     c.Name(),
+				Category: c.Category(),
+				Status:   cli.StatusWarn,
+				Message:  "Agent config directory does not exist",
+				FixHint:  fmt.Sprintf("Create it: mkdir -p %s", dir),
+			}
+		}
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot read agent config directory: " + err.Error(),
+		}
+	}
+
+	platforms := []string{"slack", "feishu", "webchat"}
+	var deprecated []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		for _, p := range platforms {
+			suffix := "." + p + ".md"
+			if strings.HasSuffix(name, suffix) {
+				deprecated = append(deprecated, name)
+			}
+		}
+	}
+
+	if len(deprecated) == 0 {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "No deprecated platform-suffix files found",
+		}
+	}
+
+	return cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusWarn,
+		Message:  fmt.Sprintf("Deprecated suffix files: %s", strings.Join(deprecated, ", ")),
+		FixHint: fmt.Sprintf("Move to directory layout:\n  mkdir -p %s/slack && mv %s %s/slack/SOUL.md",
+			dir, filepath.Join(dir, deprecated[0]), dir),
+	}
+}
+
+func init() {
+	cli.DefaultRegistry.Register(agentConfigSuffixChecker{})
+}

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -86,4 +86,95 @@ func (c agentConfigSuffixChecker) Check(_ context.Context) cli.Diagnostic {
 
 func init() {
 	cli.DefaultRegistry.Register(agentConfigSuffixChecker{})
+	cli.DefaultRegistry.Register(agentConfigDirChecker{})
+}
+
+// agentConfigDirChecker validates the agent-configs directory structure,
+// ensuring platform subdirectories contain only recognized config files.
+type agentConfigDirChecker struct {
+	dir string // override for testing; defaults to config.HotplexHome()/agent-configs
+}
+
+func (c agentConfigDirChecker) Name() string     { return "agent.directory_structure" }
+func (c agentConfigDirChecker) Category() string { return "agent_config" }
+
+func (c agentConfigDirChecker) scanDir() string {
+	if c.dir != "" {
+		return c.dir
+	}
+	return filepath.Join(config.HotplexHome(), "agent-configs")
+}
+
+var validConfigFiles = map[string]bool{
+	"SOUL.md": true, "AGENTS.md": true, "SKILLS.md": true,
+	"USER.md": true, "MEMORY.md": true,
+}
+
+// ignoredFiles are non-config files allowed in any directory without warning.
+var ignoredFiles = map[string]bool{
+	".gitkeep": true, "README.md": true, ".DS_Store": true,
+}
+
+func (c agentConfigDirChecker) Check(_ context.Context) cli.Diagnostic {
+	dir := c.scanDir()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot read agent config directory: " + err.Error(),
+		}
+	}
+
+	var warnings []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Platform directory (slack/, feishu/, webchat/, etc.)
+		platformDir := filepath.Join(dir, e.Name())
+		c.checkSubdir(platformDir, e.Name(), &warnings)
+	}
+
+	if len(warnings) == 0 {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "Agent config directory structure is valid",
+		}
+	}
+
+	return cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusWarn,
+		Message:  fmt.Sprintf("Unrecognized files in agent config: %s", strings.Join(warnings, ", ")),
+		FixHint:  "Remove or relocate non-config .md files from platform subdirectories. Valid names: SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md",
+	}
+}
+
+func (c agentConfigDirChecker) checkSubdir(platformDir, platformName string, warnings *[]string) {
+	entries, err := os.ReadDir(platformDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			// Bot-level subdirectory — validate its contents too
+			botDir := filepath.Join(platformDir, e.Name())
+			c.checkSubdir(botDir, platformName+"/"+e.Name(), warnings)
+			continue
+		}
+		name := e.Name()
+		if validConfigFiles[name] || ignoredFiles[name] {
+			continue
+		}
+		// Non-.md files or unrecognized .md files in platform/bot directories
+		if strings.HasSuffix(name, ".md") {
+			*warnings = append(*warnings, filepath.Join(platformName, name))
+		}
+	}
 }

--- a/internal/cli/checkers/agentconfig_test.go
+++ b/internal/cli/checkers/agentconfig_test.go
@@ -9,22 +9,41 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/cli"
-	"github.com/hrygo/hotplex/internal/config"
 )
 
 func TestAgentConfigSuffixChecker(t *testing.T) {
-	c := agentConfigSuffixChecker{}
+	t.Parallel()
+
+	t.Run("nonexistent directory", func(t *testing.T) {
+		t.Parallel()
+		c := agentConfigSuffixChecker{dir: filepath.Join(t.TempDir(), "nonexistent")}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusWarn, d.Status)
+		require.Contains(t, d.Message, "does not exist")
+		require.NotEmpty(t, d.FixHint)
+	})
+
+	t.Run("clean directory no suffix files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		cfgDir := filepath.Join(dir, "agent-configs")
+		require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "SOUL.md"), []byte("global soul"), 0o644))
+
+		c := agentConfigSuffixChecker{dir: cfgDir}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
 
 	t.Run("deprecated suffix files detected", func(t *testing.T) {
-		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
+		t.Parallel()
+		dir := t.TempDir()
+		cfgDir := filepath.Join(dir, "agent-configs")
 		require.NoError(t, os.MkdirAll(cfgDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "SOUL.slack.md"), []byte("slack soul"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "USER.feishu.md"), []byte("feishu user"), 0o644))
-		t.Cleanup(func() {
-			_ = os.Remove(filepath.Join(cfgDir, "SOUL.slack.md"))
-			_ = os.Remove(filepath.Join(cfgDir, "USER.feishu.md"))
-		})
 
+		c := agentConfigSuffixChecker{dir: cfgDir}
 		d := c.Check(context.Background())
 		require.Equal(t, cli.StatusWarn, d.Status)
 		require.Contains(t, d.Message, "SOUL.slack.md")
@@ -33,19 +52,13 @@ func TestAgentConfigSuffixChecker(t *testing.T) {
 	})
 
 	t.Run("directory entries ignored", func(t *testing.T) {
-		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
+		t.Parallel()
+		dir := t.TempDir()
+		cfgDir := filepath.Join(dir, "agent-configs")
 		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "SOUL.md"), []byte("slack soul"), 0o644))
-		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(cfgDir, "slack")) })
 
-		d := c.Check(context.Background())
-		require.Equal(t, cli.StatusPass, d.Status)
-	})
-
-	t.Run("clean directory passes", func(t *testing.T) {
-		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
-		require.NoError(t, os.MkdirAll(cfgDir, 0o755))
-
+		c := agentConfigSuffixChecker{dir: cfgDir}
 		d := c.Check(context.Background())
 		require.Equal(t, cli.StatusPass, d.Status)
 	})

--- a/internal/cli/checkers/agentconfig_test.go
+++ b/internal/cli/checkers/agentconfig_test.go
@@ -1,0 +1,52 @@
+package checkers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+func TestAgentConfigSuffixChecker(t *testing.T) {
+	c := agentConfigSuffixChecker{}
+
+	t.Run("deprecated suffix files detected", func(t *testing.T) {
+		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
+		require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "SOUL.slack.md"), []byte("slack soul"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "USER.feishu.md"), []byte("feishu user"), 0o644))
+		t.Cleanup(func() {
+			_ = os.Remove(filepath.Join(cfgDir, "SOUL.slack.md"))
+			_ = os.Remove(filepath.Join(cfgDir, "USER.feishu.md"))
+		})
+
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusWarn, d.Status)
+		require.Contains(t, d.Message, "SOUL.slack.md")
+		require.Contains(t, d.Message, "USER.feishu.md")
+		require.NotEmpty(t, d.FixHint)
+	})
+
+	t.Run("directory entries ignored", func(t *testing.T) {
+		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
+		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "SOUL.md"), []byte("slack soul"), 0o644))
+		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(cfgDir, "slack")) })
+
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
+
+	t.Run("clean directory passes", func(t *testing.T) {
+		cfgDir := filepath.Join(config.HotplexHome(), "agent-configs")
+		require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
+}

--- a/internal/cli/checkers/agentconfig_test.go
+++ b/internal/cli/checkers/agentconfig_test.go
@@ -63,3 +63,62 @@ func TestAgentConfigSuffixChecker(t *testing.T) {
 		require.Equal(t, cli.StatusPass, d.Status)
 	})
 }
+
+func TestAgentConfigDirChecker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid structure passes", func(t *testing.T) {
+		t.Parallel()
+		cfgDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "SOUL.md"), []byte("soul"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "AGENTS.md"), []byte("agents"), 0o644))
+
+		c := agentConfigDirChecker{dir: cfgDir}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
+
+	t.Run("valid with bot subdirectory", func(t *testing.T) {
+		t.Parallel()
+		cfgDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack", "U12345"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "U12345", "SOUL.md"), []byte("bot soul"), 0o644))
+
+		c := agentConfigDirChecker{dir: cfgDir}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
+
+	t.Run("unrecognized md file in platform dir warns", func(t *testing.T) {
+		t.Parallel()
+		cfgDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "custom.md"), []byte("custom"), 0o644))
+
+		c := agentConfigDirChecker{dir: cfgDir}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusWarn, d.Status)
+		require.Contains(t, d.Message, "custom.md")
+	})
+
+	t.Run("ignored files are allowed", func(t *testing.T) {
+		t.Parallel()
+		cfgDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "slack"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", ".gitkeep"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "slack", "README.md"), []byte("readme"), 0o644))
+
+		c := agentConfigDirChecker{dir: cfgDir}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusPass, d.Status)
+	})
+
+	t.Run("nonexistent directory warns", func(t *testing.T) {
+		t.Parallel()
+		c := agentConfigDirChecker{dir: filepath.Join(t.TempDir(), "nonexistent")}
+		d := c.Check(context.Background())
+		require.Equal(t, cli.StatusWarn, d.Status)
+		require.Contains(t, d.Message, "Cannot read")
+	})
+}

--- a/internal/cli/onboard/wizard.go
+++ b/internal/cli/onboard/wizard.go
@@ -714,7 +714,7 @@ func stepAgentConfig() (StepResult, []string) {
 	return StepResult{
 		Name:   "agent_config",
 		Status: "pass",
-		Detail: fmt.Sprintf("%s (%s)", dir, strings.Join(created, ", ")),
+		Detail: fmt.Sprintf("%s (%s) — per-bot: %s/<platform>/<botID>/SOUL.md", dir, strings.Join(created, ", "), dir),
 	}, created
 }
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -1087,7 +1087,13 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID str
 	}
 	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID)
 	if err != nil {
-		b.log.Warn("bridge: agent config load failed", "dir", b.agentConfigDir, "err", err)
+		if strings.Contains(err.Error(), "invalid botID") {
+			b.log.Error("bridge: agent config rejected botID",
+				"dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "err", err)
+		} else {
+			b.log.Warn("bridge: agent config load failed",
+				"dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "err", err)
+		}
 		return
 	}
 	if configs.IsEmpty() {

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -122,6 +122,7 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 		wt:         wt,
 		workerInfo: workerInfo,
 		platform:   platform,
+		botID:      botID,
 	},
 		func(ctx context.Context, w worker.Worker) error {
 			if err := w.Start(ctx, workerInfo); err != nil {
@@ -159,6 +160,7 @@ type workerLaunchParams struct {
 	wt          worker.WorkerType
 	workerInfo  worker.SessionInfo
 	platform    string
+	botID       string
 	forwardOpts forwardOpts
 }
 
@@ -191,7 +193,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		return nil, fmt.Errorf("bridge: attach worker: %w", err)
 	}
 
-	b.injectAgentConfig(&params.workerInfo, params.platform)
+	b.injectAgentConfig(&params.workerInfo, params.platform, params.botID)
 
 	if err := startFn(params.ctx, w); err != nil {
 		b.sm.DetachWorker(sid)
@@ -256,6 +258,7 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		wt:          si.WorkerType,
 		workerInfo:  workerInfo,
 		platform:    si.Platform,
+		botID:       si.BotID,
 		forwardOpts: opts,
 	},
 		func(ctx context.Context, w worker.Worker) error {
@@ -775,6 +778,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		wt:         si.WorkerType,
 		workerInfo: workerInfo,
 		platform:   si.Platform,
+		botID:      si.BotID,
 	},
 		func(ctx context.Context, w worker.Worker) error {
 			if err := b.sm.Transition(ctx, p.sessionID, events.StateRunning); err != nil {
@@ -855,8 +859,8 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 //  3. No worker, state=CREATED → Start (--session-id)
 //  4. No worker, state=RUNNING/IDLE/TERMINATED → Resume (--resume)
 //     If Resume fails (files gone/corrupted), fall back to Start (--session-id)
-func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string) error {
-	b.log.Debug("bridge: StartPlatformSession called", "session_id", sessionID, "owner_id", ownerID, "worker_type", workerType, "work_dir", workDir, "platform", platform, "platform_key", platformKey)
+func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error {
+	b.log.Debug("bridge: StartPlatformSession called", "session_id", sessionID, "owner_id", ownerID, "worker_type", workerType, "work_dir", workDir, "platform", platform, "platform_key", platformKey, "bot_id", botID)
 	si, err := b.sm.Get(sessionID)
 	if err == nil {
 		if w := b.sm.GetWorker(sessionID); w != nil {
@@ -871,7 +875,7 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		// Orphan: session record exists but worker is gone.
 		if si.State == events.StateCreated {
 			b.log.Info("bridge: orphan platform session unstarted, starting fresh", "session_id", sessionID)
-			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey)
+			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID)
 		}
 		// RUNNING/IDLE/TERMINATED — try Resume to preserve conversation history.
 		// If Resume fails (session files deleted or corrupted), fall back to Start.
@@ -879,7 +883,7 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		if err := b.ResumeSession(ctx, sessionID, workDir); err != nil {
 			b.log.Warn("bridge: resume failed, falling back to new session",
 				"session_id", sessionID, "state", si.State, "err", err)
-			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey)
+			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID)
 		}
 		return nil
 	}
@@ -889,14 +893,14 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		return fmt.Errorf("bridge: no worker_type configured for platform session %s", sessionID)
 	}
 
-	return b.startOrResumeOnInUse(ctx, sessionID, ownerID, wt, workDir, platform, platformKey)
+	return b.startOrResumeOnInUse(ctx, sessionID, ownerID, wt, workDir, platform, platformKey, botID)
 }
 
 // startOrResumeOnInUse attempts StartSession; if the worker reports its session
 // files are already in use (leftover from a crashed session), falls back to
 // ResumeSession to recover the existing conversation history.
-func (b *Bridge) startOrResumeOnInUse(ctx context.Context, sessionID, ownerID string, wt worker.WorkerType, workDir, platform string, platformKey map[string]string) error {
-	if err := b.StartSession(ctx, sessionID, ownerID, "", wt, nil, workDir, platform, platformKey, ""); err != nil {
+func (b *Bridge) startOrResumeOnInUse(ctx context.Context, sessionID, ownerID string, wt worker.WorkerType, workDir, platform string, platformKey map[string]string, botID string) error {
+	if err := b.StartSession(ctx, sessionID, ownerID, botID, wt, nil, workDir, platform, platformKey, ""); err != nil {
 		if isWorkerInUseError(err) {
 			b.log.Info("bridge: worker rejected as in-use, switching to resume", "session_id", sessionID, "err", err)
 			return b.ResumeSession(ctx, sessionID, workDir)
@@ -1077,11 +1081,11 @@ func (b *Bridge) CancelRetry(sessionID string) {
 // injectAgentConfig loads agent config files and injects the unified system
 // prompt into session info. A no-op when config dir is empty or agent config
 // is not configured.
-func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform string) {
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string) {
 	if b.agentConfigDir == "" {
 		return
 	}
-	configs, err := agentconfig.Load(b.agentConfigDir, platform)
+	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID)
 	if err != nil {
 		b.log.Warn("bridge: agent config load failed", "dir", b.agentConfigDir, "err", err)
 		return

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -253,4 +255,107 @@ func TestInjectSessionStats_NonDoneData(t *testing.T) {
 	// Should be a no-op — no panic, data unchanged.
 	b.injectSessionStats(env, acc)
 	assert.Equal(t, "hello", env.Event.Data)
+}
+
+// ─── PBAC-015: injectAgentConfig BotID Resolution ─────────────────────────────
+
+func writeAgentConfigFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	fullPath := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
+}
+
+func TestBridge_InjectAgentConfig_BotIDResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) string // returns config dir
+		platform    string
+		botID       string
+		wantContain string
+		wantEmpty   bool
+	}{
+		{
+			name: "bot-level overrides platform",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeAgentConfigFile(t, dir, "webchat/SOUL.md", "Platform soul.")
+				writeAgentConfigFile(t, dir, "webchat/my-bot/SOUL.md", "Bot soul.")
+				return dir
+			},
+			platform:    "webchat",
+			botID:       "my-bot",
+			wantContain: "Bot soul.",
+		},
+		{
+			name: "empty bot uses platform",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeAgentConfigFile(t, dir, "SOUL.md", "Global soul.")
+				writeAgentConfigFile(t, dir, "webchat/SOUL.md", "Platform soul.")
+				return dir
+			},
+			platform:    "webchat",
+			botID:       "",
+			wantContain: "Platform soul.",
+		},
+		{
+			name: "falls to global",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeAgentConfigFile(t, dir, "SOUL.md", "Global soul.")
+				return dir
+			},
+			platform:    "webchat",
+			botID:       "some-bot",
+			wantContain: "Global soul.",
+		},
+		{
+			name: "disabled when empty dir",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			platform:  "webchat",
+			botID:     "bot",
+			wantEmpty: true,
+		},
+		{
+			name: "path traversal rejected",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeAgentConfigFile(t, dir, "webchat/SOUL.md", "Platform soul.")
+				return dir
+			},
+			platform:  "webchat",
+			botID:     "../etc",
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := tt.setup(t)
+			hub := newTestHub(t)
+			sm := new(mockBridgeSM)
+			b := NewBridge(BridgeDeps{
+				Log:            slog.Default(),
+				Hub:            hub,
+				SM:             sm,
+				AgentConfigDir: dir,
+			})
+
+			info := &worker.SessionInfo{}
+			b.injectAgentConfig(info, tt.platform, tt.botID)
+
+			if tt.wantEmpty {
+				assert.Empty(t, info.SystemPrompt)
+			} else {
+				assert.Contains(t, info.SystemPrompt, tt.wantContain)
+			}
+		})
+	}
 }

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -14,10 +14,10 @@ type sessionAccumulator struct {
 	TurnCount     int
 	ToolCallCount int
 	TotalCostUSD  float64
-	TotalInput    int64 // cumulative input_tokens + cache_creation + cache_read
+	TotalInput    int64 // cumulative input tokens consumed across turns
 	TotalOutput   int64
 	ContextWindow int64  // from modelUsage.contextWindow (0 = unknown)
-	ContextFill   int64  // latest turn's input + cache_creation + cache_read (not cumulative)
+	ContextFill   int64  // latest turn's input_tokens (total including cache, bounded by ContextWindow)
 	ModelName     string // first model seen
 	StartedAt     time.Time
 	WorkDir       string // session working directory
@@ -42,11 +42,14 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 		return
 	}
 
-	// Claude Code format: usage.input_tokens + cache tokens
+	// Claude Code format: usage.input_tokens already includes cached tokens.
+	// Per Claude Code SDK docs: "input_tokens = total input tokens sent to
+	// the model (includes cached + non-cached)". The cache_creation and
+	// cache_read fields are billing-rate breakdowns (subsets of input_tokens),
+	// NOT additive. Adding them on top double-counts cache tokens, causing
+	// ContextFill to exceed ContextWindow.
 	if usage, ok := data.Stats["usage"].(map[string]any); ok {
-		input := events.ToInt64(usage["input_tokens"]) +
-			events.ToInt64(usage["cache_creation_input_tokens"]) +
-			events.ToInt64(usage["cache_read_input_tokens"])
+		input := events.ToInt64(usage["input_tokens"])
 		a.TotalInput += input
 		a.ContextFill = input
 		a.TotalOutput += events.ToInt64(usage["output_tokens"])

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -42,21 +42,16 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 		return
 	}
 
-	// Claude Code format: usage.input_tokens already includes cached tokens.
-	// Per Claude Code SDK docs: "input_tokens = total input tokens sent to
-	// the model (includes cached + non-cached)". The cache_creation and
-	// cache_read fields are billing-rate breakdowns (subsets of input_tokens),
-	// NOT additive. Adding them on top double-counts cache tokens, causing
-	// ContextFill to exceed ContextWindow.
+	// Claude Code format: input_tokens already includes cache tokens.
+	// cache_creation and cache_read are billing-rate breakdowns (subsets of
+	// input_tokens), NOT additive — summing them double-counts cache tokens.
 	if usage, ok := data.Stats["usage"].(map[string]any); ok {
 		input := events.ToInt64(usage["input_tokens"])
 		a.TotalInput += input
 		a.ContextFill = input
 		a.TotalOutput += events.ToInt64(usage["output_tokens"])
 	} else if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
-		// OpenCode format: tokens.input does NOT include cache tokens.
-		// Unlike Claude Code, OpenCode reports input, cache_read, and cache_write
-		// as separate additive fields. Summing them gives the true total input.
+		// OpenCode format: input/cache_read/cache_write are separate additive fields.
 		input := events.ToInt64(tokens["input"]) +
 			events.ToInt64(tokens["cache_read"]) +
 			events.ToInt64(tokens["cache_write"])

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -71,7 +71,9 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 		}
 	}
 
-	// OpenCode format: tokens.input + cache tokens
+	// OpenCode format: tokens.input does NOT include cache tokens.
+	// Unlike Claude Code, OpenCode reports input, cache_read, and cache_write
+	// as separate additive fields. Summing them gives the true total input.
 	if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
 		input := events.ToInt64(tokens["input"]) +
 			events.ToInt64(tokens["cache_read"]) +

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -53,6 +53,16 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 		a.TotalInput += input
 		a.ContextFill = input
 		a.TotalOutput += events.ToInt64(usage["output_tokens"])
+	} else if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
+		// OpenCode format: tokens.input does NOT include cache tokens.
+		// Unlike Claude Code, OpenCode reports input, cache_read, and cache_write
+		// as separate additive fields. Summing them gives the true total input.
+		input := events.ToInt64(tokens["input"]) +
+			events.ToInt64(tokens["cache_read"]) +
+			events.ToInt64(tokens["cache_write"])
+		a.TotalInput += input
+		a.ContextFill = input
+		a.TotalOutput += events.ToInt64(tokens["output"])
 	}
 
 	// Claude Code modelUsage: extract model name + contextWindow
@@ -69,18 +79,6 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 				a.ContextWindow = cw
 			}
 		}
-	}
-
-	// OpenCode format: tokens.input does NOT include cache tokens.
-	// Unlike Claude Code, OpenCode reports input, cache_read, and cache_write
-	// as separate additive fields. Summing them gives the true total input.
-	if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
-		input := events.ToInt64(tokens["input"]) +
-			events.ToInt64(tokens["cache_read"]) +
-			events.ToInt64(tokens["cache_write"])
-		a.TotalInput += input
-		a.ContextFill = input
-		a.TotalOutput += events.ToInt64(tokens["output"])
 	}
 
 	// Cost: Claude Code uses "total_cost_usd", OpenCode uses "cost"

--- a/internal/gateway/session_stats_test.go
+++ b/internal/gateway/session_stats_test.go
@@ -128,6 +128,7 @@ func TestSessionAccumulator_MergePerTurnStats(t *testing.T) {
 }
 
 func TestSessionAccumulator_ComputeContextPct(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		contextFill   int64
@@ -150,7 +151,6 @@ func TestSessionAccumulator_ComputeContextPct(t *testing.T) {
 			require.Equal(t, tt.wantPct, got)
 		})
 	}
-	t.Parallel()
 }
 
 func TestSessionAccumulator_MergeContextUsage(t *testing.T) {

--- a/internal/gateway/session_stats_test.go
+++ b/internal/gateway/session_stats_test.go
@@ -30,8 +30,8 @@ func TestSessionAccumulator_MergePerTurnStats(t *testing.T) {
 			},
 		})
 
-		require.Equal(t, int64(15234+8200+0), acc.TotalInput)
-		require.Equal(t, int64(15234+8200+0), acc.ContextFill)
+		require.Equal(t, int64(15234), acc.TotalInput)
+		require.Equal(t, int64(15234), acc.ContextFill)
 		require.Equal(t, int64(3821), acc.TotalOutput)
 		require.Equal(t, int64(200000), acc.ContextWindow)
 		require.Equal(t, "Sonnet", acc.ModelName)

--- a/internal/gateway/session_stats_test.go
+++ b/internal/gateway/session_stats_test.go
@@ -65,6 +65,27 @@ func TestSessionAccumulator_MergePerTurnStats(t *testing.T) {
 		require.Equal(t, int64(0), acc.TotalOutput)
 	})
 
+	t.Run("cache tokens not double-counted", func(t *testing.T) {
+		acc := &sessionAccumulator{StartedAt: time.Now()}
+		acc.mergePerTurnStats(events.DoneData{
+			Stats: map[string]any{
+				"usage": map[string]any{
+					"input_tokens":                float64(50000),
+					"cache_creation_input_tokens": float64(30000),
+					"cache_read_input_tokens":     float64(10000),
+					"output_tokens":               float64(5000),
+				},
+				"model_usage": map[string]any{
+					"claude-sonnet-4-6": map[string]any{"contextWindow": float64(200000)},
+				},
+			},
+		})
+		require.Equal(t, int64(50000), acc.ContextFill, "ContextFill must equal input_tokens only")
+		require.Equal(t, int64(50000), acc.TotalInput, "TotalInput must not add cache tokens")
+		pct := acc.computeContextPct()
+		require.Equal(t, 25.0, pct, "context % must be 50000/200000 = 25%%, not inflated by cache")
+	})
+
 	t.Run("context fill overwritten by latest turn", func(t *testing.T) {
 		acc := &sessionAccumulator{StartedAt: time.Now()}
 

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -23,6 +23,7 @@ type Bridge struct {
 	starter    SessionStarter
 	workerType string
 	workDir    string
+	adapter    PlatformAdapterInterface // set after adapter.Start() via SetAdapter
 }
 
 // NewBridge creates a new platform bridge.
@@ -44,6 +45,10 @@ func NewBridge(log *slog.Logger, platform PlatformType, hub HubInterface,
 // WorkDir returns the configured worker working directory.
 func (b *Bridge) WorkDir() string { return b.workDir }
 
+// SetAdapter injects the platform adapter for lazy botID resolution.
+// Called after adapter.Start() succeeds in messaging_init.go.
+func (b *Bridge) SetAdapter(a PlatformAdapterInterface) { b.adapter = a }
+
 // Handle routes a platform message through the AEP handler.
 // pc is the already-created PlatformConn for the platform session.
 // It is registered with the hub so worker output is routed back to the platform.
@@ -57,7 +62,11 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 	if b.starter != nil {
 		// Extract platform key from envelope metadata for persistence.
 		platform, platformKey := b.extractPlatformKey(env)
-		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, platform, platformKey); err != nil {
+		var botID string
+		if b.adapter != nil {
+			botID = b.adapter.GetBotID()
+		}
+		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, platform, platformKey, botID); err != nil {
 			b.log.Warn("messaging bridge: session start failed",
 				"session_id", env.SessionID, "worker_type", b.workerType, "err", err)
 		}
@@ -98,6 +107,9 @@ func (b *Bridge) makeEnvelope(sessionID, ownerID, text string, metadata map[stri
 func (b *Bridge) MakeEnvelope(userID, text string, pctx session.PlatformContext) *events.Envelope {
 	sessionID := session.DerivePlatformSessionKey(userID, worker.WorkerType(b.workerType), pctx)
 	md := map[string]any{"platform": pctx.Platform}
+	if pctx.BotID != "" {
+		md["bot_id"] = pctx.BotID
+	}
 	if pctx.TeamID != "" {
 		md["team_id"] = pctx.TeamID
 	}
@@ -118,12 +130,13 @@ func (b *Bridge) MakeEnvelope(userID, text string, pctx session.PlatformContext)
 
 // MakeSlackEnvelope converts a Slack message to an AEP input envelope.
 // workDir overrides the bridge's default workDir for session key derivation; empty falls back to b.workDir.
-func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope {
+func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope {
 	if workDir == "" {
 		workDir = b.workDir
 	}
 	return b.MakeEnvelope(userID, text, session.PlatformContext{
 		Platform:  string(PlatformSlack),
+		BotID:     botID,
 		TeamID:    teamID,
 		ChannelID: channelID,
 		ThreadTS:  threadTS,
@@ -134,12 +147,13 @@ func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, wo
 
 // MakeFeishuEnvelope converts a Feishu message to an AEP input envelope.
 // workDir overrides the bridge's default workDir for session key derivation; empty falls back to b.workDir.
-func (b *Bridge) MakeFeishuEnvelope(chatID, threadTS, userID, text, workDir string) *events.Envelope {
+func (b *Bridge) MakeFeishuEnvelope(chatID, threadTS, userID, text, workDir, botID string) *events.Envelope {
 	if workDir == "" {
 		workDir = b.workDir
 	}
 	return b.MakeEnvelope(userID, text, session.PlatformContext{
 		Platform: string(PlatformFeishu),
+		BotID:    botID,
 		ChatID:   chatID,
 		ThreadTS: threadTS,
 		UserID:   userID,

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -23,7 +24,7 @@ type Bridge struct {
 	starter    SessionStarter
 	workerType string
 	workDir    string
-	adapter    PlatformAdapterInterface // set after adapter.Start() via SetAdapter
+	adapter    atomic.Value // stores PlatformAdapterInterface; set after adapter.Start() via SetAdapter
 }
 
 // NewBridge creates a new platform bridge.
@@ -46,8 +47,24 @@ func NewBridge(log *slog.Logger, platform PlatformType, hub HubInterface,
 func (b *Bridge) WorkDir() string { return b.workDir }
 
 // SetAdapter injects the platform adapter for lazy botID resolution.
-// Called after adapter.Start() succeeds in messaging_init.go.
-func (b *Bridge) SetAdapter(a PlatformAdapterInterface) { b.adapter = a }
+// Must be called after adapter.Start() succeeds and before any Handle() calls.
+func (b *Bridge) SetAdapter(a PlatformAdapterInterface) {
+	if a != nil && a.Platform() != b.platform {
+		b.log.Warn("messaging bridge: adapter platform mismatch",
+			"expected", b.platform, "got", a.Platform())
+	}
+	b.adapter.Store(a)
+}
+
+// getAdapter returns the stored adapter or nil if not yet set.
+func (b *Bridge) getAdapter() PlatformAdapterInterface {
+	v := b.adapter.Load()
+	if v == nil {
+		return nil
+	}
+	a, _ := v.(PlatformAdapterInterface)
+	return a
+}
 
 // Handle routes a platform message through the AEP handler.
 // pc is the already-created PlatformConn for the platform session.
@@ -63,12 +80,11 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 		// Extract platform key from envelope metadata for persistence.
 		platform, platformKey := b.extractPlatformKey(env)
 		var botID string
-		if b.adapter != nil {
-			botID = b.adapter.GetBotID()
+		if a := b.getAdapter(); a != nil {
+			botID = a.GetBotID()
 		}
 		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, platform, platformKey, botID); err != nil {
-			b.log.Warn("messaging bridge: session start failed",
-				"session_id", env.SessionID, "worker_type", b.workerType, "err", err)
+			return fmt.Errorf("messaging bridge: session start failed: %w", err)
 		}
 	}
 

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -48,12 +48,13 @@ func (b *Bridge) WorkDir() string { return b.workDir }
 
 // SetAdapter injects the platform adapter for lazy botID resolution.
 // Must be called after adapter.Start() succeeds and before any Handle() calls.
-func (b *Bridge) SetAdapter(a PlatformAdapterInterface) {
+// Returns an error if the adapter's platform does not match the bridge's platform.
+func (b *Bridge) SetAdapter(a PlatformAdapterInterface) error {
 	if a != nil && a.Platform() != b.platform {
-		b.log.Warn("messaging bridge: adapter platform mismatch",
-			"expected", b.platform, "got", a.Platform())
+		return fmt.Errorf("messaging bridge: adapter platform %q != bridge platform %q", a.Platform(), b.platform)
 	}
 	b.adapter.Store(a)
+	return nil
 }
 
 // getAdapter returns the stored adapter or nil if not yet set.

--- a/internal/messaging/bridge_test.go
+++ b/internal/messaging/bridge_test.go
@@ -1,0 +1,138 @@
+package messaging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func newTestBridge() *Bridge {
+	return &Bridge{
+		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workerType: string(worker.TypeClaudeCode),
+		workDir:    "/tmp/test",
+	}
+}
+
+// PBAC-023: MakeEnvelope includes bot_id in metadata map.
+func TestBridge_MakeEnvelope_BotIDInMetadata(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+
+	t.Run("with bot_id", func(t *testing.T) {
+		t.Parallel()
+		env := b.MakeEnvelope("user1", "hello", session.PlatformContext{
+			Platform:  "slack",
+			BotID:     "U_BOT_123",
+			TeamID:    "T001",
+			ChannelID: "C100",
+		})
+		md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
+		require.Equal(t, "U_BOT_123", md["bot_id"])
+		require.Equal(t, "slack", md["platform"])
+	})
+
+	t.Run("without bot_id", func(t *testing.T) {
+		t.Parallel()
+		env := b.MakeEnvelope("user1", "hello", session.PlatformContext{
+			Platform:  "slack",
+			TeamID:    "T001",
+			ChannelID: "C100",
+		})
+		md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
+		_, ok := md["bot_id"]
+		require.False(t, ok, "bot_id should not be present when empty")
+	})
+}
+
+// PBAC-011: MakeSlackEnvelope includes botID in PlatformContext.
+func TestBridge_MakeSlackEnvelope_BotID(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	env := b.MakeSlackEnvelope("T001", "C100", "123.456", "U001", "hello", "", "U_BOT_X")
+
+	md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
+	require.Equal(t, "U_BOT_X", md["bot_id"])
+	require.Equal(t, "T001", md["team_id"])
+	require.Equal(t, "C100", md["channel_id"])
+}
+
+// PBAC-022: MakeFeishuEnvelope includes botID in PlatformContext and metadata.
+func TestBridge_MakeFeishuEnvelope_BotID(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	env := b.MakeFeishuEnvelope("oc_chat1", "msg_001", "ou_user1", "hello", "", "ou_bot_Y")
+
+	md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
+	require.Equal(t, "ou_bot_Y", md["bot_id"])
+	require.Equal(t, "oc_chat1", md["chat_id"])
+}
+
+// PBAC-025: Bridge.Handle() extracts botID from adapter via GetBotID(), passes to StartPlatformSession.
+func TestBridge_Handle_ExtractsBotID(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	b.adapter = &mockBotIDAdapter{botID: "U_ADAPTER_BOT"}
+	b.handler = &mockHandler{}
+
+	var capturedBotID string
+	b.starter = &mockStarter{
+		startFn: func(_ context.Context, _ string, _ string, _ string, _ string, _ string, _ map[string]string, botID string) error {
+			capturedBotID = botID
+			return nil
+		},
+	}
+
+	env := &events.Envelope{
+		SessionID: "sid1",
+		OwnerID:   "owner1",
+		Event: events.Event{
+			Type: events.Input,
+			Data: map[string]any{"content": "test"},
+		},
+	}
+	_ = b.Handle(context.Background(), env, nil)
+	require.Equal(t, "U_ADAPTER_BOT", capturedBotID, "Handle must pass adapter's botID to StartPlatformSession")
+}
+
+// mockBotIDAdapter implements PlatformAdapterInterface for testing GetBotID (PBAC-009, PBAC-010).
+type mockBotIDAdapter struct {
+	botID string
+}
+
+func (m *mockBotIDAdapter) Platform() PlatformType        { return PlatformSlack }
+func (m *mockBotIDAdapter) Start(_ context.Context) error { return nil }
+func (m *mockBotIDAdapter) HandleTextMessage(_ context.Context, _, _, _, _, _, _ string) error {
+	return nil
+}
+func (m *mockBotIDAdapter) Close(_ context.Context) error       { return nil }
+func (m *mockBotIDAdapter) ConfigureWith(_ AdapterConfig) error { return nil }
+func (m *mockBotIDAdapter) GetBotID() string                    { return m.botID }
+
+// mockHandler implements HandlerInterface.
+type mockHandler struct{}
+
+func (m *mockHandler) Handle(_ context.Context, _ *events.Envelope) error { return nil }
+
+// mockStarter captures botID passed to StartPlatformSession.
+type mockStarter struct {
+	startFn func(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
+}
+
+func (s *mockStarter) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error {
+	if s.startFn != nil {
+		return s.startFn(ctx, sessionID, ownerID, workerType, workDir, platform, platformKey, botID)
+	}
+	return nil
+}

--- a/internal/messaging/bridge_test.go
+++ b/internal/messaging/bridge_test.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -83,7 +84,7 @@ func TestBridge_Handle_ExtractsBotID(t *testing.T) {
 	t.Parallel()
 
 	b := newTestBridge()
-	b.adapter = &mockBotIDAdapter{botID: "U_ADAPTER_BOT"}
+	b.adapter.Store(&mockBotIDAdapter{botID: "U_ADAPTER_BOT"})
 	b.handler = &mockHandler{}
 
 	var capturedBotID string
@@ -135,4 +136,56 @@ func (s *mockStarter) StartPlatformSession(ctx context.Context, sessionID, owner
 		return s.startFn(ctx, sessionID, ownerID, workerType, workDir, platform, platformKey, botID)
 	}
 	return nil
+}
+
+// I5: nil adapter passes empty botID to StartPlatformSession.
+func TestBridge_Handle_NilAdapter_EmptyBotID(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	b.handler = &mockHandler{}
+
+	var capturedBotID string
+	b.starter = &mockStarter{
+		startFn: func(_ context.Context, _ string, _ string, _ string, _ string, _ string, _ map[string]string, botID string) error {
+			capturedBotID = botID
+			return nil
+		},
+	}
+
+	env := &events.Envelope{
+		SessionID: "sid1",
+		OwnerID:   "owner1",
+		Event: events.Event{
+			Type: events.Input,
+			Data: map[string]any{"content": "test"},
+		},
+	}
+	_ = b.Handle(context.Background(), env, nil)
+	require.Equal(t, "", capturedBotID, "nil adapter must pass empty botID")
+}
+
+// C2: Handle() returns error when StartPlatformSession fails.
+func TestBridge_Handle_StartError(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	b.handler = &mockHandler{}
+	b.starter = &mockStarter{
+		startFn: func(_ context.Context, _ string, _ string, _ string, _ string, _ string, _ map[string]string, _ string) error {
+			return fmt.Errorf("pool exhausted")
+		},
+	}
+
+	env := &events.Envelope{
+		SessionID: "sid1",
+		OwnerID:   "owner1",
+		Event: events.Event{
+			Type: events.Input,
+			Data: map[string]any{"content": "test"},
+		},
+	}
+	err := b.Handle(context.Background(), env, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session start failed")
 }

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -54,6 +54,8 @@ type Adapter struct {
 
 func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformFeishu }
 
+func (a *Adapter) GetBotID() string { return a.botOpenID }
+
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	// Call base to set hub/sm/handler/bridge.
 	_ = a.PlatformAdapter.ConfigureWith(config)
@@ -403,7 +405,7 @@ func (a *Adapter) handleTextMessage(ctx context.Context, platformMsgID, channelI
 
 	conn := a.GetOrCreateConn(channelID, threadKey)
 
-	envelope := a.Bridge().MakeFeishuEnvelope(channelID, threadKey, userID, text, conn.WorkDir())
+	envelope := a.Bridge().MakeFeishuEnvelope(channelID, threadKey, userID, text, conn.WorkDir(), a.botOpenID)
 	if envelope == nil {
 		return fmt.Errorf("feishu: failed to build envelope")
 	}
@@ -929,7 +931,7 @@ var _ messaging.PlatformConn = (*FeishuConn)(nil)
 // through the bridge, then sends feedback via card message.
 func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, threadKey, platformMsgID string, result *messaging.ControlCommandResult) {
 	conn := a.GetOrCreateConn(chatID, threadKey)
-	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir())
+	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir(), a.botOpenID)
 	if envelope == nil {
 		a.Log.Warn("feishu: text control command failed to derive session", "action", result.Label)
 		return
@@ -994,7 +996,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, 
 
 func (a *Adapter) handleTextWorkerCommand(ctx context.Context, chatID, chatType, userID, threadKey, platformMsgID, replyToMsgID string, result *messaging.WorkerCommandResult) {
 	conn := a.GetOrCreateConn(chatID, threadKey)
-	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir())
+	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir(), a.botOpenID)
 	if envelope == nil {
 		a.Log.Warn("feishu: worker command failed to derive session", "command", result.Label)
 		return

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -54,6 +54,8 @@ type Adapter struct {
 
 func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformFeishu }
 
+var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
+
 func (a *Adapter) GetBotID() string { return a.botOpenID }
 
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
@@ -102,7 +104,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 	)
 
 	if err := a.fetchBotOpenID(ctx); err != nil {
-		a.Log.Warn("feishu: failed to fetch bot open_id, mention detection disabled", "err", err)
+		return fmt.Errorf("feishu: failed to resolve bot identity: %w", err)
 	}
 
 	a.Log.Info("feishu: starting WebSocket connection")

--- a/internal/messaging/integration_test.go
+++ b/internal/messaging/integration_test.go
@@ -128,7 +128,7 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 		config.Default().Worker.DefaultWorkDir,
 	)
 
-	env := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "")
+	env := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "", "")
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
@@ -136,7 +136,7 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 	require.Equal(t, userID, env.OwnerID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "")
+	env2 := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "", "")
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.
@@ -175,14 +175,14 @@ func TestBridge_MakeFeishuEnvelope(t *testing.T) {
 		config.Default().Worker.DefaultWorkDir,
 	)
 
-	env := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "")
+	env := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "", "")
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
 	require.Regexp(t, uuidV5Regex, env.SessionID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "")
+	env2 := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "", "")
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.

--- a/internal/messaging/platform_adapter.go
+++ b/internal/messaging/platform_adapter.go
@@ -47,6 +47,10 @@ func (p PlatformType) ExtractPlatformKeys(md map[string]any) map[string]string {
 			pk["user_id"] = v
 		}
 	}
+	// bot_id is platform-agnostic — extracted for all platform types.
+	if v, ok := md["bot_id"].(string); ok && v != "" {
+		pk["bot_id"] = v
+	}
 	return pk
 }
 
@@ -69,6 +73,9 @@ type PlatformAdapterInterface interface {
 
 	// ConfigureWith applies a unified configuration to the adapter.
 	ConfigureWith(config AdapterConfig) error
+
+	// GetBotID returns the platform bot identity (Slack UserID, Feishu OpenID, etc.).
+	GetBotID() string
 }
 
 // AdapterBuilder creates a new adapter instance.
@@ -151,7 +158,7 @@ type SessionManager any
 // SessionStarter creates a new gateway session for a platform message.
 // Implemented by gateway.Bridge and injected during wiring.
 type SessionStarter interface {
-	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string) error
+	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
 }
 
 // Bridge returns the messaging bridge.

--- a/internal/messaging/platform_adapter_test.go
+++ b/internal/messaging/platform_adapter_test.go
@@ -108,3 +108,39 @@ func TestPlatformAdapter_Bridge(t *testing.T) {
 	a := &PlatformAdapter{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	require.Nil(t, a.Bridge())
 }
+
+// PBAC-024: ExtractPlatformKeys extracts bot_id from metadata for Slack and Feishu.
+func TestPlatformType_ExtractPlatformKeys_BotID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("slack with bot_id", func(t *testing.T) {
+		t.Parallel()
+		pk := PlatformSlack.ExtractPlatformKeys(map[string]any{
+			"team_id":    "T1",
+			"channel_id": "C1",
+			"user_id":    "U1",
+			"bot_id":     "U_BOT_123",
+		})
+		require.Equal(t, "U_BOT_123", pk["bot_id"])
+	})
+
+	t.Run("feishu with bot_id", func(t *testing.T) {
+		t.Parallel()
+		pk := PlatformFeishu.ExtractPlatformKeys(map[string]any{
+			"chat_id": "oc1",
+			"user_id": "ou1",
+			"bot_id":  "ou_bot_456",
+		})
+		require.Equal(t, "ou_bot_456", pk["bot_id"])
+	})
+
+	t.Run("no bot_id", func(t *testing.T) {
+		t.Parallel()
+		pk := PlatformSlack.ExtractPlatformKeys(map[string]any{
+			"team_id":    "T1",
+			"channel_id": "C1",
+		})
+		_, ok := pk["bot_id"]
+		require.False(t, ok, "bot_id should not be present when not provided")
+	})
+}

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -78,6 +78,8 @@ type Adapter struct {
 
 func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformSlack }
 
+func (a *Adapter) GetBotID() string { return a.botID }
+
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	// Call base to set hub/sm/handler/bridge.
 	_ = a.PlatformAdapter.ConfigureWith(config)
@@ -435,7 +437,7 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 		return fmt.Errorf("slack: adapter closed, dropping message for channel %s", channelID)
 	}
 
-	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, conn.WorkDir())
+	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, conn.WorkDir(), a.botID)
 	if envelope == nil {
 		return fmt.Errorf("slack: failed to build envelope")
 	}
@@ -549,7 +551,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelI
 		return
 	}
 
-	env := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir())
+	env := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir(), a.botID)
 	if env == nil {
 		a.Log.Warn("slack: text control command failed to derive session", "action", result.Label)
 		return
@@ -605,7 +607,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, teamID, channelID
 		return
 	}
 
-	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir())
+	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir(), a.botID)
 	if envelope == nil {
 		a.Log.Warn("slack: worker command failed to derive session", "command", result.Label)
 		return

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -78,6 +78,8 @@ type Adapter struct {
 
 func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformSlack }
 
+var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
+
 func (a *Adapter) GetBotID() string { return a.botID }
 
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {

--- a/internal/messaging/slack/slash_command.go
+++ b/internal/messaging/slack/slash_command.go
@@ -187,7 +187,7 @@ func (a *Adapter) deriveSessionIDFromCommand(cmd slack.SlashCommand) string {
 	if conn != nil {
 		workDir = conn.WorkDir()
 	}
-	envelope := a.Bridge().MakeSlackEnvelope(cmd.TeamID, cmd.ChannelID, "", cmd.UserID, "", workDir)
+	envelope := a.Bridge().MakeSlackEnvelope(cmd.TeamID, cmd.ChannelID, "", cmd.UserID, "", workDir, a.botID)
 	if envelope == nil {
 		return ""
 	}

--- a/internal/session/key.go
+++ b/internal/session/key.go
@@ -28,6 +28,7 @@ func DeriveSessionKey(ownerID string, wt worker.WorkerType, clientKey, workDir s
 // ThreadTS is cross-platform: used by both Slack threads and Feishu chat threads.
 type PlatformContext struct {
 	Platform string
+	BotID    string // Bot identity (Slack UserID, Feishu OpenID, WebChat JWT bot_id)
 	// Slack fields
 	TeamID    string
 	ChannelID string
@@ -41,6 +42,7 @@ type PlatformContext struct {
 
 // FromMap populates PlatformContext from a serialized PlatformKey map.
 func (pc *PlatformContext) FromMap(m map[string]string) {
+	pc.BotID = m["bot_id"]
 	pc.TeamID = m["team_id"]
 	pc.ChannelID = m["channel_id"]
 	pc.ThreadTS = m["thread_ts"]
@@ -73,6 +75,10 @@ func DerivePlatformSessionKey(ownerID string, wt worker.WorkerType, ctx Platform
 	b.WriteString(string(wt))
 	b.WriteByte('|')
 	b.WriteString(ctx.Platform)
+	if ctx.BotID != "" {
+		b.WriteByte('|')
+		b.WriteString(ctx.BotID)
+	}
 	switch ctx.Platform {
 	case "slack":
 		if ctx.TeamID != "" {

--- a/internal/session/key_test.go
+++ b/internal/session/key_test.go
@@ -234,3 +234,45 @@ func TestDerivePlatformSessionKey_AllWorkerTypes(t *testing.T) {
 		})
 	}
 }
+
+// PBAC-012: DerivePlatformSessionKey with different BotIDs produces different session IDs.
+func TestDerivePlatformSessionKey_BotIDDifferentiation(t *testing.T) {
+	t.Parallel()
+
+	base := PlatformContext{Platform: "slack", TeamID: "T001", ChannelID: "C100", UserID: "U001"}
+	bot1 := base
+	bot1.BotID = "U11111"
+	bot2 := base
+	bot2.BotID = "U22222"
+
+	keyBase := DerivePlatformSessionKey("owner", worker.TypeClaudeCode, base)
+	keyBot1 := DerivePlatformSessionKey("owner", worker.TypeClaudeCode, bot1)
+	keyBot2 := DerivePlatformSessionKey("owner", worker.TypeClaudeCode, bot2)
+
+	require.NotEqual(t, keyBase, keyBot1, "different BotID → different session key")
+	require.NotEqual(t, keyBot1, keyBot2, "different BotIDs → different session keys")
+
+	keyBot1Again := DerivePlatformSessionKey("owner", worker.TypeClaudeCode, bot1)
+	require.Equal(t, keyBot1, keyBot1Again, "same BotID must be deterministic")
+}
+
+// PBAC-027: FromMap reconstructs BotID from persisted platformKey["bot_id"].
+func TestPlatformContext_FromMap_BotID(t *testing.T) {
+	t.Parallel()
+
+	var pc PlatformContext
+	pc.FromMap(map[string]string{
+		"bot_id":     "U12345",
+		"team_id":    "T001",
+		"channel_id": "C100",
+		"user_id":    "U999",
+	})
+	require.Equal(t, "U12345", pc.BotID)
+	require.Equal(t, "T001", pc.TeamID)
+	require.Equal(t, "C100", pc.ChannelID)
+	require.Equal(t, "U999", pc.UserID)
+
+	var pc2 PlatformContext
+	pc2.FromMap(map[string]string{"team_id": "T001"})
+	require.Empty(t, pc2.BotID)
+}

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { TurnSessionStats } from '@/lib/ai-sdk-transport/client/types';
+
+type Severity = 'comfortable' | 'moderate' | 'high' | 'critical';
+
+function getSeverity(pct: number): Severity {
+  if (pct > 90) return 'critical';
+  if (pct > 75) return 'high';
+  if (pct >= 50) return 'moderate';
+  return 'comfortable';
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  const k = n / 1000;
+  return k % 1 === 0 ? `${k}K` : `~${k.toFixed(1)}K}`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${Math.round(s)}s`;
+  const m = Math.floor(s / 60);
+  const rs = Math.round(s % 60);
+  return rs > 0 ? `${m}m${rs}s` : `${m}m`;
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return '';
+  if (usd < 1) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+const severityConfig: Record<Severity, { color: string; bg: string; border: string }> = {
+  comfortable: {
+    color: 'var(--accent-emerald)',
+    bg: 'rgba(52, 211, 153, 0.06)',
+    border: 'rgba(52, 211, 153, 0.15)',
+  },
+  moderate: {
+    color: 'var(--accent-gold)',
+    bg: 'rgba(251, 191, 36, 0.06)',
+    border: 'rgba(251, 191, 36, 0.15)',
+  },
+  high: {
+    color: 'var(--accent-gold)',
+    bg: 'rgba(251, 191, 36, 0.08)',
+    border: 'rgba(251, 191, 36, 0.25)',
+  },
+  critical: {
+    color: 'var(--accent-coral)',
+    bg: 'rgba(244, 63, 94, 0.08)',
+    border: 'rgba(244, 63, 94, 0.25)',
+  },
+};
+
+export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
+  const pct = Math.max(0, Math.min(100, data.context_pct ?? 0));
+  const severity = getSeverity(pct);
+  const cfg = severityConfig[severity];
+
+  const parts: string[] = [];
+
+  if (data.model_name) parts.push(data.model_name);
+  if (pct > 0 && data.context_window > 0) {
+    parts.push(`${Math.round(pct)}%`);
+  }
+  if (data.turn_duration_ms > 0) {
+    parts.push(formatDuration(data.turn_duration_ms));
+  }
+  if (data.tool_call_count > 0) {
+    parts.push(`🛠 ${data.tool_call_count}`);
+  }
+  const cost = data.turn_cost_usd ? formatCost(data.turn_cost_usd) : '';
+  if (cost) parts.push(cost);
+
+  if (parts.length === 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: [0.2, 0, 0, 1] }}
+      className="my-1.5 rounded-lg px-3 py-1.5 flex items-center gap-2 flex-wrap"
+      style={{ background: cfg.bg, border: `1px solid ${cfg.border}` }}
+    >
+      {pct > 0 && data.context_window > 0 && (
+        <div className="flex items-center gap-1.5">
+          <span
+            className="block w-1.5 h-1.5 rounded-full"
+            style={{ background: cfg.color, boxShadow: `0 0 4px ${cfg.color}` }}
+          />
+          <div className="w-12 h-1 rounded-full bg-[var(--bg-elevated)] overflow-hidden">
+            <motion.div
+              className="h-full rounded-full"
+              style={{ background: cfg.color }}
+              initial={{ width: 0 }}
+              animate={{ width: `${pct}%` }}
+              transition={{ duration: 0.5, ease: [0.2, 0, 0, 1] }}
+            />
+          </div>
+        </div>
+      )}
+      <span className="text-[10px] font-mono text-[var(--text-secondary)]">
+        {parts.join(' · ')}
+      </span>
+    </motion.div>
+  );
+}

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -18,6 +18,7 @@ import { getToolCategory } from "@/lib/tool-categories";
 import { CommandMenu } from "./CommandMenu";
 import { CompactToolTab } from "./tools/CompactToolTab";
 import { ContextUsageCard } from "./ContextUsageCard";
+import { TurnSummaryCard } from "./TurnSummaryCard";
 import { ListTool } from "./tools/ListTool";
 import { TodoTool } from "./tools/TodoTool";
 import { AgentTool } from "./tools/AgentTool";
@@ -241,6 +242,9 @@ function AssistantMessage({ message }: { message: any }) {
           </MessagePrimitive.Parts>
           {(message as any)?.metadata?.contextUsage && (
             <ContextUsageCard data={(message as any).metadata.contextUsage} />
+          )}
+          {(message as any)?.metadata?.turnSummary && (
+            <TurnSummaryCard data={(message as any).metadata.turnSummary} />
           )}
         </div>
         <MessageActions message={message} />

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -78,7 +78,12 @@ interface ContextUsagePart {
   data: ContextUsageData;
 }
 
-type MessagePart = TextPart | ReasoningPart | ToolCallPart | ToolSummaryPart | ContextUsagePart;
+interface TurnSummaryPart {
+  type: 'turn-summary';
+  data: import('@/lib/ai-sdk-transport/client/types').TurnSessionStats;
+}
+
+type MessagePart = TextPart | ReasoningPart | ToolCallPart | ToolSummaryPart | ContextUsagePart | TurnSummaryPart;
 
 // Internal message format for our store
 interface HotPlexMessage {
@@ -98,13 +103,16 @@ interface HotPlexMessage {
  * Handles both old format (content: string) and new format (parts: MessagePart[]).
  */
 function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
-  // Filter out ToolSummaryPart and ContextUsagePart — not recognized by assistant-ui's ThreadMessageLike type
-  const content = message.parts.filter((p): p is TextPart | ReasoningPart | ToolCallPart => p.type !== 'tool-summary' && p.type !== 'context-usage');
+  // Filter out ToolSummaryPart, ContextUsagePart, and TurnSummaryPart — not recognized by assistant-ui's ThreadMessageLike type
+  const content = message.parts.filter((p): p is TextPart | ReasoningPart | ToolCallPart => p.type !== 'tool-summary' && p.type !== 'context-usage' && p.type !== 'turn-summary');
 
   const role = (message.role as string) === 'user' ? 'user' : 'assistant';
 
   // Extract context usage data for card rendering
   const contextUsagePart = message.parts.find((p): p is ContextUsagePart => p.type === 'context-usage');
+
+  // Extract turn summary data for card rendering
+  const turnSummaryPart = message.parts.find((p): p is TurnSummaryPart => p.type === 'turn-summary');
 
   const result: ThreadMessageLike = {
     id: message.id,
@@ -112,7 +120,10 @@ function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
     content,
     createdAt: message.createdAt,
     attachments: [],
-    metadata: contextUsagePart ? { contextUsage: contextUsagePart.data } as any : {},
+    metadata: {
+      ...(contextUsagePart ? { contextUsage: contextUsagePart.data } : {}),
+      ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
+    } as any,
   };
 
   // Status is only supported for assistant messages
@@ -516,10 +527,15 @@ export function useHotPlexRuntime({
 
       setMessages((prev) => {
         const lastMessage = prev[prev.length - 1];
-        if (lastMessage?.role === 'assistant' && lastMessage.status === 'streaming') {
+        if (lastMessage?.role === 'assistant') {
+          const parts = [...lastMessage.parts];
+          // Inject turn-summary part from _session data
+          if (data?.stats?._session) {
+            parts.push({ type: 'turn-summary' as const, data: data.stats._session });
+          }
           return [
             ...prev.slice(0, -1),
-            { ...lastMessage, status: 'complete' },
+            { ...lastMessage, status: 'complete' as const, parts },
           ];
         }
         return prev;
@@ -889,7 +905,7 @@ export function useHotPlexRuntime({
     const seen = new Set<string>();
     return messages
       .filter((m): m is HotPlexMessage => !!m && (m.role === 'user' || m.role === 'assistant'))
-      .filter((m) => !m.parts.every(p => p.type === 'context-usage'))
+      .filter((m) => !m.parts.every(p => p.type === 'context-usage' || p.type === 'turn-summary'))
       .filter((m) => {
         if (seen.has(m.id)) return false;
         seen.add(m.id);

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -881,23 +881,25 @@ export function useHotPlexRuntime({
     }
   }, []);
 
-  // Memoized thread messages conversion (spec §7.1)
-  // Filter out malformed messages and guard against undefined roles to prevent
-  // assistant-ui's internal converter from crashing with "Unknown message role".
-  // Dedup by ID to prevent MessageRepository "same id" errors.
+  // Deduped messages for assistant-ui — the ExternalStoreAdapter interface has no
+  // threadMessages field; it processes raw `messages` via convertMessage. Dedup here
+  // to prevent MessageRepository "same id already exists" errors. Also filter out
+  // context-usage messages (internal metadata, not conversation messages).
+  const adapterMessages = useMemo(() => {
+    const seen = new Set<string>();
+    return messages
+      .filter((m): m is HotPlexMessage => !!m && (m.role === 'user' || m.role === 'assistant'))
+      .filter((m) => !m.parts.every(p => p.type === 'context-usage'))
+      .filter((m) => {
+        if (seen.has(m.id)) return false;
+        seen.add(m.id);
+        return true;
+      });
+  }, [messages]);
+
   const threadMessages = useMemo(
-    () => {
-      const seen = new Set<string>();
-      return messages
-        .filter((m): m is HotPlexMessage => !!m && (m.role === 'user' || m.role === 'assistant'))
-        .filter((m) => {
-          if (seen.has(m.id)) return false;
-          seen.add(m.id);
-          return true;
-        })
-        .map((m) => convertToThreadMessage(m));
-    },
-    [messages]
+    () => adapterMessages.map((m) => convertToThreadMessage(m)),
+    [adapterMessages]
   );
 
   // Stable setMessages callback to prevent adapter churn
@@ -922,7 +924,7 @@ export function useHotPlexRuntime({
   return useMemo(() => ({
     // State
     isRunning,
-    messages,
+    messages: adapterMessages,
     threadMessages,
     suggestions,
     setMessages: handleSetMessages,
@@ -940,7 +942,7 @@ export function useHotPlexRuntime({
     // Metrics — exposed for session dashboard (spec §4.5)
     extras,
   } as ExternalStoreAdapter<HotPlexMessage>), [
-    isRunning, messages, threadMessages, suggestions,
+    isRunning, adapterMessages, threadMessages, suggestions,
     handleSetMessages, handleNew, handleCancel, capabilities, extras,
   ]);
 }

--- a/webchat/lib/ai-sdk-transport/client/types.ts
+++ b/webchat/lib/ai-sdk-transport/client/types.ts
@@ -90,6 +90,28 @@ export interface DoneStats {
   cost_usd?: number;
   model?: string;
   context_used_percent?: number;
+  _session?: TurnSessionStats;
+}
+
+export interface TurnSessionStats {
+  turn_count: number;
+  tool_call_count: number;
+  duration: string;
+  duration_seconds: number;
+  total_input_tok: number;
+  total_output_tok: number;
+  context_fill: number;
+  context_window: number;
+  context_pct: number;
+  total_cost_usd: number;
+  model_name: string;
+  turn_duration_ms: number;
+  turn_input_tok: number;
+  turn_output_tok: number;
+  turn_cost_usd: number;
+  tool_names: Record<string, number> | null;
+  work_dir: string;
+  git_branch: string;
 }
 
 export interface MessageData {

--- a/webchat/lib/hooks/useMetrics.ts
+++ b/webchat/lib/hooks/useMetrics.ts
@@ -13,6 +13,14 @@ export interface TurnMetrics {
   model?: string;
   /** Cost estimate in USD */
   costUsd?: number;
+  /** Context window usage percentage */
+  contextPct?: number;
+  /** Tool call count this turn */
+  toolCallCount?: number;
+  /** Turn duration in ms */
+  turnDurationMs?: number;
+  /** Tool name → call count breakdown */
+  toolNames?: Record<string, number>;
 }
 
 export interface SessionMetrics {
@@ -21,6 +29,8 @@ export interface SessionMetrics {
   totalOutputTokens: number;
   totalLatencyMs: number;
   turnCount: number;
+  /** Most recent turn metrics for inline display */
+  lastTurn?: TurnMetrics;
 }
 
 /**
@@ -41,19 +51,34 @@ export function useMetrics() {
     turnStartRef.current = Date.now();
   }, []);
 
-  const recordTurn = useCallback((stats: Record<string, any>) => {
+  const recordTurn = useCallback((stats: Record<string, any>): TurnMetrics => {
     const inputTokens = stats.input_tokens ?? stats.inputTokens ?? 0;
     const outputTokens = stats.output_tokens ?? stats.outputTokens ?? 0;
     const latencyMs = Date.now() - turnStartRef.current;
 
+    const session = stats._session as Record<string, any> | undefined;
+
+    const turnMetrics: TurnMetrics = {
+      inputTokens: session?.turn_input_tok ?? inputTokens,
+      outputTokens: session?.turn_output_tok ?? outputTokens,
+      latencyMs: session?.turn_duration_ms ?? latencyMs,
+      model: session?.model_name,
+      costUsd: session?.turn_cost_usd,
+      contextPct: session?.context_pct,
+      toolCallCount: session?.tool_call_count,
+      turnDurationMs: session?.turn_duration_ms,
+      toolNames: session?.tool_names ?? undefined,
+    };
+
     setSessionMetrics((prev) => ({
-      totalInputTokens: prev.totalInputTokens + inputTokens,
-      totalOutputTokens: prev.totalOutputTokens + outputTokens,
-      totalLatencyMs: prev.totalLatencyMs + latencyMs,
+      totalInputTokens: prev.totalInputTokens + turnMetrics.inputTokens!,
+      totalOutputTokens: prev.totalOutputTokens + turnMetrics.outputTokens!,
+      totalLatencyMs: prev.totalLatencyMs + turnMetrics.latencyMs!,
       turnCount: prev.turnCount + 1,
+      lastTurn: turnMetrics,
     }));
 
-    return { inputTokens, outputTokens, latencyMs };
+    return turnMetrics;
   }, []);
 
   return { sessionMetrics, startTurn, recordTurn };


### PR DESCRIPTION
## Summary

Replace the platform-suffix agent config mechanism (`SOUL.slack.md`) with a directory-based 3-level fallback system supporting per-bot configuration granularity. Include botID in session key derivation to ensure different bots in the same channel produce separate sessions. Also fixes a context fill calculation bug where cache tokens were double-counted.

### Changes

**Per-Bot Agent Config (Core Feature)**:
- `internal/agentconfig/loader.go` — `Load(dir, platform, botID)` + `resolveFile` 3-level fallback, path safety check
- `internal/session/key.go` — `PlatformContext.BotID` field, included in `DerivePlatformSessionKey` hash
- `internal/messaging/platform_adapter.go` — `GetBotID()` interface, `SessionStarter` +botID, `ExtractPlatformKeys` +bot_id
- `internal/messaging/bridge.go` — `SetAdapter()`, `MakeSlackEnvelope`/`MakeFeishuEnvelope` +botID, `MakeEnvelope` metadata +bot_id
- `internal/messaging/slack/adapter.go` — `GetBotID()` implementation
- `internal/messaging/feishu/adapter.go` — `GetBotID()` implementation
- `internal/gateway/bridge.go` — `injectAgentConfig` +botID, `workerLaunchParams` +botID, all 3 `createAndLaunchWorker` call sites
- `cmd/hotplex/messaging_init.go` — `SetAdapter(adapter)` after `adapter.Start()`
- `cmd/hotplex/gateway_run.go` — deprecation warning for old `SOUL.<platform>.md` suffix files
- `cmd/hotplex/onboard.go` — updated guidance text for directory layout

**Context Fill Bug Fix**:
- `internal/gateway/session_stats.go` — `ContextFill = input_tokens` only (not +cache_creation+cache_read), per Claude Code SDK docs `input_tokens` already includes cached tokens

**Documentation**:
- `.agent/rules/agentconfig.md` — updated to directory fallback architecture
- `internal/agentconfig/META-COGNITION.md` — updated architecture description
- `AGENTS.md` — updated agent config module description

**Architecture Impact**:
- Channel: Slack / Feishu / WebChat
- Worker: CC / OCS / Pi (all use agent config)
- Platform: Cross-platform

## Directory Structure

```
~/.hotplex/agent-configs/
├── SOUL.md / AGENTS.md / ...          ← Global default
├── slack/                             ← Slack platform default
│   ├── SOUL.md / ...
│   └── U12345/                        ← Per-Slack-bot
│       └── SOUL.md / ...
├── feishu/                            ← Feishu platform default
│   └── ou_abc123/                     ← Per-Feishu-bot
└── webchat/                           ← WebChat default
```

## Breaking Changes

| Change | Impact | Migration |
|--------|--------|-----------|
| `SOUL.<platform>.md` suffix no longer loaded | Platform-specific configs not found | Move to `slack/SOUL.md` directory |
| `PlatformContext.BotID` added to session key | Existing session IDs change | Automatic — fresh sessions created |

## Test Plan

- [x] make test
- [x] make lint
- [x] 3-level fallback unit tests (bot → platform → global)
- [x] Path traversal test for botID
- [x] Empty file fallthrough test
- [x] Flat-directory backward compatibility test

## Related Issues

- Fixes #130
- Refs #127