### PR TITLE
perf(webchat): delta rAF batcher, React.memo, and highlight.js lazy load

### DIFF
--- a/webchat/components/assistant-ui/MarkdownText.tsx
+++ b/webchat/components/assistant-ui/MarkdownText.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useCopyToClipboard } from "@/lib/hooks/useCopyToClipboard";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const hljs = require("highlight.js");
+import { getHighlighter } from "@/lib/highlight";
 
 function escapeHtml(text: string): string {
   return text
@@ -97,6 +96,12 @@ function CodeBlock({ raw, lang, highlighted }: { raw: string; lang: string; high
 }
 
 export function MarkdownText({ text }: { text: string }) {
+  const [hljs, setHljs] = useState<any>(null);
+
+  useEffect(() => {
+    getHighlighter().then(setHljs);
+  }, []);
+
   if (!text) return null;
 
   return (
@@ -119,7 +124,7 @@ export function MarkdownText({ text }: { text: string }) {
             }
 
             let highlighted: string;
-            if (lang && hljs.getLanguage(lang)) {
+            if (hljs && lang && hljs.getLanguage(lang)) {
               highlighted = hljs.highlight(raw, {
                 language: lang,
                 ignoreIllegals: true,

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -135,7 +135,7 @@ function MessageActions({ message, isUser }: { message: any, isUser?: boolean })
   );
 }
 
-function AssistantMessage({ message }: { message: any }) {
+const AssistantMessage = memo(function AssistantMessage({ message }: { message: any }) {
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
 
   return (
@@ -251,7 +251,11 @@ function AssistantMessage({ message }: { message: any }) {
       </div>
     </motion.div>
   );
-}
+}, (prev, next) => {
+  if (prev.message.id !== next.message.id) return false;
+  if ((next.message as any)?.status?.type === 'running') return false;
+  return prev.message.content === next.message.content;
+});
 
 /* ============================================================
    Rest of the components (UserMessage, ReasoningBlock, Composer, etc.)
@@ -302,7 +306,7 @@ function ReasoningBlock({ text }: { text: string }) {
   );
 }
 
-function UserMessage({ message }: { message: any }) {
+const UserMessage = memo(function UserMessage({ message }: { message: any }) {
   return (
     <motion.div className="group flex items-start justify-end gap-4 mb-8" variants={messageVariants} initial="hidden" animate="visible">
       <div className="relative max-w-[85%] flex-1 flex flex-col items-end min-w-0 group/msg">
@@ -326,7 +330,7 @@ function UserMessage({ message }: { message: any }) {
       </div>
     </motion.div>
   );
-}
+}, (prev, next) => prev.message.id === next.message.id);
 
 function WelcomeScreen() {
   return (

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -413,6 +413,20 @@ export function useHotPlexRuntime({
       });
     };
 
+    // Delta batcher — accumulate streaming deltas and flush once per animation frame
+    // to reduce React re-renders from 30-60/s to at most 60fps (1 per frame).
+    let pendingDelta = '';
+    let deltaRafId = 0;
+
+    const flushDelta = () => {
+      const content = pendingDelta;
+      pendingDelta = '';
+      deltaRafId = 0;
+      if (content) {
+        appendDelta(content);
+      }
+    };
+
     // Handle reasoning/thinking content (appends to last reasoning part or creates one)
     const handleReasoning = (data: ReasoningData, _env: Envelope) => {
       if (!data) return;
@@ -450,7 +464,10 @@ export function useHotPlexRuntime({
 
     const handleDelta = (data: MessageDeltaData, env: Envelope) => {
       if (!data) return;
-      appendDelta(data.content || '');
+      pendingDelta += data.content || '';
+      if (!deltaRafId) {
+        deltaRafId = requestAnimationFrame(flushDelta);
+      }
       setIsRunning(true);
     };
 
@@ -710,6 +727,7 @@ export function useHotPlexRuntime({
     });
 
     return () => {
+      if (deltaRafId) cancelAnimationFrame(deltaRafId);
       client.off('delta', handleDelta);
       client.off('message', handleMessage);
       client.off('done', handleDone);

--- a/webchat/lib/highlight.ts
+++ b/webchat/lib/highlight.ts
@@ -1,0 +1,40 @@
+type Highlighter = typeof import('highlight.js/lib/core')['default'];
+
+let cached: Highlighter | null = null;
+let pending: Promise<Highlighter> | null = null;
+
+export function getHighlighter(): Promise<Highlighter> {
+  if (cached) return Promise.resolve(cached);
+  if (pending) return pending;
+
+  pending = (async () => {
+    const [coreModule, bash, go, json, markdown, python, sql, typescript, yaml] = await Promise.all([
+      import('highlight.js/lib/core'),
+      import('highlight.js/lib/languages/bash'),
+      import('highlight.js/lib/languages/go'),
+      import('highlight.js/lib/languages/json'),
+      import('highlight.js/lib/languages/markdown'),
+      import('highlight.js/lib/languages/python'),
+      import('highlight.js/lib/languages/sql'),
+      import('highlight.js/lib/languages/typescript'),
+      import('highlight.js/lib/languages/yaml'),
+    ]);
+
+    const hljs = coreModule.default;
+
+    hljs.registerLanguage('bash', bash.default);
+    hljs.registerLanguage('go', go.default);
+    hljs.registerLanguage('json', json.default);
+    hljs.registerLanguage('markdown', markdown.default);
+    hljs.registerLanguage('python', python.default);
+    hljs.registerLanguage('sql', sql.default);
+    hljs.registerLanguage('typescript', typescript.default);
+    hljs.registerLanguage('yaml', yaml.default);
+
+    cached = hljs;
+    pending = null;
+    return hljs;
+  })();
+
+  return pending;
+}


### PR DESCRIPTION
## Summary

Three performance optimizations for WebChat (issue #89):

1. **Delta rAF batcher** — accumulate streaming deltas and flush once per animation frame, reducing React re-renders from 30-60/s to ≤60fps
2. **React.memo on AssistantMessage/UserMessage** — skip re-rendering non-streaming messages when other messages update
3. **highlight.js dynamic import** — replace full ~200KB sync `require` with lazy-loaded core + 8 languages (Go, TypeScript, Python, Bash, JSON, YAML, SQL, Markdown)

Closes #89

## Changes

### `webchat/lib/highlight.ts` (new)
- Singleton lazy loader for highlight.js core + 8 language registrations
- Cached promise ensures single load across all MarkdownText instances

### `webchat/components/assistant-ui/MarkdownText.tsx`
- Replace `const hljs = require("highlight.js")` with `useState` + dynamic import
- First render shows plain code blocks, subsequent renders have syntax highlighting

### `webchat/components/assistant-ui/thread.tsx`
- Wrap `AssistantMessage` with `memo` + custom comparator (skip if same id + complete)
- Wrap `UserMessage` with `memo` (skip if same id)

### `webchat/lib/adapters/hotplex-runtime-adapter.ts`
- Add `pendingDelta` buffer + `requestAnimationFrame` flush
- `handleDelta` accumulates content, flushes once per frame
- Cleanup cancels pending rAF on unmount

## Test plan

- [x] `pnpm build` passes (TypeScript + Next.js static export)
- [x] `make build` passes (Go gateway unaffected)
- [x] `make test` passes (all packages, -race)
- [ ] Manual: Chrome DevTools Performance tab — verify delta re-render ≤60fps
- [ ] Manual: Network tab — verify highlight.js chunks loaded on demand, not in initial bundle
- [ ] Manual: Long conversation (50+ messages) — verify scrolling smoothness

## Acceptance Criteria (from #89)

- [x] Delta 更新使用 rAF 批处理
- [x] `UserMessage` 和 `AssistantMessage` 使用 `React.memo` 包裹
- [x] highlight.js 改为动态导入 + 按需注册 8 种语言
- [ ] 消息列表实现虚拟滚动 (deferred — requires `@assistant-ui/react` API evaluation)
- [ ] 首屏 JS 体积减少 ≥ 100KB (needs bundle analysis)
- [x] `pnpm build` 无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)