### PR TITLE
feat(slack): add CLI subcommand group for Slack operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,7 @@ git push fork --delete feat/<feature-name>
 
 - **Edit 工具优先**：修改源码必须使用 Edit 工具，禁止用 `sed -i` 插入或修改代码行
 - **Edit 匹配失败时**：重新 Read 文件获取精确内容，用精确字符串重试 Edit；扩大上下文使其唯一
+- **Go 文件 tab 缩进**：Go 项目使用 tab 缩进（gofmt 标准）。使用 Edit 工具时，old_string 必须从 Read 输出中直接复制原文（保留 tab），禁止手敲空格缩进。Edit 匹配失败时先用 `cat -A` 确认实际空白字符
 - **`sed` 适用场景**：仅限非代码操作（config 快速替换、日志过滤等简单唯一 token 替换）
 
 ### 独特风格

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,22 @@ hotplex update -y             # 跳过确认提示
 hotplex update --restart      # 更新后自动重启网关
 ```
 
+### Slack 操作
+
+```bash
+hotplex slack send-message --text "Hello" --channel <id>
+hotplex slack upload-file --file ./report.pdf --title "Report"
+hotplex slack update-message --channel <id> --ts <ts> --text "Updated"
+hotplex slack schedule-message --text "Reminder" --at "2026-05-04T09:00:00+08:00"
+hotplex slack download-file --file-id <id> --output ./save.pdf
+hotplex slack list-channels --types im,public_channel --json
+hotplex slack search --query "keyword" --type messages
+hotplex slack canvas create --title "Doc" --content "# Title\nContent"
+hotplex slack canvas edit --canvas-id <id> --content "New content"
+hotplex slack bookmark add --channel <id> --title "Link" --url <url>
+hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark
+```
+
 ---
 
 ## 备注

--- a/cmd/hotplex/main.go
+++ b/cmd/hotplex/main.go
@@ -50,6 +50,7 @@ Quick start:
 		newStatusCmd(),
 		newServiceCmd(),
 		newUpdateCmd(),
+		newSlackCmd(),
 	)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)

--- a/cmd/hotplex/slack_bookmark.go
+++ b/cmd/hotplex/slack_bookmark.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackBookmarkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bookmark",
+		Short: "Manage channel bookmarks",
+		Long:  `Add, list, and remove bookmarks in Slack channels.`,
+	}
+	cmd.AddCommand(
+		newSlackBookmarkAddCmd(),
+		newSlackBookmarkListCmd(),
+		newSlackBookmarkRemoveCmd(),
+	)
+	return cmd
+}
+
+func newSlackBookmarkAddCmd() *cobra.Command {
+	var channel, title, url, emoji, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a bookmark",
+		Long:  `Add a bookmark to a Slack channel.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			result, err := slackcli.AddBookmark(cmd.Context(), client, channel, title, url, emoji)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(result)
+			}
+			fmt.Printf("ok  bookmark_id=%s  title=%q\n", result.ID, result.Title)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().StringVar(&title, "title", "", "bookmark title")
+	cmd.Flags().StringVar(&url, "url", "", "bookmark URL")
+	cmd.Flags().StringVar(&emoji, "emoji", "", "bookmark icon emoji")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("channel")
+	cmd.MarkFlagRequired("title")
+
+	return cmd
+}
+
+func newSlackBookmarkListCmd() *cobra.Command {
+	var channel, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List bookmarks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			bookmarks, err := slackcli.ListBookmarks(cmd.Context(), client, channel)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(bookmarks)
+			}
+
+			if len(bookmarks) == 0 {
+				fmt.Fprintln(os.Stderr, "No bookmarks found.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %s\n", "ID", "TITLE", "URL")
+			for _, bm := range bookmarks {
+				fmt.Printf("%-20s %-30q %s\n", bm.ID, bm.Title, bm.URL)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("channel")
+
+	return cmd
+}
+
+func newSlackBookmarkRemoveCmd() *cobra.Command {
+	var channel, bookmarkID, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a bookmark",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			if err := slackcli.RemoveBookmark(cmd.Context(), client, channel, bookmarkID); err != nil {
+				return err
+			}
+
+			fmt.Printf("ok  removed bookmark %s from %s\n", bookmarkID, channel)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().StringVar(&bookmarkID, "bookmark-id", "", "bookmark ID")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("channel")
+	cmd.MarkFlagRequired("bookmark-id")
+
+	return cmd
+}

