### PR TITLE
Batch: style cleanup, interaction fix, feishu turn summary card

### DIFF
--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -109,6 +109,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 
 		env = events.Clone(env)
 		env.SessionID = sessionID
+		env.OwnerID = sessOwner
 
 		var capturedDeltaContent string
 		if env.Event.Type == events.MessageDelta || env.Event.Type == events.Message {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -526,7 +526,12 @@ func gitBranchOf(dir string) string {
 	if err == nil {
 		branch = strings.TrimSpace(string(out))
 		if branch == "HEAD" {
-			branch = ""
+			// Detached HEAD: show short commit hash instead.
+			shortCmd := exec.CommandContext(ctx, "git", "rev-parse", "--short", "HEAD")
+			shortCmd.Dir = dir
+			if shortOut, shortErr := shortCmd.Output(); shortErr == nil {
+				branch = strings.TrimSpace(string(shortOut))
+			}
 		}
 	}
 

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -525,6 +525,9 @@ func gitBranchOf(dir string) string {
 	branch := ""
 	if err == nil {
 		branch = strings.TrimSpace(string(out))
+		if branch == "HEAD" {
+			branch = ""
+		}
 	}
 
 	gitBranchMu.Lock()

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -1243,10 +1243,8 @@ type textContent struct {
 }
 
 // buildCardContent builds a Feishu interactive card JSON using CardKit v2 format.
-// schema:"2.0" is required for the "markdown" tag to work with full markdown rendering.
-// Uses json.NewEncoder with SetEscapeHTML(false) to preserve HTML entities.
 func buildCardContent(text string) string {
-	card := map[string]any{
+	return encodeCard(map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{"wide_screen_mode": true},
 		"body": map[string]any{
@@ -1254,7 +1252,11 @@ func buildCardContent(text string) string {
 				{"tag": "markdown", "content": text},
 			},
 		},
-	}
+	})
+}
+
+// encodeCard serializes a CardKit v2 card to JSON with HTML escaping disabled.
+func encodeCard(card map[string]any) string {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
@@ -1292,26 +1294,11 @@ func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
 	if d.GitBranch != "" {
 		elements = append(elements, tableRow("🌿 Branch", d.GitBranch))
 	}
-	turnDur := ""
-	if d.TurnDurationMs > 0 {
-		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
+	if durStr := messaging.FormatDurationParts(d); durStr != "" {
+		elements = append(elements, tableRow("⏱️ Duration", durStr))
 	}
-	sessDur := ""
-	if d.SessionDuration > 0 {
-		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
-	}
-	if turnDur != "" || sessDur != "" {
-		var dp []string
-		if turnDur != "" {
-			dp = append(dp, turnDur)
-		}
-		if sessDur != "" {
-			dp = append(dp, sessDur)
-		}
-		elements = append(elements, tableRow("⏱️ Duration", strings.Join(dp, " | ")))
-	}
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		elements = append(elements, tableRow("💎 Tokens", formatTokensValue(d)))
+	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {
+		elements = append(elements, tableRow("💎 Tokens", tokStr))
 	}
 
 	if len(elements) == 0 {
@@ -1323,11 +1310,7 @@ func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
 		"config": map[string]any{"wide_screen_mode": true},
 		"body":   map[string]any{"elements": elements},
 	}
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	_ = enc.Encode(card)
-	return strings.TrimRight(buf.String(), "\n")
+	return encodeCard(card)
 }
 
 // tableRow creates a CardKit v2 column_set element with two weighted columns.
@@ -1349,32 +1332,6 @@ func tableRow(label, value string) map[string]any {
 			},
 		},
 	}
-}
-
-// formatTokensValue formats token usage matching Slack's table layout.
-func formatTokensValue(d messaging.TurnSummaryData) string {
-	var tokParts []string
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-		var tp []string
-		if d.TurnInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
-		}
-		if d.TurnOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
-		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
-	}
-	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tp []string
-		if d.TotalInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
-		}
-		if d.TotalOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
-		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
-	}
-	return strings.Join(tokParts, " | ")
 }
 
 // formatSecurityError converts technical security errors into user-friendly messages.

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -650,8 +650,7 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			now := time.Now().UnixMilli()
 			last := c.lastSummarySentMs.Load()
 			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
