### PR TITLE
style: remove dead code and fix package name shadowing

### DIFF
--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -223,15 +223,11 @@ func TruncatePath(p string, maxComponents int) string {
 			parts = append(parts, s)
 		}
 	}
-	sep := "/"
-	if prefix == "~" {
-		sep = "/"
-	}
 	if len(parts) <= maxComponents {
-		return prefix + sep + strings.Join(parts, "/")
+		return prefix + "/" + strings.Join(parts, "/")
 	}
 	kept := parts[len(parts)-maxComponents:]
-	return prefix + sep + strings.Join(kept, "/")
+	return prefix + "/" + strings.Join(kept, "/")
 }
 
 // FormatTurnSummaryRich produces a multi-line turn summary with each metric on its own line.

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -582,8 +582,8 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 		}
 	}()
 
-	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	sseURL := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
+	req, err := http.NewRequestWithContext(ctx, "GET", sseURL, http.NoBody)
 	if err != nil {
 		w.Log.Error("opencodeserver: create SSE request", "session_id", sessionID, "err", err)
 		return
@@ -828,8 +828,8 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return fmt.Errorf("opencodeserver: marshal input: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
-	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payload)))
+	msgURL := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
+	req, err := http.NewRequestWithContext(ctx, "POST", msgURL, strings.NewReader(string(payload)))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Remove unused `sep` variable in `TruncatePath` (both branches produced `"/"`)
- Rename local `url` vars to `sseURL`/`msgURL` in OCS worker to avoid shadowing `net/url` package

### Changes

- `internal/messaging/turn_summary.go` — delete dead `sep` variable and redundant `if` block
- `internal/worker/opencodeserver/worker.go` — `url` → `sseURL`/`msgURL`

## Test Plan

- [x] make test
- [x] make lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)