### PR TITLE
docs: add hierarchical AGENTS.md for config, agentconfig, eventstore, service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HotPlex 项目知识库
 
-**最后更新**: 2026-05-03 · **分支**: main · **版本**: v1.5.0
+**最后更新**: 2026-05-04 · **分支**: main · **版本**: v1.5.0
 
 ---
 
@@ -141,12 +141,13 @@ cp configs/env.example .env
 - `base/` - 共享 BaseWorker + Conn
 
 **支撑模块**：
-- `config/` - Viper 配置 + 热重载
-- `agentconfig/` - Agent 人格/上下文加载器
+- `config/` - Viper 配置 + 热重载 + 继承 + 审计/回滚
+- `agentconfig/` - B/C 双通道 Agent 人格/上下文加载器
 - `security/` - JWT、SSRF、路径安全
 - `skills/` - Skills 发现
 - `metrics/` - Prometheus 指标
-- `service/` - 系统服务管理
+- `service/` - 跨平台系统服务管理（systemd/launchd/SCM）
+- `eventstore/` - 会话事件持久化 + delta 聚合
 - `updater/` - 自更新（GitHub API、sha256 校验、原子替换）
 
 ### 公共包 (`pkg/`)
@@ -441,10 +442,16 @@ hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark
 
 | 文件 | 行数 |
 |------|------|
-| `bridge.go` | 1256 |
-| `feishu/adapter.go` | 1240 |
-| `slack/adapter.go` | 1165 |
-| `manager.go` | 961 |
-| `config.go` | 835 |
-| `opencodeserver/worker.go` | 824 |
-| `hub.go` | 818 |
+| `manager_test.go` | 2249 |
+| `adapter_test.go` (slack) | 2138 |
+| `conn_test.go` | 1424 |
+| `adapter.go` (slack) | 1321 |
+| `adapter.go` (feishu) | 1267 |
+| `hub_test.go` | 1103 |
+| `commands_test.go` (ocs) | 1050 |
+| `manager.go` | 984 |
+| `security_test.go` | 929 |
+| `config.go` | 923 |
+| `worker.go` (ocs) | 860 |
+| `streaming.go` (feishu) | 857 |
+| `handler.go` | 823 |

