### PR TITLE
Batch: reliability hardening — panic recovery + error propagation (#216, #218)

### DIFF
--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -288,13 +288,13 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	var exitCode int
 	ch := make(chan struct{})
 	go func() {
+		defer close(ch)
 		defer func() {
 			if r := recover(); r != nil {
-				b.log.Error("bridge: panic in Wait goroutine", "session_id", p.sessionID, "panic", r, "stack", string(debug.Stack()))
+				b.log.Error("bridge: panic in waitWorker", "session_id", p.sessionID, "panic", r, "stack", string(debug.Stack()))
 			}
 		}()
 		exitCode, _ = w.Wait()
-		close(ch)
 	}()
 	select {
 	case <-ch:

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -288,6 +288,11 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	var exitCode int
 	ch := make(chan struct{})
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				b.log.Error("bridge: panic in Wait goroutine", "session_id", p.sessionID, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
 		exitCode, _ = w.Wait()
 		close(ch)
 	}()

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -463,9 +463,8 @@ func (c *Conn) WritePump() {
 	defer func() {
 		if r := recover(); r != nil {
 			c.log.Error("gateway: panic in WritePump", "session_id", c.sessionID, "panic", r, "stack", string(debug.Stack()))
-			c.mu.Lock()
 			c.closed = true
-			c.mu.Unlock()
+			close(c.done)
 		}
 	}()
 

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -460,6 +460,14 @@ func (c *Conn) sendInitError(code events.ErrorCode, msg string) {
 func (c *Conn) WritePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()
+	defer func() {
+		if r := recover(); r != nil {
+			c.log.Error("gateway: panic in WritePump", "session_id", c.sessionID, "panic", r, "stack", string(debug.Stack()))
+			c.mu.Lock()
+			c.closed = true
+			c.mu.Unlock()
+		}
+	}()
 
 	for {
 		select {

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -168,6 +168,11 @@ func TestHandleInput_Success(t *testing.T) {
 	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
 	require.NoError(t, err)
 
+	w := new(mockWorkerForHandler)
+	w.On("Input", mock.Anything, "hello", mock.Anything).Return(nil)
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(sid, w)
+
 	env := inputEnvelope(sid, "hello")
 	err = handler.handleInput(context.Background(), env)
 	require.NoError(t, err)
@@ -218,6 +223,11 @@ func TestHandleInput_RunningSession_AcceptsInput(t *testing.T) {
 	// When session is RUNNING, handleInput delivers input to worker without error.
 	// This tests the fix: handleInput no longer tries TransitionWithInput for RUNNING,
 	// avoiding the invalid transition error.
+	w := new(mockWorkerForHandler)
+	w.On("Input", mock.Anything, "hello", mock.Anything).Return(nil)
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(sid, w)
+
 	env := inputEnvelope(sid, "hello")
 	err = handler.handleInput(context.Background(), env)
 	// No error — input is accepted and delivered to worker.
@@ -517,6 +527,11 @@ func TestHandle_InputRoute(t *testing.T) {
 	const sid = "sess_handle"
 	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
 	require.NoError(t, err)
+
+	w := new(mockWorkerForHandler)
+	w.On("Input", mock.Anything, "test", mock.Anything).Return(nil)
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(sid, w)
 
 	env := inputEnvelope(sid, "test")
 	err = handler.Handle(context.Background(), env)

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -216,17 +216,16 @@ func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {
 		}
 		if err := w.Input(ctx, content, nil); err != nil {
 			h.log.Warn("gateway: worker input", "err", err, "session_id", env.SessionID)
-			_ = h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker input failed: %v", err)
-		} else {
-			h.log.Debug("gateway: input delivered to worker", "session_id", env.SessionID)
-			// Capture inbound event for replay (best-effort).
-			if h.bridge != nil {
-				h.bridge.CaptureInbound(env.SessionID, env.Seq, events.Input, env.Event.Data)
-			}
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker input failed: %v", err)
+		}
+		h.log.Debug("gateway: input delivered to worker", "session_id", env.SessionID)
+		// Capture inbound event for replay (best-effort).
+		if h.bridge != nil {
+			h.bridge.CaptureInbound(env.SessionID, env.Seq, events.Input, env.Event.Data)
 		}
 	} else {
 		h.log.Warn("gateway: handleInput no worker found", "session_id", env.SessionID)
-		_ = h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "no worker attached to session")
+		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "no worker attached to session")
 	}
 
 	return nil

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -378,6 +378,11 @@ func (h *Hub) HandleHTTP(
 // The broadcast channel is never closed — sendBroadcast uses ctx.Done() to
 // detect shutdown, and this function drains remaining messages non-blockingly.
 func (h *Hub) Run() {
+	defer func() {
+		if r := recover(); r != nil {
+			h.log.Error("hub: panic in Run", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	// Start periodic cleanup for throttler
 	throttleCleanup := time.NewTicker(10 * time.Minute)
 	defer throttleCleanup.Stop()

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -137,6 +137,11 @@ func (a *Adapter) newEventHandler() *dispatcher.EventDispatcher {
 }
 
 func (a *Adapter) runWebSocket(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("feishu: panic in runWebSocket", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	baseDelay := a.BackoffBaseDelay
 	if baseDelay <= 0 {
 		baseDelay = 2 * time.Second

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -334,6 +335,11 @@ func (c *StreamingCardController) startFlushLoop() {
 
 func (c *StreamingCardController) flushLoop() {
 	defer c.flushWg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			c.log.Error("feishu: panic in flushLoop", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(flushInterval)
 	defer ticker.Stop()
 

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -149,6 +149,11 @@ func (a *Adapter) Start(ctx context.Context) error {
 
 	// Async probe for Assistant API capability
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				a.Log.Error("slack: panic in assistant probe", "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
 		probeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		capable := a.ProbeAssistantCapability(probeCtx)
@@ -167,6 +172,11 @@ func (a *Adapter) Start(ctx context.Context) error {
 }
 
 func (a *Adapter) runSocketMode(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("slack: panic in runSocketMode", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	baseDelay := a.BackoffBaseDelay
 	if baseDelay <= 0 {
 		baseDelay = 1 * time.Second
@@ -180,6 +190,11 @@ func (a *Adapter) runSocketMode(ctx context.Context) {
 	// Run() blocks until the WebSocket closes. Wrap it in a loop so that
 	// connection errors trigger automatic reconnect instead of silently exiting.
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				a.Log.Error("slack: panic in socketMode reconnect loop", "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
 		attempt := 1
 		for {
 			select {
@@ -1049,6 +1064,11 @@ func (c *SlackConn) Close() error {
 }
 
 func (a *Adapter) cleanupMedia(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("slack: panic in cleanupMedia", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(mediaCleanupInt)
 	defer ticker.Stop()
 

--- a/internal/messaging/stt/stt.go
+++ b/internal/messaging/stt/stt.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -374,6 +375,11 @@ func (s *PersistentSTT) isAlive() bool {
 
 // idleMonitor auto-shuts down the subprocess after idle TTL.
 func (s *PersistentSTT) idleMonitor(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.Error("stt: panic in idleMonitor", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	defer close(s.done)
 
 	ticker := time.NewTicker(30 * time.Second)


### PR DESCRIPTION
## Summary

This PR implements panic recovery and error propagation fixes across gateway and messaging modules (9 files, +77/-8 lines):

- **#216**: gateway panic recovery in 3 goroutines + handler error propagation
- **#218**: messaging panic recovery in 7 background goroutines

All quality gates pass: fmt + lint + vet + test + build.

Closes #216, #218

## Changes by Issue

### #216 — fix(gateway): panic recovery + error propagation (75c5924)

**Panic recovery** (3 goroutines):
- `conn.go WritePump`: add `defer recover()` + graceful close (`c.closed = true`), matching `ReadPump` pattern
- `hub.go Hub.Run`: add top-level `defer recover()` to protect `drainBroadcast()` and `throttleCleanup` paths (inner `routeMessage` closure already had recovery)
- `bridge_forward.go` w.Wait goroutine: add `defer recover()` to prevent silent goroutine crash

**Error propagation**:
- `handler.go handleInput`: return error instead of `nil` when `worker.Input()` fails or no worker is attached, so callers can distinguish success from failure
- `ctrl_test.go`: attach mock workers to 3 tests that now correctly receive errors

### #218 — fix(messaging): panic recovery in 7 goroutines (b730e87)

All follow the established pattern of `defer recover()` + `log.Error` + `debug.Stack()`:

| Goroutine | File | Function |
|-----------|------|----------|
| Assistant probe | slack/adapter.go | One-shot startup goroutine |
| SocketMode reconnect | slack/adapter.go | `socketMode.Run()` wrapper |
| runSocketMode | slack/adapter.go | Main Slack adapter goroutine |
| cleanupMedia | slack/adapter.go | Periodic filesystem cleanup |
| flushLoop | feishu/streaming.go | Card streaming update loop |
| runWebSocket | feishu/adapter.go | Main Feishu adapter goroutine |
| idleMonitor | stt/stt.go | STT process idle monitor |

## Test Plan

- [x] All unit tests pass (`go test -short ./internal/gateway/... ./internal/messaging/...`)
- [x] Linter passes (0 issues)
- [x] Build passes
- [x] Pre-push quality gates: fmt + lint + vet + test + build

## Breaking Changes

None. All changes are backwards compatible.