### PR TITLE
Batch: reliability hardening — panic recovery, data race, FD leak fixes (#202, #219, #210)

### DIFF
--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -90,6 +90,10 @@ func NewCollector(store EventStore, log *slog.Logger) *Collector {
 func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, data json.RawMessage, direction, source string) {
 	if eventType == events.MessageDelta {
 		c.accumMu.Lock()
+		if c.accum == nil {
+			c.accumMu.Unlock()
+			return
+		}
 		acc := c.accum[sessionID]
 		if acc == nil {
 			acc = newDeltaAccumulator()
@@ -256,6 +260,10 @@ func (c *Collector) flushBatch(batch []*captureRequest) {
 // Flushes immediately when accumulated content exceeds deltaFlushSize.
 func (c *Collector) CaptureDeltaString(sessionID string, seq int64, content string) {
 	c.accumMu.Lock()
+	if c.accum == nil {
+		c.accumMu.Unlock()
+		return
+	}
 	acc := c.accum[sessionID]
 	if acc == nil {
 		acc = newDeltaAccumulator()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -376,9 +376,15 @@ func (m *Manager) TransitionWithInput(ctx context.Context, id string, to events.
 		if maxTurns > 0 && ms.TurnCount > maxTurns {
 			m.log.Warn("session: max turns exceeded, initiating anti-pollution restart",
 				"session_id", id, "turn_count", ms.TurnCount, "max_turns", maxTurns)
-			_ = ms.worker.Kill()
+			if err := ms.worker.Kill(); err != nil {
+				m.log.Warn("session: worker kill failed during max-turns cleanup",
+					"session_id", id, "err", err)
+			}
 			if events.IsValidTransition(from, events.StateTerminated) {
-				_ = m.transitionState(ctx, ms, from, events.StateTerminated, "max_turns")
+				if err := m.transitionState(ctx, ms, from, events.StateTerminated, "max_turns"); err != nil {
+					m.log.Error("session: max-turns state transition failed, session may be orphaned",
+						"session_id", id, "err", err)
+				}
 			}
 			return ErrMaxTurnsReached
 		}
@@ -701,7 +707,10 @@ func (m *Manager) ListActive() []*SessionInfo {
 
 	sessions := make([]*SessionInfo, 0, len(m.sessions))
 	for _, ms := range m.sessions {
-		sessions = append(sessions, &ms.info)
+		ms.mu.RLock()
+		info := ms.info
+		ms.mu.RUnlock()
+		sessions = append(sessions, &info)
 	}
 	return sessions
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -88,7 +88,10 @@ func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
 		string(ctxJSON),
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("session store: upsert: %w", err)
+	}
+	return nil
 }
 
 type rowScanner interface{ Scan(dest ...any) error }
@@ -122,7 +125,9 @@ func scanSession(sc rowScanner) (*SessionInfo, error) {
 		}
 	}
 	if platformKeyStr.Valid && platformKeyStr.String != "" {
-		_ = json.Unmarshal([]byte(platformKeyStr.String), &info.PlatformKey)
+		if err := json.Unmarshal([]byte(platformKeyStr.String), &info.PlatformKey); err != nil {
+			return nil, fmt.Errorf("session store: unmarshal platform key: %w", err)
+		}
 	}
 	return &info, nil
 }
@@ -152,6 +157,7 @@ func (s *SQLiteStore) List(ctx context.Context, userID, platform string, limit, 
 	for rows.Next() {
 		si, err := scanSession(rows)
 		if err != nil {
+			s.log.Warn("session store: skipping corrupted row", "err", err)
 			continue
 		}
 		sessions = append(sessions, si)

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -573,6 +574,10 @@ func (w *Worker) readOutput(ctx context.Context) {
 	// close the OLD Conn that it was actually reading from.
 	entryConn := w.Conn()
 	defer func() {
+		if r := recover(); r != nil {
+			w.BaseWorker.Log.Error("claudecode: readOutput panic",
+				"session_id", w.sessionID, "panic", r, "stack", string(debug.Stack()))
+		}
 		if entryConn != nil {
 			_ = entryConn.Close()
 		}

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -255,6 +255,7 @@ func (s *SingletonProcessManager) discoverPort(stdout *os.File, timeout time.Dur
 	ch := make(chan result, 1)
 
 	go func() {
+		defer func() { _ = stdout.Close() }()
 		scanner := bufio.NewScanner(stdout)
 		deadline := time.After(timeout)
 		for scanner.Scan() {

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -205,6 +205,7 @@ func (m *Manager) Terminate(ctx context.Context, gracePeriod time.Duration) erro
 	case <-done:
 		m.captureExitCode()
 		m.untrackPID(pidKey)
+		_ = m.Close()
 		return nil
 	case <-timer.C:
 		m.log.Warn("proc: graceful shutdown timeout, force killing", "pgid", pgid)
@@ -217,9 +218,9 @@ func (m *Manager) Terminate(ctx context.Context, gracePeriod time.Duration) erro
 // Kill force-kills the entire process group.
 func (m *Manager) Kill() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if !m.started || m.exited {
+		m.mu.Unlock()
 		return nil
 	}
 
@@ -234,6 +235,9 @@ func (m *Manager) Kill() error {
 	_ = m.cmd.Wait()
 	m.captureExitCodeLocked()
 	m.untrackPID(m.pidKey)
+	m.mu.Unlock()
+
+	_ = m.Close()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR implements 9 reliability hardening fixes across 3 issues (6 files, +39/-6 lines):

- **#202**: session data race + error handling gaps (5 fixes)
- **#219**: worker panic recovery + FD leaks (3 fixes)
- **#210**: eventstore nil map panic after Close

All fixes verified against current codebase. Each commit is atomic and independently valid.

Closes #202, #219, #210

## Changes by Issue

### #202 — fix(session): data race in ListActive and error handling gaps (3804f8f)

**Problem**: Five reliability issues in session module.

**Fixes**:
- `ListActive` now acquires `ms.mu.RLock` and performs value copy before returning, preventing data race on `SessionInfo` fields
- `TransitionWithInput` max-turns cleanup now logs `worker.Kill()` failures at Warn level and `transitionState()` failures at Error level with "session may be orphaned" message
- `scanSession` no longer silently discards platformKey JSON unmarshal errors — returns wrapped error matching context unmarshal pattern
- `List()` now logs a warning when `scanSession` fails, making corrupted rows observable
- `Upsert` wraps error with `"session store: upsert:"` prefix, consistent with all other store methods

**Impact**: Eliminates verified data race, makes silent failures observable, improves error consistency.

### #219 — fix(worker): panic recovery in readOutput and FD leaks in process lifecycle (7cac31d)

**Problem**: Three reliability issues in worker module.

**Fixes**:
- `claudecode/readOutput` goroutine now has `defer recover()` + `debug.Stack()` logging, matching the existing `readSSE` (opencodeserver) and `drainStderr` (proc) patterns
- `proc.Manager.Terminate()` and `Kill()` now call `Close()` after process exit, releasing parent-side stdin/stdout/stderr file descriptors
- `opencodeserver.discoverPort` goroutine now closes stdout FD after port discovery

**Impact**: Prevents silent goroutine crash, eliminates FD leaks (3 FDs per session + 1 per singleton lifecycle).

### #210 — fix(eventstore): nil map panic guard in Collector after Close (76173a7)

**Problem**: `Collector.Close()` sets `c.accum = nil`, but `Capture()` and `CaptureDeltaString()` can still write to the nil map if events arrive after Close — causing runtime panic.

**Fixes**:
- Added nil guard at the top of `Capture()` and `CaptureDeltaString()`: if `c.accum == nil` after acquiring lock, unlock and return early

**Impact**: Prevents potential production panic during gateway shutdown.

## Test Plan

- [x] All unit tests pass (`go test -short ./internal/session/... ./internal/eventstore/... ./internal/worker/...`)
- [x] Linter passes (0 issues)
- [x] Build passes
- [x] Pre-push quality gates: fmt + lint + vet + build + test

## Breaking Changes

None. All changes are backwards compatible.