### PR TITLE
refactor(config): remove stt_local_mode, auto-infer from stt_local_cmd

### DIFF
--- a/.agent/skills/hotplex-setup/references/stt.md
+++ b/.agent/skills/hotplex-setup/references/stt.md
@@ -86,7 +86,6 @@ chmod +x ~/.hotplex/scripts/stt_*.py
 **Slack（仅本地）**：
 ```bash
 HOTPLEX_MESSAGING_SLACK_STT_PROVIDER=local
-HOTPLEX_MESSAGING_SLACK_STT_LOCAL_MODE=ephemeral
 HOTPLEX_MESSAGING_SLACK_STT_LOCAL_CMD=python3 ~/.hotplex/scripts/stt_once.py
 HOTPLEX_MESSAGING_SLACK_STT_LOCAL_IDLE_TTL=1h
 ```
@@ -94,7 +93,6 @@ HOTPLEX_MESSAGING_SLACK_STT_LOCAL_IDLE_TTL=1h
 **飞书（云端 + 本地降级）**：
 ```bash
 HOTPLEX_MESSAGING_FEISHU_STT_PROVIDER=feishu+local
-HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_MODE=ephemeral
 HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_CMD=python3 ~/.hotplex/scripts/stt_server.py
 HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_IDLE_TTL=1h
 ```
@@ -164,9 +162,9 @@ ls -lh ~/.hotplex/scripts/stt_once.py
 ```
 
 ### Q: STT 占用内存过高？
-**A**: 使用 `ephemeral` 模式：
+**A**: 使用 ephemeral 模式（带 `{file}` 占位符，每次 fork 后自动释放）：
 ```bash
-HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_MODE=ephemeral
+HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_CMD="python3 ~/.hotplex/scripts/stt_once.py {file}"
 ```
 
 ### Q: 如何禁用 STT？

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -196,18 +196,18 @@ func buildLocalSTT(platform string, cfg config.STTConfig, log *slog.Logger) stt.
 	var transcriber stt.Transcriber
 	expandedCmd := expandCommand(cfg.LocalCmd)
 
-	cacheKey := cfg.LocalMode + ":" + expandedCmd
+	cacheKey := expandedCmd
 
 	if existing, ok := sttCache[cacheKey]; ok {
 		if existing.Refs() <= 0 {
 			delete(sttCache, cacheKey)
 		} else {
-			log.Debug(platform+": reusing shared stt transcriber", "mode", cfg.LocalMode, "cmd", expandedCmd)
+			log.Debug(platform+": reusing shared stt transcriber", "cmd", expandedCmd)
 			return existing.Acquire()
 		}
 	}
 
-	if cfg.LocalMode == config.STTModePersistent {
+	if cfg.IsPersistent() {
 		hash := sha256.Sum256([]byte(expandedCmd))
 		pidKey := "stt-server-" + hex.EncodeToString(hash[:])[:12]
 		transcriber = stt.NewPersistentSTT(expandedCmd, pidKey, cfg.LocalIdleTTL, log)

--- a/cmd/yaml_verify_test.go
+++ b/cmd/yaml_verify_test.go
@@ -28,7 +28,7 @@ func main() {
 		"max_retries: 9", "base_delay: 5s", "max_delay: 120s",
 		"notify_user: true", "retry_input:",
 		"dm_policy:", "group_policy:", "require_mention:",
-		"stt_provider:", "stt_local_cmd:", "stt_local_mode:",
+		"stt_provider:", "stt_local_cmd:",
 		"stt_local_idle_ttl:", "socket_mode: true",
 		"type:", "enabled:",
 	}

--- a/configs/README.md
+++ b/configs/README.md
@@ -264,9 +264,8 @@ Worker 进程启动时的工作目录遵循以下优先级覆盖逻辑：
 | `allow_dm_from` | []string | `[]` | — | 仅单聊白名单 |
 | `allow_group_from` | []string | `[]` | — | 仅群组白名单 |
 | `stt_provider` | string | `feishu+local` | — | 语音转文字引擎。`feishu` = 飞书 speech_to_text API（需开通权限），`local` = 本地命令行引擎（SenseVoice-Small ONNX），`feishu+local` = 云端优先本地降级（推荐），空 = 禁用 STT |
-| `stt_local_cmd` | string | `python3 scripts/stt_once.py {file}` | — | 本地 STT 命令模板。`{file}` 占位符替换为音频文件路径。ephemeral 模式下每次请求直接执行此命令；persistent 模式下需配合 `stt_server.py` 使用 JSON-over-stdio 协议。详细的安装和配置说明见 [STT 安装手册](../docs/STT-Setup.md) |
-| `stt_local_mode` | string | `ephemeral` | — | 本地 STT 运行模式。`ephemeral` = 每次请求启动新进程（冷启动约 3-5s，简单可靠），`persistent` = 常驻子进程（零冷启动，适合高频使用，模型约占 900MB 内存） |
-| `stt_local_idle_ttl` | duration | `1h` | — | 持久模式空闲超时。常驻 STT 子进程在此时间内无转写请求则自动关闭，节省内存（模型约占 900MB）。0 = 永不关闭。仅 `persistent` 模式下生效 |
+| `stt_local_cmd` | string | `python3 scripts/stt_server.py` | — | 本地 STT 命令。含 `{file}` → 每次请求 fork 新进程（冷启动约 3-5s）；不含 `{file}` → 常驻子进程 + stdin/stdout JSON 协议（零冷启动，适合高频使用，模型约占 900MB 内存）。详细安装说明见 [STT 安装手册](../docs/STT-Setup.md) |
+| `stt_local_idle_ttl` | duration | `1h` | — | 常驻模式空闲超时。STT 子进程在此时间内无转写请求则自动关闭，节省内存。0 = 永不关闭。仅常驻模式生效 |
 
 > **完整的 STT 安装配置说明**见 [STT-Setup.md](../docs/STT-Setup.md) —— 涵盖 Python 依赖安装、模型下载、Ephemeral/Persistent 模式配置、Docker 部署和故障排查。
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -183,7 +183,6 @@ messaging:
     # STT (Speech-to-Text)
     stt_provider: "local"
     stt_local_cmd: "python3 ~/.hotplex/scripts/stt_server.py"
-    stt_local_mode: "persistent"
     stt_local_idle_ttl: 1h
 
   feishu:
@@ -195,5 +194,4 @@ messaging:
     # STT (Speech-to-Text)
     stt_provider: "feishu+local"
     stt_local_cmd: "python3 ~/.hotplex/scripts/stt_server.py"
-    stt_local_mode: "persistent"
     stt_local_idle_ttl: 1h

--- a/configs/env.example
+++ b/configs/env.example
@@ -84,11 +84,8 @@ HOTPLEX_ADMIN_TOKEN_1=
 # Default: feishu+local
 # HOTPLEX_MESSAGING_FEISHU_STT_PROVIDER=feishu+local
 
-# Local command template ({file} replaced with audio path). Default: funasr-onnx --model iic/SenseVoiceSmall --quantize {file}
-# HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_CMD=python3 scripts/stt_once.py {file}
-
-# Local STT mode: ephemeral (per-request process) or persistent (long-lived subprocess). Default: ephemeral
-# HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_MODE=ephemeral
+# Local command template. With {file} → ephemeral (fork per request); without → persistent (long-lived subprocess). Default: stt_server.py
+# HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_CMD=python3 ~/.hotplex/scripts/stt_server.py
 
 # Persistent mode idle timeout. Subprocess auto-shuts after this duration with no requests. Default: 1h
 # HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_IDLE_TTL=1h
@@ -97,8 +94,7 @@ HOTPLEX_ADMIN_TOKEN_1=
 
 # Default: local
 # HOTPLEX_MESSAGING_SLACK_STT_PROVIDER=local
-# HOTPLEX_MESSAGING_SLACK_STT_LOCAL_CMD=python3 scripts/stt_once.py {file}
-# HOTPLEX_MESSAGING_SLACK_STT_LOCAL_MODE=ephemeral
+# HOTPLEX_MESSAGING_SLACK_STT_LOCAL_CMD=python3 ~/.hotplex/scripts/stt_server.py
 # HOTPLEX_MESSAGING_SLACK_STT_LOCAL_IDLE_TTL=1h
 
 # ── Agent Config (Persona & Context) ───────────────────────────────────────────

--- a/docs/STT-SETUP.md
+++ b/docs/STT-SETUP.md
@@ -195,7 +195,6 @@ feishu:
   enabled: true
   stt_provider: "local"
   stt_local_cmd: "python3 scripts/stt_once.py {file}"
-  stt_local_mode: "ephemeral"
 ```
 
 ### 6.2 Persistent 模式
