### PR TITLE
feat(slack): render markdown tables as Block Kit TableBlock

### DIFF
--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -828,8 +828,11 @@ func (c *SlackConn) writeWithPostMessage(ctx context.Context, text string, isDel
 		text += "\n\n"
 	}
 
-	// Try image block rendering for non-delta messages
+	// Try table block rendering for non-delta messages (TableBlock > ImageBlock)
 	if !isDelta {
+		if err := c.tryTableBlocks(ctx, text); err == nil {
+			return nil
+		}
 		if err := c.tryImageBlocks(ctx, text); err == nil {
 			return nil
 		}
@@ -845,6 +848,41 @@ func (c *SlackConn) writeWithPostMessage(ctx context.Context, text string, isDel
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// tryTableBlocks extracts markdown tables and sends as Block Kit (MarkdownBlock + TableBlock).
+// Returns error if no tables found or block send fails (caller falls back to text).
+func (c *SlackConn) tryTableBlocks(ctx context.Context, text string) error {
+	segments, tables := ExtractTables(text)
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables")
+	}
+
+	blocks := BuildTableBlocks(text, segments, tables)
+	if len(blocks) == 0 {
+		return fmt.Errorf("no valid table blocks")
+	}
+
+	if err := ValidateBlocks(blocks); err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+
+	opts := []slack.MsgOption{
+		slack.MsgOptionBlocks(blocks...),
+		slack.MsgOptionText(text, false),
+	}
+	if c.threadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(c.threadTS))
+	}
+
+	_, _, pErr := c.adapter.client.PostMessageContext(ctx, c.channelID, opts...)
+	if pErr != nil {
+		if isInvalidBlocksError(pErr) {
+			c.adapter.Log.Warn("slack: table blocks rejected", "err", pErr)
+		}
+		return pErr
 	}
 	return nil
 }

