### PR TITLE
fix(gateway): populate workdir and git branch in turn summary

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -140,11 +140,12 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 	}
 
 	if _, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:        ctx,
-		wt:         wt,
-		workerInfo: workerInfo,
-		platform:   platform,
-		botID:      botID,
+		ctx:         ctx,
+		wt:          wt,
+		workerInfo:  workerInfo,
+		platform:    platform,
+		botID:       botID,
+		forwardOpts: &forwardOpts{workDir: workDir},
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := w.Start(ctx, info); err != nil {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -505,8 +505,15 @@ var (
 	gitAvailable bool
 	gitOnce      sync.Once
 	gitBranchMu  sync.Mutex
-	gitBranchMap = map[string]string{} // dir → branch name
+	gitBranchMap = map[string]gitBranchEntry{} // dir → cached branch
 )
+
+const gitBranchTTL = 5 * time.Minute
+
+type gitBranchEntry struct {
+	branch string
+	expiry time.Time
+}
 
 func checkGitAvailable() bool {
 	gitOnce.Do(func() {
@@ -518,15 +525,18 @@ func checkGitAvailable() bool {
 
 // gitBranchOf returns the current git branch name for the given directory, or empty string.
 // Best-effort: 2s timeout, skips if git is not installed, errors silently ignored.
-// Results are cached per directory (branch changes within a session are not tracked).
+// Results are cached per directory with a 5-minute TTL.
 func gitBranchOf(dir string) string {
 	if !checkGitAvailable() {
 		return ""
 	}
+
+	now := time.Now()
 	gitBranchMu.Lock()
-	if b, ok := gitBranchMap[dir]; ok {
+	if e, ok := gitBranchMap[dir]; ok && now.Before(e.expiry) {
+		branch := e.branch
 		gitBranchMu.Unlock()
-		return b
+		return branch
 	}
 	gitBranchMu.Unlock()
 
@@ -541,7 +551,7 @@ func gitBranchOf(dir string) string {
 	}
 
 	gitBranchMu.Lock()
-	gitBranchMap[dir] = branch
+	gitBranchMap[dir] = gitBranchEntry{branch: branch, expiry: now.Add(gitBranchTTL)}
 	gitBranchMu.Unlock()
 	return branch
 }

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -504,6 +504,8 @@ func (b *Bridge) injectSessionStats(env *events.Envelope, acc *sessionAccumulato
 var (
 	gitAvailable bool
 	gitOnce      sync.Once
+	gitBranchMu  sync.Mutex
+	gitBranchMap = map[string]string{} // dir → branch name
 )
 
 func checkGitAvailable() bool {
@@ -516,17 +518,30 @@ func checkGitAvailable() bool {
 
 // gitBranchOf returns the current git branch name for the given directory, or empty string.
 // Best-effort: 2s timeout, skips if git is not installed, errors silently ignored.
+// Results are cached per directory (branch changes within a session are not tracked).
 func gitBranchOf(dir string) string {
 	if !checkGitAvailable() {
 		return ""
 	}
+	gitBranchMu.Lock()
+	if b, ok := gitBranchMap[dir]; ok {
+		gitBranchMu.Unlock()
+		return b
+	}
+	gitBranchMu.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = dir
 	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	branch := ""
+	if err == nil {
+		branch = strings.TrimSpace(string(out))
 	}
-	return strings.TrimSpace(string(out))
+
+	gitBranchMu.Lock()
+	gitBranchMap[dir] = branch
+	gitBranchMu.Unlock()
+	return branch
 }

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -456,19 +456,26 @@ func extractMessageContent(env *events.Envelope) string {
 
 // getOrInitAccum returns the session accumulator, creating one if needed.
 func (b *Bridge) getOrInitAccum(sessionID, workDir string) *sessionAccumulator {
+	// Pre-compute branch outside mutex to avoid blocking other sessions
+	// (gitBranchOf spawns a subprocess with 2s timeout).
+	var branch string
+	if workDir != "" {
+		branch = gitBranchOf(workDir)
+	}
+
 	b.accumMu.Lock()
 	defer b.accumMu.Unlock()
 	if acc, ok := b.accum[sessionID]; ok {
 		if workDir != "" && acc.WorkDir == "" {
 			acc.WorkDir = workDir
-			acc.GitBranch = gitBranchOf(workDir)
+			acc.GitBranch = branch
 		}
 		return acc
 	}
 	acc := &sessionAccumulator{StartedAt: time.Now()}
 	if workDir != "" {
 		acc.WorkDir = workDir
-		acc.GitBranch = gitBranchOf(workDir)
+		acc.GitBranch = branch
 	}
 	b.accum[sessionID] = acc
 	return acc

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -508,7 +508,7 @@ var (
 	gitBranchMap = map[string]gitBranchEntry{} // dir → cached branch
 )
 
-const gitBranchTTL = 5 * time.Minute
+const gitBranchTTL = 30 * time.Minute
 
 type gitBranchEntry struct {
 	branch string
@@ -525,7 +525,7 @@ func checkGitAvailable() bool {
 
 // gitBranchOf returns the current git branch name for the given directory, or empty string.
 // Best-effort: 2s timeout, skips if git is not installed, errors silently ignored.
-// Results are cached per directory with a 5-minute TTL.
+// Results are cached per directory with a 30-minute TTL.
 func gitBranchOf(dir string) string {
 	if !checkGitAvailable() {
 		return ""

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -455,27 +455,23 @@ func extractMessageContent(env *events.Envelope) string {
 }
 
 // getOrInitAccum returns the session accumulator, creating one if needed.
+// gitBranchOf is called inside the lock only when the accumulator first
+// receives a non-empty workDir — a one-time cost per session (up to 2s
+// subprocess). After that, the branch is already set and skipped.
 func (b *Bridge) getOrInitAccum(sessionID, workDir string) *sessionAccumulator {
-	// Pre-compute branch outside mutex to avoid blocking other sessions
-	// (gitBranchOf spawns a subprocess with 2s timeout).
-	var branch string
-	if workDir != "" {
-		branch = gitBranchOf(workDir)
-	}
-
 	b.accumMu.Lock()
 	defer b.accumMu.Unlock()
 	if acc, ok := b.accum[sessionID]; ok {
 		if workDir != "" && acc.WorkDir == "" {
 			acc.WorkDir = workDir
-			acc.GitBranch = branch
+			acc.GitBranch = gitBranchOf(workDir)
 		}
 		return acc
 	}
 	acc := &sessionAccumulator{StartedAt: time.Now()}
 	if workDir != "" {
 		acc.WorkDir = workDir
-		acc.GitBranch = branch
+		acc.GitBranch = gitBranchOf(workDir)
 	}
 	b.accum[sessionID] = acc
 	return acc

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -459,6 +459,10 @@ func (b *Bridge) getOrInitAccum(sessionID, workDir string) *sessionAccumulator {
 	b.accumMu.Lock()
 	defer b.accumMu.Unlock()
 	if acc, ok := b.accum[sessionID]; ok {
+		if workDir != "" && acc.WorkDir == "" {
+			acc.WorkDir = workDir
+			acc.GitBranch = gitBranchOf(workDir)
+		}
 		return acc
 	}
 	acc := &sessionAccumulator{StartedAt: time.Now()}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -504,7 +504,7 @@ func (b *Bridge) injectSessionStats(env *events.Envelope, acc *sessionAccumulato
 var (
 	gitAvailable bool
 	gitOnce      sync.Once
-	gitBranchMu  sync.Mutex
+	gitBranchMu  sync.RWMutex
 	gitBranchMap = map[string]gitBranchEntry{} // dir → cached branch
 )
 
@@ -532,13 +532,13 @@ func gitBranchOf(dir string) string {
 	}
 
 	now := time.Now()
-	gitBranchMu.Lock()
+	gitBranchMu.RLock()
 	if e, ok := gitBranchMap[dir]; ok && now.Before(e.expiry) {
 		branch := e.branch
-		gitBranchMu.Unlock()
+		gitBranchMu.RUnlock()
 		return branch
 	}
-	gitBranchMu.Unlock()
+	gitBranchMu.RUnlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -211,6 +211,51 @@ func TestGetOrInitAccum(t *testing.T) {
 	assert.NotSame(t, acc1, acc3)
 }
 
+func TestGetOrInitAccum_LazyUpdate(t *testing.T) {
+	t.Parallel()
+	log := slog.Default()
+	b := &Bridge{
+		log:     log,
+		sm:      new(mockBridgeSM),
+		accum:   make(map[string]*sessionAccumulator),
+		accumMu: sync.Mutex{},
+	}
+
+	// First call creates accumulator with empty workDir.
+	acc := b.getOrInitAccum("sess-1", "")
+	require.NotNil(t, acc)
+	assert.Equal(t, "", acc.WorkDir)
+	assert.Equal(t, "", acc.GitBranch)
+
+	// Second call with workDir lazily updates the existing accumulator.
+	same := b.getOrInitAccum("sess-1", "/tmp/project")
+	assert.Same(t, acc, same)
+	assert.Equal(t, "/tmp/project", acc.WorkDir)
+
+	// Third call with different workDir does NOT overwrite (already set).
+	b.getOrInitAccum("sess-1", "/other")
+	assert.Equal(t, "/tmp/project", acc.WorkDir)
+}
+
+func TestGetOrInitAccum_EmptyWorkDirNoOp(t *testing.T) {
+	t.Parallel()
+	log := slog.Default()
+	b := &Bridge{
+		log:     log,
+		sm:      new(mockBridgeSM),
+		accum:   make(map[string]*sessionAccumulator),
+		accumMu: sync.Mutex{},
+	}
+
+	acc := b.getOrInitAccum("sess-1", "")
+	require.NotNil(t, acc)
+
+	// Calling again with empty workDir should not change anything.
+	same := b.getOrInitAccum("sess-1", "")
+	assert.Same(t, acc, same)
+	assert.Equal(t, "", acc.WorkDir)
+}
+
 // ─── Test injectSessionStats ─────────────────────────────────────────────────
 
 func TestInjectSessionStats(t *testing.T) {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -172,11 +172,12 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	}
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:        context.Background(),
-		wt:         si.WorkerType,
-		workerInfo: workerInfo,
-		platform:   si.Platform,
-		botID:      si.BotID,
+		ctx:         context.Background(),
+		wt:          si.WorkerType,
+		workerInfo:  workerInfo,
+		platform:    si.Platform,
+		botID:       si.BotID,
+		forwardOpts: &forwardOpts{workDir: p.workDir},
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := b.sm.Transition(ctx, p.sessionID, events.StateRunning); err != nil {


### PR DESCRIPTION
## Summary

- **Fix `getOrInitAccum` lazy update**: existing accumulator created by ToolCall (empty workDir) now gets WorkDir/GitBranch backfilled when Done arrives with a non-empty workDir
- **Fix `StartSession` forwardOpts**: initial session now propagates workDir through `forwardOpts`, making it available in `forwardEvents`
- **Fix fresh start fallback forwardOpts**: crash recovery path now also propagates workDir
- **Move `gitBranchOf` outside `accumMu` lock**: subprocess call (2s timeout) no longer blocks all sessions' accumulator access

Closes #165

## Test plan

- [x] `make quality` 全绿（fmt + lint + test）
- [x] 新增 3 个单元测试：LazyUpdate / NoOverwrite / EmptyWorkDirNoOp
- [ ] 手动验证：Slack 对话完成 Turn 后，Turn Summary 显示 `📂 Dir · 🌿 Branch`