@@ -208,7 +207,6 @@ feishu:
   enabled: true
   stt_provider: "local"
   stt_local_cmd: "python3 scripts/stt_server.py --model iic/SenseVoiceSmall"
-  stt_local_mode: "persistent"
   stt_local_idle_ttl: 1h       # 空闲 1 小时后自动关闭子进程
 ```
 
@@ -228,7 +226,6 @@ feishu:
   enabled: true
   stt_provider: "feishu+local"
   stt_local_cmd: "python3 scripts/stt_server.py --model iic/SenseVoiceSmall"
-  stt_local_mode: "persistent"
   stt_local_idle_ttl: 1h
 ```
 
@@ -262,7 +259,6 @@ slack:
   enabled: true
   stt_provider: "local"
   stt_local_cmd: "python3 scripts/stt_once.py {file}"
-  stt_local_mode: "ephemeral"
 ```
 
 ### 7.2 Persistent 模式
@@ -273,7 +269,6 @@ slack:
   enabled: true
   stt_provider: "local"
   stt_local_cmd: "python3 scripts/stt_server.py --model iic/SenseVoiceSmall"
-  stt_local_mode: "persistent"
   stt_local_idle_ttl: 1h
 ```
 
@@ -385,7 +380,6 @@ volumes:
 feishu:
   stt_provider: "feishu+local"
   stt_local_cmd: "python3 /opt/hotplex/scripts/stt_server.py --model iic/SenseVoiceSmall"
-  stt_local_mode: "persistent"
   stt_local_idle_ttl: 30m    # 容器环境建议缩短空闲超时
 ```
 
@@ -395,7 +389,6 @@ feishu:
 slack:
   stt_provider: "local"
   stt_local_cmd: "python3 /opt/hotplex/scripts/stt_server.py --model iic/SenseVoiceSmall"
-  stt_local_mode: "persistent"
   stt_local_idle_ttl: 30m
 ```
 
@@ -490,7 +483,6 @@ grep "persistent stt" logs/gateway.log
 
 ```yaml
 # 从 ephemeral 切换到 persistent
-stt_local_mode: "persistent"
 stt_local_cmd: "python3 scripts/stt_server.py --model iic/SenseVoiceSmall"
 ```
 
@@ -517,7 +509,6 @@ mkdir -p ~/.cache/modelscope/hub/models/iic/SenseVoiceSmall
 
 ### 飞书
 
-| 场景 | stt_provider | stt_local_cmd | stt_local_mode | stt_local_idle_ttl |
 |------|-------------|---------------|----------------|-------------------|
 | 仅云端 | `feishu` | — | — | — |
 | 仅本地（低频） | `local` | `python3 scripts/stt_once.py {file}` | `ephemeral` | — |
@@ -527,7 +518,6 @@ mkdir -p ~/.cache/modelscope/hub/models/iic/SenseVoiceSmall
 
 ### Slack
 
