### PR TITLE
Batch: cleanup fixes for #178, #150, #146, #143

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,71 +70,58 @@ type Event struct {
 	Data    any    `json:"data,omitempty"`
 }
 
-// decodeAs is a generic helper that round-trips map[string]any through JSON
-// to produce a typed struct. Returns (zero, false) if data is not a map.
-func decodeAs[T any](data any) (T, bool) {
-	d, ok := data.(map[string]any)
-	if !ok {
-		var zero T
-		return zero, false
-	}
-	b, _ := json.Marshal(d)
-	var res T
-	_ = json.Unmarshal(b, &res)
-	return res, true
-}
 
 // AsDoneData parses event data as DoneData.
-func (e Event) AsDoneData() (DoneData, bool) { return decodeAs[DoneData](e.Data) }
+func (e Event) AsDoneData() (DoneData, bool) { return events.DecodeAs[DoneData](e.Data) }
 
 // AsErrorData parses event data as ErrorData.
-func (e Event) AsErrorData() (ErrorData, bool) { return decodeAs[ErrorData](e.Data) }
+func (e Event) AsErrorData() (ErrorData, bool) { return events.DecodeAs[ErrorData](e.Data) }
 
 // AsToolCallData parses event data as ToolCallData.
-func (e Event) AsToolCallData() (ToolCallData, bool) { return decodeAs[ToolCallData](e.Data) }
+func (e Event) AsToolCallData() (ToolCallData, bool) { return events.DecodeAs[ToolCallData](e.Data) }
 
 // AsPermissionRequestData parses event data as PermissionRequestData.
 func (e Event) AsPermissionRequestData() (PermissionRequestData, bool) {
-	return decodeAs[PermissionRequestData](e.Data)
+	return events.DecodeAs[PermissionRequestData](e.Data)
 }
 
 // AsQuestionRequestData parses event data as QuestionRequestData.
 func (e Event) AsQuestionRequestData() (QuestionRequestData, bool) {
-	return decodeAs[QuestionRequestData](e.Data)
+	return events.DecodeAs[QuestionRequestData](e.Data)
 }
 
 // AsElicitationRequestData parses event data as ElicitationRequestData.
 func (e Event) AsElicitationRequestData() (ElicitationRequestData, bool) {
-	return decodeAs[ElicitationRequestData](e.Data)
+	return events.DecodeAs[ElicitationRequestData](e.Data)
 }
 
 // AsMessageStartData parses event data as MessageStartData.
 func (e Event) AsMessageStartData() (MessageStartData, bool) {
-	return decodeAs[MessageStartData](e.Data)
+	return events.DecodeAs[MessageStartData](e.Data)
 }
 
 // AsMessageDeltaData parses event data as MessageDeltaData.
 func (e Event) AsMessageDeltaData() (MessageDeltaData, bool) {
-	return decodeAs[MessageDeltaData](e.Data)
+	return events.DecodeAs[MessageDeltaData](e.Data)
 }
 
 // AsMessageEndData parses event data as MessageEndData.
-func (e Event) AsMessageEndData() (MessageEndData, bool) { return decodeAs[MessageEndData](e.Data) }
+func (e Event) AsMessageEndData() (MessageEndData, bool) { return events.DecodeAs[MessageEndData](e.Data) }
 
 // AsStateData parses event data as StateData.
-func (e Event) AsStateData() (StateData, bool) { return decodeAs[StateData](e.Data) }
+func (e Event) AsStateData() (StateData, bool) { return events.DecodeAs[StateData](e.Data) }
 
 // AsReasoningData parses event data as ReasoningData.
-func (e Event) AsReasoningData() (ReasoningData, bool) { return decodeAs[ReasoningData](e.Data) }
+func (e Event) AsReasoningData() (ReasoningData, bool) { return events.DecodeAs[ReasoningData](e.Data) }
 
 // AsStepData parses event data as StepData.
-func (e Event) AsStepData() (StepData, bool) { return decodeAs[StepData](e.Data) }
+func (e Event) AsStepData() (StepData, bool) { return events.DecodeAs[StepData](e.Data) }
 
 // AsToolResultData parses event data as ToolResultData.
-func (e Event) AsToolResultData() (ToolResultData, bool) { return decodeAs[ToolResultData](e.Data) }
+func (e Event) AsToolResultData() (ToolResultData, bool) { return events.DecodeAs[ToolResultData](e.Data) }
 
 // AsInitAckData parses event data as InitAckData.