--- a/internal/messaging/slack/format.go
+++ b/internal/messaging/slack/format.go
@@ -14,6 +14,9 @@ func FormatMrkdwn(text string) string {
 	placeholders := make(map[string]string)
 	text = protectCode(text, placeholders)
 
+	// Wrap markdown tables in code blocks (preserves column alignment in mrkdwn)
+	text = wrapTablesInCodeBlocks(text)
+
 	// Convert CommonMark *italic* → _italic_ BEFORE heading/bold conversion.
 	// This ensures *italic* (single-asterisk emphasis) is captured before
 	// **bold** → *bold* creates new single-asterisk patterns.

--- a/internal/messaging/slack/stream.go
+++ b/internal/messaging/slack/stream.go
@@ -117,6 +117,9 @@ type NativeStreamingWriter struct {
 	bytesFlushed      int64
 	failedFlushChunks []string
 
+	// Post-stream table upgrade: accumulates full content for table detection on Close.
+	fullContent strings.Builder
+
 	// TTL 监控
 	streamStartTime  time.Time
 	streamExpired    bool
@@ -190,6 +193,7 @@ func (w *NativeStreamingWriter) Write(p []byte) (int, error) {
 	}
 
 	w.buf.Write(p)
+	w.fullContent.Write(p)
 	w.bytesWritten += int64(len(p))
 
 	// 超过阈值触发即时 flush
@@ -354,6 +358,11 @@ func (w *NativeStreamingWriter) Close() error {
 
 	_, _, _ = w.client.StopStreamContext(cleanupCtx, w.channelID, w.messageTS)
 
+	// Post-stream table upgrade: replace raw tables with Block Kit if possible.
+	if integrityOK && !streamExpired {
+		w.upgradeToTableBlocks(cleanupCtx)
+	}
+
 	if w.onComplete != nil {
 		w.onComplete(w.messageTS)
 	}
@@ -376,6 +385,47 @@ func (w *NativeStreamingWriter) Close() error {
 		}
 	}
 	return nil
+}
+
+// upgradeToTableBlocks replaces the streamed message with Block Kit (MarkdownBlock + TableBlock)
+// if the content contains markdown tables. No-op if no tables or upgrade fails.
+func (w *NativeStreamingWriter) upgradeToTableBlocks(ctx context.Context) {
+	w.mu.Lock()
+	content := w.fullContent.String()
+	w.mu.Unlock()
+
+	if content == "" {
+		return
+	}
+
+	segments, tables := ExtractTables(content)
+	if len(tables) == 0 {
+		return
+	}
+
+	blocks := BuildTableBlocks(content, segments, tables)
+	if len(blocks) == 0 {
+		return
+	}
+
+	if len(blocks) > 50 {
+		w.log.Debug("slack: too many blocks for table upgrade, keeping raw message")
+		return
+	}
+
+	opts := []slack.MsgOption{
+		slack.MsgOptionBlocks(blocks...),
+		slack.MsgOptionText(content, false),
+	}
+
+	_, _, _, err := w.client.UpdateMessageContext(ctx, w.channelID, w.messageTS, opts...)
+	if err != nil {
+		if isInvalidBlocksError(err) {
+			w.log.Debug("slack: table blocks rejected by workspace, keeping raw message")
+			return
+		}
+		w.log.Warn("slack: failed to upgrade message with table blocks", "err", err)
+	}
 }
 
 // Compile-time check

--- a/internal/messaging/slack/table.go
+++ b/internal/messaging/slack/table.go
@@ -131,11 +131,10 @@ type tableMatch struct {
 	end   int
 }
 
-// ExtractTables splits text into non-table segments and parsed tables.
-// Tables inside fenced code blocks are ignored.
-func ExtractTables(text string) ([]TextSegment, []ParsedTable) {
+// findTableMatches scans text for markdown table positions, skipping code blocks.
+func findTableMatches(text string) []tableMatch {
 	if !strings.Contains(text, "|") {
-		return []TextSegment{{Text: text}}, nil
+		return nil
 	}
 
 	// Collect code block ranges for exclusion.
@@ -186,11 +185,17 @@ func ExtractTables(text string) ([]TextSegment, []ParsedTable) {
 		}
 	}
 
+	return matches
+}
+
+// ExtractTables splits text into non-table segments and parsed tables.
+// Tables inside fenced code blocks are ignored.
+func ExtractTables(text string) ([]TextSegment, []ParsedTable) {
+	matches := findTableMatches(text)
 	if len(matches) == 0 {
 		return []TextSegment{{Text: text}}, nil
 	}
 
-	// Build segments and parsed tables.
 	var segments []TextSegment
 	var tables []ParsedTable
 	prev := 0
@@ -391,56 +396,7 @@ func joinSegments(segments []TextSegment) string {
 // wrapTablesInCodeBlocks wraps markdown tables that are not inside fenced code
 // blocks in ``` fences for monospace rendering.
 func wrapTablesInCodeBlocks(text string) string {
-	if !strings.Contains(text, "|") {
-		return text
-	}
-
-	// Use ExtractTables to find table positions.
-	cbRanges := codeBlockTableRe.FindAllStringIndex(text, -1)
-	inCodeBlock := func(idx int) bool {
-		for _, r := range cbRanges {
-			if idx >= r[0] && idx < r[1] {
-				return true
-			}
-		}
-		return false
-	}
-
-	var matches []tableMatch
-	searchFrom := 0
-
-	if text != "" && text[0] == '|' && !inCodeBlock(0) {
-		if m, ok := tryParseTableAt(text, 0); ok {
-			matches = append(matches, m)
-			searchFrom = nextSearchFrom(text, m.end)
-		}
-	}
-
-	for searchFrom < len(text) {
-		np := strings.Index(text[searchFrom:], "\n\n")
-		if np < 0 {
-			break
-		}
-		pos := searchFrom + np
-		afterBlank := pos + 2
-		for afterBlank < len(text) && (text[afterBlank] == '\n' || text[afterBlank] == ' ') {
-			afterBlank++
-		}
-		if afterBlank >= len(text) {
-			break
-		}
-		if inCodeBlock(afterBlank) {
-			searchFrom = afterBlank
-			continue
-		}
-		if m, ok := tryParseTableAt(text, afterBlank); ok {
-			matches = append(matches, m)
-			searchFrom = nextSearchFrom(text, m.end)
-		} else {
-			searchFrom = afterBlank
-		}
-	}
-
+	matches := findTableMatches(text)
 	if len(matches) == 0 {
 		return text
 	}

--- a/internal/messaging/slack/table.go
+++ b/internal/messaging/slack/table.go
@@ -387,11 +387,15 @@ func buildOneTableBlock(blockID string, t ParsedTable) *slack.TableBlock {
 
 func joinSegments(segments []TextSegment) string {
 	var sb strings.Builder
-	for i, s := range segments {
-		if i > 0 {
+	for _, s := range segments {
+		t := strings.Trim(s.Text, "\n")
+		if t == "" {
+			continue
+		}
+		if sb.Len() > 0 {
 			sb.WriteString("\n\n")
 		}
-		sb.WriteString(s.Text)
+		sb.WriteString(t)
 	}
 	return strings.TrimSpace(sb.String())
 }

--- a/internal/messaging/slack/table.go
+++ b/internal/messaging/slack/table.go
@@ -239,7 +239,10 @@ func tryParseTableAt(text string, headerStart int) (tableMatch, bool) {
 		return tableMatch{}, false
 	}
 
-	tableEnd := sepEnd + 1
+	tableEnd := sepEnd
+	if tableEnd < len(text) {
+		tableEnd++ // skip past separator newline
+	}
 	for tableEnd < len(text) {
 		if text[tableEnd] == '\n' {
 			break
@@ -357,7 +360,11 @@ func buildMultiTableBlocks(content string) []slack.Block {
 func buildOneTableBlock(blockID string, t ParsedTable) *slack.TableBlock {
 	table := slack.NewTableBlock(blockID)
 	settings := make([]slack.ColumnSetting, len(t.Headers))
-	for j, align := range t.ColAligns {
+	for j := range settings {
+		align := slack.ColumnAlignmentLeft
+		if j < len(t.ColAligns) {
+			align = t.ColAligns[j]
+		}
 		settings[j] = slack.ColumnSetting{Align: align, IsWrapped: true}
 	}
 	table = table.WithColumnSettings(settings...)

--- a/internal/messaging/slack/table.go
+++ b/internal/messaging/slack/table.go
@@ -1,0 +1,456 @@
+package slack
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// TextSegment represents a non-table portion of the original markdown text.
+type TextSegment struct {
+	Text string
+}
+
+// ParsedTable holds the structured data extracted from a markdown table.
+type ParsedTable struct {
+	Headers   []string
+	Rows      [][]string
+	ColAligns []slack.ColumnAlignment
+}
+
+// ---------------------------------------------------------------------------
+// Table detection (reuses Feishu-validated regex patterns)
+// ---------------------------------------------------------------------------
+
+var codeBlockTableRe = regexp.MustCompile("(?s)```.*?```|~~~.*?~~~")
+
+// isMarkdownTableHeader returns true if s looks like a markdown table header row.
+func isMarkdownTableHeader(s string) bool {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "|") || !strings.HasSuffix(s, "|") {
+		return false
+	}
+	cells := strings.Split(s[1:len(s)-1], "|")
+	if len(cells) < 2 {
+		return false
+	}
+	allSep := true
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		if !isOnlySepChars(c) {
+			allSep = false
+		}
+	}
+	if allSep {
+		return false
+	}
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		if strings.Contains(c, "```") || strings.Contains(c, "~~~") {
+			return false
+		}
+	}
+	return true
+}
+
+func isOnlySepChars(s string) bool {
+	for _, c := range s {
+		if c != '-' && c != ':' && c != ' ' {
+			return false
+		}
+	}
+	return true
+}
+
+func isSeparatorLine(s string) bool {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "|") || !strings.HasSuffix(s, "|") {
+		return false
+	}
+	s = strings.Trim(s, "|")
+	hasDash := false
+	for _, cell := range strings.Split(s, "|") {
+		cell = strings.TrimSpace(cell)
+		if cell == "" {
+			continue
+		}
+		for _, ch := range cell {
+			if ch != '-' && ch != ':' && ch != ' ' {
+				return false
+			}
+			if ch == '-' {
+				hasDash = true
+			}
+		}
+	}
+	return hasDash
+}
+
+func isMarkdownTableRow(s string) bool {
+	s = strings.TrimSpace(s)
+	return strings.HasPrefix(s, "|")
+}
+
+// ---------------------------------------------------------------------------
+// Column alignment from separator
+// ---------------------------------------------------------------------------
+
+func parseColumnAlign(sepRow string) []slack.ColumnAlignment {
+	sepRow = strings.TrimSpace(sepRow)
+	sepRow = strings.Trim(sepRow, "|")
+	cells := strings.Split(sepRow, "|")
+	aligns := make([]slack.ColumnAlignment, len(cells))
+	for i, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		left := strings.HasPrefix(cell, ":")
+		right := strings.HasSuffix(cell, ":")
+		switch {
+		case left && right:
+			aligns[i] = slack.ColumnAlignmentCenter
+		case right:
+			aligns[i] = slack.ColumnAlignmentRight
+		default:
+			aligns[i] = slack.ColumnAlignmentLeft
+		}
+	}
+	return aligns
+}
+
+// ---------------------------------------------------------------------------
+// ExtractTables
+// ---------------------------------------------------------------------------
+
+type tableMatch struct {
+	start int
+	end   int
+}
+
+// ExtractTables splits text into non-table segments and parsed tables.
+// Tables inside fenced code blocks are ignored.
+func ExtractTables(text string) ([]TextSegment, []ParsedTable) {
+	if !strings.Contains(text, "|") {
+		return []TextSegment{{Text: text}}, nil
+	}
+
+	// Collect code block ranges for exclusion.
+	cbRanges := codeBlockTableRe.FindAllStringIndex(text, -1)
+	inCodeBlock := func(idx int) bool {
+		for _, r := range cbRanges {
+			if idx >= r[0] && idx < r[1] {
+				return true
+			}
+		}
+		return false
+	}
+
+	var matches []tableMatch
+	searchFrom := 0
+
+	// Check for table at start of text.
+	if text != "" && text[0] == '|' && !inCodeBlock(0) {
+		if m, ok := tryParseTableAt(text, 0); ok {
+			matches = append(matches, m)
+			searchFrom = nextSearchFrom(text, m.end)
+		}
+	}
+
+	// Scan for \n\n paragraph boundaries.
+	for searchFrom < len(text) {
+		np := strings.Index(text[searchFrom:], "\n\n")
+		if np < 0 {
+			break
+		}
+		pos := searchFrom + np
+		afterBlank := pos + 2
+		for afterBlank < len(text) && (text[afterBlank] == '\n' || text[afterBlank] == ' ') {
+			afterBlank++
+		}
+		if afterBlank >= len(text) {
+			break
+		}
+		if inCodeBlock(afterBlank) {
+			searchFrom = afterBlank
+			continue
+		}
+		if m, ok := tryParseTableAt(text, afterBlank); ok {
+			matches = append(matches, m)
+			searchFrom = nextSearchFrom(text, m.end)
+		} else {
+			searchFrom = afterBlank
+		}
+	}
+
+	if len(matches) == 0 {
+		return []TextSegment{{Text: text}}, nil
+	}
+
+	// Build segments and parsed tables.
+	var segments []TextSegment
+	var tables []ParsedTable
+	prev := 0
+
+	for _, m := range matches {
+		if m.start > prev {
+			segments = append(segments, TextSegment{Text: text[prev:m.start]})
+		}
+		tables = append(tables, parseTable(text[m.start:m.end]))
+		prev = m.end
+	}
+	if prev < len(text) {
+		segments = append(segments, TextSegment{Text: text[prev:]})
+	}
+
+	return segments, tables
+}
+
+func tryParseTableAt(text string, headerStart int) (tableMatch, bool) {
+	headerEnd := headerStart
+	for headerEnd < len(text) && text[headerEnd] != '\n' {
+		headerEnd++
+	}
+	headerLine := text[headerStart:headerEnd]
+	if !isMarkdownTableHeader(headerLine) {
+		return tableMatch{}, false
+	}
+
+	sepStart := headerEnd
+	if sepStart < len(text) && text[sepStart] == '\n' {
+		sepStart++
+	}
+	if sepStart >= len(text) {
+		return tableMatch{}, false
+	}
+	sepEnd := sepStart
+	for sepEnd < len(text) && text[sepEnd] != '\n' {
+		sepEnd++
+	}
+	if !isSeparatorLine(text[sepStart:sepEnd]) {
+		return tableMatch{}, false
+	}
+
+	tableEnd := sepEnd + 1
+	for tableEnd < len(text) {
+		if text[tableEnd] == '\n' {
+			break
+		}
+		lineEnd := tableEnd
+		for lineEnd < len(text) && text[lineEnd] != '\n' {
+			lineEnd++
+		}
+		if isMarkdownTableRow(text[tableEnd:lineEnd]) {
+			if lineEnd < len(text) {
+				tableEnd = lineEnd + 1
+			} else {
+				tableEnd = lineEnd
+			}
+		} else {
+			break
+		}
+	}
+
+	return tableMatch{start: headerStart, end: tableEnd}, true
+}
+
+func nextSearchFrom(text string, tableEnd int) int {
+	if tableEnd > 0 && tableEnd < len(text) && text[tableEnd] == '\n' {
+		return tableEnd - 1
+	}
+	return tableEnd
+}
+
+func parseTable(raw string) ParsedTable {
+	raw = strings.TrimRight(raw, "\n")
+	lines := strings.Split(raw, "\n")
+	if len(lines) < 2 {
+		return ParsedTable{}
+	}
+
+	headers := parseRowCells(lines[0])
+	aligns := parseColumnAlign(lines[1])
+
+	var rows [][]string
+	for _, line := range lines[2:] {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		rows = append(rows, parseRowCells(line))
+	}
+
+	return ParsedTable{
+		Headers:   headers,
+		Rows:      rows,
+		ColAligns: aligns,
+	}
+}
+
+func parseRowCells(line string) []string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+	cells := strings.Split(line, "|")
+	for i := range cells {
+		cells[i] = strings.TrimSpace(cells[i])
+	}
+	return cells
+}
+
+// ---------------------------------------------------------------------------
+// BuildTableBlocks
+// ---------------------------------------------------------------------------
+
+const maxMarkdownBlockChars = 11000 // safety margin under Slack's 12K cumulative limit
+
+// BuildTableBlocks constructs Block Kit blocks from extracted tables and text.
+//
+//   - 1 table: MarkdownBlock(text) + TableBlock → best visual
+//   - 2+ tables: MarkdownBlock(full text with tables wrapped in code blocks)
+//   - oversized or no tables: returns nil
+func BuildTableBlocks(content string, segments []TextSegment, tables []ParsedTable) []slack.Block {
+	if len(tables) == 0 {
+		return nil
+	}
+	for _, t := range tables {
+		if len(t.Headers) > 20 || len(t.Rows) > 99 {
+			return nil
+		}
+	}
+	if len(tables) == 1 {
+		return buildSingleTableBlocks(segments, tables[0])
+	}
+	return buildMultiTableBlocks(content)
+}
+
+func buildSingleTableBlocks(segments []TextSegment, table ParsedTable) []slack.Block {
+	var blocks []slack.Block
+
+	text := joinSegments(segments)
+	if text != "" {
+		if len(text) > maxMarkdownBlockChars {
+			return nil
+		}
+		blocks = append(blocks, slack.NewMarkdownBlock("md_text", text))
+	}
+
+	blocks = append(blocks, buildOneTableBlock("md_table", table))
+	return blocks
+}
+
+func buildMultiTableBlocks(content string) []slack.Block {
+	wrapped := wrapTablesInCodeBlocks(content)
+	if len(wrapped) > maxMarkdownBlockChars {
+		return nil
+	}
+	return []slack.Block{slack.NewMarkdownBlock("md_full", wrapped)}
+}
+
+func buildOneTableBlock(blockID string, t ParsedTable) *slack.TableBlock {
+	table := slack.NewTableBlock(blockID)
+	settings := make([]slack.ColumnSetting, len(t.Headers))
+	for j, align := range t.ColAligns {
+		settings[j] = slack.ColumnSetting{Align: align, IsWrapped: true}
+	}
+	table = table.WithColumnSettings(settings...)
+
+	headerRow := make([]*slack.RichTextBlock, len(t.Headers))
+	for j, h := range t.Headers {
+		headerRow[j] = richTextCell(h)
+	}
+	table.AddRow(headerRow...)
+
+	for _, row := range t.Rows {
+		cells := make([]*slack.RichTextBlock, len(row))
+		for j, cell := range row {
+			cells[j] = richTextCell(cell)
+		}
+		table.AddRow(cells...)
+	}
+	return table
+}
+
+func joinSegments(segments []TextSegment) string {
+	var sb strings.Builder
+	for i, s := range segments {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(s.Text)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// ---------------------------------------------------------------------------
+// wrapTablesInCodeBlocks
+// ---------------------------------------------------------------------------
+
+// wrapTablesInCodeBlocks wraps markdown tables that are not inside fenced code
+// blocks in ``` fences for monospace rendering.
+func wrapTablesInCodeBlocks(text string) string {
+	if !strings.Contains(text, "|") {
+		return text
+	}
+
+	// Use ExtractTables to find table positions.
+	cbRanges := codeBlockTableRe.FindAllStringIndex(text, -1)
+	inCodeBlock := func(idx int) bool {
+		for _, r := range cbRanges {
+			if idx >= r[0] && idx < r[1] {
+				return true
+			}
+		}
+		return false
+	}
+
+	var matches []tableMatch
+	searchFrom := 0
+
+	if text != "" && text[0] == '|' && !inCodeBlock(0) {
+		if m, ok := tryParseTableAt(text, 0); ok {
+			matches = append(matches, m)
+			searchFrom = nextSearchFrom(text, m.end)
+		}
+	}
+
+	for searchFrom < len(text) {
+		np := strings.Index(text[searchFrom:], "\n\n")
+		if np < 0 {
+			break
+		}
+		pos := searchFrom + np
+		afterBlank := pos + 2
+		for afterBlank < len(text) && (text[afterBlank] == '\n' || text[afterBlank] == ' ') {
+			afterBlank++
+		}
+		if afterBlank >= len(text) {
+			break
+		}
+		if inCodeBlock(afterBlank) {
+			searchFrom = afterBlank
+			continue
+		}
+		if m, ok := tryParseTableAt(text, afterBlank); ok {
+			matches = append(matches, m)
+			searchFrom = nextSearchFrom(text, m.end)
+		} else {
+			searchFrom = afterBlank
+		}
+	}
+
+	if len(matches) == 0 {
+		return text
+	}
+
+	// Process back-to-front to keep indices stable.
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		content := strings.TrimRight(text[m.start:m.end], "\n")
+		fenced := fmt.Sprintf("\n```\n%s\n```\n", content)
+		text = text[:m.start] + fenced + text[m.end:]
+	}
+	return text
+}

--- a/internal/messaging/slack/table_test.go
+++ b/internal/messaging/slack/table_test.go
@@ -59,6 +59,23 @@ func TestExtractTables(t *testing.T) {
 		require.Len(t, segments, 1)
 	})
 
+	t.Run("header and separator only no data rows", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---|---|"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Len(t, tables[0].Rows, 0)
+		require.Equal(t, []string{"H1", "H2"}, tables[0].Headers)
+	})
+
+	t.Run("header and separator with trailing newline", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---|---|\n"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Len(t, tables[0].Rows, 0)
+	})
+
 	t.Run("empty cells", func(t *testing.T) {
 		t.Parallel()
 		input := "| H1 | H2 |\n|---|---|\n| A |  |"

--- a/internal/messaging/slack/table_test.go
+++ b/internal/messaging/slack/table_test.go
@@ -1,0 +1,237 @@
+package slack
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ExtractTables
+// ---------------------------------------------------------------------------
+
+func TestExtractTables(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no tables", func(t *testing.T) {
+		t.Parallel()
+		segments, tables := ExtractTables("hello world")
+		require.Len(t, tables, 0)
+		require.Len(t, segments, 1)
+		require.Equal(t, "hello world", segments[0].Text)
+	})
+
+	t.Run("single table", func(t *testing.T) {
+		t.Parallel()
+		input := "before\n\n| H1 | H2 |\n|---|---|\n| A | B |\n\nafter"
+		segments, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Len(t, segments, 2)
+		require.Equal(t, []string{"H1", "H2"}, tables[0].Headers)
+		require.Len(t, tables[0].Rows, 1)
+		require.Equal(t, []string{"A", "B"}, tables[0].Rows[0])
+	})
+
+	t.Run("multiple tables", func(t *testing.T) {
+		t.Parallel()
+		input := "| A | B |\n|---|---|\n| 1 | 2 |\n\ntext\n\n| C | D |\n|---|---|\n| 3 | 4 |"
+		segments, tables := ExtractTables(input)
+		require.Len(t, tables, 2)
+		require.Len(t, segments, 1) // only text between tables
+		require.Equal(t, []string{"A", "B"}, tables[0].Headers)
+		require.Equal(t, []string{"C", "D"}, tables[1].Headers)
+	})
+
+	t.Run("table inside code block ignored", func(t *testing.T) {
+		t.Parallel()
+		input := "```\n| H1 | H2 |\n|---|---|\n| A | B |\n```\n\ntext"
+		segments, tables := ExtractTables(input)
+		require.Len(t, tables, 0)
+		require.Len(t, segments, 1)
+	})
+
+	t.Run("incomplete table no separator", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n| A | B |"
+		segments, tables := ExtractTables(input)
+		require.Len(t, tables, 0)
+		require.Len(t, segments, 1)
+	})
+
+	t.Run("empty cells", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---|---|\n| A |  |"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Equal(t, "", tables[0].Rows[0][1])
+	})
+
+	t.Run("table at start of text", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---|---|\n| A | B |\n\nafter"
+		segments, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Len(t, segments, 1) // only "after"
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Column alignment
+// ---------------------------------------------------------------------------
+
+func TestColumnAlignment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("left align", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|:---|---|\n| A | B |"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Equal(t, slack.ColumnAlignmentLeft, tables[0].ColAligns[0])
+	})
+
+	t.Run("right align", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---:|---|\n| A | B |"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Equal(t, slack.ColumnAlignmentRight, tables[0].ColAligns[0])
+	})
+
+	t.Run("center align", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|:---:|---|\n| A | B |"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Equal(t, slack.ColumnAlignmentCenter, tables[0].ColAligns[0])
+	})
+
+	t.Run("default left", func(t *testing.T) {
+		t.Parallel()
+		input := "| H1 | H2 |\n|---|---|\n| A | B |"
+		_, tables := ExtractTables(input)
+		require.Len(t, tables, 1)
+		require.Equal(t, slack.ColumnAlignmentLeft, tables[0].ColAligns[0])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// BuildTableBlocks
+// ---------------------------------------------------------------------------
+
+func TestBuildTableBlocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no tables returns nil", func(t *testing.T) {
+		t.Parallel()
+		blocks := BuildTableBlocks("text", []TextSegment{{Text: "text"}}, nil)
+		require.Nil(t, blocks)
+	})
+
+	t.Run("single table produces MarkdownBlock + TableBlock", func(t *testing.T) {
+		t.Parallel()
+		segments := []TextSegment{{Text: "before"}, {Text: "after"}}
+		tables := []ParsedTable{{Headers: []string{"H1", "H2"}, Rows: [][]string{{"A", "B"}}, ColAligns: []slack.ColumnAlignment{slack.ColumnAlignmentLeft, slack.ColumnAlignmentLeft}}}
+		blocks := BuildTableBlocks("before\n\n| H1 | H2 |\n|---|---|\n| A | B |\n\nafter", segments, tables)
+		require.Len(t, blocks, 2)
+		require.IsType(t, &slack.MarkdownBlock{}, blocks[0])
+		require.IsType(t, &slack.TableBlock{}, blocks[1])
+	})
+
+	t.Run("multiple tables produces single MarkdownBlock with code blocks", func(t *testing.T) {
+		t.Parallel()
+		content := "| A | B |\n|---|---|\n| 1 | 2 |\n\ntext\n\n| C | D |\n|---|---|\n| 3 | 4 |"
+		_, tables := ExtractTables(content)
+		require.Len(t, tables, 2)
+		blocks := BuildTableBlocks(content, nil, tables)
+		require.Len(t, blocks, 1)
+		require.IsType(t, &slack.MarkdownBlock{}, blocks[0])
+		mb := blocks[0].(*slack.MarkdownBlock)
+		require.Contains(t, mb.Text, "```")
+	})
+
+	t.Run("oversized columns returns nil", func(t *testing.T) {
+		t.Parallel()
+		headers := make([]string, 21)
+		tables := []ParsedTable{{Headers: headers, Rows: nil, ColAligns: nil}}
+		blocks := BuildTableBlocks("", nil, tables)
+		require.Nil(t, blocks)
+	})
+
+	t.Run("oversized rows returns nil", func(t *testing.T) {
+		t.Parallel()
+		rows := make([][]string, 100)
+		tables := []ParsedTable{{Headers: []string{"H"}, Rows: rows, ColAligns: nil}}
+		blocks := BuildTableBlocks("", nil, tables)
+		require.Nil(t, blocks)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// wrapTablesInCodeBlocks
+// ---------------------------------------------------------------------------
+
+func TestWrapTablesInCodeBlocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no tables unchanged", func(t *testing.T) {
+		t.Parallel()
+		result := wrapTablesInCodeBlocks("hello world")
+		require.Equal(t, "hello world", result)
+	})
+
+	t.Run("wraps single table", func(t *testing.T) {
+		t.Parallel()
+		input := "before\n\n| H1 | H2 |\n|---|---|\n| A | B |\n\nafter"
+		result := wrapTablesInCodeBlocks(input)
+		require.Contains(t, result, "```\n| H1 | H2 |")
+		require.Contains(t, result, "```")
+	})
+
+	t.Run("table inside code block untouched", func(t *testing.T) {
+		t.Parallel()
+		input := "```\n| H1 | H2 |\n|---|---|\n| A | B |\n```"
+		result := wrapTablesInCodeBlocks(input)
+		require.Equal(t, input, result)
+	})
+
+	t.Run("multiple tables all wrapped", func(t *testing.T) {
+		t.Parallel()
+		input := "| A | B |\n|---|---|\n| 1 | 2 |\n\ntext\n\n| C | D |\n|---|---|\n| 3 | 4 |"
+		result := wrapTablesInCodeBlocks(input)
+		// Should have 2 code fences wrapping each table
+		count := 0
+		for i := 0; i < len(result)-2; i++ {
+			if result[i:i+3] == "```" {
+				count++
+			}
+		}
+		require.Equal(t, 4, count) // 2 opening + 2 closing
+	})
+}
+
+// ---------------------------------------------------------------------------
+// FormatMrkdwn table integration
+// ---------------------------------------------------------------------------
+
+func TestFormatMrkdwn_TableWrap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("table wrapped in code block", func(t *testing.T) {
+		t.Parallel()
+		input := "text\n\n| H1 | H2 |\n|---|---|\n| A | B |"
+		result := FormatMrkdwn(input)
+		require.Contains(t, result, "```")
+		require.Contains(t, result, "| H1 | H2 |")
+	})
+
+	t.Run("table in existing code block not double-wrapped", func(t *testing.T) {
+		t.Parallel()
+		input := "```\n| H1 | H2 |\n|---|---|\n| A | B |\n```"
+		result := FormatMrkdwn(input)
+		require.Contains(t, result, "| H1 | H2 |")
+		// Should not have nested code fences
+		require.NotContains(t, result, "``````")
+	})
+}