-				go c.sendTurnSummaryCard(ctx, d)
-				c.lastSummarySentMs.Store(now)
+				go c.sendTurnSummaryCard(d)
 			}
 		}
 
@@ -868,7 +867,7 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 	return c.adapter.sendTextMessage(ctx, chatID, OptimizeMarkdownStyle(SanitizeForCard(text)))
 }
 
-func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSummaryData) {
+func (c *FeishuConn) sendTurnSummaryCard(d messaging.TurnSummaryData) {
 	cardJSON := buildTurnSummaryCard(d)
 	if cardJSON == "" {
 		return
@@ -881,13 +880,15 @@ func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSumm
 	c.mu.RUnlock()
 	var err error
 	if replyToMsgID != "" {
-		err = c.adapter.replyCardJSON(sendCtx, replyToMsgID, cardJSON)
+		err = c.adapter.doReplyCard(sendCtx, replyToMsgID, cardJSON, false)
 	} else {
 		err = c.adapter.sendCardMessage(sendCtx, chatID, cardJSON)
 	}
 	if err != nil {
 		c.adapter.Log.Warn("turn summary card send failed", "err", err)
+		return
 	}
+	c.lastSummarySentMs.Store(time.Now().UnixMilli())
 }
 
 func (c *FeishuConn) sendContextUsage(ctx context.Context, env *events.Envelope) error {
@@ -1073,46 +1074,27 @@ func (a *Adapter) sendTextMessage(ctx context.Context, chatID, text string) erro
 
 //nolint:unparam // replyInThread reserved for future thread reply support
 func (a *Adapter) replyMessage(ctx context.Context, messageID, content string, replyInThread bool) error {
-	if a.larkClient == nil {
-		return fmt.Errorf("feishu: lark client not initialized")
-	}
-
 	cardJSON := buildCardContent(content)
 	preview := cardJSON
 	if len(preview) > 200 {
 		preview = preview[:200] + "..."
 	}
 	a.Log.Debug("feishu: sending reply card", "msg_id", messageID, "content_len", len(cardJSON), "content_preview", preview)
-	body := larkim.NewReplyMessageReqBodyBuilder().
-		MsgType(larkim.MsgTypeInteractive).
-		Content(cardJSON).
-		ReplyInThread(replyInThread).
-		Build()
-
-	req := larkim.NewReplyMessageReqBuilder().
-		MessageId(messageID).
-		Body(body).
-		Build()
-
-	resp, err := a.larkClient.Im.V1.Message.Reply(ctx, req)
-	if err != nil {
-		return fmt.Errorf("feishu: reply message: %w", err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("feishu: reply message failed: code=%d msg=%s", resp.Code, resp.Msg)
+	if err := a.doReplyCard(ctx, messageID, cardJSON, replyInThread); err != nil {
+		return err
 	}
 	a.Log.Debug("feishu: reply message sent", "msg_id", messageID, "content_len", len(content))
 	return nil
 }
 
-// replyCardJSON replies to a message with a pre-built CardKit v2 JSON card.
-func (a *Adapter) replyCardJSON(ctx context.Context, messageID, cardJSON string) error {
+func (a *Adapter) doReplyCard(ctx context.Context, messageID, cardJSON string, replyInThread bool) error {
 	if a.larkClient == nil {
 		return fmt.Errorf("feishu: lark client not initialized")
 	}
 	body := larkim.NewReplyMessageReqBodyBuilder().
 		MsgType(larkim.MsgTypeInteractive).
 		Content(cardJSON).
+		ReplyInThread(replyInThread).
 		Build()
 	req := larkim.NewReplyMessageReqBuilder().
 		MessageId(messageID).

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -639,8 +639,7 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.adapter.Interactions.CancelAll(env.SessionID)
 
 		d := messaging.ExtractTurnSummary(env)
-		summaryText := messaging.FormatTurnSummaryRich(d)
-		if summaryText != "" {
+		if d.TurnCount > 0 || d.ModelName != "" || d.ToolCallCount > 0 {
 			c.adapter.Log.Info("turn summary",
 				"turn_count", d.TurnCount,
 				"duration_ms", d.TurnDurationMs,
@@ -651,14 +650,8 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			now := time.Now().UnixMilli()
 			last := c.lastSummarySentMs.Load()
 			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
-				if streamCtrl != nil && streamCtrl.IsCreated() {
-					if streamCtrl.Write("\n\n---\n"+summaryText) == nil {
-						c.lastSummarySentMs.Store(now)
-					}
-				} else {
-					go c.sendTurnSummaryText(summaryText)
-					c.lastSummarySentMs.Store(now)
-				}
+				go c.sendTurnSummaryCard(ctx, d)
+				c.lastSummarySentMs.Store(now)
 			}
 		}
 
@@ -875,7 +868,11 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 	return c.adapter.sendTextMessage(ctx, chatID, OptimizeMarkdownStyle(SanitizeForCard(text)))
 }
 
-func (c *FeishuConn) sendTurnSummaryText(text string) {
+func (c *FeishuConn) sendTurnSummaryCard(_ context.Context, d messaging.TurnSummaryData) {
+	cardJSON := buildTurnSummaryCard(d)
+	if cardJSON == "" {
+		return
+	}
 	sendCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c.mu.RLock()
@@ -884,12 +881,12 @@ func (c *FeishuConn) sendTurnSummaryText(text string) {
 	c.mu.RUnlock()
 	var err error
 	if replyToMsgID != "" {
-		err = c.adapter.replyMessage(sendCtx, replyToMsgID, text, false)
+		err = c.adapter.replyCardJSON(sendCtx, replyToMsgID, cardJSON)
 	} else {
-		err = c.adapter.sendTextMessage(sendCtx, chatID, text)
+		err = c.adapter.sendCardMessage(sendCtx, chatID, cardJSON)
 	}
 	if err != nil {
-		c.adapter.Log.Warn("turn summary send failed", "err", err)
+		c.adapter.Log.Warn("turn summary card send failed", "err", err)
 	}
 }
 
@@ -1108,6 +1105,29 @@ func (a *Adapter) replyMessage(ctx context.Context, messageID, content string, r
 	return nil
 }
 
+// replyCardJSON replies to a message with a pre-built CardKit v2 JSON card.
+func (a *Adapter) replyCardJSON(ctx context.Context, messageID, cardJSON string) error {
+	if a.larkClient == nil {
+		return fmt.Errorf("feishu: lark client not initialized")
+	}
+	body := larkim.NewReplyMessageReqBodyBuilder().
+		MsgType(larkim.MsgTypeInteractive).
+		Content(cardJSON).
+		Build()
+	req := larkim.NewReplyMessageReqBuilder().
+		MessageId(messageID).
+		Body(body).
+		Build()
+	resp, err := a.larkClient.Im.V1.Message.Reply(ctx, req)
+	if err != nil {
+		return fmt.Errorf("feishu: reply card: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("feishu: reply card failed: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
 const mediaMaxSize = 10 * 1024 * 1024 // 10 MB
 
 // mediaTypeToResourceType maps our internal media types to Feishu resource types.
@@ -1258,6 +1278,121 @@ func buildCardContent(text string) string {
 	enc.SetEscapeHTML(false)
 	_ = enc.Encode(card)
 	return strings.TrimRight(buf.String(), "\n")
+}
+
+// buildTurnSummaryCard builds a CardKit v2 card with column_set rows matching
+// Slack's TableBlock layout: two columns per row (label | value).
+func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
+	var elements []map[string]any
+
+	if d.TurnCount > 0 {
+		elements = append(elements, tableRow("🔄 Turn", fmt.Sprintf("#%d", d.TurnCount)))
+	}
+	if d.ModelName != "" {
+		elements = append(elements, tableRow("🤖 Model", d.ModelName))
+	}
+	if d.ContextWindow > 0 && d.ContextFill > 0 {
+		pct := int(d.ContextPct + 0.5)
+		if pct > 100 {
+			pct = 100
+		}
+		used := messaging.FormatTokenCount(int(d.ContextFill))
+		max := messaging.FormatTokenCount(int(d.ContextWindow))
+		elements = append(elements, tableRow("🧠 Context", fmt.Sprintf("%d%% %s/%s", pct, used, max)))
+	}
+	if d.ToolCallCount > 0 {
+		toolStr := messaging.FormatToolNames(d.ToolNames, d.ToolCallCount)
+		elements = append(elements, tableRow("🔧 Tools", toolStr))
+	}
+	if d.WorkDir != "" {
+		elements = append(elements, tableRow("📂 Dir", messaging.TruncatePath(d.WorkDir, 3)))
+	}
+	if d.GitBranch != "" {
+		elements = append(elements, tableRow("🌿 Branch", d.GitBranch))
+	}
+	turnDur := ""
+	if d.TurnDurationMs > 0 {
+		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
+	}
+	sessDur := ""
+	if d.SessionDuration > 0 {
+		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
+	}
+	if turnDur != "" || sessDur != "" {
+		var dp []string
+		if turnDur != "" {
+			dp = append(dp, turnDur)
+		}
+		if sessDur != "" {
+			dp = append(dp, sessDur)
+		}
+		elements = append(elements, tableRow("⏱️ Duration", strings.Join(dp, " | ")))
+	}
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		elements = append(elements, tableRow("💎 Tokens", formatTokensValue(d)))
+	}
+
+	if len(elements) == 0 {
+		return ""
+	}
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"wide_screen_mode": true},
+		"body":   map[string]any{"elements": elements},
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(card)
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// tableRow creates a CardKit v2 column_set element with two weighted columns.
+func tableRow(label, value string) map[string]any {
+	return map[string]any{
+		"tag": "column_set",
+		"columns": []map[string]any{
+			{
+				"tag":      "column",
+				"width":    "weighted",
+				"weight":   1,
+				"elements": []map[string]any{{"tag": "markdown", "content": "**" + label + "**"}},
+			},
+			{
+				"tag":      "column",
+				"width":    "weighted",
+				"weight":   3,
+				"elements": []map[string]any{{"tag": "markdown", "content": value}},
+			},
+		},
+	}
+}
+
+// formatTokensValue formats token usage matching Slack's table layout.
+func formatTokensValue(d messaging.TurnSummaryData) string {
+	var tokParts []string
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
+		var tp []string
+		if d.TurnInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
+		}
+		if d.TurnOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		var tp []string
+		if d.TotalInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
+		}
+		if d.TotalOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	return strings.Join(tokParts, " | ")
 }
 
 // formatSecurityError converts technical security errors into user-friendly messages.

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -639,20 +639,14 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.adapter.Interactions.CancelAll(env.SessionID)
 
 		d := messaging.ExtractTurnSummary(env)
-		if d.TurnCount > 0 || d.ModelName != "" || d.ToolCallCount > 0 {
-			c.adapter.Log.Info("turn summary",
-				"turn_count", d.TurnCount,
-				"duration_ms", d.TurnDurationMs,
-				"model", d.ModelName,
-				"tool_calls", d.ToolCallCount,
-				"input_tok", d.TotalInputTok,
-			)
-			now := time.Now().UnixMilli()
-			last := c.lastSummarySentMs.Load()
-			if now-last >= messaging.TurnSummaryCooldown.Milliseconds() {
-				go c.sendTurnSummaryCard(d)
-			}
-		}
+		c.adapter.Log.Info("turn summary",
+			"turn_count", d.TurnCount,
+			"duration_ms", d.TurnDurationMs,
+			"model", d.ModelName,
+			"tool_calls", d.ToolCallCount,
+			"input_tok", d.TotalInputTok,
+		)
+		go c.sendTurnSummaryCard(d)
 
 		var closeErr error
 		if streamCtrl != nil && streamCtrl.IsCreated() {
@@ -870,6 +864,15 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 func (c *FeishuConn) sendTurnSummaryCard(d messaging.TurnSummaryData) {
 	cardJSON := buildTurnSummaryCard(d)
 	if cardJSON == "" {
+		return
+	}
+	now := time.Now().UnixMilli()
+	last := c.lastSummarySentMs.Load()
+	if now-last < messaging.TurnSummaryCooldown.Milliseconds() {
+		return
+	}
+	// CAS to win the race: only one goroutine proceeds past the cooldown.
+	if !c.lastSummarySentMs.CompareAndSwap(last, now) {
 		return
 	}
 	sendCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1295,7 +1298,7 @@ func buildTurnSummaryCard(d messaging.TurnSummaryData) string {
 		elements = append(elements, tableRow("🌿 Branch", d.GitBranch))
 	}
 	if durStr := messaging.FormatDurationParts(d); durStr != "" {
-		elements = append(elements, tableRow("⏱️ Duration", durStr))
+		elements = append(elements, tableRow("⏱ Time", durStr))
 	}
 	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {
 		elements = append(elements, tableRow("💎 Tokens", tokStr))

--- a/internal/messaging/feishu/interaction.go
+++ b/internal/messaging/feishu/interaction.go
@@ -2,7 +2,6 @@ package feishu
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -322,11 +321,7 @@ func buildInteractionCard(body, footer string) string {
 		"body":   map[string]any{"elements": elements},
 	}
 
-	var buf strings.Builder
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	_ = enc.Encode(card)
-	return strings.TrimRight(buf.String(), "\n")
+	return encodeCard(card)
 }
 
 // truncate shortens a string to maxLen.

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -515,7 +515,7 @@ func (c *StreamingCardController) sendCardMessage(ctx context.Context, chatID, c
 			},
 		},
 	}
-	contentJSON, _ := json.Marshal(cardContent)
+	contentJSON := encodeCard(cardContent)
 
 	// Group chat: reply to user's message. DM: send directly.
 	c.mu.Lock()
@@ -524,9 +524,9 @@ func (c *StreamingCardController) sendCardMessage(ctx context.Context, chatID, c
 	c.mu.Unlock()
 
 	if isGroup && replyTo != "" {
-		return c.replyCardMessage(ctx, replyTo, string(contentJSON))
+		return c.replyCardMessage(ctx, replyTo, contentJSON)
 	}
-	return c.createCardMessage(ctx, chatID, string(contentJSON))
+	return c.createCardMessage(ctx, chatID, contentJSON)
 }
 
 func (c *StreamingCardController) createCardMessage(ctx context.Context, chatID, contentJSON string) (string, error) {
@@ -707,10 +707,10 @@ func (c *StreamingCardController) flushIMPatch(ctx context.Context, content stri
 			},
 		},
 	}
-	contentJSON, _ := json.Marshal(cardContent)
+	contentJSON := encodeCard(cardContent)
 
 	body := larkim.NewPatchMessageReqBodyBuilder().
-		Content(string(contentJSON)).
+		Content(contentJSON).
 		Build()
 
 	req := larkim.NewPatchMessageReqBuilder().
@@ -750,10 +750,10 @@ func (c *StreamingCardController) flushIMPatchWithConfig(ctx context.Context, co
 			},
 		},
 	}
-	contentJSON, _ := json.Marshal(cardContent)
+	contentJSON := encodeCard(cardContent)
 
 	body := larkim.NewPatchMessageReqBodyBuilder().
-		Content(string(contentJSON)).
+		Content(contentJSON).
 		Build()
 
 	req := larkim.NewPatchMessageReqBuilder().

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -1147,48 +1147,12 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 		table.AddRow(richTextCell("🌿 Branch"), richTextCell(d.GitBranch))
 	}
 	// Duration (merged Turn + Session)
-	turnDur := ""
-	if d.TurnDurationMs > 0 {
-		turnDur = "Turn " + messaging.FormatDuration(d.TurnDurationMs)
-	}
-	sessDur := ""
-	if d.SessionDuration > 0 {
-		sessDur = "Session " + messaging.FormatSessionDuration(d.SessionDuration)
-	}
-	if turnDur != "" || sessDur != "" {
-		dParts := make([]string, 0, 2)
-		if turnDur != "" {
-			dParts = append(dParts, turnDur)
-		}
-		if sessDur != "" {
-			dParts = append(dParts, sessDur)
-		}
-		table.AddRow(richTextCell("⏱️ Duration"), richTextCell(strings.Join(dParts, " | ")))
+	if durStr := messaging.FormatDurationParts(d); durStr != "" {
+		table.AddRow(richTextCell("⏱️ Duration"), richTextCell(durStr))
 	}
 	// Tokens (turn + session total)
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tokParts []string
-		if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-			var tp []string
-			if d.TurnInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s in", messaging.FormatTokenCount(int(d.TurnInputTok))))
-			}
-			if d.TurnOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s out", messaging.FormatTokenCount(int(d.TurnOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-			var tp []string
-			if d.TotalInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s in", messaging.FormatTokenCount(int(d.TotalInputTok))))
-			}
-			if d.TotalOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s out", messaging.FormatTokenCount(int(d.TotalOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		table.AddRow(richTextCell("💎 Tokens"), richTextCell(strings.Join(tokParts, " | ")))
+	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {
+		table.AddRow(richTextCell("💎 Tokens"), richTextCell(tokStr))
 	}
 
 	return []slack.Block{table}

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -1148,7 +1148,7 @@ func (c *SlackConn) buildTurnSummaryTable(d messaging.TurnSummaryData) []slack.B
 	}
 	// Duration (merged Turn + Session)
 	if durStr := messaging.FormatDurationParts(d); durStr != "" {
-		table.AddRow(richTextCell("⏱️ Duration"), richTextCell(durStr))
+		table.AddRow(richTextCell("⏱ Time"), richTextCell(durStr))
 	}
 	// Tokens (turn + session total)
 	if tokStr := messaging.FormatTokenUsage(d); tokStr != "" {

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -274,7 +274,7 @@ func FormatTurnSummaryRich(d TurnSummaryData) string {
 
 	// Line 6: Duration (merged Turn + Session)
 	if durStr := FormatDurationParts(d); durStr != "" {
-		lines = append(lines, "⏱️ "+durStr)
+		lines = append(lines, "⏱ "+durStr)
 	}
 
 	// Line 7: Tokens (turn + session total)
@@ -290,10 +290,10 @@ func FormatTurnSummaryRich(d TurnSummaryData) string {
 func FormatDurationParts(d TurnSummaryData) string {
 	var parts []string
 	if d.TurnDurationMs > 0 {
-		parts = append(parts, "Turn "+FormatDuration(d.TurnDurationMs))
+		parts = append(parts, FormatDuration(d.TurnDurationMs))
 	}
-	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
-		parts = append(parts, "Session "+sessDur)
+	if d.SessionDuration > 0 {
+		parts = append(parts, "Σ "+FormatSessionDuration(d.SessionDuration))
 	}
 	return strings.Join(parts, " · ")
 }
@@ -308,22 +308,22 @@ func FormatTokenUsage(d TurnSummaryData) string {
 	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
 		var tp []string
 		if d.TurnInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s in", FormatTokenCount(int(d.TurnInputTok))))
+			tp = append(tp, FormatTokenCount(int(d.TurnInputTok))+"↓")
 		}
 		if d.TurnOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("%s out", FormatTokenCount(int(d.TurnOutputTok))))
+			tp = append(tp, FormatTokenCount(int(d.TurnOutputTok))+"↑")
 		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
+		tokParts = append(tokParts, strings.Join(tp, " "))
 	}
 	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
 		var tp []string
 		if d.TotalInputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s in", FormatTokenCount(int(d.TotalInputTok))))
+			tp = append(tp, "Σ"+FormatTokenCount(int(d.TotalInputTok))+"↓")
 		}
 		if d.TotalOutputTok > 0 {
-			tp = append(tp, fmt.Sprintf("Σ %s out", FormatTokenCount(int(d.TotalOutputTok))))
+			tp = append(tp, "Σ"+FormatTokenCount(int(d.TotalOutputTok))+"↑")
 		}
-		tokParts = append(tokParts, strings.Join(tp, " · "))
+		tokParts = append(tokParts, strings.Join(tp, " "))
 	}
 	return strings.Join(tokParts, " | ")
 }

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -223,15 +223,11 @@ func TruncatePath(p string, maxComponents int) string {
 			parts = append(parts, s)
 		}
 	}
