### PR TITLE
fix(gateway): session lifecycle fixes — resume blind retry, GC race, empty session ID

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -271,16 +271,13 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 					return err
 				}
 			}
-			// Check if session files still exist before attempting resume.
-			// Zombie GC may have deleted them, causing --resume to fail immediately.
+			// Zombie GC may delete session files; fall back to fresh start if missing.
 			if fc, ok := w.(worker.SessionFileChecker); ok && !fc.HasSessionFiles(workerInfo.SessionID) {
 				b.log.Info("bridge: session files missing, falling back to fresh start",
 					"session_id", id)
 				if err := w.Start(ctx, workerInfo); err != nil {
 					return fmt.Errorf("bridge: fresh start after missing files: %w", err)
 				}
-				// Clear resumed flag so forwardEvents treats this as a fresh session,
-				// ensuring retry and fallback logic work correctly.
 				opts.resumed = false
 				return nil
 			}

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -268,6 +268,16 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 					return err
 				}
 			}
+			// Check if session files still exist before attempting resume.
+			// Zombie GC may have deleted them, causing --resume to fail immediately.
+			if fc, ok := w.(worker.SessionFileChecker); ok && !fc.HasSessionFiles(workerInfo.SessionID) {
+				b.log.Info("bridge: session files missing, falling back to fresh start",
+					"session_id", id)
+				if err := w.Start(ctx, workerInfo); err != nil {
+					return fmt.Errorf("bridge: fresh start after missing files: %w", err)
+				}
+				return nil
+			}
 			if err := w.Resume(ctx, workerInfo); err != nil {
 				return fmt.Errorf("bridge: resume start: %w", err)
 			}
@@ -469,7 +479,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			if b.log.Enabled(context.Background(), slog.LevelDebug) {
 				b.log.Debug("bridge: turn completed",
 					"session_id", sessionID, "worker_type", workerType, "turn", acc.TurnCount,
-					"duration", time.Since(startTime).Round(time.Millisecond),
+					"duration", time.Since(turnStartTime).Round(time.Millisecond),
 					"text_len", turnText.Len(), "tools", acc.ToolCallCount)
 			}
 		}

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -161,7 +161,7 @@ type workerLaunchParams struct {
 	workerInfo  worker.SessionInfo
 	platform    string
 	botID       string
-	forwardOpts forwardOpts
+	forwardOpts *forwardOpts
 }
 
 // workerStartFunc is called after AttachWorker and injectAgentConfig.
