### PR TITLE
feat(feishu): turn summary uses dedicated CardKit v2 table card

### DIFF
--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -1243,10 +1243,8 @@ type textContent struct {
 }
 
 // buildCardContent builds a Feishu interactive card JSON using CardKit v2 format.
-// schema:"2.0" is required for the "markdown" tag to work with full markdown rendering.
-// Uses json.NewEncoder with SetEscapeHTML(false) to preserve HTML entities.
 func buildCardContent(text string) string {
-	card := map[string]any{
+	return encodeCard(map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{"wide_screen_mode": true},
 		"body": map[string]any{
@@ -1254,7 +1252,11 @@ func buildCardContent(text string) string {
 				{"tag": "markdown", "content": text},
 			},
 		},
-	}
+	})
+}
+
+// encodeCard serializes a CardKit v2 card to JSON with HTML escaping disabled.
+func encodeCard(card map[string]any) string {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
@@ -1292,26 +1294,11 @@ func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
 	if d.GitBranch != "" {
 		elements = append(elements, tableRow("🌿 Branch", d.GitBranch))
 	}
-	turnDur := ""
-	if d.TurnDurationMs > 0 {
-		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
+	if durStr := messaging.FormatDurationParts(d); durStr != "" {
+		elements = append(elements, tableRow("⏱️ Duration", durStr))
 	}
-	sessDur := ""
-	if d.SessionDuration > 0 {
-		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
-	}
-	if turnDur != "" || sessDur != "" {
-		var dp []string
-		if turnDur != "" {
-			dp = append(dp, turnDur)
-		}
-		if sessDur != "" {
-			dp = append(dp, sessDur)
-		}
-		elements = append(elements, tableRow("⏱️ Duration", strings.Join(dp, " | ")))
-	}
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		elements = append(elements, tableRow("💎 Tokens", formatTokensValue(d)))
+	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {
+		elements = append(elements, tableRow("💎 Tokens", tokStr))
 	}
 
 	if len(elements) == 0 {
@@ -1323,11 +1310,7 @@ func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
 		"config": map[string]any{"wide_screen_mode": true},
 		"body":   map[string]any{"elements": elements},
 	}
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	_ = enc.Encode(card)
-	return strings.TrimRight(buf.String(), "\n")
+	return encodeCard(card)
 }
 
 // tableRow creates a CardKit v2 column_set element with two weighted columns.
@@ -1349,32 +1332,6 @@ func tableRow(label, value string) map[string]any {
 			},
 		},
 	}
-}
-
-// formatTokensValue formats token usage matching Slack's table layout.
-func formatTokensValue(d messaging.TurnSummaryData) string {
-	var tokParts []string
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-		var tp []string
-		if d.TurnInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
-		}
-		if d.TurnOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
-		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
-	}
-	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tp []string
-		if d.TotalInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
-		}
-		if d.TotalOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
-		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
-	}
-	return strings.Join(tokParts, " | ")
 }
 
 // formatSecurityError converts technical security errors into user-friendly messages.

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -650,8 +650,7 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			now := time.Now().UnixMilli()
 			last := c.lastSummarySentMs.Load()
 			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
-				go c.sendTurnSummaryCard(ctx, d)
-				c.lastSummarySentMs.Store(now)
+				go c.sendTurnSummaryCard(d)
 			}
 		}
 
@@ -868,7 +867,7 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 	return c.adapter.sendTextMessage(ctx, chatID, OptimizeMarkdownStyle(SanitizeForCard(text)))
 }
 