--- a/internal/agentconfig/AGENTS.md
+++ b/internal/agentconfig/AGENTS.md
@@ -1,0 +1,54 @@
+# Agent Config Package
+
+## OVERVIEW
+Loads agent personality/context from filesystem with 3-level fallback (global → platform → bot). B/C dual-channel system prompt assembly with embedded meta-cognition. Size-limited, YAML-frontmatter-aware file loading.
+
+## STRUCTURE
+```
+agentconfig/
+  loader.go            # Load(dir, platform, botID), resolveFile, readFile, stripFrontmatter, size limits
+  prompt.go            # BuildSystemPrompt: B-channel (directives) + C-channel (context) + hotplex meta-cognition
+  META-COGNITION.md    # Embedded meta-cognition instructions (go:embed)
+  loader_test.go       # Load, fallback, size limits, frontmatter stripping, BuildSystemPrompt tests
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Load agent configs | `loader.go:39` Load(dir, platform, botID) | 3-level fallback per file |
+| System prompt assembly | `prompt.go:24` BuildSystemPrompt | B-channel + C-channel + meta-cognition |
+| Add config file type | `loader.go` fileNames slice | SOUL, AGENTS, SKILLS, USER, MEMORY |
+| Change size limits | `loader.go` MaxFileChars, MaxTotalChars | Per-file and total limits |
+| Meta-cognition content | `META-COGNITION.md` | Embedded via go:embed |
+| File resolution logic | `loader.go:110` resolveFile | bot/<id>/ → platform/ → global → empty → fallback |
+
+## KEY PATTERNS
+
+**3-level fallback** (per file, independent resolution):
+```
+~/.hotplex/agent-configs/
+  SOUL.md              # global
+  slack/
+    SOUL.md            # platform override
+    U12345/
+      SOUL.md          # bot-specific override
+```
+Empty content at a level → fall through to next level. Each file resolves independently.
+
+**B/C dual-channel assembly** (BuildSystemPrompt):
+- B-channel `<directives>`: `<persona>` (SOUL) + `<rules>` (AGENTS) + `<skills>` (SKILLS)
+- C-channel `<context>`: `<hotplex>` (meta-cognition, always present) + `<user>` (USER) + `<memory>` (MEMORY)
+- B-channel always precedes C-channel
+- Each section has behavioral directives injected automatically
+
+**Size limits**: MaxFileChars per file (truncation), MaxTotalChars total (enforced after all loads). Prevents runaway config sizes.
+
+**YAML frontmatter stripping**: `---\n...\n---\n` patterns removed. Content after closing `---` used.
+
+**Path traversal protection**: botID validated (no `/`, `..`), platform validated.
+
+## ANTI-PATTERNS
+- ❌ Load config files without size limits — unbounded strings
+- ❌ Skip frontmatter stripping — YAML headers would pollute prompts
+- ❌ Use suffix files (SOUL.slack.md) — old mechanism removed, use directory fallback
+- ❌ Inject meta-cognition outside `<hotplex>` tag — always use BuildSystemPrompt

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -1,0 +1,47 @@
+# Config Package
+
+## OVERVIEW
+Central configuration via Viper + YAML with config inheritance, secrets provider chain, hot-reload watcher with audit log and rollback, and atomic ConfigStore with observer pattern.
+
+## STRUCTURE
+```
+config/
+  config.go          # Config struct (20+ sub-configs), Load, Validate, SecretsProvider chain, path normalization (923 lines)
+  store.go           # ConfigStore: atomic Pointer[Config], Observer registration, Swap/Get
+  watcher.go         # Watcher: fsnotify debounce, diffConfigs, hot/static change split, audit trail, rollback
+  paths_unix.go      # DataDir/LogDir/PIDDir for Linux/macOS
+  paths_windows.go   # DataDir/LogDir/PIDDir for Windows
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add config field | `config.go` Config struct | Add field + mapstructure tag + default in `applyDefaults()` |
+| Config inheritance | `config.go` Load | `Inherits` field → recursive merge with cycle detection |
+| Secrets loading | `config.go` SecretsProvider | EnvSecretsProvider (HOTPLEX_*) → ChainedSecretsProvider |
+| Hot reload | `watcher.go` Watcher | fsnotify → debounce 500ms → diffConfigs → hot/static split |
+| Audit trail | `watcher.go` ConfigChange | Field-level diff with old/new values, hot flag |
+| Rollback | `watcher.go` Rollback() | History ring buffer, latestIdx tracking |
+| Atomic access | `store.go` ConfigStore | `atomic.Pointer[Config]` for lock-free reads |
+| Observer pattern | `store.go` Observer | Register observers for config changes |
+| Path defaults | `paths_*.go` | Platform-specific data/log/PID directories |
+| Validation | `config.go` Validate() | Required fields, value ranges, cross-field checks |
+
+## KEY PATTERNS
+
+**Config hierarchy**: `Config` contains 12 sub-configs (Gateway, DB, Worker, Security, Session, Pool, Log, Admin, WebChat, Messaging, AgentConfig, Skills). Each has mapstructure tags for Viper binding.
+
+**Secrets provider chain**: `EnvSecretsProvider` reads HOTPLEX_* env vars → `ChainedSecretsProvider` tries multiple providers in order. JWT secret never from config file (mapstructure:"-").
+
+**Hot reload flow**: fsnotify event → debounce timer → reload() → Load() → Validate() → diffConfigs() → split hot/static → apply via ConfigStore.Swap() → notify observers. Static changes logged but not applied (require restart).
+
+**Audit + rollback**: Every change recorded as ConfigChange. History ring buffer (default 10 snapshots). Rollback() decrements latestIdx and applies previous snapshot.
+
+**Inheritance**: `inherits: path/to/parent.yaml` → recursive Load with cycle detection (visited map). Child values override parent.
+
+## ANTI-PATTERNS
+- ❌ Read config without ConfigStore.Get() — direct field access bypasses atomic updates
+- ❌ Add secrets to YAML config — use SecretsProvider or env vars only
+- ❌ Skip Validate() after Load — invalid configs silently accepted
+- ❌ Hot-reload static fields (addr, db.path) — they require restart
+- ❌ Forget `mapstructure:"-"` for sensitive fields — they'd appear in config dump

