### PR TITLE
Batch: security and observability fixes for #185, #145

### DIFF
--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -178,6 +179,9 @@ func FormatSessionDuration(secs float64) string {
 // Returns empty string if maxComponents <= 0. If the path is already short enough,
 // it is returned unchanged. Uses "/" as separator for cross-platform display in
 // messaging (Slack/Feishu). Preserves Windows drive letters (e.g. "C:").
+// Replaces the user's home directory prefix with "~" before truncation so that
+// paths under home are displayed relative to "~" instead of showing misleading
+// truncated segments like "/.hotplex/workspace/hotplex".
 func TruncatePath(p string, maxComponents int) string {
 	if p == "" || maxComponents <= 0 {
 		return ""
@@ -187,11 +191,28 @@ func TruncatePath(p string, maxComponents int) string {
 	p = strings.ReplaceAll(p, "\\", "/")
 	p = filepath.Clean(p)
 
+	// Track home directory prefix for user-friendly display.
+	prefix := ""
+
+	// Replace home directory prefix with ~ so components are counted relative to home.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		homeNorm := strings.ReplaceAll(home, "\\", "/")
+		homeNorm = filepath.Clean(homeNorm)
+		if p == homeNorm {
+			return "~"
+		}
+		if strings.HasPrefix(p, homeNorm+"/") {
+			p = p[len(homeNorm):] // e.g. "/.hotplex/workspace/hotplex"
+			prefix = "~"
+		}
+	}
+
 	// Detect and preserve Windows drive letter (e.g. "C:").
-	drive := ""
-	if len(p) >= 2 && p[1] == ':' && (p[0] >= 'A' && p[0] <= 'Z' || p[0] >= 'a' && p[0] <= 'z') {
-		drive = p[:2]
-		p = p[2:]
+	if prefix == "" {
+		if len(p) >= 2 && p[1] == ':' && (p[0] >= 'A' && p[0] <= 'Z' || p[0] >= 'a' && p[0] <= 'z') {
+			prefix = p[:2]
+			p = p[2:]
+		}
 	}
 
 	// Split and filter empty parts.
@@ -202,11 +223,15 @@ func TruncatePath(p string, maxComponents int) string {
 			parts = append(parts, s)
 		}
 	}
+	sep := "/"
+	if prefix == "~" {
+		sep = "/"
+	}
 	if len(parts) <= maxComponents {
-		return drive + "/" + strings.Join(parts, "/")
+		return prefix + sep + strings.Join(parts, "/")
 	}
 	kept := parts[len(parts)-maxComponents:]
-	return drive + "/" + strings.Join(kept, "/")
+	return prefix + sep + strings.Join(kept, "/")
 }
 
 // FormatTurnSummaryRich produces a multi-line turn summary with each metric on its own line.

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -8,6 +9,13 @@ import (
 
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+func homeDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	return home
+}
 
 func TestExtractTurnSummary_Full(t *testing.T) {
 	t.Parallel()
@@ -259,6 +267,11 @@ func TestTruncatePath(t *testing.T) {
 		{"zero max", "/home/user", 0, ""},
 		{"windows absolute", "C:\\Users\\admin\\workspace\\project", 2, "C:/workspace/project"},
 		{"windows short", "D:\\dev\\app", 5, "D:/dev/app"},
+		{"home dir path", homeDir(t) + "/.hotplex/workspace/hotplex", 3, "~/.hotplex/workspace/hotplex"},
+		{"home dir exact", homeDir(t), 3, "~"},
+		{"home dir short", homeDir(t) + "/projects", 3, "~/projects"},
+		{"home dir truncated", homeDir(t) + "/.hotplex/workspace/hotplex/deep/pkg", 3, "~/hotplex/deep/pkg"},
+		{"home dir one", homeDir(t) + "/.hotplex/workspace/hotplex", 1, "~/hotplex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (c *ServerCommander) Compact(ctx context.Context, args map[string]any) erro
 		}
 	}
 	var result bool
-	if err := c.doPost(ctx, "/session/"+c.sessionID+"/summarize", reqBody, &result); err != nil {
+	if err := c.doPost(ctx, "/session/"+url.PathEscape(c.sessionID)+"/summarize", reqBody, &result); err != nil {
 		return fmt.Errorf("opencode compact: %w", err)
 	}
 	return nil
@@ -63,7 +64,7 @@ func (c *ServerCommander) Compact(ctx context.Context, args map[string]any) erro
 
 // Clear implements WorkerCommander — delete session + create new.
 func (c *ServerCommander) Clear(ctx context.Context) error {
-	if err := c.doDelete(ctx, "/session/"+c.sessionID); err != nil {
+	if err := c.doDelete(ctx, "/session/"+url.PathEscape(c.sessionID)); err != nil {
 		return fmt.Errorf("opencode clear (delete): %w", err)
 	}
 	var newSession struct {
@@ -86,7 +87,7 @@ func (c *ServerCommander) Rewind(ctx context.Context, targetID string) error {
 		reqBody["messageID"] = targetID
 	}
 	var result any
-	if err := c.doPost(ctx, "/session/"+c.sessionID+"/revert", reqBody, &result); err != nil {
+	if err := c.doPost(ctx, "/session/"+url.PathEscape(c.sessionID)+"/revert", reqBody, &result); err != nil {
 		return fmt.Errorf("opencode rewind: %w", err)
 	}
 	return nil
@@ -103,7 +104,7 @@ func (c *ServerCommander) UpdateSessionID(id string) { c.sessionID = id }
 
 func (c *ServerCommander) queryContextUsage(ctx context.Context) (map[string]any, error) {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=100", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=100", &messages); err != nil {
 		return nil, fmt.Errorf("opencode context query: %w", err)
 	}
 	var totalInput, totalOutput, totalReasoning, totalCacheRead, totalCacheWrite int
@@ -170,7 +171,7 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 	default:
 		rules = []map[string]any{}
 	}
-	if err := c.doPatch(ctx, "/session/"+c.sessionID, map[string]any{"permission": rules}); err != nil {
+	if err := c.doPatch(ctx, "/session/"+url.PathEscape(c.sessionID), map[string]any{"permission": rules}); err != nil {
 		return nil, fmt.Errorf("opencode set permission: %w", err)
 	}
 	return map[string]any{"success": true, "mode": mode}, nil
@@ -242,7 +243,7 @@ func (c *ServerCommander) doRequest(ctx context.Context, method, path string, bo
 // lastKnownModel scans recent messages for the model used by the last assistant turn.
 func (c *ServerCommander) lastKnownModel(ctx context.Context) (providerID, modelID string) {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=50", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=50", &messages); err != nil {
 		return "", ""
 	}
 	for i := len(messages) - 1; i >= 0; i-- {
@@ -262,7 +263,7 @@ func (c *ServerCommander) lastKnownModel(ctx context.Context) (providerID, model
 // lastAssistantMessageID returns the ID of the most recent assistant message.
 func (c *ServerCommander) lastAssistantMessageID(ctx context.Context) string {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=50", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=50", &messages); err != nil {
 		return ""
 	}
 	for i := len(messages) - 1; i >= 0; i-- {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -40,6 +40,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -241,7 +242,7 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 			if !allowed {
 				reply = "reject"
 			}
-			return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", reqID),
+			return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", url.PathEscape(reqID)),
 				map[string]string{"reply": reply})
 		}
 		if qResp, ok := metadata["question_response"].(map[string]any); ok {
@@ -445,7 +446,7 @@ func (w *Worker) ResetContext(ctx context.Context) error {
 		return fmt.Errorf("opencodeserver: reset: worker not started")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", httpAddr+"/session/"+sessionID+"/reset", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", httpAddr+"/session/"+url.PathEscape(sessionID)+"/reset", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("opencodeserver: reset: new request: %w", err)
 	}
@@ -532,7 +533,7 @@ func (w *Worker) createSession(ctx context.Context, projectDir string) (string, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return "", fmt.Errorf("create session failed: status %d, body: %s", resp.StatusCode, string(body))
 	}
 
@@ -581,7 +582,7 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 		}
 	}()
 
-	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, sessionID)
+	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		w.Log.Error("opencodeserver: create SSE request", "session_id", sessionID, "err", err)
@@ -598,7 +599,7 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		w.Log.Error("opencodeserver: SSE status",
 			"session_id", sessionID,
 			"status", resp.StatusCode,
@@ -766,7 +767,7 @@ func (w *Worker) httpPost(ctx context.Context, path string, payload any) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("opencodeserver: post %s failed: status %d, body: %s",
 			path, resp.StatusCode, string(respBody))
 	}
@@ -827,7 +828,7 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return fmt.Errorf("opencodeserver: marshal input: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, c.sessionID)
+	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
 	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payload)))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
@@ -841,7 +842,7 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("opencodeserver: input failed: status %d, body: %s",
 			resp.StatusCode, string(respBody))
 	}


### PR DESCRIPTION
## Summary

Batch PR addressing security and observability fixes. Issues #156 and #149 were verified as already fixed in main and require no code changes.

## Changes by Issue

### #185 — fix(turn-summary): WorkDir display shows truncated internal path
- `TruncatePath` now substitutes `$HOME` prefix with `~` before component counting
- Paths like `/home/user/.hotplex/workspace/hotplex` display as `~/.hotplex/workspace/hotplex` instead of misleading `/.hotplex/workspace/hotplex`
- Added test cases for home dir substitution scenarios

### #145 — fix(worker/ocs): unbounded reads and URL injection
- Bounded 4 `io.ReadAll(resp.Body)` calls with `io.LimitReader(resp.Body, 4096)` in error paths
- URL-encoded all session IDs and request IDs using `url.PathEscape`/`url.QueryEscape` in both `worker.go` and `commands.go`

### #156 — security(config): JWT weak keys + API keys plaintext (already fixed)
- `decodeJWTSecret` returns `nil` for non-32-byte keys
- `RequireSecrets` validates JWTSecret length >= 32 bytes
- `sensitiveFields` map redacts `security.api_keys` and `security.jwt_secret` in audit logs

### #149 — fix(admin): IP bypass + token timing (already fixed)
- `clientIP` uses `r.RemoteAddr` directly, no X-Forwarded-For trust
- `validateToken` uses `subtle.ConstantTimeCompare` for all comparisons

## Testing
- [x] `make check` passes (lint + test + build)
- [x] `go test -race` clean
- [x] New test cases for `TruncatePath` home dir handling

Closes #185, #145, #156, #149