-func (e Event) AsInitAckData() (InitAckData, bool) { return decodeAs[InitAckData](e.Data) }
+func (e Event) AsInitAckData() (InitAckData, bool) { return events.DecodeAs[InitAckData](e.Data) }
 
 // New creates a new client with the given options.
 func New(ctx context.Context, opts ...Option) (*Client, error) {
@@ -492,7 +479,7 @@ func (c *Client) recvPump() {
 
 		// Update local state on state events.
 		if env.Event.Type == events.State {
-			if d, ok := decodeAs[StateData](env.Event.Data); ok {
+			if d, ok := events.DecodeAs[StateData](env.Event.Data); ok {
 				c.mu.Lock()
 				c.state = d.State
 				c.mu.Unlock()
@@ -571,7 +558,7 @@ func (c *Client) deliver(evt Event) {
 }
 
 func parseInitAck(env *events.Envelope) *InitAckData {
-	ack, _ := decodeAs[InitAckData](env.Event.Data)
+	ack, _ := events.DecodeAs[InitAckData](env.Event.Data)
 	if ack.SessionID == "" {
 		ack.SessionID = env.SessionID
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -239,20 +239,3 @@ func TestSendInputBeforeConnect(t *testing.T) {
 	err := c.SendInput(context.Background(), "test")
 	require.ErrorIs(t, err, ErrNotConnected)
 }
-
-func TestDecodeAs(t *testing.T) {
-	t.Parallel()
-
-	t.Run("non-map returns false", func(t *testing.T) {
-		t.Parallel()
-		_, ok := decodeAs[DoneData]("not a map")
-		require.False(t, ok)
-	})
-
-	t.Run("map converts correctly", func(t *testing.T) {
-		t.Parallel()
-		d, ok := decodeAs[DoneData](map[string]any{"success": true})
-		require.True(t, ok)
-		require.True(t, d.Success)
-	})
-}

--- a/internal/cli/checkers/security.go
+++ b/internal/cli/checkers/security.go
@@ -332,15 +332,22 @@ func envFilePath() string {
 
 func writeEnvVar(key, value string) error {
 	envPath := envFilePath()
-	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("open .env: %w", err)
-	}
-	defer func() { _ = f.Close() }()
 
-	line := fmt.Sprintf("%s=%s\n", key, value)
-	_, err = f.WriteString(line)
-	return err
+	// Read existing content and remove any existing entry for this key.
+	var lines []string
+	data, err := os.ReadFile(envPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .env: %w", err)
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" && !strings.HasPrefix(line, prefix) {
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(envPath, []byte(content), 0o600)
 }
 
 func unsetEnvVar(key string) error {

--- a/internal/cli/onboard/wizard.go
+++ b/internal/cli/onboard/wizard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hrygo/hotplex/internal/cli/checkers"
 	"github.com/hrygo/hotplex/internal/cli/output"
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/service"
 )
 
@@ -630,7 +631,7 @@ func loadEnvFile(dir string) {
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
 		val = strings.Trim(val, `"'`)
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" && !security.IsProtected(key) {
 			_ = os.Setenv(key, val)
 			loaded++
 		}

--- a/internal/cli/slack/client.go
+++ b/internal/cli/slack/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/security"
 )
 
 func NewClient(botToken string) (*slack.Client, error) {
@@ -84,7 +85,7 @@ func loadEnvFile(dir string) {
 		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
 			val = val[1 : len(val)-1]
 		}
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" && !security.IsProtected(key) {
 			os.Setenv(key, val)
 		}
 	}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -75,8 +75,9 @@ type Watcher struct {
 	callbackSem chan struct{}
 
 	// Audit log of all changes.
-	muAudit sync.Mutex
-	audit   []ConfigChange
+	muAudit     sync.Mutex
+	audit       []ConfigChange
+	maxAuditLen int
 
 	// Config history for rollback. index 0 = oldest, len-1 = latest.
 	// Only full config snapshots are stored (not every diff).
@@ -114,6 +115,7 @@ func NewWatcher(log *slog.Logger, path string, sp SecretsProvider, store *Config
 		onStatic:      onStatic,
 		callbackSem:   make(chan struct{}, 4),
 		audit:         make([]ConfigChange, 0, 64),
+		maxAuditLen:   256,
 		maxHistoryLen: 64,
 	}
 }
@@ -232,6 +234,10 @@ func (w *Watcher) reload() {
 			hasStatic = true
 		}
 	}
+	if len(w.audit) > w.maxAuditLen {
+		trim := len(w.audit) - w.maxAuditLen
+		w.audit = w.audit[trim:]
+	}
 	w.muAudit.Unlock()
 
 	w.muHistory.Lock()
@@ -260,15 +266,22 @@ func (w *Watcher) reload() {
 			w.onChange(newCfg)
 		}()
 	}
-	for _, c := range changes {
-		if !c.Hot && hasStatic && w.onStatic != nil {
-			c := c
-			go func() {
-				w.callbackSem <- struct{}{}
-				defer func() { <-w.callbackSem }()
-				w.onStatic(c.Field)
-			}()
+	// Batch all static callbacks into a single goroutine to reduce
+	// goroutine proliferation under rapid config reloads.
+	if hasStatic && w.onStatic != nil {
+		var staticFields []string
+		for _, c := range changes {
+			if !c.Hot {
+				staticFields = append(staticFields, c.Field)
+			}
 		}
+		go func() {
+			w.callbackSem <- struct{}{}
+			defer func() { <-w.callbackSem }()
+			for _, f := range staticFields {
+				w.onStatic(f)
+			}
+		}()
 	}
 }
 

--- a/internal/security/env.go
+++ b/internal/security/env.go
@@ -60,6 +60,17 @@ var protectedVars = map[string]bool{
 	"CLAUDECODE":    true,
 	"GATEWAY_ADDR":  true,
 	"GATEWAY_TOKEN": true,
+	"HOME":          true,
+	"PATH":          true,
+	"USER":          true,
+	"SHELL":         true,
+}
+
+// IsProtected reports whether an environment variable key should not be
+// overwritten from .env files. This prevents accidental override of critical
+// system and gateway variables.
+func IsProtected(key string) bool {
+	return protectedVars[strings.ToUpper(key)]
 }
 
 // BuildWorkerEnv constructs a safe environment for worker processes.

--- a/internal/security/env.go
+++ b/internal/security/env.go
@@ -60,17 +60,26 @@ var protectedVars = map[string]bool{
 	"CLAUDECODE":    true,
 	"GATEWAY_ADDR":  true,
 	"GATEWAY_TOKEN": true,
+}
+
+// cliProtectedVars are system variables that .env files must not override.
+// Separate from worker protectedVars since BuildWorkerEnv must pass
+// HOME/PATH/USER through to worker processes.
+var cliProtectedVars = map[string]bool{
 	"HOME":          true,
 	"PATH":          true,
 	"USER":          true,
 	"SHELL":         true,
+	"CLAUDECODE":    true,
+	"GATEWAY_ADDR":  true,
+	"GATEWAY_TOKEN": true,
 }
 
 // IsProtected reports whether an environment variable key should not be
 // overwritten from .env files. This prevents accidental override of critical
 // system and gateway variables.
 func IsProtected(key string) bool {
-	return protectedVars[strings.ToUpper(key)]
+	return cliProtectedVars[strings.ToUpper(key)]
 }
 
 // BuildWorkerEnv constructs a safe environment for worker processes.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -583,6 +583,11 @@ func (m *Manager) ValidateOwnership(ctx context.Context, sessionID, userID, admi
 		return err
 	}
 	if adminUserID != "" {
+		m.log.Info("session: admin access to session",
+			"session_id", sessionID,
+			"admin_user_id", adminUserID,
+			"session_owner", si.UserID,
+		)
 		return nil // admin bypass
 	}
 	if si.UserID != userID {


### PR DESCRIPTION
## Summary

Batch PR addressing 4 P3 cleanup issues: client refactor, CLI security hardening, config memory management, and session audit logging.

## Changes by Issue

### #178 — refactor(client): migrate decodeAs to events.DecodeAs
- Replace local decodeAs with superset events.DecodeAs (also handles typed T passthrough)
- Delete local decodeAs function and its redundant test
- No external API change (As*Data method signatures unchanged)

### #150 — fix(cli): env loading protected-var filtering + writeEnvVar dedup
- Add `security.IsProtected()` accessor for CLI env loading
- `loadEnvFile` in wizard.go and slack/client.go now skip protected keys (HOME, PATH, USER, SHELL, CLAUDECODE, GATEWAY_*)
- `writeEnvVar` reads existing .env, removes prior key entry, writes full file back (prevents duplicate lines)

### #146 — fix(config): unbounded audit log + callback goroutine spawning
- Add `maxAuditLen` (256) trim after each audit append, matching existing history trim pattern
- Batch all static field callbacks into single goroutine instead of N per reload

### #143 — security(session): admin ownership bypass audit logging
- Log Info-level audit when admin bypasses `ValidateOwnership`, recording admin_user_id, session_id, and session_owner

## Testing
- [x] `make check` passes (lint + test + build)
- [x] `go test -race` clean

Closes #178, #150, #146, #143