-func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSummaryData) {
+func (c *FeishuConn) sendTurnSummaryCard(d messaging.TurnSummaryData) {
 	cardJSON := buildTurnSummaryCard(d)
 	if cardJSON == "" {
 		return
@@ -881,13 +880,15 @@ func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSumm
 	c.mu.RUnlock()
 	var err error
 	if replyToMsgID != "" {
-		err = c.adapter.replyCardJSON(sendCtx, replyToMsgID, cardJSON)
+		err = c.adapter.doReplyCard(sendCtx, replyToMsgID, cardJSON, false)
 	} else {
 		err = c.adapter.sendCardMessage(sendCtx, chatID, cardJSON)
 	}
 	if err != nil {
 		c.adapter.Log.Warn("turn summary card send failed", "err", err)
+		return
 	}
+	c.lastSummarySentMs.Store(time.Now().UnixMilli())
 }
 
 func (c *FeishuConn) sendContextUsage(ctx context.Context, env *events.Envelope) error {
@@ -1073,46 +1074,27 @@ func (a *Adapter) sendTextMessage(ctx context.Context, chatID, text string) erro
 
 //nolint:unparam // replyInThread reserved for future thread reply support
 func (a *Adapter) replyMessage(ctx context.Context, messageID, content string, replyInThread bool) error {
-	if a.larkClient == nil {
-		return fmt.Errorf("feishu: lark client not initialized")
-	}
-
 	cardJSON := buildCardContent(content)
 	preview := cardJSON
 	if len(preview) > 200 {
 		preview = preview[:200] + "..."
 	}
 	a.Log.Debug("feishu: sending reply card", "msg_id", messageID, "content_len", len(cardJSON), "content_preview", preview)
-	body := larkim.NewReplyMessageReqBodyBuilder().
-		MsgType(larkim.MsgTypeInteractive).
-		Content(cardJSON).
-		ReplyInThread(replyInThread).
-		Build()
-
-	req := larkim.NewReplyMessageReqBuilder().
-		MessageId(messageID).
-		Body(body).
-		Build()
-
-	resp, err := a.larkClient.Im.V1.Message.Reply(ctx, req)
-	if err != nil {
-		return fmt.Errorf("feishu: reply message: %w", err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("feishu: reply message failed: code=%d msg=%s", resp.Code, resp.Msg)
+	if err := a.doReplyCard(ctx, messageID, cardJSON, replyInThread); err != nil {
+		return err
 	}
 	a.Log.Debug("feishu: reply message sent", "msg_id", messageID, "content_len", len(content))
 	return nil
 }
 
-// replyCardJSON replies to a message with a pre-built CardKit v2 JSON card.
-func (a *Adapter) replyCardJSON(ctx context.Context, messageID, cardJSON string) error {
+func (a *Adapter) doReplyCard(ctx context.Context, messageID, cardJSON string, replyInThread bool) error {
 	if a.larkClient == nil {
 		return fmt.Errorf("feishu: lark client not initialized")
 	}
 	body := larkim.NewReplyMessageReqBodyBuilder().
 		MsgType(larkim.MsgTypeInteractive).
 		Content(cardJSON).
+		ReplyInThread(replyInThread).
 		Build()
 	req := larkim.NewReplyMessageReqBuilder().
 		MessageId(messageID).

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -639,8 +639,7 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.adapter.Interactions.CancelAll(env.SessionID)
 
 		d := messaging.ExtractTurnSummary(env)
-		summaryText := messaging.FormatTurnSummaryRich(d)
-		if summaryText != "" {
+		if d.TurnCount > 0 || d.ModelName != "" || d.ToolCallCount > 0 {
 			c.adapter.Log.Info("turn summary",
 				"turn_count", d.TurnCount,
 				"duration_ms", d.TurnDurationMs,
@@ -651,14 +650,8 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			now := time.Now().UnixMilli()
 			last := c.lastSummarySentMs.Load()
 			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
-				if streamCtrl != nil && streamCtrl.IsCreated() {
-					if streamCtrl.Write("\n\n---\n"+summaryText) == nil {
-						c.lastSummarySentMs.Store(now)
-					}
-				} else {
-					go c.sendTurnSummaryText(summaryText)
-					c.lastSummarySentMs.Store(now)
-				}
+				go c.sendTurnSummaryCard(ctx, d)
+				c.lastSummarySentMs.Store(now)
 			}
 		}
 
@@ -875,7 +868,11 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 	return c.adapter.sendTextMessage(ctx, chatID, OptimizeMarkdownStyle(SanitizeForCard(text)))
 }
 
-func (c *FeishuConn) sendTurnSummaryText(text string) {
+func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSummaryData) {
+	cardJSON := buildTurnSummaryCard(d)
+	if cardJSON == "" {
+		return
+	}
 	sendCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c.mu.RLock()
@@ -884,12 +881,12 @@ func (c *FeishuConn) sendTurnSummaryText(text string) {
 	c.mu.RUnlock()
 	var err error
 	if replyToMsgID != "" {
-		err = c.adapter.replyMessage(sendCtx, replyToMsgID, text, false)
+		err = c.adapter.replyCardJSON(sendCtx, replyToMsgID, cardJSON)
 	} else {
-		err = c.adapter.sendTextMessage(sendCtx, chatID, text)
+		err = c.adapter.sendCardMessage(sendCtx, chatID, cardJSON)
 	}
 	if err != nil {
-		c.adapter.Log.Warn("turn summary send failed", "err", err)
+		c.adapter.Log.Warn("turn summary card send failed", "err", err)
 	}
 }
 
@@ -1108,6 +1105,29 @@ func (a *Adapter) replyMessage(ctx context.Context, messageID, content string, r
 	return nil
 }
 
+// replyCardJSON replies to a message with a pre-built CardKit v2 JSON card.
+func (a *Adapter) replyCardJSON(ctx context.Context, messageID, cardJSON string) error {
+	if a.larkClient == nil {
+		return fmt.Errorf("feishu: lark client not initialized")
+	}
+	body := larkim.NewReplyMessageReqBodyBuilder().
+		MsgType(larkim.MsgTypeInteractive).
+		Content(cardJSON).
+		Build()
+	req := larkim.NewReplyMessageReqBuilder().
+		MessageId(messageID).
+		Body(body).
+		Build()
+	resp, err := a.larkClient.Im.V1.Message.Reply(ctx, req)
+	if err != nil {
+		return fmt.Errorf("feishu: reply card: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("feishu: reply card failed: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
 const mediaMaxSize = 10 * 1024 * 1024 // 10 MB
 
 // mediaTypeToResourceType maps our internal media types to Feishu resource types.
@@ -1258,6 +1278,121 @@ func buildCardContent(text string) string {
 	enc.SetEscapeHTML(false)
 	_ = enc.Encode(card)
 	return strings.TrimRight(buf.String(), "\n")
+}
+
+// buildTurnSummaryCard builds a CardKit v2 card with column_set rows matching
+// Slack's TableBlock layout: two columns per row (label | value).
+func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
+	var elements []map[string]any
+
+	if d.TurnCount > 0 {
+		elements = append(elements, tableRow("🔄 Turn", fmt.Sprintf("#%d", d.TurnCount)))
+	}
+	if d.ModelName != "" {
+		elements = append(elements, tableRow("🤖 Model", d.ModelName))
+	}
+	if d.ContextWindow > 0 && d.ContextFill > 0 {
+		pct := int(d.ContextPct + 0.5)
+		if pct > 100 {
+			pct = 100
+		}
+		used := messaging.FormatTokenCount(int(d.ContextFill))
+		max := messaging.FormatTokenCount(int(d.ContextWindow))
+		elements = append(elements, tableRow("🧠 Context", fmt.Sprintf("%d%% %s/%s", pct, used, max)))
+	}
+	if d.ToolCallCount > 0 {
+		toolStr := messaging.FormatToolNames(d.ToolNames, d.ToolCallCount)
+		elements = append(elements, tableRow("🔧 Tools", toolStr))
+	}
+	if d.WorkDir != "" {
+		elements = append(elements, tableRow("📂 Dir", messaging.TruncatePath(d.WorkDir, 3)))
+	}
+	if d.GitBranch != "" {
+		elements = append(elements, tableRow("🌿 Branch", d.GitBranch))
+	}
+	turnDur := ""
+	if d.TurnDurationMs > 0 {
+		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
+	}
+	sessDur := ""
+	if d.SessionDuration > 0 {
+		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
+	}
+	if turnDur != "" || sessDur != "" {
+		var dp []string
+		if turnDur != "" {
+			dp = append(dp, turnDur)
+		}
+		if sessDur != "" {
+			dp = append(dp, sessDur)
+		}
+		elements = append(elements, tableRow("⏱️ Duration", strings.Join(dp, " | ")))
+	}
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		elements = append(elements, tableRow("💎 Tokens", formatTokensValue(d)))
+	}
+
+	if len(elements) == 0 {
+		return ""
+	}
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"wide_screen_mode": true},
+		"body":   map[string]any{"elements": elements},
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(card)
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// tableRow creates a CardKit v2 column_set element with two weighted columns.
+func tableRow(label, value string) map[string]any {
+	return map[string]any{
+		"tag": "column_set",
+		"columns": []map[string]any{
+			{
+				"tag":      "column",
+				"width":    "weighted",
+				"weight":   1,
+				"elements": []map[string]any{{"tag": "markdown", "content": "**" + label + "**"}},
+			},
+			{
+				"tag":      "column",
+				"width":    "weighted",
+				"weight":   3,
+				"elements": []map[string]any{{"tag": "markdown", "content": value}},
+			},
+		},
+	}
+}
+
+// formatTokensValue formats token usage matching Slack's table layout.
+func formatTokensValue(d messaging.TurnSummaryData) string {
+	var tokParts []string
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
+		var tp []string
+		if d.TurnInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
+		}
+		if d.TurnOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		var tp []string
+		if d.TotalInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
+		}
+		if d.TotalOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	return strings.Join(tokParts, " | ")
 }
 
 // formatSecurityError converts technical security errors into user-friendly messages.

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -1147,48 +1147,12 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 		table.AddRow(richTextCell("🌿 Branch"), richTextCell(d.GitBranch))
 	}
 	// Duration (merged Turn + Session)
-	turnDur := ""
-	if d.TurnDurationMs > 0 {
-		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
-	}
-	sessDur := ""
-	if d.SessionDuration > 0 {
-		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
-	}
-	if turnDur != "" || sessDur != "" {
-		dParts := make([]string, 0, 2)
-		if turnDur != "" {
-			dParts = append(dParts, turnDur)
-		}
-		if sessDur != "" {
-			dParts = append(dParts, sessDur)
-		}
-		table.AddRow(richTextCell("⏱️ Duration"), richTextCell(strings.Join(dParts, " | ")))
+	if durStr := messaging.FormatDurationParts(d); durStr != "" {
+		table.AddRow(richTextCell("⏱️ Duration"), richTextCell(durStr))
 	}
 	// Tokens (turn + session total)
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tokParts []string
-		if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-			var tp []string
-			if d.TurnInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
-			}
-			if d.TurnOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-			var tp []string
-			if d.TotalInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
-			}
-			if d.TotalOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		table.AddRow(richTextCell("💎 Tokens"), richTextCell(strings.Join(tokParts, " | ")))
+	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {
+		table.AddRow(richTextCell("💎 Tokens"), richTextCell(tokStr))
 	}
 
 	return []slack.Block{table}

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -277,42 +277,57 @@ func FormatTurnSummaryRich(d TurnSummaryData) string {
 	}
 
 	// Line 6: Duration (merged Turn + Session)
-	var durParts []string
-	if d.TurnDurationMs > 0 {
-		durParts = append(durParts, "Turn "+FormatDuration(d.TurnDurationMs))
-	}
-	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
-		durParts = append(durParts, "Session "+sessDur)
-	}
-	if len(durParts) > 0 {
-		lines = append(lines, "⏱️ "+strings.Join(durParts, " · "))
+	if durStr := FormatDurationParts(d); durStr != "" {
+		lines = append(lines, "⏱️ "+durStr)
 	}
 
 	// Line 7: Tokens (turn + session total)
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tokParts []string
-		if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-			var tp []string
-			if d.TurnInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s in", FormatTokenCount(int(d.TurnInputTok))))
-			}
-			if d.TurnOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s out", FormatTokenCount(int(d.TurnOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-			var tp []string
-			if d.TotalInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s in", FormatTokenCount(int(d.TotalInputTok))))
-			}
-			if d.TotalOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s out", FormatTokenCount(int(d.TotalOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		lines = append(lines, "💎 "+strings.Join(tokParts, " | "))
+	if tokStr := FormatTokenUsage(d); tokStr != "" {
+		lines = append(lines, "💎 "+tokStr)
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// FormatDurationParts returns a formatted duration string combining turn and session durations.
+// Returns empty string if no duration data is available.
+func FormatDurationParts(d TurnSummaryData) string {
+	var parts []string
+	if d.TurnDurationMs > 0 {
+		parts = append(parts, "Turn "+FormatDuration(d.TurnDurationMs))
+	}
+	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
+		parts = append(parts, "Session "+sessDur)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// FormatTokenUsage returns a formatted token usage string with turn and total breakdowns.
+// Returns empty string if no token data is available.
+func FormatTokenUsage(d TurnSummaryData) string {
+	if d.TurnInputTok <= 0 && d.TurnOutputTok <= 0 && d.TotalInputTok <= 0 && d.TotalOutputTok <= 0 {
+		return ""
+	}
+	var tokParts []string
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
+		var tp []string
+		if d.TurnInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s in", FormatTokenCount(int(d.TurnInputTok))))
+		}
+		if d.TurnOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s out", FormatTokenCount(int(d.TurnOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		var tp []string
+		if d.TotalInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s in", FormatTokenCount(int(d.TotalInputTok))))
+		}
+		if d.TotalOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s out", FormatTokenCount(int(d.TotalOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	return strings.Join(tokParts, " | ")
 }


### PR DESCRIPTION
## Summary

- Feishu turn summary 改用独立 CardKit v2 卡片输出（column_set 两列布局），与 Slack TableBlock 对齐
- 提取 `FormatDurationParts` / `FormatTokenUsage` 到共享包，消除 feishu/slack/rich-text 三处重复格式化
- 提取 `encodeCard` 辅助函数消除飞书 adapter 内 JSON 序列化重复
- 修复 cooldown 时序问题（发送成功后才更新时间戳）

### Changes

- `internal/messaging/feishu/adapter.go` — 独立卡片发送、`doReplyCard` 提取、`encodeCard` 提取
- `internal/messaging/slack/adapter.go` — duration/token 行用共享 helper
- `internal/messaging/turn_summary.go` — 新增 `FormatDurationParts`、`FormatTokenUsage`

**架构影响**：
- Channel: 飞书（主要）、Slack（去重）
- 平台: 跨平台

## Test Plan

- [x] make test
- [x] make lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)