-| 场景 | stt_provider | stt_local_cmd | stt_local_mode | stt_local_idle_ttl |
 |------|-------------|---------------|----------------|-------------------|
 | 仅本地（低频） | `local` | `python3 scripts/stt_once.py {file}` | `ephemeral` | — |
 | 仅本地（高频） | `local` | `python3 scripts/stt_server.py --model iic/SenseVoiceSmall` | `persistent` | `1h` |

--- a/docs/channels/slack/slack-integration-guide.md
+++ b/docs/channels/slack/slack-integration-guide.md
@@ -439,7 +439,6 @@ messaging:
     reconnect_max_delay: 60s          # reconnect max delay
     stt_provider: "local"             # speech-to-text: local / empty (disabled)
     stt_local_cmd: "python3 ~/.hotplex/scripts/stt_server.py"
-    stt_local_mode: "persistent"      # ephemeral / persistent
     stt_local_idle_ttl: 1h            # persistent mode idle timeout
 ```
 

--- a/docs/channels/slack/slack-integration-guide_zh.md
+++ b/docs/channels/slack/slack-integration-guide_zh.md
@@ -439,7 +439,6 @@ messaging:
     reconnect_max_delay: 60s          # 断线重连最大延迟
     stt_provider: "local"             # 语音转文字：local / 空（禁用）
     stt_local_cmd: "python3 ~/.hotplex/scripts/stt_server.py"
-    stt_local_mode: "persistent"      # ephemeral / persistent
     stt_local_idle_ttl: 1h            # 持久模式空闲超时
 ```
 

--- a/docs/management/Config-Reference.md
+++ b/docs/management/Config-Reference.md
@@ -338,7 +338,6 @@ messaging:
 
     # Local STT mode: "ephemeral" (per-request process) or "persistent" (long-lived subprocess)
     # Persistent mode keeps the model in memory, avoiding ~2-3s cold start per request.
-    stt_local_mode: "persistent"
 
     # Idle timeout for persistent mode. Subprocess auto-shuts down after this duration
     # with no transcription requests. 0 = disabled (never auto-shutdown).
@@ -386,7 +385,6 @@ HOTPLEX_MESSAGING_FEISHU_DM_POLICY=allowlist  # open | allowlist | disabled (def
 HOTPLEX_MESSAGING_FEISHU_GROUP_POLICY=allowlist # open | allowlist | disabled (default: allowlist)
 HOTPLEX_MESSAGING_FEISHU_STT_PROVIDER=local
 HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_CMD="python3 /path/to/stt_server.py"
-HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_MODE=persistent
 HOTPLEX_MESSAGING_FEISHU_STT_LOCAL_IDLE_TTL=10m
 ```
 
@@ -612,7 +610,6 @@ vim configs/config.yaml
 - Pool settings (`max_size`, `max_idle_per_user`)
 - Session retention (`retention_period`, `gc_scan_interval`)
 - Admin settings (`rate_limit_enabled`, `requests_per_sec`)
-- STT settings (`stt_provider`, `stt_local_cmd`, `stt_local_mode`, `stt_local_idle_ttl`)
 
 **Non-reloadable fields** (require restart):
 - Network addresses (`gateway.addr`, `admin.addr`)

--- a/docs/specs/Feishu-Adapter-Improvement-Spec.md
+++ b/docs/specs/Feishu-Adapter-Improvement-Spec.md
@@ -442,7 +442,6 @@ if media != nil {
 - **推理**: `funasr-onnx` ONNX Runtime，FP32 非量化
 - **性能**: ~0.35s/file，CER ~2%（中文）
 - **语言**: 中文、英文、日语、韩语、粤语（自动检测）
-- **持久模式** (`stt_local_mode: "persistent"`): 长驻子进程 `stt_server.py`，模型常驻内存，避免冷启动
 - **ONNX 补丁**: `fix_onnx_model.py` 自动修复 ModelScope 预导出模型的 `Less` 节点类型不匹配
 
 **配置示例**:
@@ -452,7 +451,6 @@ messaging:
   feishu:
     stt_provider: "local"
     stt_local_cmd: "python3 scripts/stt_server.py --model iic/SenseVoiceSmall"
-    stt_local_mode: "persistent"
     stt_local_idle_ttl: "10m"
 ```
 

