### PR TITLE
fix(security): prevent path traversal in Slack and Feishu media handling

### DIFF
--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -1172,7 +1172,9 @@ func (a *Adapter) saveMediaBytes(data []byte, media *MediaInfo, ext string) (str
 
 	filename := media.Key + ext
 	if media.Name != "" {
-		filename = media.Key + "_" + media.Name
+		if base := filepath.Base(media.Name); base != "." && base != ".." && base != string(filepath.Separator) {
+			filename = media.Key + "_" + base
+		}
 	}
 	filePath := filepath.Join(mediaDir, filename)
 

--- a/internal/messaging/feishu/adapter_helper_test.go
+++ b/internal/messaging/feishu/adapter_helper_test.go
@@ -15,6 +15,7 @@ import (
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/stt"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -242,12 +243,13 @@ func TestSaveMediaBytes(t *testing.T) {
 	adapter := newTestAdapter(t)
 
 	tests := []struct {
-		name      string
-		media     *MediaInfo
-		data      []byte
-		wantErr   bool
-		checkFile bool
-		checkName bool
+		name       string
+		media      *MediaInfo
+		data       []byte
+		wantErr    bool
+		checkFile  bool
+		checkName  bool
+		checkInDir bool
 	}{
 		{
 			name:      "image jpg",
@@ -263,6 +265,30 @@ func TestSaveMediaBytes(t *testing.T) {
 			wantErr:   false,
 			checkFile: true,
 			checkName: true,
+		},
+		{
+			name:       "path traversal with dotdot",
+			media:      &MediaInfo{Key: "evil_key", Type: "file", Name: "../../../etc/crontab"},
+			data:       []byte("evil"),
+			wantErr:    false,
+			checkFile:  true,
+			checkInDir: true,
+		},
+		{
+			name:       "path traversal with dot",
+			media:      &MediaInfo{Key: "dot_key", Type: "image", Name: "."},
+			data:       []byte("data"),
+			wantErr:    false,
+			checkFile:  true,
+			checkInDir: true,
+		},
+		{
+			name:       "path traversal with dotdot only",
+			media:      &MediaInfo{Key: "dd_key", Type: "image", Name: ".."},
+			data:       []byte("data"),
+			wantErr:    false,
+			checkFile:  true,
+			checkInDir: true,
 		},
 	}
 
@@ -280,6 +306,13 @@ func TestSaveMediaBytes(t *testing.T) {
 				data, err := os.ReadFile(path)
 				require.NoError(t, err)
 				require.Equal(t, tt.data, data)
+				if tt.checkInDir {
+					mediaDir := filepath.Join(config.TempBaseDir(), "media", tt.media.Type+"s")
+					absPath, dirErr := filepath.Abs(path)
+					require.NoError(t, dirErr)
+					require.True(t, strings.HasPrefix(absPath, mediaDir+string(filepath.Separator)),
+						"file %q escaped media dir %q", absPath, mediaDir)
+				}
 				t.Cleanup(func() { os.RemoveAll(filepath.Dir(path)) })
 			}
 		})

--- a/internal/messaging/feishu/adapter_helper_test.go
+++ b/internal/messaging/feishu/adapter_helper_test.go
@@ -275,7 +275,7 @@ func TestSaveMediaBytes(t *testing.T) {
 			checkInDir: true,
 		},
 		{
-			name:       "path traversal with dot",
+			name:       "dot name falls back to key",
 			media:      &MediaInfo{Key: "dot_key", Type: "image", Name: "."},
 			data:       []byte("data"),
 			wantErr:    false,
@@ -283,7 +283,7 @@ func TestSaveMediaBytes(t *testing.T) {
 			checkInDir: true,
 		},
 		{
-			name:       "path traversal with dotdot only",
+			name:       "dotdot name falls back to key",
 			media:      &MediaInfo{Key: "dd_key", Type: "image", Name: ".."},
 			data:       []byte("data"),
 			wantErr:    false,

--- a/internal/messaging/slack/image_blocks.go
+++ b/internal/messaging/slack/image_blocks.go
@@ -37,7 +37,7 @@ func extractImages(text string) (parts []imagePart, remaining string) {
 		trimmed := strings.TrimSpace(line)
 
 		if isLocalMediaPath(trimmed) {
-			imgURL, altText := localFileToImagePart(trimmed)
+			imgURL, altText := localFileToImagePart(filepath.Clean(trimmed))
 			if imgURL != "" {
 				parts = append(parts, imagePart{URL: imgURL, AltText: altText})
 				continue

--- a/internal/messaging/slack/image_blocks.go
+++ b/internal/messaging/slack/image_blocks.go
@@ -55,8 +55,9 @@ func extractImages(text string) (parts []imagePart, remaining string) {
 }
 
 func isLocalMediaPath(s string) bool {
-	return strings.HasPrefix(s, mediaImagesPrefix) ||
-		strings.HasPrefix(s, mediaVideosPrefix)
+	cleaned := filepath.Clean(s)
+	return strings.HasPrefix(cleaned, mediaImagesPrefix) ||
+		strings.HasPrefix(cleaned, mediaVideosPrefix)
 }
 
 func isImageURL(s string) bool {

--- a/internal/messaging/slack/image_blocks_test.go
+++ b/internal/messaging/slack/image_blocks_test.go
@@ -1,0 +1,37 @@
+package slack
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalMediaPath(t *testing.T) {
+	t.Parallel()
+
+	imageDir := filepath.Join(MediaPathPrefix, "images") + string(filepath.Separator)
+	videoDir := filepath.Join(MediaPathPrefix, "videos") + string(filepath.Separator)
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"valid image path", imageDir + "photo.png", true},
+		{"valid video path", videoDir + "clip.mp4", true},
+		{"dotdot traversal", imageDir + "../../../../etc/passwd", false},
+		{"dotdot traversal video", videoDir + "../../../tmp/evil", false},
+		{"absolute system path", "/etc/passwd", false},
+		{"empty path", "", false},
+		{"relative path no prefix", "images/photo.png", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isLocalMediaPath(tt.path)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Batch fix for path traversal vulnerabilities in media file handling across Slack and Feishu adapters.

- **#154**: Slack `isLocalMediaPath` 使用 `strings.HasPrefix` 检查路径前缀但不解析 `..` 组件，AI 输出注入可绕过前缀检查读取任意文件
- **#152**: Feishu `saveMediaBytes` 使用用户上传文件名 `media.Name` 构建路径未做清理，可写入 media 目录外

## Changes by Issue

### #154 — Slack image path traversal

**Fix**: `isLocalMediaPath` 添加 `filepath.Clean` 后再做前缀匹配

**Changes**:
- `internal/messaging/slack/image_blocks.go` — 1 行核心修改
- `internal/messaging/slack/image_blocks_test.go` — 新增 7 个 table-driven 测试用例

### #152 — Feishu media filename path traversal

**Fix**: `saveMediaBytes` 对 `media.Name` 使用 `filepath.Base` 去除目录组件，拒绝 `.` 和 `..`

**Changes**:
- `internal/messaging/feishu/adapter.go` — 3 行核心修改
- `internal/messaging/feishu/adapter_helper_test.go` — 新增 3 个路径穿越测试用例 + 目录边界断言

Closes #154, #152

## Test Plan

- [x] `go build ./...` passes
- [x] `make lint` — 0 issues
- [x] `go test -race ./internal/messaging/slack/ ./internal/messaging/feishu/` passes
- [x] Path traversal vectors verified: `../`, `..`, `.` 均被拦截
- [x] 正常文件名功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)