--- a/internal/eventstore/AGENTS.md
+++ b/internal/eventstore/AGENTS.md
@@ -1,0 +1,45 @@
+# Event Store Package
+
+## OVERVIEW
+Session event persistence with SQLite backend, delta accumulation/coalescing, batched writes, and cursor-based pagination. Collector pattern with channel-based async writer.
+
+## STRUCTURE
+```
+eventstore/
+  store.go            # EventStore interface, SQLiteStore, StoredEvent, EventPage, cursor pagination
+  collector.go        # Collector: delta accumulator, batched async writer, timed flush
+  sql/                # Embedded SQL queries (go:embed)
+    queries/          # Per-query .sql files
+  store_test.go       # Store tests
+  collector_test.go   # Collector tests
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Event storage interface | `store.go` EventStore | Append, Query, DeleteBySession, BeginTx |
+| SQLite implementation | `store.go:123` SQLiteStore | WAL mode, busy_timeout |
+| Stored event schema | `store.go:74` StoredEvent | session_id, seq, type, data, direction, created_at |
+| Pagination | `store.go` EventPage | cursor-based (oldest/newest seq), HasOlder flag |
+| Delta coalescing | `collector.go:62` Collector | per-session deltaAccumulator, flush on MessageEnd or timeout |
+| Batch writer | `collector.go:169` runWriter | batch up to collectorBatchMax, flush on interval or close |
+| Event filtering | `collector.go:90` IsStorable | Only storable event types persisted |
+
+## KEY PATTERNS
+
+**Delta accumulation**: message.delta events are accumulated per-session in memory. Flushed to single StoredEvent when:
+- MessageEnd received for session
+- Content exceeds deltaFlushSize threshold
+- Timeout (deltaFlushInterval) exceeded
+
+**Batch writer goroutine**: Single writer reads from captureC channel (cap 1024). Batches up to collectorBatchMax items. Flushes on ticker interval or channel close. Uses transaction for batch atomicity.
+
+**Cursor pagination**: Query returns EventPage with oldest/newest seq bounds. HasOlder flag for backward navigation. No offset-based pagination.
+
+**Drop on full**: captureC channel non-blocking send — events silently dropped if channel full (logged as warning).
+
+## ANTI-PATTERNS
+- ❌ Store every message.delta individually — use Collector coalescing
+- ❌ Query with OFFSET — use cursor-based pagination
+- ❌ Skip flushTimedOutAccumulators — orphaned deltas would leak memory
+- ❌ Access SQLite directly — use EventStore interface for testability

--- a/internal/service/AGENTS.md
+++ b/internal/service/AGENTS.md
@@ -1,0 +1,50 @@
+# Service Management Package
+
+## OVERVIEW
+Cross-platform system service management (systemd/launchd/Windows SCM). Template-based unit/plist generation with user-level and system-level support. Privilege detection and log directory resolution.
+
+## STRUCTURE
+```
+service/
+  service.go           # Manager interface, InstallOptions, Status, Level type, ParseLevel, ResolveBinaryPath, LogDir
+  manager_linux.go     # linuxManager: systemd unit install/uninstall/status/start/stop/restart/logs
+  manager_darwin.go    # darwinManager: launchd plist install/uninstall/status/start/stop/restart/logs
+  manager_windows.go   # windowsManager: Windows SCM install/uninstall/status/start/stop/restart/logs
+  templates.go         # BuildSystemdUnit, BuildLaunchdPlist, resolveWorkDir, logDirForHome
+  admin_windows.go     # IsPrivileged (Windows admin check)
+  admin_other.go       # IsPrivileged (POSIX uid check)
+  logdir_windows.go    # systemLogDir (Windows event log)
+  logdir_other.go      # systemLogDir (/var/log)
+  templates_test.go    # Template generation tests, ParseLevel tests
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Manager interface | `service.go` Manager | Install, Uninstall, Status, Start, Stop, Restart, Logs |
+| Install options | `service.go:28` InstallOptions | BinaryPath, ConfigPath, Level, Name, WorkDir |
+| Service level | `service.go` Level | User vs System (affects install path and privileges) |
+| Systemd unit template | `templates.go:17` BuildSystemdUnit | User: ~/.config/systemd, System: /etc/systemd |
+| Launchd plist template | `templates.go:78` BuildLaunchdPlist | User: ~/Library/LaunchAgents, System: /Library/LaunchDaemons |
+| Windows SCM | `manager_windows.go` | golang.org/x/sys/windows/svc/mgr for service control |
+| Binary path resolution | `service.go:55` ResolveBinaryPath | os.Executable → symlink resolve → /usr/local/bin fallback |
+| Log directory | `service.go:81` LogDir | Platform + level dependent |
+| Privilege check | `admin_*.go` IsPrivileged | Windows: admin group, POSIX: uid == 0 |
+
+## KEY PATTERNS
+
+**Platform-conditional compilation**: `manager_linux.go`, `manager_darwin.go`, `manager_windows.go` with build tags. `NewManager()` returns platform-specific implementation.
+
+**Template-based config generation**: BuildSystemdUnit/BuildLaunchdPlist generate complete unit/plist files from InstallOptions. Includes: WorkingDirectory, ExecStart, log paths, auto-restart, environment variables.
+
+**User vs System level**: User-level installs to home directory (no root). System-level requires elevated privileges. Affects unit path, log directory, and plist label.
+
+**Linger enablement** (Linux): User-level systemd auto-enables linger for the user to ensure service survives logout.
+
+**Logs subcommand**: Platform-specific log access — journalctl (Linux), log show (macOS), Windows event log.
+
+## ANTI-PATTERNS
+- ❌ Hard-code service paths — use template generation functions
+- ❌ Install system-level service without privilege check — IsPrivileged() gate required
+- ❌ Assume systemd on Linux — verify via systemctl availability
+- ❌ Skip WorkDir in service unit — worker processes need WorkingDirectory