--- a/cmd/hotplex/slack_canvas.go
+++ b/cmd/hotplex/slack_canvas.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackCanvasCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "canvas",
+		Short: "Manage Slack Canvas documents",
+		Long:  `Create, edit, and inspect Slack Canvas documents (native Slack document system).`,
+	}
+	cmd.AddCommand(
+		newSlackCanvasCreateCmd(),
+		newSlackCanvasEditCmd(),
+		newSlackCanvasListSectionsCmd(),
+	)
+	return cmd
+}
+
+func newSlackCanvasCreateCmd() *cobra.Command {
+	var title, content, file, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new Canvas",
+		Long:  `Create a new Canvas document in Slack with Markdown content.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			body := content
+			if file != "" {
+				data, err := os.ReadFile(file)
+				if err != nil {
+					return fmt.Errorf("read file: %w", err)
+				}
+				body = string(data)
+			}
+
+			if body == "" {
+				return fmt.Errorf("--content or --file is required")
+			}
+
+			result, err := slackcli.CreateCanvas(cmd.Context(), client, title, body)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(result)
+			}
+			fmt.Printf("ok  canvas_id=%s  title=%q\n", result.CanvasID, result.Title)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "canvas title")
+	cmd.Flags().StringVar(&content, "content", "", "initial content (markdown)")
+	cmd.Flags().StringVar(&file, "file", "", "read content from file")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("title")
+
+	return cmd
+}
+
+func newSlackCanvasEditCmd() *cobra.Command {
+	var canvasID, content, file, sectionID, operation, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit a Canvas",
+		Long:  `Edit content of an existing Canvas document.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			body := content
+			if file != "" {
+				data, err := os.ReadFile(file)
+				if err != nil {
+					return fmt.Errorf("read file: %w", err)
+				}
+				body = string(data)
+			}
+
+			if body == "" {
+				return fmt.Errorf("--content or --file is required")
+			}
+
+			if err := slackcli.EditCanvas(cmd.Context(), client, canvasID, body, sectionID, operation); err != nil {
+				return err
+			}
+
+			fmt.Printf("ok  canvas_id=%s  operation=%s\n", canvasID, operation)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	cmd.Flags().StringVar(&content, "content", "", "new content (markdown)")
+	cmd.Flags().StringVar(&file, "file", "", "read content from file")
+	cmd.Flags().StringVar(&sectionID, "section-id", "", "edit specific section only")
+	cmd.Flags().StringVar(&operation, "operation", "replace", "operation: replace, insert_after, insert_before, delete")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("canvas-id")
+
+	return cmd
+}
+
+func newSlackCanvasListSectionsCmd() *cobra.Command {
+	var canvasID, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "list-sections",
+		Short: "List Canvas sections",
+		Long:  `List all sections in a Canvas document.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			sections, err := slackcli.ListCanvasSections(cmd.Context(), client, canvasID)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(sections)
+			}
+
+			if len(sections) == 0 {
+				fmt.Fprintln(os.Stderr, "No sections found.")
+				return nil
+			}
+
+			for _, s := range sections {
+				fmt.Printf("%s\n", s.ID)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("canvas-id")
+
+	return cmd
+}

--- a/cmd/hotplex/slack_channels.go
+++ b/cmd/hotplex/slack_channels.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackListChannelsCmd() *cobra.Command {
+	var types string
+	var limit int
+	var configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "list-channels",
+		Short: "List channels and DMs",
+		Long:  `List Slack channels, DMs, and group DMs.`,
+		Example: `  hotplex slack list-channels --types im
+  hotplex slack list-channels --types im,public_channel,private_channel --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			channels, err := slackcli.ListChannels(cmd.Context(), client, types, limit)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(channels)
+			}
+
+			if len(channels) == 0 {
+				fmt.Fprintln(os.Stderr, "No channels found.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %-10s\n", "ID", "NAME", "TYPE")
+			for _, ch := range channels {
+				typ := "Channel"
+				if ch.IsIM {
+					typ = "DM"
+				} else if ch.IsGroup {
+					typ = "Group"
+				}
+				fmt.Printf("%-20s %-30s %-10s\n", ch.ID, ch.Name, typ)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&types, "types", "im", "channel types (comma-separated: im,public_channel,private_channel)")
+	cmd.Flags().IntVarP(&limit, "limit", "n", 100, "max results")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+
+	return cmd
+}

--- a/cmd/hotplex/slack_cmd.go
+++ b/cmd/hotplex/slack_cmd.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newSlackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "slack",
+		Short: "Slack messaging operations",
+		Long: `Send messages, upload files, and interact with Slack workspaces.
+Uses the same configuration as the gateway (~/.hotplex/.env).`,
+	}
+	cmd.AddCommand(
+		newSlackSendMessageCmd(),
+		newSlackUpdateMessageCmd(),
+		newSlackScheduleMessageCmd(),
+		newSlackUploadFileCmd(),
+		newSlackDownloadFileCmd(),
+		newSlackListChannelsCmd(),
+		newSlackSearchCmd(),
+		newSlackCanvasCmd(),
+		newSlackBookmarkCmd(),
+		newSlackReactCmd(),
+	)
+	return cmd
+}