@@ -176,6 +176,9 @@ type workerAttachErrFunc func(w worker.Worker, err error)
 // On startFn failure, the worker is detached before returning.
 func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn workerStartFunc, attachErrFn workerAttachErrFunc) (worker.Worker, error) {
 	sid := params.workerInfo.SessionID
+	if params.forwardOpts == nil {
+		params.forwardOpts = &forwardOpts{}
+	}
 
 	w, err := b.wf.NewWorker(params.wt)
 	if err != nil {
@@ -203,7 +206,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
-		b.forwardEvents(w, sid, params.forwardOpts)
+		b.forwardEvents(w, sid, *params.forwardOpts)
 	}()
 
 	return w, nil
@@ -259,7 +262,7 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		workerInfo:  workerInfo,
 		platform:    si.Platform,
 		botID:       si.BotID,
-		forwardOpts: opts,
+		forwardOpts: &opts,
 	},
 		func(ctx context.Context, w worker.Worker) error {
 			// Transition IDLE/RESUMED/TERMINATED sessions to RUNNING.
@@ -276,6 +279,9 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 				if err := w.Start(ctx, workerInfo); err != nil {
 					return fmt.Errorf("bridge: fresh start after missing files: %w", err)
 				}
+				// Clear resumed flag so forwardEvents treats this as a fresh session,
+				// ensuring retry and fallback logic work correctly.
+				opts.resumed = false
 				return nil
 			}
 			if err := w.Resume(ctx, workerInfo); err != nil {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -459,6 +459,8 @@ func (h *Handler) handleGC(ctx context.Context, env *events.Envelope) error {
 	if fresh, err := h.sm.Get(env.SessionID); err == nil && fresh.State == events.StateTerminated {
 		h.log.Info("gateway: gc idempotent (concurrently terminated)", "session_id", env.SessionID)
 		return nil
+	} else if err != nil {
+		h.log.Debug("gateway: gc re-read failed, proceeding with transition", "session_id", env.SessionID, "err", err)
 	}
 
 	if err := h.sm.TransitionWithReason(ctx, env.SessionID, events.StateTerminated, "gc"); err != nil {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -454,13 +454,13 @@ func (h *Handler) handleGC(ctx context.Context, env *events.Envelope) error {
 		h.sm.DetachWorker(env.SessionID)
 	}
 
-	// Re-read state after worker cleanup to avoid stale snapshot race
-	// with concurrent cleanupCrashedWorker transitions.
+	// Re-read after worker cleanup to avoid stale-snapshot race with concurrent
+	// cleanupCrashedWorker transitions.
 	if fresh, err := h.sm.Get(env.SessionID); err == nil && fresh.State == events.StateTerminated {
 		h.log.Info("gateway: gc idempotent (concurrently terminated)", "session_id", env.SessionID)
 		return nil
 	} else if err != nil {
-		h.log.Debug("gateway: gc re-read failed, proceeding with transition", "session_id", env.SessionID, "err", err)
+		h.log.Debug("gateway: gc re-read failed, proceeding", "session_id", env.SessionID, "err", err)
 	}
 
 	if err := h.sm.TransitionWithReason(ctx, env.SessionID, events.StateTerminated, "gc"); err != nil {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -454,6 +454,13 @@ func (h *Handler) handleGC(ctx context.Context, env *events.Envelope) error {
 		h.sm.DetachWorker(env.SessionID)
 	}
 
+	// Re-read state after worker cleanup to avoid stale snapshot race
+	// with concurrent cleanupCrashedWorker transitions.
+	if fresh, err := h.sm.Get(env.SessionID); err == nil && fresh.State == events.StateTerminated {
+		h.log.Info("gateway: gc idempotent (concurrently terminated)", "session_id", env.SessionID)
+		return nil
+	}
+
 	if err := h.sm.TransitionWithReason(ctx, env.SessionID, events.StateTerminated, "gc"); err != nil {
 		return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "gc transition failed: %v", err)
 	}

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -181,8 +181,7 @@ func (h *testableHandler) handleGC(ctx context.Context, sessionID, ownerID strin
 		_ = w.Terminate(ctx)
 		h.sm.DetachWorker(sessionID)
 	}
-	// 4. Re-read state after worker cleanup to avoid stale snapshot race
-	// with concurrent cleanupCrashedWorker transitions.
+	// 4. Re-read after worker cleanup to avoid stale-snapshot race.
 	if fresh, err := h.sm.Get(sessionID); err == nil && fresh.State == events.StateTerminated {
 		return nil
 	}

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -189,7 +189,7 @@ func (h *testableHandler) handleGC(ctx context.Context, sessionID, ownerID strin
 	if err := h.sm.TransitionWithReason(ctx, sessionID, events.StateTerminated, "gc"); err != nil {
 		return err
 	}
-	// 5. Send state notification
+	// 6. Send state notification
 	return h.sendState(ctx, sessionID, events.StateTerminated, "session_archived")
 }
 

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -181,7 +181,12 @@ func (h *testableHandler) handleGC(ctx context.Context, sessionID, ownerID strin
 		_ = w.Terminate(ctx)
 		h.sm.DetachWorker(sessionID)
 	}
-	// 4. Transition to TERMINATED
+	// 4. Re-read state after worker cleanup to avoid stale snapshot race
+	// with concurrent cleanupCrashedWorker transitions.
+	if fresh, err := h.sm.Get(sessionID); err == nil && fresh.State == events.StateTerminated {
+		return nil
+	}
+	// 5. Transition to TERMINATED
 	if err := h.sm.TransitionWithReason(ctx, sessionID, events.StateTerminated, "gc"); err != nil {
 		return err
 	}

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -435,8 +435,7 @@ func (w *Worker) ResetContext(ctx context.Context) error {
 	return w.Start(ctx, orig)
 }
 
-// deleteSessionFiles removes Claude session files to prevent "already in use" errors on reset.
-// sessionFileGlobs returns the glob patterns for Claude Code session files.
+// sessionFileGlobs returns glob patterns for Claude Code session files.
 func sessionFileGlobs(homeDir, parsedID string) []string {
 	return []string{
 		filepath.Join(homeDir, ".claude", "projects", "*", parsedID+".jsonl"),
@@ -445,14 +444,12 @@ func sessionFileGlobs(homeDir, parsedID string) []string {
 	}
 }
 
-// HasSessionFiles checks whether session files still exist on disk for the
-// given session ID. It uses the same glob patterns as deleteSessionFiles.
+// HasSessionFiles checks whether session files still exist on disk.
 func (w *Worker) HasSessionFiles(sessionID string) bool {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		// Fail-open: assume files exist so the normal resume path is attempted.
-		// If files are truly missing, the existing crash-detection fallback handles it.
-		w.Log.Warn("claudecode: HasSessionFiles cannot resolve home dir, assuming files exist",
+		// Fail-open: assume files exist so normal resume path is attempted.
+		w.Log.Warn("claudecode: cannot resolve home dir, assuming files exist",
 			"session_id", sessionID, "err", err)
 		return true
 	}
@@ -466,12 +463,7 @@ func (w *Worker) HasSessionFiles(sessionID string) bool {
 	return false
 }
 
-// Claude Code stores session data at:
-//   - ~/.claude/projects/<hash>/<uuid>.jsonl  (conversation transcript)
-//   - ~/.claude/projects/<hash>/<uuid>         (session metadata directory)
-//   - ~/.claude/session-env/<uuid>              (session environment)
-//
-// The glob spans all project hashes since the hash algorithm is internal to Claude Code.
+// deleteSessionFiles removes Claude session files to prevent "already in use" errors on reset.
 func (w *Worker) deleteSessionFiles() error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -437,6 +436,32 @@ func (w *Worker) ResetContext(ctx context.Context) error {
 }
 
 // deleteSessionFiles removes Claude session files to prevent "already in use" errors on reset.
+// sessionFileGlobs returns the glob patterns for Claude Code session files.
+func sessionFileGlobs(homeDir, parsedID string) []string {
+	return []string{
+		filepath.Join(homeDir, ".claude", "projects", "*", parsedID+".jsonl"),
+		filepath.Join(homeDir, ".claude", "projects", "*", parsedID),
+		filepath.Join(homeDir, ".claude", "session-env", parsedID),
+	}
+}
+
+// HasSessionFiles checks whether session files still exist on disk for the
+// given session ID. It uses the same glob patterns as deleteSessionFiles.
+func (w *Worker) HasSessionFiles(sessionID string) bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	parsedID := aep.ParseSessionID(sessionID)
+	for _, pattern := range sessionFileGlobs(homeDir, parsedID) {
+		matches, _ := filepath.Glob(pattern)
+		if len(matches) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // Claude Code stores session data at:
 //   - ~/.claude/projects/<hash>/<uuid>.jsonl  (conversation transcript)
 //   - ~/.claude/projects/<hash>/<uuid>         (session metadata directory)
@@ -444,19 +469,13 @@ func (w *Worker) ResetContext(ctx context.Context) error {
 //
 // The glob spans all project hashes since the hash algorithm is internal to Claude Code.
 func (w *Worker) deleteSessionFiles() error {
-	currentUser, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("get home dir: %w", err)
 	}
-	homeDir := currentUser.HomeDir
 
 	parsedID := aep.ParseSessionID(w.sessionID)
-
-	patterns := []string{
-		filepath.Join(homeDir, ".claude", "projects", "*", parsedID+".jsonl"), // transcript
-		filepath.Join(homeDir, ".claude", "projects", "*", parsedID),          // metadata dir
-		filepath.Join(homeDir, ".claude", "session-env", parsedID),            // env
-	}
+	patterns := sessionFileGlobs(homeDir, parsedID)
 
 	var (
 		firstErr error

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -450,7 +450,11 @@ func sessionFileGlobs(homeDir, parsedID string) []string {
 func (w *Worker) HasSessionFiles(sessionID string) bool {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return false
+		// Fail-open: assume files exist so the normal resume path is attempted.
+		// If files are truly missing, the existing crash-detection fallback handles it.
+		w.Log.Warn("claudecode: HasSessionFiles cannot resolve home dir, assuming files exist",
+			"session_id", sessionID, "err", err)
+		return true
 	}
 	parsedID := aep.ParseSessionID(sessionID)
 	for _, pattern := range sessionFileGlobs(homeDir, parsedID) {

--- a/internal/worker/claudecode/worker_test.go
+++ b/internal/worker/claudecode/worker_test.go
@@ -537,41 +537,37 @@ func TestSessionFileGlobs(t *testing.T) {
 	require.Contains(t, patterns[2], "session-env/abc-123")
 }
 
-func TestHasSessionFiles(t *testing.T) {
+func TestSessionFileGlobs_Matches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches transcript file", func(t *testing.T) {
+		t.Parallel()
+
+		homeDir := t.TempDir()
+		projectDir := filepath.Join(homeDir, ".claude", "projects", "hash")
+		require.NoError(t, os.MkdirAll(projectDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, "test-uuid-1234.jsonl"), []byte("{}"), 0o644))
+
+		matches, _ := filepath.Glob(sessionFileGlobs(homeDir, "test-uuid-1234")[0])
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("matches env file", func(t *testing.T) {
+		t.Parallel()
+
+		homeDir := t.TempDir()
+		envDir := filepath.Join(homeDir, ".claude", "session-env")
+		require.NoError(t, os.MkdirAll(envDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(envDir, "test-uuid-1234"), []byte("env"), 0o644))
+
+		matches, _ := filepath.Glob(sessionFileGlobs(homeDir, "test-uuid-1234")[2])
+		require.Len(t, matches, 1)
+	})
+}
+
+func TestHasSessionFiles_NoFiles(t *testing.T) {
 	t.Parallel()
 
 	w := New()
-	sessionID := "sess_test-uuid-1234"
-
-	t.Run("returns false when no files exist", func(t *testing.T) {
-		t.Parallel()
-		require.False(t, w.HasSessionFiles(sessionID))
-	})
-
-	t.Run("returns true when transcript exists", func(t *testing.T) {
-		t.Parallel()
-
-		homeDir := t.TempDir()
-		projectDir := homeDir + "/.claude/projects/hash"
-		require.NoError(t, os.MkdirAll(projectDir, 0o755))
-		require.NoError(t, os.WriteFile(projectDir+"/test-uuid-1234.jsonl", []byte("{}"), 0o644))
-
-		// Override home dir by testing via sessionFileGlobs directly
-		patterns := sessionFileGlobs(homeDir, "test-uuid-1234")
-		matches, _ := filepath.Glob(patterns[0])
-		require.Len(t, matches, 1)
-	})
-
-	t.Run("returns true when env dir exists", func(t *testing.T) {
-		t.Parallel()
-
-		homeDir := t.TempDir()
-		envDir := homeDir + "/.claude/session-env"
-		require.NoError(t, os.MkdirAll(envDir, 0o755))
-		require.NoError(t, os.WriteFile(envDir+"/test-uuid-1234", []byte("env"), 0o644))
-
-		patterns := sessionFileGlobs(homeDir, "test-uuid-1234")
-		matches, _ := filepath.Glob(patterns[2])
-		require.Len(t, matches, 1)
-	})
+	require.False(t, w.HasSessionFiles("sess_test-uuid-1234"))
 }

--- a/internal/worker/claudecode/worker_test.go
+++ b/internal/worker/claudecode/worker_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -523,4 +525,53 @@ func TestControlHandler_SendElicitationResponse(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
 	require.Equal(t, "req_e1", resp.Response.RequestID)
 	require.Equal(t, "accept", resp.Response.Response["action"])
+}
+
+func TestSessionFileGlobs(t *testing.T) {
+	t.Parallel()
+
+	patterns := sessionFileGlobs("/home/user", "abc-123")
+	require.Len(t, patterns, 3)
+	require.Contains(t, patterns[0], "projects/*/abc-123.jsonl")
+	require.Contains(t, patterns[1], "projects/*/abc-123")
+	require.Contains(t, patterns[2], "session-env/abc-123")
+}
+
+func TestHasSessionFiles(t *testing.T) {
+	t.Parallel()
+
+	w := New()
+	sessionID := "sess_test-uuid-1234"
+
+	t.Run("returns false when no files exist", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, w.HasSessionFiles(sessionID))
+	})
+
+	t.Run("returns true when transcript exists", func(t *testing.T) {
+		t.Parallel()
+
+		homeDir := t.TempDir()
+		projectDir := homeDir + "/.claude/projects/hash"
+		require.NoError(t, os.MkdirAll(projectDir, 0o755))
+		require.NoError(t, os.WriteFile(projectDir+"/test-uuid-1234.jsonl", []byte("{}"), 0o644))
+
+		// Override home dir by testing via sessionFileGlobs directly
+		patterns := sessionFileGlobs(homeDir, "test-uuid-1234")
+		matches, _ := filepath.Glob(patterns[0])
+		require.Len(t, matches, 1)
+	})
+
+	t.Run("returns true when env dir exists", func(t *testing.T) {
+		t.Parallel()
+
+		homeDir := t.TempDir()
+		envDir := homeDir + "/.claude/session-env"
+		require.NoError(t, os.MkdirAll(envDir, 0o755))
+		require.NoError(t, os.WriteFile(envDir+"/test-uuid-1234", []byte("env"), 0o644))
+
+		patterns := sessionFileGlobs(homeDir, "test-uuid-1234")
+		matches, _ := filepath.Glob(patterns[2])
+		require.Len(t, matches, 1)
+	})
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -144,7 +144,7 @@ type InputRecoverer interface {
 
 // SessionFileChecker is an optional interface for workers that can verify
 // whether session files still exist on disk. Bridge uses this before resume
-// to avoid passing --resume to a CLI when files have been garbage-collected.
+// to fall back to a fresh start when files have been garbage-collected.
 type SessionFileChecker interface {
 	HasSessionFiles(sessionID string) bool
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -142,6 +142,13 @@ type InputRecoverer interface {
 	LastInput() string
 }
 
+// SessionFileChecker is an optional interface for workers that can verify
+// whether session files still exist on disk. Bridge uses this before resume
+// to avoid passing --resume to a CLI when files have been garbage-collected.
+type SessionFileChecker interface {
+	HasSessionFiles(sessionID string) bool
+}
+
 // InPlaceReseter is an optional interface for workers whose ResetContext
 // resets state in-place without replacing the Conn or restarting the process.
 // Bridge.ResetSession uses this to decide whether to spawn a new forwardEvents

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -101,7 +101,7 @@ export async function getSessionHistory(
   sessionId: string,
   options?: { beforeSeq?: number; limit?: number }
 ): Promise<GetHistoryResponse> {
-  if (!sessionId || sessionId.trim() === '') {
+  if (!sessionId?.trim()) {
     throw new Error('getSessionHistory: empty session ID');
   }
   const limit = options?.limit ?? 50;

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -101,6 +101,9 @@ export async function getSessionHistory(
   sessionId: string,
   options?: { beforeSeq?: number; limit?: number }
 ): Promise<GetHistoryResponse> {
+  if (!sessionId || sessionId.trim() === '') {
+    throw new Error('getSessionHistory: empty session ID');
+  }
   const limit = options?.limit ?? 50;
   let url = `${BASE}/api/sessions/${sessionId}/history?${AUTH}&limit=${limit}`;
   if (options?.beforeSeq) {

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -83,7 +83,7 @@ export function useSessions({
       }
 
       // 2. Try to restore from localStorage for persistence
-      const savedId = localStorage.getItem(STORAGE_KEY);
+      const savedId = localStorage.getItem(STORAGE_KEY)?.trim();
       if (savedId) {
         const found = filtered.find(s => s.id === savedId);
         if (found) {


### PR DESCRIPTION
## Summary

- **P0 (resume blind retry)**: Add `SessionFileChecker` optional interface + `HasSessionFiles()` to claudecode worker. Bridge `resumeWithOpts` now checks file existence before passing `--resume` to CLI, falling back to fresh start when zombie GC has deleted session files. Eliminates ~5s crash-detect-then-fallback delay.
- **P1 (GC race condition)**: `handleGC` re-reads session state atomically after worker cleanup to avoid stale snapshot race with concurrent `cleanupCrashedWorker`, preventing redundant `terminated→terminated` transitions.
- **P3 (empty session ID)**: `getSessionHistory` validates non-empty session ID before API call; `useSessions` trims localStorage value to filter whitespace-only entries.
- **#134 (turn duration log)**: Fix `bridge.go` debug log to use `turnStartTime` instead of goroutine `startTime`, resolving misleading multi-hour duration entries.

## Test plan

- [x] `make check` — fmt + lint + vet + test + build all pass (0 issues)
- [x] `pnpm build` — webchat frontend compiles successfully
- [ ] Manual: trigger zombie GC on a session, verify resume falls back to fresh start without crash-detect delay
- [ ] Manual: check logs no longer show `terminated → terminated` transitions on concurrent GC
- [ ] Manual: verify no 400 errors from empty session ID in browser console

Closes #133
Closes #134