### PR DESCRIPTION
## Summary

Generate sub-AGENTS.md documentation for 4 internal modules that lacked dedicated knowledge-base files, and update the root AGENTS.md with current metrics and descriptions.

### Changes

- **NEW** `internal/config/AGENTS.md` — Viper + hot-reload + inheritance + audit/rollback documentation
- **NEW** `internal/agentconfig/AGENTS.md` — B/C dual-channel prompt assembly + 3-level fallback
- **NEW** `internal/eventstore/AGENTS.md` — Delta coalescing + batched SQLite writes + cursor pagination
- **NEW** `internal/service/AGENTS.md` — Cross-platform systemd/launchd/SCM service management
- **UPD** `AGENTS.md` (root) — refresh date, improve support module descriptions, update max-file table

**架构影响**：
- Channel: N/A
- Worker: N/A
- 平台: N/A (documentation only)

## Test Plan

- [x] `make test` — N/A (documentation only, no code changes)
- [x] `make lint` — N/A
- [x] All 22 AGENTS.md files validated: size bounds (30-88 lines for subdirs), no parent-child duplication, telegraphic style

## Related Issues

- Addresses documentation coverage gap for internal modules: config (2731 LOC), agentconfig (651 LOC), eventstore (1110 LOC), service (1092 LOC)