### PR DESCRIPTION
## Summary

Closes #148

- **Streaming path**: Accumulates full content during stream, upgrades to `MarkdownBlock` + `TableBlock` via `UpdateMessage` after stream ends
- **PostMessage path**: Tries `TableBlock` first, falls back to code-block-wrapped `FormatMrkdwn`
- **FormatMrkdwn path**: Wraps tables in code fences as final fallback
- Multi-table responses use code blocks in `MarkdownBlock` (Slack limits 1 `TableBlock` per message)

## Changes

| File | Type | Description |
|------|------|-------------|
| `table.go` | New | Core table extraction (`ExtractTables`), Block Kit construction (`BuildTableBlocks`), code-block wrapping |
| `table_test.go` | New | 23 test cases covering extraction, alignment, block building, wrapping, FormatMrkdwn integration |
| `stream.go` | Modified | `fullContent` accumulator + `upgradeToTableBlocks` post-stream upgrade |
| `adapter.go` | Modified | `tryTableBlocks` method, called before `tryImageBlocks` in PostMessage path |
| `format.go` | Modified | `wrapTablesInCodeBlocks` in `FormatMrkdwn` pipeline |

## Test plan

- [x] `make test` — all packages pass (including 23 new table tests)
- [x] `make lint` — 0 issues
- [x] `make build` — compiles clean
- [ ] Manual: Send AI response with single table in Slack → renders as TableBlock
- [ ] Manual: Send AI response with multiple tables → renders with code block wrapping
- [ ] Manual: Streaming response with table → upgrades after stream ends