### PR TITLE
fix(skills): Locator lifecycle — close on shutdown, log sweep exit

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -191,12 +191,14 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		WorkerEnvBlocklist: cfg.Worker.EnvBlocklist,
 	})
 
+	skillsLocator := skills.NewLocator(log, cfg.Skills.CacheTTL)
+
 	handler := gateway.NewHandler(gateway.HandlerDeps{
 		Log:           log,
 		Hub:           hub,
 		SM:            sm,
 		JWTValidator:  jwtValidator,
-		SkillsLocator: skills.NewLocator(log, cfg.Skills.CacheTTL),
+		SkillsLocator: skillsLocator,
 	})
 
 	if cfg.Worker.AutoRetry.Enabled {
@@ -317,7 +319,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	}
 
 	cancel()
-	shutdownGateway(ctx, log, deps, msgAdapters, server, jwtValidator, pidTracker, cleanupWG)
+	shutdownGateway(ctx, log, deps, msgAdapters, server, jwtValidator, skillsLocator, pidTracker, cleanupWG)
 	return nil
 }
 
@@ -429,6 +431,7 @@ func shutdownGateway(
 	msgAdapters []messaging.PlatformAdapterInterface,
 	server *http.Server,
 	jwtValidator *security.JWTValidator,
+	skillsLocator *skills.Locator,
 	pidTracker *proc.Tracker,
 	cleanupWG *sync.WaitGroup,
 ) {
@@ -443,6 +446,8 @@ func shutdownGateway(
 	if err := deps.Hub.Shutdown(shutdownCtx); err != nil {
 		log.Warn("gateway: hub shutdown", "err", err)
 	}
+
+	skillsLocator.Close()
 
 	if deps.ConfigWatcher != nil {
 		_ = deps.ConfigWatcher.Close()

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -36,6 +36,7 @@ type Handler struct {
 // SkillsLocator discovers skills from the filesystem.
 type SkillsLocator interface {
 	List(ctx context.Context, homeDir, workDir string) ([]skills.Skill, error)
+	Close()
 }
 
 // NewHandler creates a new message handler.

--- a/internal/skills/locator.go
+++ b/internal/skills/locator.go
@@ -95,6 +95,7 @@ func (l *Locator) sweep() {
 			}
 			l.mu.Unlock()
 		case <-l.stopCh:
+			l.log.Debug("skills: sweep goroutine stopped")
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

- **Issue 1**: `SkillsLocator.Close()` was never called in `shutdownGateway`, causing goroutine + memory leak on every gateway stop/restart. Added `Close()` to `SkillsLocator` interface and call it in the shutdown sequence.
- **Issue 2**: `sweep()` goroutine exited silently via `<-stopCh` with no log. Added `Debug` log on exit for shutdown observability.

## Changes

| File | Change |
|------|--------|
| `internal/gateway/handler.go:38` | Add `Close()` to `SkillsLocator` interface |
| `cmd/hotplex/gateway_run.go:199` | Store `*Locator` as local var for shutdown access |
| `cmd/hotplex/gateway_run.go:322,434,449` | Pass locator to `shutdownGateway`, call `Close()` after hub shutdown |
| `internal/skills/locator.go:98` | Add `Debug` log when sweep goroutine stops |

## Test plan

- [x] `make check` — lint + test + build 全部通过
- [ ] 手动验证：启动 gateway → `Ctrl+C` → 确认日志输出 `skills: sweep goroutine stopped`

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)