--- a/internal/cli/onboard/templates.go
+++ b/internal/cli/onboard/templates.go
@@ -174,7 +174,7 @@ log:
 			GroupPolicy:    defaultStr(opts.SlackGroupPolicy, "allowlist"),
 			RequireMention: defaultBool(opts.SlackRequireMention, true),
 			AllowFrom:      opts.SlackAllowFrom,
-			Extra:          "    socket_mode: true\n    worker_type: \"claude_code\"\n    stt_provider: \"local\"\n    stt_local_cmd: \"python3 scripts/stt_once.py {file}\"\n    stt_local_mode: \"persistent\"\n    stt_local_idle_ttl: 1h\n",
+			Extra:          "    socket_mode: true\n    worker_type: \"claude_code\"\n    stt_provider: \"local\"\n    stt_local_cmd: \"python3 ~/.hotplex/scripts/stt_server.py --model iic/SenseVoiceSmall\"\n    stt_local_idle_ttl: 1h\n",
 		})
 	}
 
@@ -186,7 +186,7 @@ log:
 			GroupPolicy:    defaultStr(opts.FeishuGroupPolicy, "allowlist"),
 			RequireMention: defaultBool(opts.FeishuRequireMention, true),
 			AllowFrom:      opts.FeishuAllowFrom,
-			Extra:          "    worker_type: \"claude_code\"\n    stt_provider: \"feishu+local\"\n    stt_local_mode: \"ephemeral\"\n    stt_local_idle_ttl: 1h\n",
+			Extra:          "    worker_type: \"claude_code\"\n    stt_provider: \"feishu+local\"\n    stt_local_cmd: \"python3 ~/.hotplex/scripts/stt_server.py --model iic/SenseVoiceSmall\"\n    stt_local_idle_ttl: 1h\n",
 		})
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,13 +158,11 @@ type MessagingConfig struct {
 	Feishu FeishuConfig `mapstructure:"feishu"`
 }
 
-// STT constants for provider and mode values.
+// STT constants for provider values.
 const (
 	STTProviderLocal       = "local"
 	STTProviderFeishu      = "feishu"
 	STTProviderFeishuLocal = "feishu+local"
-	STTModeEphemeral       = "ephemeral"
-	STTModePersistent      = "persistent"
 )
 
 // STTConfig holds speech-to-text configuration shared across messaging adapters.
@@ -173,11 +171,16 @@ type STTConfig struct {
 	// "feishu+local" (cloud primary, local fallback), "" (disabled).
 	Provider string `mapstructure:"stt_provider"`
 	// LocalCmd is the command template. {file} is replaced with the audio file path.
+	// If {file} is present → ephemeral mode (fork per request).
+	// If absent → persistent mode (long-lived subprocess, stdin/stdout JSON protocol).
 	LocalCmd string `mapstructure:"stt_local_cmd"`
-	// LocalMode: "ephemeral" (per-request process) or "persistent" (long-lived subprocess).
-	LocalMode string `mapstructure:"stt_local_mode"`
 	// LocalIdleTTL controls auto-shutdown of persistent subprocess. 0 = disabled.
 	LocalIdleTTL time.Duration `mapstructure:"stt_local_idle_ttl"`
+}
+
+// IsPersistent returns true when LocalCmd uses persistent mode (no {file} placeholder).
+func (c STTConfig) IsPersistent() bool {
+	return c.LocalCmd != "" && !strings.Contains(c.LocalCmd, "{file}")
 }
 
 // SlackConfig holds Slack Socket Mode adapter settings.
