### PR TITLE
fix(skills): use sync.Once to prevent panic on double Close()

### DIFF
--- a/internal/skills/locator.go
+++ b/internal/skills/locator.go
@@ -20,11 +20,12 @@ type cacheEntry struct {
 
 // Locator discovers skills from the filesystem with TTL-based caching.
 type Locator struct {
-	log    *slog.Logger
-	cache  map[string]*cacheEntry
-	mu     sync.RWMutex
-	ttl    time.Duration
-	stopCh chan struct{}
+	log       *slog.Logger
+	cache     map[string]*cacheEntry
+	mu        sync.RWMutex
+	ttl       time.Duration
+	stopCh    chan struct{}
+	closeOnce sync.Once
 }
 
 // NewLocator creates a skill locator with TTL cache.
@@ -72,8 +73,11 @@ func (l *Locator) List(_ context.Context, homeDir, workDir string) ([]Skill, err
 }
 
 // Close stops the background sweep goroutine.
+// It is safe to call multiple times (uses sync.Once).
 func (l *Locator) Close() {
-	close(l.stopCh)
+	l.closeOnce.Do(func() {
+		close(l.stopCh)
+	})
 }
 
 func (l *Locator) sweep() {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -62,6 +62,16 @@ func TestLocator_Close(t *testing.T) {
 	require.NotPanics(t, func() { l.Close() })
 }
 
+func TestLocator_DoubleClose_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	l := NewLocator(slog.Default(), time.Minute)
+	// First close should not panic
+	require.NotPanics(t, func() { l.Close() })
+	// Second close should also not panic (sync.Once guarantees single execution)
+	require.NotPanics(t, func() { l.Close() })
+}
+
 func TestLocator_EvictOldest(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #232 - uses sync.Once to prevent panic when Locator.Close() is called twice