### PR TITLE
Batch: security hardening, observability, and cleanup fixes (#185 #145 #156 #149 #178 #150 #146 #143)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,71 +70,58 @@ type Event struct {
 	Data    any    `json:"data,omitempty"`
 }
 
-// decodeAs is a generic helper that round-trips map[string]any through JSON
-// to produce a typed struct. Returns (zero, false) if data is not a map.
-func decodeAs[T any](data any) (T, bool) {
-	d, ok := data.(map[string]any)
-	if !ok {
-		var zero T
-		return zero, false
-	}
-	b, _ := json.Marshal(d)
-	var res T
-	_ = json.Unmarshal(b, &res)
-	return res, true
-}
 
 // AsDoneData parses event data as DoneData.
-func (e Event) AsDoneData() (DoneData, bool) { return decodeAs[DoneData](e.Data) }
+func (e Event) AsDoneData() (DoneData, bool) { return events.DecodeAs[DoneData](e.Data) }
 
 // AsErrorData parses event data as ErrorData.
-func (e Event) AsErrorData() (ErrorData, bool) { return decodeAs[ErrorData](e.Data) }
+func (e Event) AsErrorData() (ErrorData, bool) { return events.DecodeAs[ErrorData](e.Data) }
 
 // AsToolCallData parses event data as ToolCallData.
-func (e Event) AsToolCallData() (ToolCallData, bool) { return decodeAs[ToolCallData](e.Data) }
+func (e Event) AsToolCallData() (ToolCallData, bool) { return events.DecodeAs[ToolCallData](e.Data) }
 
 // AsPermissionRequestData parses event data as PermissionRequestData.
 func (e Event) AsPermissionRequestData() (PermissionRequestData, bool) {
-	return decodeAs[PermissionRequestData](e.Data)
+	return events.DecodeAs[PermissionRequestData](e.Data)
 }
 
 // AsQuestionRequestData parses event data as QuestionRequestData.
 func (e Event) AsQuestionRequestData() (QuestionRequestData, bool) {
-	return decodeAs[QuestionRequestData](e.Data)
+	return events.DecodeAs[QuestionRequestData](e.Data)
 }
 
 // AsElicitationRequestData parses event data as ElicitationRequestData.
 func (e Event) AsElicitationRequestData() (ElicitationRequestData, bool) {
-	return decodeAs[ElicitationRequestData](e.Data)
+	return events.DecodeAs[ElicitationRequestData](e.Data)
 }
 
 // AsMessageStartData parses event data as MessageStartData.
 func (e Event) AsMessageStartData() (MessageStartData, bool) {
-	return decodeAs[MessageStartData](e.Data)
+	return events.DecodeAs[MessageStartData](e.Data)
 }
 
 // AsMessageDeltaData parses event data as MessageDeltaData.
 func (e Event) AsMessageDeltaData() (MessageDeltaData, bool) {
-	return decodeAs[MessageDeltaData](e.Data)
+	return events.DecodeAs[MessageDeltaData](e.Data)
 }
 
 // AsMessageEndData parses event data as MessageEndData.
-func (e Event) AsMessageEndData() (MessageEndData, bool) { return decodeAs[MessageEndData](e.Data) }
+func (e Event) AsMessageEndData() (MessageEndData, bool) { return events.DecodeAs[MessageEndData](e.Data) }
 
 // AsStateData parses event data as StateData.
-func (e Event) AsStateData() (StateData, bool) { return decodeAs[StateData](e.Data) }
+func (e Event) AsStateData() (StateData, bool) { return events.DecodeAs[StateData](e.Data) }
 
 // AsReasoningData parses event data as ReasoningData.
-func (e Event) AsReasoningData() (ReasoningData, bool) { return decodeAs[ReasoningData](e.Data) }
+func (e Event) AsReasoningData() (ReasoningData, bool) { return events.DecodeAs[ReasoningData](e.Data) }
 
 // AsStepData parses event data as StepData.