@@ -488,7 +491,6 @@ func Default() *Config {
 				STTConfig: STTConfig{
 					Provider:     "feishu+local",
 					LocalCmd:     "python3 " + filepath.Join(HotplexHome(), "scripts", "stt_server.py"),
-					LocalMode:    "persistent",
 					LocalIdleTTL: time.Hour,
 				},
 			},
@@ -499,7 +501,6 @@ func Default() *Config {
 				STTConfig: STTConfig{
 					Provider:     "local",
 					LocalCmd:     "python3 " + filepath.Join(HotplexHome(), "scripts", "stt_server.py"),
-					LocalMode:    "persistent",
 					LocalIdleTTL: time.Hour,
 				},
 			},
@@ -582,12 +583,10 @@ func Load(filePath string, opts LoadOptions) (*Config, error) {
 	_ = v.BindEnv("messaging.slack.work_dir")
 	_ = v.BindEnv("messaging.slack.stt_provider")
 	_ = v.BindEnv("messaging.slack.stt_local_cmd")
-	_ = v.BindEnv("messaging.slack.stt_local_mode")
 	_ = v.BindEnv("messaging.slack.stt_local_idle_ttl")
 	_ = v.BindEnv("messaging.feishu.work_dir")
 	_ = v.BindEnv("messaging.feishu.stt_provider")
 	_ = v.BindEnv("messaging.feishu.stt_local_cmd")
-	_ = v.BindEnv("messaging.feishu.stt_local_mode")
 	_ = v.BindEnv("messaging.feishu.stt_local_idle_ttl")
 
 	if err := v.Unmarshal(cfg); err != nil {

--- a/scripts/stt_server.py
+++ b/scripts/stt_server.py
@@ -33,7 +33,6 @@ Configuration (config.yaml):
     feishu:
       stt_provider: "local"
       stt_local_cmd: "python3 /path/to/stt_server.py --model iic/SenseVoiceSmall"
-      stt_local_mode: "persistent"
       stt_local_idle_ttl: "10m"
 """
 


### PR DESCRIPTION
## Summary
- 删除 `stt_local_mode` 配置项，改为从 `stt_local_cmd` 自动推断运行模式
- 含 `{file}` → ephemeral（每次 fork），不含 → persistent（长驻子进程）
- 清理全部 24 处文档/配置/测试残留引用

## Motivation
`stt_local_mode` 与 `stt_local_cmd` 可以不匹配，导致 `stt_server.py` 被配成 `ephemeral` 模式，进程等待 stdin 而 `LocalSTT` 等待 stdout，卡住直到超时。环境变量 `.env` 中的 `STT_LOCAL_MODE=ephemeral` 还会覆盖 YAML 配置，进一步增加排查难度。

## Changes
| File | Change |
|------|--------|
| `internal/config/config.go` | 删除 `LocalMode` 字段和 `STTMode*` 常量，新增 `IsPersistent()` 方法 |
| `cmd/hotplex/messaging_init.go` | `buildLocalSTT` 用 `cfg.IsPersistent()` 替代 `cfg.LocalMode` |
| `internal/cli/onboard/templates.go` | 删除模板中的 `stt_local_mode` |
| `configs/config.yaml` | 删除 `stt_local_mode` 行 |
| `configs/README.md` | 更新 STT 配置说明 |
| `configs/env.example` | 删除 `STT_LOCAL_MODE` 环境变量 |
| `scripts/stt_server.py` | 更新 docstring |
| `docs/*` (5 files) | 同步删除所有 `stt_local_mode` 引用 |
| `cmd/yaml_verify_test.go` | 更新验证检查项 |
| `.agent/skills/` | 更新 agent 参考文档 |

## Test plan
- [x] `make build` 通过
- [x] `make test-short` 通过
- [x] `grep -rn 'stt_local_mode' --include='*.go' --include='*.md' --include='*.yaml'` 零结果
- [ ] 部署后发送飞书语音消息验证 STT 链路

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)