### PR TITLE
fix(slack): pass thread_ts and team_id to streaming API for DM support

### DIFF
--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -452,7 +452,7 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 
 // NewStreamingWriter creates a streaming writer for the given channel/thread.
 func (a *Adapter) NewStreamingWriter(ctx context.Context, channelID, threadTS string, onComplete func(string)) *NativeStreamingWriter {
-	w := NewNativeStreamingWriter(ctx, a.client, channelID, threadTS, a.rateLimiter, a.Log, func(ts string) {
+	w := NewNativeStreamingWriter(ctx, a.client, channelID, threadTS, a.teamID, a.rateLimiter, a.Log, func(ts string) {
 		if !a.IsClosed() {
 			a.mu.Lock()
 			delete(a.activeStreams, ts)
@@ -778,7 +778,8 @@ func (c *SlackConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 	// Try streaming for delta/text events
 	if env.Event.Type == events.MessageDelta || env.Event.Type == "text" {
 		if err := c.writeWithStreaming(ctx, text); err != nil {
-			// Fall back to PostMessage on streaming failure
+			c.adapter.Log.Info("slack: streaming failed, falling back to PostMessage",
+				"channel", c.channelID, "err", err)
 			return c.writeWithPostMessage(ctx, text, env.Event.Type == events.MessageDelta)
 		}
 		return nil
@@ -831,14 +832,11 @@ func (c *SlackConn) writeWithPostMessage(ctx context.Context, text string, isDel
 		text += "\n\n"
 	}
 
-	// Try table block rendering for non-delta messages (TableBlock > ImageBlock)
-	if !isDelta {
-		if err := c.tryTableBlocks(ctx, text); err == nil {
-			return nil
-		}
-		if err := c.tryImageBlocks(ctx, text); err == nil {
-			return nil
-		}
+	if err := c.tryTableBlocks(ctx, text); err == nil {
+		return nil
+	}
+	if err := c.tryImageBlocks(ctx, text); err == nil {
+		return nil
 	}
 
 	chunks := ChunkContent(text, maxMessageLength)

--- a/internal/messaging/slack/stream.go
+++ b/internal/messaging/slack/stream.go
@@ -96,6 +96,7 @@ type NativeStreamingWriter struct {
 	client    *slack.Client
 	channelID string
 	threadTS  string
+	teamID    string
 	log       *slog.Logger
 
 	mu          sync.Mutex
@@ -127,13 +128,14 @@ type NativeStreamingWriter struct {
 }
 
 // NewNativeStreamingWriter creates a new streaming writer for Slack.
-func NewNativeStreamingWriter(ctx context.Context, client *slack.Client, channelID, threadTS string,
+func NewNativeStreamingWriter(ctx context.Context, client *slack.Client, channelID, threadTS, teamID string,
 	rateLimiter *ChannelRateLimiter, log *slog.Logger, onComplete func(string), onRegister func(*NativeStreamingWriter)) *NativeStreamingWriter {
 	w := &NativeStreamingWriter{
 		ctx:          ctx,
 		client:       client,
 		channelID:    channelID,
 		threadTS:     threadTS,
+		teamID:       teamID,
 		log:          log,
 		onComplete:   onComplete,
 		onRegister:   onRegister,
@@ -177,9 +179,16 @@ func (w *NativeStreamingWriter) Write(p []byte) (int, error) {
 
 	// 首次调用：同步启动流
 	if !w.started {
+		opts := []slack.MsgOption{slack.MsgOptionMarkdownText(":thought_balloon: Thinking...")}
+		if w.threadTS != "" {
+			opts = append(opts, slack.MsgOptionTS(w.threadTS))
+		}
+		if w.teamID != "" {
+			opts = append(opts, slack.MsgOptionRecipientTeamID(w.teamID))
+		}
 		_, streamTS, err := w.client.StartStreamContext(w.ctx,
 			w.channelID,
-			slack.MsgOptionMarkdownText(":thought_balloon: Thinking..."),
+			opts...,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("start stream: %w", err)


### PR DESCRIPTION
## Summary

- Fix `chat.startStream` returning `invalid_arguments` by passing `thread_ts` for threaded DM messages
- Add `teamID` field to `NativeStreamingWriter` and pass `recipient_team_id` for Slack Connect DM scenarios
- Remove `!isDelta` guard on `tryTableBlocks`/`tryImageBlocks` in fallback path so table rendering works when streaming fails

## Root Cause

Slack's `chat.startStream` API requires `thread_ts` for threaded messages. Without it, the call returned `invalid_arguments`, causing every streaming attempt to fail silently and fall back to `PostMessage`. The fallback path previously skipped `tryTableBlocks` for delta events, so tables were rendered as plain markdown code blocks via `FormatMrkdwn` → `wrapTablesInCodeBlocks`.

## Test Plan

- [x] Direct API testing: `chat.startStream` with `thread_ts` → ok
- [x] `chat.appendStream` with table markdown → ok  
- [x] `chat.stopStream` with TableBlock blocks → renders correctly
- [x] End-to-end test via HotPlex confirmed tables render as visual tables in Slack