--- a/cmd/hotplex/slack_download.go
+++ b/cmd/hotplex/slack_download.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackDownloadFileCmd() *cobra.Command {
+	var fileID, output, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "download-file",
+		Short: "Download a file from Slack",
+		Long:  `Download a file from Slack by its file ID and save to a local path.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			if err := slackcli.DownloadFile(cmd.Context(), client, fileID, output); err != nil {
+				return err
+			}
+
+			fmt.Printf("ok  file_id=%s  output=%s\n", fileID, output)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fileID, "file-id", "", "Slack file ID")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "local save path")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("file-id")
+	cmd.MarkFlagRequired("output")
+
+	return cmd
+}

--- a/cmd/hotplex/slack_message.go
+++ b/cmd/hotplex/slack_message.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackSendMessageCmd() *cobra.Command {
+	var text, channel, threadTS, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "send-message",
+		Short: "Send a text message",
+		Long:  `Send a text message to a Slack channel or DM. Supports mrkdwn formatting.`,
+		Example: `  hotplex slack send-message --text "Hello" --channel D0AQJ5CLZN0
+  hotplex slack send-message -t "Reply" --thread-ts 1777797319.120439`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			ch, err := slackcli.ResolveChannel(channel)
+			if err != nil {
+				return err
+			}
+			ts := slackcli.ResolveThreadTS(threadTS)
+
+			result, err := slackcli.SendMessage(cmd.Context(), client, ch, ts, text)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(result)
+			}
+			fmt.Printf("ok  channel=%s  ts=%s\n", result.Channel, result.TS)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&text, "text", "t", "", "message text (supports mrkdwn)")
+	cmd.Flags().StringVar(&channel, "channel", "", "target channel/DM ID")
+	cmd.Flags().StringVar(&threadTS, "thread-ts", "", "thread timestamp for reply")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("text")
+
+	return cmd
+}
+
+func newSlackUpdateMessageCmd() *cobra.Command {
+	var text, channel, ts, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "update-message",
+		Short: "Update an existing message",
+		Long:  `Update the content of a previously sent message.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			result, err := slackcli.UpdateMessage(cmd.Context(), client, channel, ts, text)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(result)
+			}
+			fmt.Printf("ok  channel=%s  ts=%s\n", result.Channel, result.TS)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&text, "text", "t", "", "new message text")
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().StringVar(&ts, "ts", "", "message timestamp")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("text")
+	cmd.MarkFlagRequired("channel")
+	cmd.MarkFlagRequired("ts")
+
+	return cmd
+}
+
+func newSlackScheduleMessageCmd() *cobra.Command {
+	var text, channel, at, configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "schedule-message",
+		Short: "Schedule a message for future delivery",
+		Long:  `Schedule a message to be sent at a specified time. Accepts ISO 8601 or Unix timestamp.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			ch, err := slackcli.ResolveChannel(channel)
+			if err != nil {
+				return err
+			}
+
+			var postAt int64
+			if t, err := time.Parse(time.RFC3339, at); err == nil {
+				postAt = t.Unix()
+			} else {
+				_, err := fmt.Sscanf(at, "%d", &postAt)
+				if err != nil {
+					return fmt.Errorf("--at must be ISO 8601 or Unix timestamp")
+				}
+			}
+
+			scheduledID, err := slackcli.ScheduleMessage(cmd.Context(), client, ch, postAt, text)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"ok": true,
+					"scheduled_message_id": scheduledID,
+					"channel": ch,
+					"post_at": postAt,
+				})
+			}
+			fmt.Printf("ok  scheduled_id=%s  channel=%s  post_at=%d\n", scheduledID, ch, postAt)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&text, "text", "t", "", "message text")
+	cmd.Flags().StringVar(&channel, "channel", "", "target channel")
+	cmd.Flags().StringVar(&at, "at", "", "send time (ISO 8601 or Unix timestamp)")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("text")
+	cmd.MarkFlagRequired("at")
+
+	return cmd
+}

--- a/cmd/hotplex/slack_react.go
+++ b/cmd/hotplex/slack_react.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackReactCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "react",
+		Short: "Add or remove emoji reactions",
+		Long:  `Add or remove emoji reactions on Slack messages.`,
+	}
+	cmd.AddCommand(
+		newSlackReactAddCmd(),
+		newSlackReactRemoveCmd(),
+	)
+	return cmd
+}
+
+func newSlackReactAddCmd() *cobra.Command {
+	var channel, ts, emoji, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a reaction",
+		Example: `  hotplex slack react add --channel D0AQJ5CLZN0 --ts 1777797319.120439 --emoji white_check_mark`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			if err := slackcli.AddReaction(cmd.Context(), client, channel, ts, emoji); err != nil {
+				return err
+			}
+
+			fmt.Printf("ok  added :%s: on %s/%s\n", emoji, channel, ts)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().StringVar(&ts, "ts", "", "message timestamp")
+	cmd.Flags().StringVarP(&emoji, "emoji", "e", "", "emoji name (without colons)")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("channel")
+	cmd.MarkFlagRequired("ts")
+	cmd.MarkFlagRequired("emoji")
+
+	return cmd
+}
+
+func newSlackReactRemoveCmd() *cobra.Command {
+	var channel, ts, emoji, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a reaction",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			if err := slackcli.RemoveReaction(cmd.Context(), client, channel, ts, emoji); err != nil {
+				return err
+			}
+
+			fmt.Printf("ok  removed :%s: on %s/%s\n", emoji, channel, ts)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&channel, "channel", "", "channel ID")
+	cmd.Flags().StringVar(&ts, "ts", "", "message timestamp")
+	cmd.Flags().StringVarP(&emoji, "emoji", "e", "", "emoji name (without colons)")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("channel")
+	cmd.MarkFlagRequired("ts")
+	cmd.MarkFlagRequired("emoji")
+
+	return cmd
+}

--- a/cmd/hotplex/slack_search.go
+++ b/cmd/hotplex/slack_search.go
@@ -64,8 +64,12 @@ func newSlackSearchCmd() *cobra.Command {
 }
 
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
-	return s[:max-3] + "..."
+	if max <= 1 {
+		return "…"
+	}
+	return string(runes[:max-1]) + "…"
 }

--- a/cmd/hotplex/slack_search.go
+++ b/cmd/hotplex/slack_search.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackSearchCmd() *cobra.Command {
+	var query, searchType string
+	var limit int
+	var configPath string
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search messages and files",
+		Long:  `Search Slack for messages and files matching a query.`,
+		Example: `  hotplex slack search --query "deploy failure" --type messages
+  hotplex slack search -q "report" --type files --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			results, err := slackcli.Search(cmd.Context(), client, query, searchType, limit)
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(results)
+			}
+
+			if len(results) == 0 {
+				fmt.Fprintln(os.Stderr, "No results found.")
+				return nil
+			}
+
+			for _, r := range results {
+				if r.Type == "message" {
+					fmt.Printf("[MESSAGE] %s #%s %q\n", r.Timestamp, r.Channel, truncate(r.Text, 60))
+				} else {
+					fmt.Printf("[FILE]    %s (%d bytes)\n", r.Title, r.Size)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "search query")
+	cmd.Flags().StringVar(&searchType, "type", "all", "search scope: messages, files, all")
+	cmd.Flags().IntVarP(&limit, "limit", "n", 20, "max results")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("query")
+
+	return cmd
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/hotplex/slack_upload.go
+++ b/cmd/hotplex/slack_upload.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	slackcli "github.com/hrygo/hotplex/internal/cli/slack"
+)
+
+func newSlackUploadFileCmd() *cobra.Command {
+	var file, title, comment, channel, threadTS, configPath string
+	var maxSize int64
+	var useJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "upload-file",
+		Short: "Upload a file to Slack",
+		Long:  `Upload a file (any type) to a Slack channel or DM. Supports files up to 50MB by default.`,
+		Example: `  hotplex slack upload-file --file ./podcast.mp3 --title "Podcast" --channel D0AQJ5CLZN0
+  hotplex slack upload-file -f report.pdf --comment "Q4 report"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, client, err := slackcli.LoadConfigAndClient(configPath)
+			if err != nil {
+				return err
+			}
+
+			ch, err := slackcli.ResolveChannel(channel)
+			if err != nil {
+				return err
+			}
+			ts := slackcli.ResolveThreadTS(threadTS)
+
+			if maxSize == 0 {
+				maxSize = 50 * 1024 * 1024
+			}
+
+			result, err := slackcli.UploadFile(cmd.Context(), client, &slackcli.UploadParams{
+				FilePath: file,
+				Title:    title,
+				Comment:  comment,
+				Channel:  ch,
+				ThreadTS: ts,
+				MaxSize:  maxSize,
+			})
+			if err != nil {
+				return err
+			}
+
+			if useJSON {
+				return json.NewEncoder(os.Stdout).Encode(result)
+			}
+			fmt.Printf("ok  file_id=%s  title=%q  size=%d  channel=%s\n",
+				result.FileID, result.Title, result.Size, result.Channel)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "local file path")
+	cmd.Flags().StringVar(&title, "title", "", "file title (defaults to filename)")
+	cmd.Flags().StringVar(&comment, "comment", "", "file description")
+	cmd.Flags().StringVar(&channel, "channel", "", "target channel/DM")
+	cmd.Flags().StringVar(&threadTS, "thread-ts", "", "thread timestamp for reply")
+	cmd.Flags().Int64Var(&maxSize, "max-size", 0, "max file size in bytes (default 50MB)")
+	cmd.Flags().BoolVar(&useJSON, "json", false, "JSON output")
+	configFlag(cmd, &configPath)
+	cmd.MarkFlagRequired("file")
+
+	return cmd
+}

--- a/internal/cli/slack/bookmark.go
+++ b/internal/cli/slack/bookmark.go
@@ -1,0 +1,59 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+type BookmarkResult struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	URL   string `json:"url,omitempty"`
+	Emoji string `json:"emoji,omitempty"`
+}
+
+func AddBookmark(ctx context.Context, client *slack.Client, channel, title, link, emoji string) (*BookmarkResult, error) {
+	params := slack.AddBookmarkParameters{
+		Title: title,
+		Type:  "link",
+		Link:  link,
+		Emoji: emoji,
+	}
+
+	bm, err := client.AddBookmarkContext(ctx, channel, params)
+	if err != nil {
+		return nil, fmt.Errorf("add bookmark: %w", err)
+	}
+
+	return &BookmarkResult{
+		ID:    bm.ID,
+		Title: bm.Title,
+		URL:   bm.Link,
+		Emoji: bm.Emoji,
+	}, nil
+}
+
+func ListBookmarks(ctx context.Context, client *slack.Client, channel string) ([]BookmarkResult, error) {
+	bookmarks, err := client.ListBookmarksContext(ctx, channel)
+	if err != nil {
+		return nil, fmt.Errorf("list bookmarks: %w", err)
+	}
+
+	var result []BookmarkResult
+	for _, bm := range bookmarks {
+		result = append(result, BookmarkResult{
+			ID:    bm.ID,
+			Title: bm.Title,
+			URL:   bm.Link,
+			Emoji: bm.Emoji,
+		})
+	}
+
+	return result, nil
+}
+
+func RemoveBookmark(ctx context.Context, client *slack.Client, channel, bookmarkID string) error {
+	return client.RemoveBookmarkContext(ctx, channel, bookmarkID)
+}

--- a/internal/cli/slack/canvas.go
+++ b/internal/cli/slack/canvas.go
@@ -1,0 +1,76 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+type CanvasResult struct {
+	CanvasID string `json:"canvas_id"`
+	Title    string `json:"title"`
+}
+
+func CreateCanvas(ctx context.Context, client *slack.Client, title, content string) (*CanvasResult, error) {
+	docContent := slack.DocumentContent{
+		Type:     "markdown",
+		Markdown: content,
+	}
+
+	canvasID, err := client.CreateCanvasContext(ctx, title, docContent)
+	if err != nil {
+		return nil, fmt.Errorf("create canvas: %w", err)
+	}
+
+	return &CanvasResult{
+		CanvasID: canvasID,
+		Title:    title,
+	}, nil
+}
+
+func EditCanvas(ctx context.Context, client *slack.Client, canvasID, content, sectionID, operation string) error {
+	if operation == "" {
+		operation = "replace"
+	}
+
+	change := slack.CanvasChange{
+		Operation: operation,
+		DocumentContent: slack.DocumentContent{
+			Type:     "markdown",
+			Markdown: content,
+		},
+	}
+	if sectionID != "" {
+		change.SectionID = sectionID
+	}
+
+	params := slack.EditCanvasParams{
+		CanvasID: canvasID,
+		Changes:  []slack.CanvasChange{change},
+	}
+
+	return client.EditCanvasContext(ctx, params)
+}
+
+type CanvasSection struct {
+	ID string `json:"id"`
+}
+
+func ListCanvasSections(ctx context.Context, client *slack.Client, canvasID string) ([]CanvasSection, error) {
+	params := slack.LookupCanvasSectionsParams{
+		CanvasID: canvasID,
+	}
+
+	sections, err := client.LookupCanvasSectionsContext(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("list canvas sections: %w", err)
+	}
+
+	var result []CanvasSection
+	for _, s := range sections {
+		result = append(result, CanvasSection{ID: s.ID})
+	}
+
+	return result, nil
+}

--- a/internal/cli/slack/channels.go
+++ b/internal/cli/slack/channels.go
@@ -1,0 +1,60 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+type ChannelInfo struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	IsDM     bool   `json:"is_dm"`
+	IsGroup  bool   `json:"is_group"`
+	IsIM     bool   `json:"is_im"`
+	NumMembers int  `json:"num_members,omitempty"`
+}
+
+func ListChannels(ctx context.Context, client *slack.Client, types string, limit int) ([]ChannelInfo, error) {
+	typeSlice := []string{"im"}
+	if types != "" {
+		typeSlice = strings.Split(types, ",")
+	}
+
+	params := &slack.GetConversationsParameters{
+		Types:  typeSlice,
+		Limit:  limit,
+	}
+
+	var result []ChannelInfo
+	for {
+		channels, next, err := client.GetConversationsContext(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("list channels: %w", err)
+		}
+
+		for _, ch := range channels {
+			result = append(result, ChannelInfo{
+				ID:         ch.ID,
+				Name:       ch.Name,
+				IsDM:       ch.IsIM,
+				IsGroup:    ch.IsGroup,
+				IsIM:       ch.IsIM,
+				NumMembers: ch.NumMembers,
+			})
+		}
+
+		if next == "" || len(result) >= limit {
+			break
+		}
+		params.Cursor = next
+	}
+
+	if len(result) > limit {
+		result = result[:limit]
+	}
+
+	return result, nil
+}

--- a/internal/cli/slack/client.go
+++ b/internal/cli/slack/client.go
@@ -81,6 +81,8 @@ func loadEnvFile(dir string) {
 		}
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
-		os.Setenv(key, val)
+		if os.Getenv(key) == "" {
+			os.Setenv(key, val)
+		}
 	}
 }

--- a/internal/cli/slack/client.go
+++ b/internal/cli/slack/client.go
@@ -1,0 +1,86 @@
+package slackcli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/slack-go/slack"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+func NewClient(botToken string) (*slack.Client, error) {
+	if botToken == "" {
+		return nil, fmt.Errorf("slack bot token not configured (HOTPLEX_MESSAGING_SLACK_BOT_TOKEN)")
+	}
+	return slack.New(botToken), nil
+}
+
+func ResolveChannel(flagCh string) (string, error) {
+	if flagCh != "" {
+		return flagCh, nil
+	}
+	if env := os.Getenv("HOTPLEX_SLACK_CHANNEL_ID"); env != "" {
+		return env, nil
+	}
+	return "", fmt.Errorf("--channel is required (or set HOTPLEX_SLACK_CHANNEL_ID env var)")
+}
+
+func ResolveThreadTS(flagTS string) string {
+	if flagTS != "" {
+		return flagTS
+	}
+	return os.Getenv("HOTPLEX_SLACK_THREAD_TS")
+}
+
+func LoadConfigAndClient(configPath string) (*config.Config, *slack.Client, error) {
+	configPath, err := config.ExpandAndAbs(configPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve config path: %w", err)
+	}
+
+	loadEnvFile(filepath.Dir(configPath))
+
+	cfg, err := config.Load(configPath, config.LoadOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("load config: %w", err)
+	}
+
+	if !cfg.Messaging.Slack.Enabled {
+		return nil, nil, fmt.Errorf("slack is not enabled in configuration")
+	}
+
+	client, err := NewClient(cfg.Messaging.Slack.BotToken)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cfg, client, nil
+}
+
+func loadEnvFile(dir string) {
+	envPath := filepath.Join(dir, ".env")
+	f, err := os.Open(envPath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.Index(line, "=")
+		if idx <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		os.Setenv(key, val)
+	}
+}

--- a/internal/cli/slack/download.go
+++ b/internal/cli/slack/download.go
@@ -1,0 +1,33 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/slack-go/slack"
+)
+
+func DownloadFile(ctx context.Context, client *slack.Client, fileID, outputPath string) error {
+	info, _, _, err := client.GetFileInfoContext(ctx, fileID, 0, 0)
+	if err != nil {
+		return fmt.Errorf("get file info: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create output file: %w", err)
+	}
+	defer f.Close()
+
+	if err := client.GetFileContext(ctx, info.URLPrivateDownload, f); err != nil {
+		return fmt.Errorf("download file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cli/slack/message.go
+++ b/internal/cli/slack/message.go
@@ -1,0 +1,45 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/slack-go/slack"
+)
+
+type SendResult struct {
+	Channel string `json:"channel"`
+	TS      string `json:"ts"`
+}
+
+func SendMessage(ctx context.Context, client *slack.Client, channel, threadTS, text string) (*SendResult, error) {
+	opts := []slack.MsgOption{slack.MsgOptionText(text, false)}
+	if threadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(threadTS))
+	}
+
+	ch, ts, err := client.PostMessageContext(ctx, channel, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+	return &SendResult{Channel: ch, TS: ts}, nil
+}
+
+func UpdateMessage(ctx context.Context, client *slack.Client, channel, ts, text string) (*SendResult, error) {
+	_, ch, newTS, err := client.UpdateMessageContext(ctx, channel, ts, slack.MsgOptionText(text, false))
+	if err != nil {
+		return nil, fmt.Errorf("update message: %w", err)
+	}
+	return &SendResult{Channel: ch, TS: newTS}, nil
+}
+
+func ScheduleMessage(ctx context.Context, client *slack.Client, channel string, postAt int64, text string) (string, error) {
+	opts := []slack.MsgOption{slack.MsgOptionText(text, false)}
+	ch, ts, err := client.ScheduleMessageContext(ctx, channel, strconv.FormatInt(postAt, 10), opts...)
+	if err != nil {
+		return "", fmt.Errorf("schedule message: %w", err)
+	}
+	_ = ch
+	return ts, nil
+}

--- a/internal/cli/slack/react.go
+++ b/internal/cli/slack/react.go
@@ -1,0 +1,30 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+func AddReaction(ctx context.Context, client *slack.Client, channel, ts, emoji string) error {
+	item := slack.ItemRef{
+		Channel:   channel,
+		Timestamp: ts,
+	}
+	if err := client.AddReactionContext(ctx, emoji, item); err != nil {
+		return fmt.Errorf("add reaction: %w", err)
+	}
+	return nil
+}
+
+func RemoveReaction(ctx context.Context, client *slack.Client, channel, ts, emoji string) error {
+	item := slack.ItemRef{
+		Channel:   channel,
+		Timestamp: ts,
+	}
+	if err := client.RemoveReactionContext(ctx, emoji, item); err != nil {
+		return fmt.Errorf("remove reaction: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/slack/search.go
+++ b/internal/cli/slack/search.go
@@ -1,0 +1,65 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+type SearchResult struct {
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	Text      string `json:"text,omitempty"`
+	User      string `json:"user,omitempty"`
+	Title     string `json:"title,omitempty"`
+	FileID    string `json:"file_id,omitempty"`
+	Size      int    `json:"size,omitempty"`
+}
+
+func Search(ctx context.Context, client *slack.Client, query, searchType string, limit int) ([]SearchResult, error) {
+	params := slack.SearchParameters{
+		Count: limit,
+		Sort:  "timestamp",
+	}
+
+	var results []SearchResult
+
+	if searchType == "all" || searchType == "messages" {
+		msgs, err := client.SearchMessagesContext(ctx, query, params)
+		if err != nil {
+			return nil, fmt.Errorf("search messages: %w", err)
+		}
+		if msgs != nil {
+			for _, m := range msgs.Matches {
+				results = append(results, SearchResult{
+					Type:      "message",
+					Timestamp: m.Timestamp,
+					Channel:   m.Channel.Name,
+					Text:      m.Text,
+					User:      m.User,
+				})
+			}
+		}
+	}
+
+	if searchType == "all" || searchType == "files" {
+		files, err := client.SearchFilesContext(ctx, query, params)
+		if err != nil {
+			return nil, fmt.Errorf("search files: %w", err)
+		}
+		if files != nil {
+			for _, f := range files.Matches {
+				results = append(results, SearchResult{
+					Type:   "file",
+					Title:  f.Title,
+					FileID: f.ID,
+					Size:   f.Size,
+				})
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/internal/cli/slack/upload.go
+++ b/internal/cli/slack/upload.go
@@ -1,0 +1,64 @@
+package slackcli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/slack-go/slack"
+)
+
+type UploadParams struct {
+	FilePath  string
+	Title     string
+	Comment   string
+	Channel   string
+	ThreadTS  string
+	MaxSize   int64
+}
+
+type UploadResult struct {
+	FileID  string `json:"file_id"`
+	Title   string `json:"title"`
+	Size    int64  `json:"size"`
+	Channel string `json:"channel"`
+}
+
+func UploadFile(ctx context.Context, client *slack.Client, params *UploadParams) (*UploadResult, error) {
+	stat, err := os.Stat(params.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+
+	if params.MaxSize > 0 && stat.Size() > params.MaxSize {
+		return nil, fmt.Errorf("file size %d exceeds limit %d", stat.Size(), params.MaxSize)
+	}
+
+	title := params.Title
+	if title == "" {
+		title = filepath.Base(params.FilePath)
+	}
+
+	uploadParams := slack.UploadFileParameters{
+		Filename:       filepath.Base(params.FilePath),
+		File:           params.FilePath,
+		FileSize:       int(stat.Size()),
+		Title:          title,
+		InitialComment: params.Comment,
+		Channel:        params.Channel,
+		ThreadTimestamp: params.ThreadTS,
+	}
+
+	result, err := client.UploadFileContext(ctx, uploadParams)
+	if err != nil {
+		return nil, fmt.Errorf("upload failed: %w", err)
+	}
+
+	return &UploadResult{
+		FileID:  result.ID,
+		Title:   result.Title,
+		Size:    stat.Size(),
+		Channel: params.Channel,
+	}, nil
+}

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -267,6 +267,19 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		ConfigWhitelist: b.workerEnvWhitelist,
 	}
 
+	// Inject Slack context for CLI subcommand auto-resolution (same as StartSession).
+	if si.PlatformKey != nil {
+		if chID, ok := si.PlatformKey["channel_id"]; ok && chID != "" {
+			if workerInfo.Env == nil {
+				workerInfo.Env = make(map[string]string)
+			}
+			workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
+			if threadTS, ok := si.PlatformKey["thread_ts"]; ok && threadTS != "" {
+				workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
+			}
+		}
+	}
+
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:         ctx,
 		wt:          si.WorkerType,
@@ -795,6 +808,19 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		ProjectDir:      p.workDir,
 		ConfigEnv:       b.workerEnv,
 		ConfigWhitelist: b.workerEnvWhitelist,
+	}
+
+	// Inject Slack context for CLI subcommand auto-resolution (same as StartSession).
+	if si.PlatformKey != nil {
+		if chID, ok := si.PlatformKey["channel_id"]; ok && chID != "" {
+			if workerInfo.Env == nil {
+				workerInfo.Env = make(map[string]string)
+			}
+			workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
+			if threadTS, ok := si.PlatformKey["thread_ts"]; ok && threadTS != "" {
+				workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
+			}
+		}
 	}
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -117,6 +117,17 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 		ConfigWhitelist: b.workerEnvWhitelist,
 	}
 
+	// Inject Slack context for CLI subcommand auto-resolution.
+	if chID, ok := platformKey["channel_id"]; ok && chID != "" {
+		if workerInfo.Env == nil {
+			workerInfo.Env = make(map[string]string)
+		}
+		workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
+		if threadTS, ok := platformKey["thread_ts"]; ok && threadTS != "" {
+			workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
+		}
+	}
+
 	if _, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:        ctx,
 		wt:         wt,

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -74,8 +74,9 @@ var claudeCodeEnvWhitelist = []string{
 	"BUN_RUNTIME_NV",
 	// OpenTelemetry (prefix-matched in BuildEnv)
 	"OTEL_",
-	// HotPlex Slack context (prefix-matched)
-	"HOTPLEX_SLACK_",
+	// HotPlex Slack context (exact-match only)
+	"HOTPLEX_SLACK_CHANNEL_ID",
+	"HOTPLEX_SLACK_THREAD_TS",
 }
 
 // Default session store directory.

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -74,6 +74,8 @@ var claudeCodeEnvWhitelist = []string{
 	"BUN_RUNTIME_NV",
 	// OpenTelemetry (prefix-matched in BuildEnv)
 	"OTEL_",
+	// HotPlex Slack context (prefix-matched)
+	"HOTPLEX_SLACK_",
 }
 
 // Default session store directory.

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: slack
+description: Send messages, upload files, and interact with Slack via hotplex CLI
+version: 1.0.0
+---
+
+# Slack Integration
+
+Send messages, upload files, and interact with Slack workspaces via `hotplex slack` CLI subcommands.
+
+## When to Use
+
+- User says "send to Slack", "slack send", "发到 Slack"
+- Content generated and needs delivery (podcasts, reports, images, videos)
+- Need persistent Slack documents (Canvas)
+- Need to add bookmarks/links in a channel
+- Need to search Slack history
+
+## Command Reference
+
+| Scenario | Command |
+|----------|---------|
+| Send message | `hotplex slack send-message --text "content"` |
+| Upload file | `hotplex slack upload-file --file <path> --title "title"` |
+| Update message | `hotplex slack update-message --channel <id> --ts <ts> --text "new"` |
+| Schedule message | `hotplex slack schedule-message --text "reminder" --at "09:00"` |
+| Download file | `hotplex slack download-file --file-id <id> --output ./path` |
+| List channels | `hotplex slack list-channels --types im,public_channel` |
+| Search | `hotplex slack search --query "keyword" --type messages` |
+| Create Canvas | `hotplex slack canvas create --title "title" --content "# content"` |
+| Edit Canvas | `hotplex slack canvas edit --canvas-id <id> --content "new"` |
+| Add bookmark | `hotplex slack bookmark add --channel <id> --title "title" --url <url>` |
+| Add reaction | `hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark` |
+
+## Default Behavior
+
+- Without `--channel`: auto-sends to current conversation (via `HOTPLEX_SLACK_CHANNEL_ID` env var injected by Gateway)
+- Without `--title`: uses filename
+- Add `--json` for structured JSON output
+
+## Workflow Examples
+
+### Podcast → Slack
+```bash
+notebooklm download audio ./podcast.mp3 -n <notebook_id>
+hotplex slack upload-file --file ./podcast.mp3 --title "Podcast"
+```
+
+### Report → Canvas + Bookmark
+```bash
+hotplex slack canvas create --title "Research Report" --file ./report.md --channel C0ABC
+hotplex slack bookmark add --channel C0ABC --title "Report" --url "https://hotplex.slack.com/docs/<canvas_id>"
+```
+
+### Task Complete → Visual Feedback
+```bash
+hotplex slack react add --ts <ts> --emoji white_check_mark
+```


### PR DESCRIPTION
## Summary

- Add `hotplex slack` CLI subcommand group with 10 subcommands: send-message, update-message, schedule-message, upload-file, download-file, list-channels, search, canvas create/edit/list-sections, bookmark add/list/remove, react add/remove
- Inject Slack platform context (`HOTPLEX_SLACK_CHANNEL_ID`/`HOTPLEX_SLACK_THREAD_TS`) into Worker environment via bridge.go for all session paths (StartSession, ResumeSession, attemptResumeFallback)
- Add Claude Code skill (`skills/slack/SKILL.md`) for auto-invocation by Oracle

### Architecture

Two-layer split following existing `cmd/hotplex/` + `internal/cli/` pattern:
- **CLI layer** (`cmd/hotplex/slack_*.go`): Cobra command definitions, flag parsing, output formatting
- **Business layer** (`internal/cli/slack/`): SDK calls, config loading, env var resolution

### Security hardening (included in this PR)

- `loadEnvFile`: guard against overwriting existing env vars
- Worker whitelist: exact entries (`HOTPLEX_SLACK_CHANNEL_ID`, `HOTPLEX_SLACK_THREAD_TS`) instead of broad prefix match
- `download-file`: authenticated download via `client.GetFileContext` instead of bare `http.Get`
- `truncate()`: rune-based truncation for correct CJK handling

## Test plan

- [x] `go build ./cmd/hotplex/` compiles
- [x] `go test ./internal/gateway/ ./internal/worker/claudecode/ ./internal/worker/base/ ./internal/messaging/slack/` all pass
- [x] `hotplex slack --help` shows all 10 subcommands
- [ ] Integration test with valid Slack bot token: send-message, upload-file, list-channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)