-func (e Event) AsStepData() (StepData, bool) { return decodeAs[StepData](e.Data) }
+func (e Event) AsStepData() (StepData, bool) { return events.DecodeAs[StepData](e.Data) }
 
 // AsToolResultData parses event data as ToolResultData.
-func (e Event) AsToolResultData() (ToolResultData, bool) { return decodeAs[ToolResultData](e.Data) }
+func (e Event) AsToolResultData() (ToolResultData, bool) { return events.DecodeAs[ToolResultData](e.Data) }
 
 // AsInitAckData parses event data as InitAckData.
-func (e Event) AsInitAckData() (InitAckData, bool) { return decodeAs[InitAckData](e.Data) }
+func (e Event) AsInitAckData() (InitAckData, bool) { return events.DecodeAs[InitAckData](e.Data) }
 
 // New creates a new client with the given options.
 func New(ctx context.Context, opts ...Option) (*Client, error) {
@@ -492,7 +479,7 @@ func (c *Client) recvPump() {
 
 		// Update local state on state events.
 		if env.Event.Type == events.State {
-			if d, ok := decodeAs[StateData](env.Event.Data); ok {
+			if d, ok := events.DecodeAs[StateData](env.Event.Data); ok {
 				c.mu.Lock()
 				c.state = d.State
 				c.mu.Unlock()
@@ -571,7 +558,7 @@ func (c *Client) deliver(evt Event) {
 }
 
 func parseInitAck(env *events.Envelope) *InitAckData {
-	ack, _ := decodeAs[InitAckData](env.Event.Data)
+	ack, _ := events.DecodeAs[InitAckData](env.Event.Data)
 	if ack.SessionID == "" {
 		ack.SessionID = env.SessionID
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -239,20 +239,3 @@ func TestSendInputBeforeConnect(t *testing.T) {
 	err := c.SendInput(context.Background(), "test")
 	require.ErrorIs(t, err, ErrNotConnected)
 }
-
-func TestDecodeAs(t *testing.T) {
-	t.Parallel()
-
-	t.Run("non-map returns false", func(t *testing.T) {
-		t.Parallel()
-		_, ok := decodeAs[DoneData]("not a map")
-		require.False(t, ok)
-	})
-
-	t.Run("map converts correctly", func(t *testing.T) {
-		t.Parallel()
-		d, ok := decodeAs[DoneData](map[string]any{"success": true})
-		require.True(t, ok)
-		require.True(t, d.Success)
-	})
-}

--- a/internal/cli/checkers/security.go
+++ b/internal/cli/checkers/security.go
@@ -332,15 +332,22 @@ func envFilePath() string {
 
 func writeEnvVar(key, value string) error {
 	envPath := envFilePath()
-	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return fmt.Errorf("open .env: %w", err)
-	}
-	defer func() { _ = f.Close() }()
 
-	line := fmt.Sprintf("%s=%s\n", key, value)
-	_, err = f.WriteString(line)
-	return err
+	// Read existing content and remove any existing entry for this key.
+	var lines []string
+	data, err := os.ReadFile(envPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .env: %w", err)
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" && !strings.HasPrefix(line, prefix) {
+			lines = append(lines, line)
+		}
+	}
+	lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(envPath, []byte(content), 0o600)
 }
 
 func unsetEnvVar(key string) error {

--- a/internal/cli/onboard/wizard.go
+++ b/internal/cli/onboard/wizard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hrygo/hotplex/internal/cli/checkers"
 	"github.com/hrygo/hotplex/internal/cli/output"
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/service"
 )
 
@@ -630,7 +631,7 @@ func loadEnvFile(dir string) {
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
 		val = strings.Trim(val, `"'`)
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" && !security.IsProtected(key) {
 			_ = os.Setenv(key, val)
 			loaded++
 		}

--- a/internal/cli/slack/client.go
+++ b/internal/cli/slack/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/slack-go/slack"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/security"
 )
 
 func NewClient(botToken string) (*slack.Client, error) {
@@ -84,7 +85,7 @@ func loadEnvFile(dir string) {
 		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
 			val = val[1 : len(val)-1]
 		}
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" && !security.IsProtected(key) {
 			os.Setenv(key, val)
 		}
 	}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -75,8 +75,9 @@ type Watcher struct {
 	callbackSem chan struct{}
 
 	// Audit log of all changes.
-	muAudit sync.Mutex
-	audit   []ConfigChange
+	muAudit     sync.Mutex
+	audit       []ConfigChange
+	maxAuditLen int
 
 	// Config history for rollback. index 0 = oldest, len-1 = latest.
 	// Only full config snapshots are stored (not every diff).
@@ -114,6 +115,7 @@ func NewWatcher(log *slog.Logger, path string, sp SecretsProvider, store *Config
 		onStatic:      onStatic,
 		callbackSem:   make(chan struct{}, 4),
 		audit:         make([]ConfigChange, 0, 64),
+		maxAuditLen:   256,
 		maxHistoryLen: 64,
 	}
 }
@@ -232,6 +234,10 @@ func (w *Watcher) reload() {
 			hasStatic = true
 		}
 	}
+	if len(w.audit) > w.maxAuditLen {
+		trim := len(w.audit) - w.maxAuditLen
+		w.audit = w.audit[trim:]
+	}
 	w.muAudit.Unlock()
 
 	w.muHistory.Lock()
@@ -260,15 +266,22 @@ func (w *Watcher) reload() {
 			w.onChange(newCfg)
 		}()
 	}
-	for _, c := range changes {
-		if !c.Hot && hasStatic && w.onStatic != nil {
-			c := c
-			go func() {
-				w.callbackSem <- struct{}{}
-				defer func() { <-w.callbackSem }()
-				w.onStatic(c.Field)
-			}()
+	// Batch all static callbacks into a single goroutine to reduce
+	// goroutine proliferation under rapid config reloads.
+	if hasStatic && w.onStatic != nil {
+		var staticFields []string
+		for _, c := range changes {
+			if !c.Hot {
+				staticFields = append(staticFields, c.Field)
+			}
 		}
+		go func() {
+			w.callbackSem <- struct{}{}
+			defer func() { <-w.callbackSem }()
+			for _, f := range staticFields {
+				w.onStatic(f)
+			}
+		}()
 	}
 }
 

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -178,6 +179,9 @@ func FormatSessionDuration(secs float64) string {
 // Returns empty string if maxComponents <= 0. If the path is already short enough,
 // it is returned unchanged. Uses "/" as separator for cross-platform display in
 // messaging (Slack/Feishu). Preserves Windows drive letters (e.g. "C:").
+// Replaces the user's home directory prefix with "~" before truncation so that
+// paths under home are displayed relative to "~" instead of showing misleading
+// truncated segments like "/.hotplex/workspace/hotplex".
 func TruncatePath(p string, maxComponents int) string {
 	if p == "" || maxComponents <= 0 {
 		return ""
@@ -187,11 +191,28 @@ func TruncatePath(p string, maxComponents int) string {
 	p = strings.ReplaceAll(p, "\\", "/")
 	p = filepath.Clean(p)
 
+	// Track home directory prefix for user-friendly display.
+	prefix := ""
+
+	// Replace home directory prefix with ~ so components are counted relative to home.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		homeNorm := strings.ReplaceAll(home, "\\", "/")
+		homeNorm = filepath.Clean(homeNorm)
+		if p == homeNorm {
+			return "~"
+		}
+		if strings.HasPrefix(p, homeNorm+"/") {
+			p = p[len(homeNorm):] // e.g. "/.hotplex/workspace/hotplex"
+			prefix = "~"
+		}
+	}
+
 	// Detect and preserve Windows drive letter (e.g. "C:").
-	drive := ""
-	if len(p) >= 2 && p[1] == ':' && (p[0] >= 'A' && p[0] <= 'Z' || p[0] >= 'a' && p[0] <= 'z') {
-		drive = p[:2]
-		p = p[2:]
+	if prefix == "" {
+		if len(p) >= 2 && p[1] == ':' && (p[0] >= 'A' && p[0] <= 'Z' || p[0] >= 'a' && p[0] <= 'z') {
+			prefix = p[:2]
+			p = p[2:]
+		}
 	}
 
 	// Split and filter empty parts.
@@ -202,11 +223,15 @@ func TruncatePath(p string, maxComponents int) string {
 			parts = append(parts, s)
 		}
 	}
+	sep := "/"
+	if prefix == "~" {
+		sep = "/"
+	}
 	if len(parts) <= maxComponents {
-		return drive + "/" + strings.Join(parts, "/")
+		return prefix + sep + strings.Join(parts, "/")
 	}
 	kept := parts[len(parts)-maxComponents:]
-	return drive + "/" + strings.Join(kept, "/")
+	return prefix + sep + strings.Join(kept, "/")
 }
 
 // FormatTurnSummaryRich produces a multi-line turn summary with each metric on its own line.

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -8,6 +9,13 @@ import (
 
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+func homeDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	return home
+}
 
 func TestExtractTurnSummary_Full(t *testing.T) {
 	t.Parallel()
@@ -259,6 +267,11 @@ func TestTruncatePath(t *testing.T) {
 		{"zero max", "/home/user", 0, ""},
 		{"windows absolute", "C:\\Users\\admin\\workspace\\project", 2, "C:/workspace/project"},
 		{"windows short", "D:\\dev\\app", 5, "D:/dev/app"},
+		{"home dir path", homeDir(t) + "/.hotplex/workspace/hotplex", 3, "~/.hotplex/workspace/hotplex"},
+		{"home dir exact", homeDir(t), 3, "~"},
+		{"home dir short", homeDir(t) + "/projects", 3, "~/projects"},
+		{"home dir truncated", homeDir(t) + "/.hotplex/workspace/hotplex/deep/pkg", 3, "~/hotplex/deep/pkg"},
+		{"home dir one", homeDir(t) + "/.hotplex/workspace/hotplex", 1, "~/hotplex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/security/env.go
+++ b/internal/security/env.go
@@ -60,6 +60,17 @@ var protectedVars = map[string]bool{
 	"CLAUDECODE":    true,
 	"GATEWAY_ADDR":  true,
 	"GATEWAY_TOKEN": true,
+	"HOME":          true,
+	"PATH":          true,
+	"USER":          true,
+	"SHELL":         true,
+}
+
+// IsProtected reports whether an environment variable key should not be
+// overwritten from .env files. This prevents accidental override of critical
+// system and gateway variables.
+func IsProtected(key string) bool {
+	return protectedVars[strings.ToUpper(key)]
 }
 
 // BuildWorkerEnv constructs a safe environment for worker processes.

--- a/internal/security/env.go
+++ b/internal/security/env.go
@@ -60,17 +60,26 @@ var protectedVars = map[string]bool{
 	"CLAUDECODE":    true,
 	"GATEWAY_ADDR":  true,
 	"GATEWAY_TOKEN": true,
+}
+
+// cliProtectedVars are system variables that .env files must not override.
+// Separate from worker protectedVars since BuildWorkerEnv must pass
+// HOME/PATH/USER through to worker processes.
+var cliProtectedVars = map[string]bool{
 	"HOME":          true,
 	"PATH":          true,
 	"USER":          true,
 	"SHELL":         true,
+	"CLAUDECODE":    true,
+	"GATEWAY_ADDR":  true,
+	"GATEWAY_TOKEN": true,
 }
 
 // IsProtected reports whether an environment variable key should not be
 // overwritten from .env files. This prevents accidental override of critical
 // system and gateway variables.
 func IsProtected(key string) bool {
-	return protectedVars[strings.ToUpper(key)]
+	return cliProtectedVars[strings.ToUpper(key)]
 }
 
 // BuildWorkerEnv constructs a safe environment for worker processes.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -583,6 +583,11 @@ func (m *Manager) ValidateOwnership(ctx context.Context, sessionID, userID, admi
 		return err
 	}
 	if adminUserID != "" {
+		m.log.Info("session: admin access to session",
+			"session_id", sessionID,
+			"admin_user_id", adminUserID,
+			"session_owner", si.UserID,
+		)
 		return nil // admin bypass
 	}
 	if si.UserID != userID {

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func (c *ServerCommander) Compact(ctx context.Context, args map[string]any) erro
 		}
 	}
 	var result bool
-	if err := c.doPost(ctx, "/session/"+c.sessionID+"/summarize", reqBody, &result); err != nil {
+	if err := c.doPost(ctx, "/session/"+url.PathEscape(c.sessionID)+"/summarize", reqBody, &result); err != nil {
 		return fmt.Errorf("opencode compact: %w", err)
 	}
 	return nil
@@ -63,7 +64,7 @@ func (c *ServerCommander) Compact(ctx context.Context, args map[string]any) erro
 
 // Clear implements WorkerCommander — delete session + create new.
 func (c *ServerCommander) Clear(ctx context.Context) error {
-	if err := c.doDelete(ctx, "/session/"+c.sessionID); err != nil {
+	if err := c.doDelete(ctx, "/session/"+url.PathEscape(c.sessionID)); err != nil {
 		return fmt.Errorf("opencode clear (delete): %w", err)
 	}
 	var newSession struct {
@@ -86,7 +87,7 @@ func (c *ServerCommander) Rewind(ctx context.Context, targetID string) error {
 		reqBody["messageID"] = targetID
 	}
 	var result any
-	if err := c.doPost(ctx, "/session/"+c.sessionID+"/revert", reqBody, &result); err != nil {
+	if err := c.doPost(ctx, "/session/"+url.PathEscape(c.sessionID)+"/revert", reqBody, &result); err != nil {
 		return fmt.Errorf("opencode rewind: %w", err)
 	}
 	return nil
@@ -103,7 +104,7 @@ func (c *ServerCommander) UpdateSessionID(id string) { c.sessionID = id }
 
 func (c *ServerCommander) queryContextUsage(ctx context.Context) (map[string]any, error) {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=100", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=100", &messages); err != nil {
 		return nil, fmt.Errorf("opencode context query: %w", err)
 	}
 	var totalInput, totalOutput, totalReasoning, totalCacheRead, totalCacheWrite int
@@ -170,7 +171,7 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 	default:
 		rules = []map[string]any{}
 	}
-	if err := c.doPatch(ctx, "/session/"+c.sessionID, map[string]any{"permission": rules}); err != nil {
+	if err := c.doPatch(ctx, "/session/"+url.PathEscape(c.sessionID), map[string]any{"permission": rules}); err != nil {
 		return nil, fmt.Errorf("opencode set permission: %w", err)
 	}
 	return map[string]any{"success": true, "mode": mode}, nil
@@ -242,7 +243,7 @@ func (c *ServerCommander) doRequest(ctx context.Context, method, path string, bo
 // lastKnownModel scans recent messages for the model used by the last assistant turn.
 func (c *ServerCommander) lastKnownModel(ctx context.Context) (providerID, modelID string) {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=50", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=50", &messages); err != nil {
 		return "", ""
 	}
 	for i := len(messages) - 1; i >= 0; i-- {
@@ -262,7 +263,7 @@ func (c *ServerCommander) lastKnownModel(ctx context.Context) (providerID, model
 // lastAssistantMessageID returns the ID of the most recent assistant message.
 func (c *ServerCommander) lastAssistantMessageID(ctx context.Context) string {
 	var messages []openCodeMessage
-	if err := c.doGet(ctx, "/session/"+c.sessionID+"/message?limit=50", &messages); err != nil {
+	if err := c.doGet(ctx, "/session/"+url.PathEscape(c.sessionID)+"/message?limit=50", &messages); err != nil {
 		return ""
 	}
 	for i := len(messages) - 1; i >= 0; i-- {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -40,6 +40,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -241,7 +242,7 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 			if !allowed {
 				reply = "reject"
 			}
-			return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", reqID),
+			return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", url.PathEscape(reqID)),
 				map[string]string{"reply": reply})
 		}
 		if qResp, ok := metadata["question_response"].(map[string]any); ok {
@@ -445,7 +446,7 @@ func (w *Worker) ResetContext(ctx context.Context) error {
 		return fmt.Errorf("opencodeserver: reset: worker not started")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", httpAddr+"/session/"+sessionID+"/reset", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", httpAddr+"/session/"+url.PathEscape(sessionID)+"/reset", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("opencodeserver: reset: new request: %w", err)
 	}
@@ -532,7 +533,7 @@ func (w *Worker) createSession(ctx context.Context, projectDir string) (string, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return "", fmt.Errorf("create session failed: status %d, body: %s", resp.StatusCode, string(body))
 	}
 
@@ -581,7 +582,7 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 		}
 	}()
 
-	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, sessionID)
+	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		w.Log.Error("opencodeserver: create SSE request", "session_id", sessionID, "err", err)
@@ -598,7 +599,7 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		w.Log.Error("opencodeserver: SSE status",
 			"session_id", sessionID,
 			"status", resp.StatusCode,
@@ -766,7 +767,7 @@ func (w *Worker) httpPost(ctx context.Context, path string, payload any) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("opencodeserver: post %s failed: status %d, body: %s",
 			path, resp.StatusCode, string(respBody))
 	}
@@ -827,7 +828,7 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return fmt.Errorf("opencodeserver: marshal input: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, c.sessionID)
+	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
 	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payload)))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
@@ -841,7 +842,7 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("opencodeserver: input failed: status %d, body: %s",
 			resp.StatusCode, string(respBody))
 	}


### PR DESCRIPTION
## Summary

Consolidated batch PR addressing 8 issues across security hardening, observability, code cleanup, and reliability. Issues #156 and #149 were verified as already fixed in main and require no code changes.

## Commits (6 atomic commits, one per issue)

| Commit | Issue | Description |
|--------|-------|-------------|
| `336805c` | #185 | **fix(turn-summary)**: TruncatePath substitutes $HOME with ~ before component counting |
| `1a37ea4` | #145 | **fix(worker/ocs)**: Bound 4 io.ReadAll with LimitReader(4096) + URL-encode all path segments |
| `058d6a2` | #178 | **refactor(client)**: Migrate local decodeAs to superset events.DecodeAs, delete 46 lines |
| `c74d288` | #150 | **fix(cli)**: loadEnvFile skips protected keys (HOME/PATH/USER/SHELL/GATEWAY_*) + writeEnvVar dedup |
| `e2ea308` | #146 | **fix(config)**: Cap audit log at 256 entries + batch static callbacks into 1 goroutine |
| `316d172` | #143 | **security(session)**: Log audit when admin bypasses ValidateOwnership |

## Verified Already Fixed (no changes needed)

| Issue | Finding | Current Code |
|-------|---------|--------------|
| #156 | JWT weak keys + API key plaintext | decodeJWTSecret returns nil for non-32-byte + sensitiveFields redaction |
| #149 | X-Forwarded-For bypass + token timing | clientIP uses r.RemoteAddr + subtle.ConstantTimeCompare |

## Changed Files

- `internal/messaging/turn_summary.go` + `_test.go` — #185
- `internal/worker/opencodeserver/worker.go`, `commands.go` — #145
- `client/client.go`, `client_test.go` — #178
- `internal/security/env.go` — #150
- `internal/cli/onboard/wizard.go`, `internal/cli/slack/client.go`, `internal/cli/checkers/security.go` — #150
- `internal/config/watcher.go` — #146
- `internal/session/manager.go` — #143

## Testing
- [x] `make check` passes (lint 0 issues + test + race detector + build)
- [x] All new test cases pass
- [x] No breaking changes

Closes #185, #145, #156, #149, #178, #150, #146, #143