-	sep := "/"
-	if prefix == "~" {
-		sep = "/"
-	}
 	if len(parts) <= maxComponents {
-		return prefix + sep + strings.Join(parts, "/")
+		return prefix + "/" + strings.Join(parts, "/")
 	}
 	kept := parts[len(parts)-maxComponents:]
-	return prefix + sep + strings.Join(kept, "/")
+	return prefix + "/" + strings.Join(kept, "/")
 }
 
 // FormatTurnSummaryRich produces a multi-line turn summary with each metric on its own line.

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -273,42 +273,57 @@ func FormatTurnSummaryRich(d TurnSummaryData) string {
 	}
 
 	// Line 6: Duration (merged Turn + Session)
-	var durParts []string
-	if d.TurnDurationMs > 0 {
-		durParts = append(durParts, "Turn "+FormatDuration(d.TurnDurationMs))
-	}
-	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
-		durParts = append(durParts, "Session "+sessDur)
-	}
-	if len(durParts) > 0 {
-		lines = append(lines, "⏱️ "+strings.Join(durParts, " · "))
+	if durStr := FormatDurationParts(d); durStr != "" {
+		lines = append(lines, "⏱️ "+durStr)
 	}
 
 	// Line 7: Tokens (turn + session total)
-	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 || d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-		var tokParts []string
-		if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
-			var tp []string
-			if d.TurnInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s in", FormatTokenCount(int(d.TurnInputTok))))
-			}
-			if d.TurnOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("%s out", FormatTokenCount(int(d.TurnOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
-			var tp []string
-			if d.TotalInputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s in", FormatTokenCount(int(d.TotalInputTok))))
-			}
-			if d.TotalOutputTok > 0 {
-				tp = append(tp, fmt.Sprintf("Σ %s out", FormatTokenCount(int(d.TotalOutputTok))))
-			}
-			tokParts = append(tokParts, strings.Join(tp, " · "))
-		}
-		lines = append(lines, "💎 "+strings.Join(tokParts, " | "))
+	if tokStr := FormatTokenUsage(d); tokStr != "" {
+		lines = append(lines, "💎 "+tokStr)
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// FormatDurationParts returns a formatted duration string combining turn and session durations.
+// Returns empty string if no duration data is available.
+func FormatDurationParts(d TurnSummaryData) string {
+	var parts []string
+	if d.TurnDurationMs > 0 {
+		parts = append(parts, "Turn "+FormatDuration(d.TurnDurationMs))
+	}
+	if sessDur := FormatSessionDuration(d.SessionDuration); sessDur != "" {
+		parts = append(parts, "Session "+sessDur)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// FormatTokenUsage returns a formatted token usage string with turn and total breakdowns.
+// Returns empty string if no token data is available.
+func FormatTokenUsage(d TurnSummaryData) string {
+	if d.TurnInputTok <= 0 && d.TurnOutputTok <= 0 && d.TotalInputTok <= 0 && d.TotalOutputTok <= 0 {
+		return ""
+	}
+	var tokParts []string
+	if d.TurnInputTok > 0 || d.TurnOutputTok > 0 {
+		var tp []string
+		if d.TurnInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s in", FormatTokenCount(int(d.TurnInputTok))))
+		}
+		if d.TurnOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("%s out", FormatTokenCount(int(d.TurnOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	if d.TotalInputTok > 0 || d.TotalOutputTok > 0 {
+		var tp []string
+		if d.TotalInputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s in", FormatTokenCount(int(d.TotalInputTok))))
+		}
+		if d.TotalOutputTok > 0 {
+			tp = append(tp, fmt.Sprintf("Σ %s out", FormatTokenCount(int(d.TotalOutputTok))))
+		}
+		tokParts = append(tokParts, strings.Join(tp, " · "))
+	}
+	return strings.Join(tokParts, " | ")
 }

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -309,15 +309,15 @@ func TestFormatTurnSummaryRich_Full(t *testing.T) {
 	require.Contains(t, got, "🔧 12 (")
 	require.Contains(t, got, "📂")
 	require.Contains(t, got, "🌿 feat/117-turn-summary")
-	require.Contains(t, got, "⏱️ Turn 42s · Session 12m30s")
+	require.Contains(t, got, "⏱ 42s · Σ 12m30s")
 	require.Contains(t, got, "💎")
-	require.Contains(t, got, "12K in · 2K out | Σ 48.4K in · Σ 2K out")
+	require.Contains(t, got, "12K↓ 2K↑ | Σ48.4K↓ Σ2K↑")
 }
 
 func TestFormatTurnSummaryRich_Minimal(t *testing.T) {
 	t.Parallel()
 	got := FormatTurnSummaryRich(TurnSummaryData{TurnDurationMs: 3000})
-	require.Contains(t, got, "⏱️ Turn 3s")
+	require.Contains(t, got, "⏱ 3s")
 }
 
 func TestFormatTurnSummaryRich_Empty(t *testing.T) {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -582,8 +582,8 @@ func (w *Worker) readSSE(ctx context.Context, sessionID string) {
 		}
 	}()
 
-	url := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	sseURL := fmt.Sprintf("%s/events?session_id=%s", w.httpAddr, url.QueryEscape(sessionID))
+	req, err := http.NewRequestWithContext(ctx, "GET", sseURL, http.NoBody)
 	if err != nil {
 		w.Log.Error("opencodeserver: create SSE request", "session_id", sessionID, "err", err)
 		return
@@ -828,8 +828,8 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return fmt.Errorf("opencodeserver: marshal input: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
-	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payload)))
+	msgURL := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(c.sessionID))
+	req, err := http.NewRequestWithContext(ctx, "POST", msgURL, strings.NewReader(string(payload)))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

Consolidates PRs #190 #192 #193 into a single batch.

1. **Style cleanup** — remove dead `sep` variable in TruncatePath, rename local `url` vars to avoid shadowing `net/url` package
2. **Interaction fix** — inject OwnerID into worker envelopes to fix interaction responses
3. **Feishu turn summary card** — dedicated CardKit v2 column_set card, shared format helpers, deduplicate token/duration formatting across platforms

### Changes

- `internal/messaging/turn_summary.go` — add `FormatDurationParts`, `FormatTokenUsage`, simplify `FormatTurnSummaryRich`
- `internal/messaging/feishu/adapter.go` — independent CardKit v2 card, `doReplyCard`, `encodeCard` extraction, cooldown fix
- `internal/messaging/slack/adapter.go` — use shared duration/token helpers
- `internal/worker/opencodeserver/worker.go` — fix `url` variable shadowing
- `internal/gateway/bridge.go` — inject OwnerID

**架构影响**：
- Channel: 飞书 / Slack
- Worker: OCS / CC

## Test Plan

- [x] make test
- [x] make lint

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)