### PR TITLE
fix(worker): correct control_request field mapping to prevent Worker deadlock

### DIFF
--- a/internal/worker/claudecode/parser.go
+++ b/internal/worker/claudecode/parser.go
@@ -300,8 +300,16 @@ func (p *Parser) parseResult(msg *SDKMessage) ([]*WorkerEvent, error) {
 // All subtypes (can_use_tool, set_*, mcp_*, etc.) are returned as
 // EventControl with Payload=*ControlRequestPayload, routing by Subtype in worker.go.
 func (p *Parser) parseControlRequest(msg *SDKMessage) ([]*WorkerEvent, error) {
+	// Claude Code uses "request" as the inner payload field for control_request.
+	payload := msg.Request
+	if len(payload) == 0 {
+		payload = msg.Response // fallback for older protocol versions
+	}
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("parser: control_request has no request/response payload")
+	}
 	var req ControlRequestPayload
-	if err := json.Unmarshal(msg.Response, &req); err != nil {
+	if err := json.Unmarshal(payload, &req); err != nil {
 		return nil, fmt.Errorf("parser: unmarshal control_request: %w", err)
 	}
 	req.RequestID = msg.RequestID // canonical source is outer SDKMessage

--- a/internal/worker/claudecode/parser_test.go
+++ b/internal/worker/claudecode/parser_test.go
@@ -191,6 +191,57 @@ func TestParser_ParseLine_ControlRequestMCPStatus(t *testing.T) {
 	require.Equal(t, "mcp_status", cr.Subtype)
 }
 
+func TestParser_ParseLine_ControlRequest_WithRequestField(t *testing.T) {
+	log := newTestLogger()
+	parser := NewParser(log)
+
+	tests := []struct {
+		name    string
+		line    string
+		wantID  string
+		wantSub string
+		wantOk  bool
+	}{
+		{
+			name:    "can_use_tool with request field (actual Claude Code format)",
+			line:    `{"type":"control_request","request_id":"req_auq_1","request":{"subtype":"can_use_tool","tool_name":"AskUserQuestion","input":{"questions":[{"question":"PR strategy?","header":"PR","options":[{"label":"Single PR","description":"All phases in one PR"}],"multiSelect":false}]},"tool_use_id":"call_abc123"}}`,
+			wantID:  "req_auq_1",
+			wantSub: "can_use_tool",
+			wantOk:  true,
+		},
+		{
+			name:    "can_use_tool with response field (backward compat)",
+			line:    `{"type":"control_request","request_id":"req_old","response":{"subtype":"can_use_tool","tool_name":"read_file","input":{"path":"/app/main.go"}}}`,
+			wantID:  "req_old",
+			wantSub: "can_use_tool",
+			wantOk:  true,
+		},
+		{
+			name:   "control_request with neither request nor response field",
+			line:   `{"type":"control_request","request_id":"req_empty"}`,
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			events, err := parser.ParseLine(tt.line)
+			if !tt.wantOk {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			require.Equal(t, EventControl, events[0].Type)
+			cr, ok := events[0].Payload.(*ControlRequestPayload)
+			require.True(t, ok)
+			require.Equal(t, tt.wantID, cr.RequestID)
+			require.Equal(t, tt.wantSub, cr.Subtype)
+		})
+	}
+}
+
 func TestParser_ParseLine_SystemStatus(t *testing.T) {
 	log := newTestLogger()
 	parser := NewParser(log)

--- a/internal/worker/claudecode/types.go
+++ b/internal/worker/claudecode/types.go
@@ -12,7 +12,8 @@ type SDKMessage struct {
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Content   json.RawMessage `json:"content,omitempty"`    // For tool_progress
 	RequestID string          `json:"request_id,omitempty"` // For control_request
-	Response  json.RawMessage `json:"response,omitempty"`   // For control_request
+	Request   json.RawMessage `json:"request,omitempty"`    // For control_request (outbound name)
+	Response  json.RawMessage `json:"response,omitempty"`   // For control_response
 
 	// Result fields (type="result")
 	DurationMs        int64           `json:"duration_ms,omitempty"`

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -577,6 +577,16 @@ func (w *Worker) readOutput(ctx context.Context) {
 		workerEvents, err := w.parser.ParseLine(line)
 		if err != nil {
 			w.BaseWorker.Log.Warn("claudecode: parse line", "session_id", w.sessionID, "err", err, "line", line)
+			// If this is a control_request that failed to parse, deny it to prevent
+			// the Worker from blocking indefinitely waiting for a response.
+			if rawType.Type == "control_request" && w.control != nil {
+				var idHolder struct {
+					RequestID string `json:"request_id"`
+				}
+				if json.Unmarshal([]byte(line), &idHolder) == nil && idHolder.RequestID != "" {
+					_ = w.control.SendPermissionResponse(idHolder.RequestID, false, "gateway: parse error, auto-denied")
+				}
+			}
 			continue
 		}
 		if len(workerEvents) == 0 {


### PR DESCRIPTION
## Summary

- Claude Code SDK 使用 `"request"` 而非 `"response"` 作为 `control_request` 的内嵌 payload 字段名，`SDKMessage` 类型映射错误导致 `can_use_tool` 解析失败
- 解析失败时控制请求被静默丢弃，Worker 无限等待 `control_response`，造成 session 永久卡死
- 新增防御性拒绝机制：解析失败时自动发送 denial 响应，防止 Worker 阻塞

## 根因链

1. `types.go:15` — `SDKMessage.Response` 映射 `json:"response"`，但 Claude Code CLI 对 `control_request` 输出 `json:"request"`
2. `parser.go:304` — `json.Unmarshal(msg.Response, &req)` 拿到 nil bytes → `unexpected end of JSON input`
3. `worker.go:579` — 解析错误后 `continue`，未发送任何响应 → Worker 阻塞

## Changes

| 文件 | 变更 |
|------|------|
| `types.go` | 新增 `Request json.RawMessage` 字段 |
| `parser.go` | 优先使用 `msg.Request`，fallback `msg.Response` |
| `worker.go` | 解析失败时自动发送 denial 响应 |
| `parser_test.go` | 3 个新测试：request 字段、response 兼容、空 payload |

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test -race ./internal/worker/...` 全部通过
- [x] 新增 `TestParser_ParseLine_ControlRequest_WithRequestField` 覆盖三种场景
- [ ] 飞书端发送触发 `AskUserQuestion` 的消息，验证 Worker 不再卡死
- [ ] 验证飞书 `/gc` `/reset` 命令可恢复当前卡死的 session

🤖 Generated with [Claude Code](https://claude.com/claude-code)