### PR TITLE
fix(gateway,messaging): recover lost turn summary fixes

### DIFF
--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -96,6 +96,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 
 		if firstEvent {
 			b.persistWorkerSessionID(w, sessionID)
+			turnStartTime = time.Now() // exclude worker cold-start from Turn 1
 			firstEvent = false
 		}
 
@@ -122,7 +123,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		// Stats accumulation: track tool calls and merge per-turn stats on done.
 		switch env.Event.Type {
 		case events.ToolCall:
-			acc := b.getOrInitAccum(sessionID, "")
+			acc := b.getOrInitAccum(sessionID, "", startTime)
 			acc.ToolCallCount++
 			if tc, ok := asToolCallData(env.Event.Data); ok {
 				if acc.ToolNames == nil {
@@ -134,7 +135,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			if turnTimer != nil {
 				turnTimer.Stop()
 			}
-			acc := b.getOrInitAccum(sessionID, opts.workDir)
+			acc := b.getOrInitAccum(sessionID, opts.workDir, startTime)
 			if dd, ok := asDoneData(env.Event.Data); ok {
 				acc.mergePerTurnStats(dd)
 			}
@@ -155,6 +156,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			}
 
 			b.injectSessionStats(env, acc)
+			acc.resetPerTurn()
 			if b.log.Enabled(context.Background(), slog.LevelDebug) {
 				b.log.Debug("bridge: turn completed",
 					"session_id", sessionID, "worker_type", workerType, "turn", acc.TurnCount,
@@ -201,11 +203,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			if err := b.hub.SendToSession(context.Background(), pendingError); err != nil {
 				b.log.Warn("bridge: forward buffered error failed", "err", err, "session_id", sessionID, "worker_type", workerType)
 			}
-			if b.collector != nil {
-				if ed, err := json.Marshal(pendingError.Event.Data); err == nil {
-					b.captureEvent(sessionID, pendingError.Seq, pendingError.Event.Type, ed)
-				}
-			}
+			b.captureEvent(sessionID, pendingError.Seq, pendingError.Event.Type, pendingError.Event.Data)
 			pendingError = nil
 		}
 
@@ -357,7 +355,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode,
 			"done_received", p.doneReceived, "turn_text_len", p.turnTextLen)
 	} else if exitCode != 0 && exitCode != -1 {
-		acc := b.getOrInitAccum(p.sessionID, "")
+		acc := b.getOrInitAccum(p.sessionID, "", p.startTime)
 		b.log.Warn("bridge: worker exited with non-zero code, sending crash error",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode,
 			"duration", time.Since(p.startTime).Round(time.Millisecond), "turn_count", acc.TurnCount)
@@ -436,7 +434,7 @@ func extractMessageContent(env *events.Envelope) string {
 // gitBranchOf is called inside the lock only when the accumulator first
 // receives a non-empty workDir — a one-time cost per session (up to 2s
 // subprocess). After that, the branch is already set and skipped.
-func (b *Bridge) getOrInitAccum(sessionID, workDir string) *sessionAccumulator {
+func (b *Bridge) getOrInitAccum(sessionID, workDir string, startTime time.Time) *sessionAccumulator {
 	b.accumMu.Lock()
 	defer b.accumMu.Unlock()
 	if acc, ok := b.accum[sessionID]; ok {
@@ -446,7 +444,7 @@ func (b *Bridge) getOrInitAccum(sessionID, workDir string) *sessionAccumulator {
 		}
 		return acc
 	}
-	acc := &sessionAccumulator{StartedAt: time.Now()}
+	acc := &sessionAccumulator{StartedAt: startTime}
 	if workDir != "" {
 		acc.WorkDir = workDir
 		acc.GitBranch = gitBranchOf(workDir)

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -201,13 +201,13 @@ func TestGetOrInitAccum(t *testing.T) {
 		accumMu: sync.Mutex{},
 	}
 
-	acc1 := b.getOrInitAccum("sess-1", "")
+	acc1 := b.getOrInitAccum("sess-1", "", time.Now())
 	require.NotNil(t, acc1)
 
-	acc2 := b.getOrInitAccum("sess-1", "")
+	acc2 := b.getOrInitAccum("sess-1", "", time.Now())
 	assert.Same(t, acc1, acc2)
 
-	acc3 := b.getOrInitAccum("sess-2", "")
+	acc3 := b.getOrInitAccum("sess-2", "", time.Now())
 	assert.NotSame(t, acc1, acc3)
 }
 
@@ -222,18 +222,18 @@ func TestGetOrInitAccum_LazyUpdate(t *testing.T) {
 	}
 
 	// First call creates accumulator with empty workDir.
-	acc := b.getOrInitAccum("sess-1", "")
+	acc := b.getOrInitAccum("sess-1", "", time.Now())
 	require.NotNil(t, acc)
 	assert.Equal(t, "", acc.WorkDir)
 	assert.Equal(t, "", acc.GitBranch)
 
 	// Second call with workDir lazily updates the existing accumulator.
-	same := b.getOrInitAccum("sess-1", "/tmp/project")
+	same := b.getOrInitAccum("sess-1", "/tmp/project", time.Now())
 	assert.Same(t, acc, same)
 	assert.Equal(t, "/tmp/project", acc.WorkDir)
 
 	// Third call with different workDir does NOT overwrite (already set).
-	b.getOrInitAccum("sess-1", "/other")
+	b.getOrInitAccum("sess-1", "/other", time.Now())
 	assert.Equal(t, "/tmp/project", acc.WorkDir)
 }
 
@@ -247,11 +247,11 @@ func TestGetOrInitAccum_EmptyWorkDirNoOp(t *testing.T) {
 		accumMu: sync.Mutex{},
 	}
 
-	acc := b.getOrInitAccum("sess-1", "")
+	acc := b.getOrInitAccum("sess-1", "", time.Now())
 	require.NotNil(t, acc)
 
 	// Calling again with empty workDir should not change anything.
-	same := b.getOrInitAccum("sess-1", "")
+	same := b.getOrInitAccum("sess-1", "", time.Now())
 	assert.Same(t, acc, same)
 	assert.Equal(t, "", acc.WorkDir)
 }
@@ -264,7 +264,7 @@ func TestInjectSessionStats(t *testing.T) {
 	hub := newTestHub(t)
 	b := NewBridge(BridgeDeps{Log: log, Hub: hub, SM: sm})
 
-	acc := b.getOrInitAccum("sess-1", "")
+	acc := b.getOrInitAccum("sess-1", "", time.Now())
 	acc.ToolCallCount = 4
 
 	env := &events.Envelope{
@@ -289,7 +289,7 @@ func TestInjectSessionStats_NonDoneData(t *testing.T) {
 	hub := newTestHub(t)
 	b := NewBridge(BridgeDeps{Log: log, Hub: hub, SM: sm})
 
-	acc := b.getOrInitAccum("sess-1", "")
+	acc := b.getOrInitAccum("sess-1", "", time.Now())
 	env := &events.Envelope{
 		Event: events.Event{
 			Type: events.Message,

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -219,7 +219,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 // Uses CAS via crashedWorker to avoid detaching a worker that was already replaced
 // by a concurrent ResumeSession or attemptResumeFallback.
 func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Worker) {
-	acc := b.getOrInitAccum(sessionID, "")
+	acc := b.getOrInitAccum(sessionID, "", time.Now())
 	b.log.Debug("bridge: cleaning up crashed worker", "session_id", sessionID, "turn_count", acc.TurnCount)
 	if b.sm == nil {
 		return

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -639,8 +639,8 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.adapter.Interactions.CancelAll(env.SessionID)
 
 		d := messaging.ExtractTurnSummary(env)
-		richText := messaging.FormatTurnSummaryRich(d)
-		if richText != "" {
+		summaryText := messaging.FormatTurnSummaryRich(d)
+		if summaryText != "" {
 			c.adapter.Log.Info("turn summary",
 				"turn_count", d.TurnCount,
 				"duration_ms", d.TurnDurationMs,
@@ -652,11 +652,11 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			last := c.lastSummarySentMs.Load()
 			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
 				if streamCtrl != nil && streamCtrl.IsCreated() {
-					if streamCtrl.Write("\n\n---\n"+richText) == nil {
+					if streamCtrl.Write("\n\n---\n"+summaryText) == nil {
 						c.lastSummarySentMs.Store(now)
 					}
 				} else {
-					go c.sendTurnSummaryText(richText)
+					go c.sendTurnSummaryText(summaryText)
 					c.lastSummarySentMs.Store(now)
 				}
 			}

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1133,10 +1132,9 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 		if pct > 100 {
 			pct = 100
 		}
-		bar := messaging.BuildProgressBar(pct, 5)
 		used := messaging.FormatTokenCount(int(d.ContextFill))
 		max := messaging.FormatTokenCount(int(d.ContextWindow))
-		table.AddRow(richTextCell("🧠 Context"), richTextCell(fmt.Sprintf("%s %s/%s", bar, used, max)))
+		table.AddRow(richTextCell("🧠 Context"), richTextCell(fmt.Sprintf("%d%% %s/%s", pct, used, max)))
 	}
 	if d.ToolCallCount > 0 {
 		toolStr := formatToolNamesSlack(d.ToolNames, d.ToolCallCount)
@@ -1151,7 +1149,7 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 	// Duration (merged Turn + Session)
 	turnDur := ""
 	if d.TurnDurationMs > 0 {
-		turnDur = "Turn " + formatDurationSlack(d.TurnDurationMs)
+		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
 	}
 	sessDur := ""
 	if d.SessionDuration > 0 {
@@ -1197,52 +1195,13 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 }
 
 func formatToolNamesSlack(names map[string]int, total int) string {
+	s := messaging.FormatToolNames(names, total)
 	if len(names) == 0 {
-		return fmt.Sprintf("%d calls", total)
+		return s + " calls"
 	}
-	type kv struct {
-		name  string
-		count int
-	}
-	sorted := make([]kv, 0, len(names))
-	for k, v := range names {
-		sorted = append(sorted, kv{k, v})
-	}
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].count != sorted[j].count {
-			return sorted[i].count > sorted[j].count
-		}
-		return sorted[i].name < sorted[j].name
-	})
-	const topN = 5
-	shown := sorted
-	remaining := len(sorted) - topN
-	if remaining > 0 {
-		shown = sorted[:topN]
-	}
-	parts := make([]string, len(shown))
-	for i, s := range shown {
-		parts[i] = fmt.Sprintf("%s×%d", s.name, s.count)
-	}
-	result := fmt.Sprintf("%d calls (%s)", total, strings.Join(parts, ", "))
-	if remaining > 0 {
-		result += fmt.Sprintf(" +%d", remaining)
-	}
-	return result
+	return strings.Replace(s, fmt.Sprintf("%d (", total), fmt.Sprintf("%d calls (", total), 1)
 }
 
-func formatDurationSlack(ms int64) string {
-	switch {
-	case ms < 1000:
-		return fmt.Sprintf("%dms", ms)
-	case ms < 60_000:
-		return fmt.Sprintf("%ds", ms/1000)
-	case ms < 3_600_000:
-		return fmt.Sprintf("%dm%ds", ms/60_000, (ms%60_000)/1000)
-	default:
-		return fmt.Sprintf("%dh%dm", ms/3_600_000, (ms%3_600_000)/60_000)
-	}
-}
 func (c *SlackConn) sendContextUsage(ctx context.Context, env *events.Envelope) error {
 	if c.adapter == nil || c.adapter.client == nil {
 		return fmt.Errorf("slack: client not initialized")

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -105,20 +105,20 @@ func FormatTurnSummary(d TurnSummaryData) string {
 	}
 
 	if d.TurnDurationMs > 0 {
-		parts = append(parts, "⏱ "+formatDuration(d.TurnDurationMs))
+		parts = append(parts, "⏱ "+FormatDuration(d.TurnDurationMs))
 	}
 
 	if d.ToolCallCount > 0 {
-		toolStr := formatToolNames(d.ToolNames, d.ToolCallCount)
+		toolStr := FormatToolNames(d.ToolNames, d.ToolCallCount)
 		parts = append(parts, "🔧 "+toolStr)
 	}
 
 	return strings.Join(parts, " · ")
 }
 
-// formatToolNames produces "N (Tool×M, ...)" sorted by count descending.
+// FormatToolNames produces "N (Tool×M, ...)" sorted by count descending.
 // Shows at most top 5 tools; remaining tools are summarized as "+N".
-func formatToolNames(names map[string]int, total int) string {
+func FormatToolNames(names map[string]int, total int) string {
 	if len(names) == 0 {
 		return fmt.Sprintf("%d", total)
 	}
@@ -153,7 +153,7 @@ func formatToolNames(names map[string]int, total int) string {
 	return result
 }
 
-func formatDuration(ms int64) string {
+func FormatDuration(ms int64) string {
 	switch {
 	case ms < 1000:
 		return fmt.Sprintf("%dms", ms)
@@ -171,7 +171,7 @@ func FormatSessionDuration(secs float64) string {
 	if secs <= 0 {
 		return ""
 	}
-	return formatDuration(int64(secs * 1000))
+	return FormatDuration(int64(secs * 1000))
 }
 
 // TruncatePath shortens a file path for display, keeping the last n path components.
@@ -209,62 +209,61 @@ func TruncatePath(p string, maxComponents int) string {
 	return drive + "/" + strings.Join(kept, "/")
 }
 
-// FormatTurnSummaryRich produces a multi-line turn summary with emoji-prefixed fields.
-// Used as rich fallback when TableBlock is rejected.
+// FormatTurnSummaryRich produces a multi-line turn summary with each metric on its own line.
+// Used as the primary format for Feishu and rich fallback for Slack.
 // Returns empty string if no meaningful data is available.
 func FormatTurnSummaryRich(d TurnSummaryData) string {
 	var lines []string
 
-	// Line 1: Core metrics
-	var core []string
+	// Line 1: Turn count
 	if d.TurnCount > 0 {
-		core = append(core, fmt.Sprintf("🔄 #%d", d.TurnCount))
+		lines = append(lines, fmt.Sprintf("🔄 #%d", d.TurnCount))
 	}
+
+	// Line 2: Model
 	if d.ModelName != "" {
-		core = append(core, "🤖 "+d.ModelName)
+		lines = append(lines, "🤖 "+d.ModelName)
 	}
+
+	// Line 2: Context window
 	if d.ContextWindow > 0 && d.ContextFill > 0 {
 		pct := int(d.ContextPct + 0.5)
 		if pct > 100 {
 			pct = 100
 		}
-		bar := BuildProgressBar(pct, 5)
 		used := FormatTokenCount(int(d.ContextFill))
 		max := FormatTokenCount(int(d.ContextWindow))
-		core = append(core, fmt.Sprintf("🧠 %s %s/%s", bar, used, max))
-	}
-	if d.ToolCallCount > 0 {
-		core = append(core, "🔧 "+formatToolNames(d.ToolNames, d.ToolCallCount))
-	}
-	if len(core) > 0 {
-		lines = append(lines, strings.Join(core, " · "))
+		lines = append(lines, fmt.Sprintf("🧠 %d%% · %s/%s", pct, used, max))
 	}
 
-	// Line 2: Environment
-	var envParts []string
-	if d.WorkDir != "" {
-		envParts = append(envParts, "📂 "+TruncatePath(d.WorkDir, 3))
-	}
+	// Line 3: Git branch
 	if d.GitBranch != "" {
-		envParts = append(envParts, "🌿 "+d.GitBranch)
-	}
-	if len(envParts) > 0 {
-		lines = append(lines, strings.Join(envParts, " · "))
+		lines = append(lines, "🌿 "+d.GitBranch)
 	}
 
-	// Line 3: Duration (merged Turn + Session)
+	// Line 4: Work directory
+	if d.WorkDir != "" {
+		lines = append(lines, "📂 "+TruncatePath(d.WorkDir, 3))
+	}
+
+	// Line 5: Tools
+	if d.ToolCallCount > 0 {
+		lines = append(lines, "🔧 "+FormatToolNames(d.ToolNames, d.ToolCallCount))
+	}
+
+	// Line 6: Duration (merged Turn + Session)
 	var durParts []string
 	if d.TurnDurationMs > 0 {
-		durParts = append(durParts, "Turn "+formatDuration(d.TurnDurationMs))
+		durParts = append(durParts, "Turn "+FormatDuration(d.TurnDurationMs))
 	}
 	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
 		durParts = append(durParts, "Session "+sessDur)
 	}
 	if len(durParts) > 0 {
-		lines = append(lines, "⏱️ "+strings.Join(durParts, " | "))
+		lines = append(lines, "⏱️ "+strings.Join(durParts, " · "))
 	}
 
-	// Line 4: Tokens (turn + session total)
+	// Line 7: Tokens (turn + session total)
 	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
 		var tokParts []string
 		if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -159,7 +160,7 @@ func TestFormatTurnSummary_DurationFormats(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatDuration(tt.ms)
+			got := FormatDuration(tt.ms)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -222,7 +223,7 @@ func TestFormatSessionDuration(t *testing.T) {
 func TestFormatToolNames_Sorted(t *testing.T) {
 	t.Parallel()
 	names := map[string]int{"Edit": 1, "Read": 5, "Bash": 3}
-	got := formatToolNames(names, 9)
+	got := FormatToolNames(names, 9)
 	require.Equal(t, "9 (Read×5, Bash×3, Edit×1)", got)
 }
 
@@ -231,14 +232,14 @@ func TestFormatToolNames_Top5(t *testing.T) {
 	names := map[string]int{
 		"Read": 10, "Edit": 8, "Bash": 5, "Grep": 4, "Glob": 3, "Agent": 2, "Write": 1,
 	}
-	got := formatToolNames(names, 33)
+	got := FormatToolNames(names, 33)
 	require.Equal(t, "33 (Read×10, Edit×8, Bash×5, Grep×4, Glob×3) +2", got)
 }
 
 func TestFormatToolNames_Exactly5(t *testing.T) {
 	t.Parallel()
 	names := map[string]int{"Read": 5, "Edit": 3, "Bash": 2, "Grep": 2, "Glob": 1}
-	got := formatToolNames(names, 13)
+	got := FormatToolNames(names, 13)
 	require.Equal(t, "13 (Read×5, Edit×3, Bash×2, Grep×2, Glob×1)", got)
 }
 
@@ -288,13 +289,14 @@ func TestFormatTurnSummaryRich_Full(t *testing.T) {
 		SessionDuration: 750,
 	}
 	got := FormatTurnSummaryRich(d)
-	require.Contains(t, got, "🔄 #3")
-	require.Contains(t, got, "🤖 Sonnet")
-	require.Contains(t, got, "🧠 [█░░░░] 48.4K/200K")
+	lines := strings.Split(got, "\n")
+	require.Contains(t, lines[0], "🔄 #3")
+	require.Contains(t, lines[1], "🤖 Sonnet")
+	require.Contains(t, got, "🧠 24% · 48.4K/200K")
 	require.Contains(t, got, "🔧 12 (")
 	require.Contains(t, got, "📂")
 	require.Contains(t, got, "🌿 feat/117-turn-summary")
-	require.Contains(t, got, "⏱️ Turn 42s | Session 12m30s")
+	require.Contains(t, got, "⏱️ Turn 42s · Session 12m30s")
 	require.Contains(t, got, "💎")
 	require.Contains(t, got, "12K in · 2K out | Σ 48.4K in · Σ 2K out")
 }


### PR DESCRIPTION
## Summary

Cherry-pick from `6a19087` (branch `fix/webchat-parts-null-guard`) whose gateway/messaging changes were lost during PR #177 squash merge.

### Lost fixes recovered:

- **`resetPerTurn()` dead code fix**: per-turn token deltas now computed correctly (were showing cumulative totals from Turn 2+)
- **Turn 1 duration fix**: `turnStartTime` initialized on `firstEvent` to exclude worker cold-start
- **Session `StartedAt` fix**: use goroutine `startTime` for accurate session duration
- **`FormatTurnSummaryRich` rewrite**: per-line card layout with precise percentage
- **Slack dedup**: eliminate duplicate `formatDurationSlack`/`formatToolNamesSlack`
- **Shared helpers**: export `FormatDuration`/`FormatToolNames`
- **Double encoding fix**: `pendingError` capture in LLM retry path

### Root cause

PR #177 squash-merged only the webchat changes from the branch, dropping 4 gateway/messaging files. The branch was then deleted, making the fixes unrecoverable without cherry-pick.

## Test plan

- [x] `go build ./internal/gateway/... ./internal/messaging/...` compiles
- [x] `go test -race ./internal/gateway/... ./internal/messaging/...` all pass
- [x] pre-commit hooks pass (gofmt + golangci-lint)
- [x] pre-push validation pass (fmt + lint + vet + build + test)