### PR TITLE
Batch: worker/admin fixes for issues #269, #225, #272

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HotPlex 项目知识库
 
-**最后更新**: 2026-05-07 · **分支**: main · **版本**: v1.7.0
+**最后更新**: 2026-05-08 · **分支**: main · **版本**: v1.7.0
 
 ---
 
@@ -150,7 +150,7 @@ cp configs/env.example .env
 - `claudecode/` - Claude Code 适配器 (stdio, `--print --session-id`)
 - `opencodeserver/` - Open Code Server 适配器（单例进程, HTTP+SSE）
 - `proc/` - 跨平台进程生命周期管理 (PGID/Job Object)
-- `base/` - 共享 BaseWorker + Conn
+- `base/` - 共享 BaseWorker + Conn + MetadataHandler
 
 **支撑模块**：
 - `config/` - Viper 配置 + 热重载 + 继承 + 审计/回滚
@@ -466,18 +466,17 @@ hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark
 | `init_test.go` (brain) | 1472 |
 | `conn_test.go` | 1424 |
 | `adapter.go` (feishu) | 1384 |
-| `wizard.go` (onboard) | 1377 |
+| `wizard.go` (onboard) | 1380 |
 | `adapter.go` (slack) | 1366 |
 | `guard_test.go` (brain) | 1179 |
 | `hub_test.go` | 1172 |
+| `handler_test.go` | 1105 |
 | `memory_test.go` (brain) | 1062 |
 | `commands_test.go` (ocs) | 1050 |
 | `router_test.go` (brain) | 1035 |
-| `handler_test.go` | 1000 |
 | `manager.go` | 998 |
 | `e2e_test.go` (slack) | 970 |
-| `config.go` | 952 |
-| `worker.go` (ocs) | 873 |
+| `worker.go` (ocs) | 878 |
 | `streaming.go` (feishu) | 870 |
-| `worker.go` (claudecode) | 855 |
-| `handler.go` | 840 |
+| `worker.go` (claudecode) | 846 |
+| `handler.go` | 843 |

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/config"
@@ -73,8 +74,8 @@ type AdminAPI struct {
 	hub           HubProvider
 	bridge        BridgeProvider
 	configWatcher ConfigWatcherProvider
-	rateLimiter   *simpleRateLimiter
-	allowedCIDRs  []string
+	rateLimiter   atomic.Value // *simpleRateLimiter
+	allowedCIDRs  atomic.Value // []string
 	version       func() string
 	newSessionID  func() string
 }
@@ -130,16 +131,16 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 			}
 		}()
 
-		if a.rateLimiter != nil {
-			if !a.rateLimiter.Allow() {
+		if rl, _ := a.rateLimiter.Load().(*simpleRateLimiter); rl != nil {
+			if !rl.Allow() {
 				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 				return
 			}
 		}
 
-		if len(a.allowedCIDRs) > 0 {
+		if cidrs, _ := a.allowedCIDRs.Load().([]string); len(cidrs) > 0 {
 			addr := clientIP(r)
-			if !ipAllowed(addr, a.allowedCIDRs) {
+			if !ipAllowed(addr, cidrs) {
 				a.log.Warn("admin: IP not whitelisted", "ip", addr)
 				http.Error(w, "IP not allowed", http.StatusForbidden)
 				return
@@ -184,9 +185,9 @@ func (a *AdminAPI) validateToken(token string) ([]string, bool) {
 }
 
 func (a *AdminAPI) SetRateLimiter(rl *simpleRateLimiter) {
-	a.rateLimiter = rl
+	a.rateLimiter.Store(rl)
 }
 
 func (a *AdminAPI) SetAllowedCIDRs(cidrs []string) {
-	a.allowedCIDRs = cidrs
+	a.allowedCIDRs.Store(cidrs)
 }

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -16,7 +16,9 @@ func (a *AdminAPI) HandleStats(w http.ResponseWriter, r *http.Request) {
 	total, _, _ := a.sm.Stats()
 	sessions, err := a.sm.List(r.Context(), "", "", 0, 0)
 	if err != nil {
-		a.log.Warn("admin: failed to list sessions", "err", err)
+		a.log.Error("admin: failed to list sessions for stats", "err", err)
+		http.Error(w, "failed to query sessions", http.StatusServiceUnavailable)
+		return
 	}
 
 	byType := make(map[string]map[string]any)
@@ -267,8 +269,8 @@ func (a *AdminAPI) HandleDebugSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snap, dbgErr := a.sm.DebugSnapshot(id)
-	if !dbgErr {
+	snap, dbgOK := a.sm.DebugSnapshot(id)
+	if !dbgOK {
 		a.log.Warn("admin: failed to get debug snapshot", "session_id", id)
 	}
 
@@ -276,6 +278,7 @@ func (a *AdminAPI) HandleDebugSession(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]any{
 		"session": siMap,
 		"debug": map[string]any{
+			"available":     dbgOK,
 			"has_worker":    snap.HasWorker,
 			"turn_count":    snap.TurnCount,
 			"last_seq_sent": a.hub.NextSeqPeek(id),

--- a/internal/worker/base/metadata.go
+++ b/internal/worker/base/metadata.go
@@ -1,0 +1,39 @@
+package base
+
+import "context"
+
+// MetadataHandler dispatches control responses extracted from Input metadata.
+// Both ClaudeCode (stdin control) and OCS (HTTP POST) adapters implement this
+// to unify the metadata type-switch pattern.
+type MetadataHandler interface {
+	HandlePermissionResponse(ctx context.Context, reqID string, allowed bool, reason string) error
+	HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error
+	HandleElicitationResponse(ctx context.Context, reqID string, action string, content map[string]any) error
+}
+
+// DispatchMetadata checks metadata for control response keys and dispatches
+// to the handler. Returns (true, nil) if handled, (false, nil) if no match,
+// or (true, err) on dispatch failure.
+func DispatchMetadata(ctx context.Context, metadata map[string]any, h MetadataHandler) (bool, error) {
+	if metadata == nil {
+		return false, nil
+	}
+	if permResp, ok := metadata["permission_response"].(map[string]any); ok {
+		reqID, _ := permResp["request_id"].(string)
+		allowed, _ := permResp["allowed"].(bool)
+		reason, _ := permResp["reason"].(string)
+		return true, h.HandlePermissionResponse(ctx, reqID, allowed, reason)
+	}
+	if qResp, ok := metadata["question_response"].(map[string]any); ok {
+		reqID, _ := qResp["id"].(string)
+		answers, _ := qResp["answers"].(map[string]string)
+		return true, h.HandleQuestionResponse(ctx, reqID, answers)
+	}
+	if eResp, ok := metadata["elicitation_response"].(map[string]any); ok {
+		reqID, _ := eResp["id"].(string)
+		action, _ := eResp["action"].(string)
+		content, _ := eResp["content"].(map[string]any)
+		return true, h.HandleElicitationResponse(ctx, reqID, action, content)
+	}
+	return false, nil
+}

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -339,47 +339,13 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	}
 
 	// Check if this is a control response (permission, question, or elicitation)
-	if metadata != nil {
-		if permResp, ok := metadata["permission_response"].(map[string]any); ok {
-			reqID, _ := permResp["request_id"].(string)
-			allowed, _ := permResp["allowed"].(bool)
-			reason, _ := permResp["reason"].(string)
-
-			w.Log.Info("claudecode: sending permission response to stdin",
-				"request_id", reqID,
-				"allowed", allowed,
-				"session_id", w.sessionID)
-
-			if err := w.control.SendPermissionResponse(reqID, allowed, reason); err != nil {
-				return fmt.Errorf("claudecode: permission response: %w", err)
-			}
-
-			w.SetLastIO(time.Now())
-			return nil
-		}
-		if qResp, ok := metadata["question_response"].(map[string]any); ok {
-			reqID, _ := qResp["id"].(string)
-			answers, _ := qResp["answers"].(map[string]string)
-
-			if err := w.control.SendQuestionResponse(reqID, answers); err != nil {
-				return fmt.Errorf("claudecode: question response: %w", err)
-			}
-
-			w.SetLastIO(time.Now())
-			return nil
-		}
-		if eResp, ok := metadata["elicitation_response"].(map[string]any); ok {
-			reqID, _ := eResp["id"].(string)
-			action, _ := eResp["action"].(string)
-			eContent, _ := eResp["content"].(map[string]any)
-
-			if err := w.control.SendElicitationResponse(reqID, action, eContent); err != nil {
-				return fmt.Errorf("claudecode: elicitation response: %w", err)
-			}
-
-			w.SetLastIO(time.Now())
-			return nil
-		}
+	handled, err := base.DispatchMetadata(ctx, metadata, w)
+	if err != nil {
+		return err
+	}
+	if handled {
+		w.SetLastIO(time.Now())
+		return nil
 	}
 
 	// Normal input: use SendUserMessage for Claude Code's stream-json format
@@ -406,6 +372,31 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	}
 
 	w.SetLastIO(time.Now())
+	return nil
+}
+
+func (w *Worker) HandlePermissionResponse(_ context.Context, reqID string, allowed bool, reason string) error {
+	w.Log.Info("claudecode: sending permission response to stdin",
+		"request_id", reqID,
+		"allowed", allowed,
+		"session_id", w.sessionID)
+	if err := w.control.SendPermissionResponse(reqID, allowed, reason); err != nil {
+		return fmt.Errorf("claudecode: permission response: %w", err)
+	}
+	return nil
+}
+
+func (w *Worker) HandleQuestionResponse(_ context.Context, reqID string, answers map[string]string) error {
+	if err := w.control.SendQuestionResponse(reqID, answers); err != nil {
+		return fmt.Errorf("claudecode: question response: %w", err)
+	}
+	return nil
+}
+
+func (w *Worker) HandleElicitationResponse(_ context.Context, reqID string, action string, content map[string]any) error {
+	if err := w.control.SendElicitationResponse(reqID, action, content); err != nil {
+		return fmt.Errorf("claudecode: elicitation response: %w", err)
+	}
 	return nil
 }
 

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -393,7 +393,7 @@ func (w *Worker) HandleQuestionResponse(_ context.Context, reqID string, answers
 	return nil
 }
 
-func (w *Worker) HandleElicitationResponse(_ context.Context, reqID string, action string, content map[string]any) error {
+func (w *Worker) HandleElicitationResponse(_ context.Context, reqID, action string, content map[string]any) error {
 	if err := w.control.SendElicitationResponse(reqID, action, content); err != nil {
 		return fmt.Errorf("claudecode: elicitation response: %w", err)
 	}

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -266,7 +266,6 @@ func (s *SingletonProcessManager) discoverPort(stdout *os.File, timeout time.Dur
 	go func() {
 		defer func() { _ = stdout.Close() }()
 		scanner := bufio.NewScanner(stdout)
-		deadline := time.After(timeout)
 		for scanner.Scan() {
 			line := scanner.Text()
 			s.log.Debug("opencode-server-singleton: stdout", "line", line)
@@ -274,12 +273,6 @@ func (s *SingletonProcessManager) discoverPort(stdout *os.File, timeout time.Dur
 				p, err := strconv.Atoi(m[1])
 				ch <- result{port: p, err: err}
 				return
-			}
-			select {
-			case <-deadline:
-				ch <- result{err: fmt.Errorf("timeout waiting for port in stdout")}
-				return
-			default:
 			}
 		}
 		if err := scanner.Err(); err != nil {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -231,32 +231,13 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 		return fmt.Errorf("opencodeserver: worker not started")
 	}
 
-	if metadata != nil {
-		if permResp, ok := metadata["permission_response"].(map[string]any); ok {
-			reqID, _ := permResp["request_id"].(string)
-			allowed, _ := permResp["allowed"].(bool)
-			reply := "once"
-			if !allowed {
-				reply = "reject"
-			}
-			return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", url.PathEscape(reqID)),
-				map[string]string{"reply": reply})
-		}
-		if qResp, ok := metadata["question_response"].(map[string]any); ok {
-			reqID, _ := qResp["id"].(string)
-			answers, _ := qResp["answers"].(map[string]string)
-			return w.httpPost(ctx, fmt.Sprintf("/question/%s/reply", reqID),
-				map[string][][]string{"answers": answersToArrays(answers)})
-		}
-		if eResp, ok := metadata["elicitation_response"].(map[string]any); ok {
-			reqID, _ := eResp["id"].(string)
-			action, _ := eResp["action"].(string)
-			payload := map[string]any{"action": action}
-			if content, ok := eResp["content"].(map[string]any); ok {
-				payload["content"] = content
-			}
-			return w.httpPost(ctx, fmt.Sprintf("/elicitation/%s/reply", reqID), payload)
-		}
+	handled, err := base.DispatchMetadata(ctx, metadata, w)
+	if err != nil {
+		return err
+	}
+	if handled {
+		w.SetLastIO(time.Now())
+		return nil
 	}
 
 	msg := events.NewEnvelope(
@@ -276,6 +257,28 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 
 	w.SetLastIO(time.Now())
 	return nil
+}
+
+func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, allowed bool, _ string) error {
+	reply := "once"
+	if !allowed {
+		reply = "reject"
+	}
+	return w.httpPost(ctx, fmt.Sprintf("/permission/%s/reply", url.PathEscape(reqID)),
+		map[string]string{"reply": reply})
+}
+
+func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
+	return w.httpPost(ctx, fmt.Sprintf("/question/%s/reply", reqID),
+		map[string][][]string{"answers": answersToArrays(answers)})
+}
+
+func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID string, action string, content map[string]any) error {
+	payload := map[string]any{"action": action}
+	if content != nil {
+		payload["content"] = content
+	}
+	return w.httpPost(ctx, fmt.Sprintf("/elicitation/%s/reply", reqID), payload)
 }
 
 // Resume reconnects to an existing session on the shared OpenCode server.
@@ -372,6 +375,8 @@ func (w *Worker) Kill() error {
 
 // Wait reports exit code based on whether the singleton process crashed.
 // 0 = normal session end, 1 = process crashed.
+// Blocks briefly to allow crash detection after Release(); aligns with the
+// blocking Wait() contract defined in the Worker interface.
 func (w *Worker) Wait() (int, error) {
 	if w.singleton == nil {
 		return 0, fmt.Errorf("opencodeserver: not started")
@@ -382,8 +387,8 @@ func (w *Worker) Wait() (int, error) {
 	select {
 	case <-w.crashSub:
 		return 1, nil // process crashed
-	default:
-		return 0, nil // normal session end
+	case <-time.After(2 * time.Second):
+		return 0, nil // no crash detected within grace window
 	}
 }
 

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -273,7 +273,7 @@ func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answe
 		map[string][][]string{"answers": answersToArrays(answers)})
 }
 
-func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID string, action string, content map[string]any) error {
+func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID, action string, content map[string]any) error {
 	payload := map[string]any{"action": action}
 	if content != nil {
 		payload["content"] = content

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -37,6 +37,10 @@ type Manager struct {
 	exited   bool
 	exitCode int
 
+	// waitOnce ensures cmd.Wait() is called exactly once across Terminate/Wait/Kill.
+	waitOnce sync.Once
+	waitErr  error // captured by waitOnce closure
+
 	// scanner reads stdout line-by-line with a 10MB per-line cap.
 	// Created in Start(); safe to call ReadLine() concurrently from one goroutine.
 	scanner      *bufio.Scanner
@@ -195,7 +199,7 @@ func (m *Manager) Terminate(ctx context.Context, gracePeriod time.Duration) erro
 	// Wait for exit with deadline.
 	done := make(chan struct{})
 	go func() {
-		_ = m.cmd.Wait()
+		m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 		close(done)
 	}()
 
@@ -211,7 +215,8 @@ func (m *Manager) Terminate(ctx context.Context, gracePeriod time.Duration) erro
 		m.log.Warn("proc: graceful shutdown timeout, force killing", "pgid", pgid)
 		return m.Kill()
 	case <-ctx.Done():
-		return ctx.Err()
+		m.log.Warn("proc: context cancelled during termination, force killing", "pgid", pgid)
+		return m.Kill()
 	}
 }
 
@@ -232,7 +237,7 @@ func (m *Manager) Kill() error {
 		_ = ForceKill(m.pgid)
 		m.log.Info("proc: force killed", "pgid", m.pgid)
 	}
-	_ = m.cmd.Wait()
+	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 	m.captureExitCodeLocked()
 	m.untrackPID(m.pidKey)
 	m.mu.Unlock()
@@ -250,9 +255,9 @@ func (m *Manager) Wait() (int, error) {
 		return -1, fmt.Errorf("proc: not started")
 	}
 
-	err := m.cmd.Wait()
+	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 	m.captureExitCodeLocked()
-	return m.exitCode, err
+	return m.exitCode, m.waitErr
 }
 
 // PID returns the process ID, or -1 if not started.

--- a/internal/worker/proc/manager_test.go
+++ b/internal/worker/proc/manager_test.go
@@ -458,3 +458,95 @@ func TestManager_Start_AllowedTools(t *testing.T) {
 		require.True(t, m.IsRunning())
 	})
 }
+
+// --- TestManager_WaitOnce_Dedup -----------------------------------------------
+// Verify that waitOnce sync.Once correctly deduplicates cmd.Wait() across
+// Terminate→Wait and Kill→Wait call sequences.
+
+func TestManager_WaitOnce_TerminateThenWait(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("skipping: real process tests cause TSAN OOM under -race")
+	}
+
+	t.Parallel()
+
+	t.Run("Wait after Terminate returns cached result", func(t *testing.T) {
+		t.Parallel()
+		m := New(Opts{Logger: slog.Default()})
+		ctx := context.Background()
+
+		_, _, _, err := m.Start(ctx, "sleep", []string{"60"}, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { m.Close() })
+
+		err = m.Terminate(ctx, 5*time.Second)
+		require.NoError(t, err)
+
+		// Wait after Terminate: waitOnce already fired via the <-done path.
+		// Signal-killed processes have exit code -1 and cmd.Wait returns ExitError.
+		code, waitErr := m.Wait()
+		require.Equal(t, -1, code)
+		require.Error(t, waitErr)
+		require.False(t, m.IsRunning())
+	})
+
+	t.Run("Wait after Terminate ctx cancel triggers Kill", func(t *testing.T) {
+		t.Parallel()
+		m := New(Opts{Logger: slog.Default()})
+		ctx := context.Background()
+
+		_, _, _, err := m.Start(ctx, "sleep", []string{"60"}, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { m.Close() })
+
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel() // immediately cancel -> ctx.Done -> Kill()
+
+		err = m.Terminate(cancelCtx, 5*time.Second)
+		require.NoError(t, err) // Kill() returns nil
+
+		_, waitErr := m.Wait()
+		require.Error(t, waitErr) // exec.ExitError: signal
+		require.False(t, m.IsRunning())
+	})
+}
+
+func TestManager_WaitOnce_KillThenWait(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("skipping: real process tests cause TSAN OOM under -race")
+	}
+
+	t.Parallel()
+
+	t.Run("Wait after Kill returns cached result", func(t *testing.T) {
+		t.Parallel()
+		m := New(Opts{Logger: slog.Default()})
+		ctx := context.Background()
+
+		_, _, _, err := m.Start(ctx, "sleep", []string{"60"}, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { m.Close() })
+
+		err = m.Kill()
+		require.NoError(t, err)
+
+		_, waitErr := m.Wait()
+		require.Error(t, waitErr) // exec.ExitError: signal: killed
+		require.False(t, m.IsRunning())
+	})
+
+	t.Run("double Wait returns same result", func(t *testing.T) {
+		t.Parallel()
+		m := New(Opts{Logger: slog.Default()})
+		ctx := context.Background()
+
+		_, _, _, err := m.Start(ctx, "echo", []string{"done"}, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { m.Close() })
+
+		code1, err1 := m.Wait()
+		code2, err2 := m.Wait()
+		require.Equal(t, code1, code2)
+		require.Equal(t, err1, err2)
+	})
+}


### PR DESCRIPTION
## Summary

Batch PR consolidating 3 issues across worker process management and admin API:

- **#269**: Fix proc.Manager resource leak (ctx.Done path) and double cmd.Wait() hazard via sync.Once
- **#225**: Fix OCS Wait() non-blocking crash miss, extract shared metadata dispatch, remove discoverPort double timeout
- **#272**: Fix admin data race (atomic.Value), error swallowing in HandleStats (503), debug snapshot transparency

## Fixes

Closes #269, #225, #272

## Changes by Issue

### #269 — proc.Manager resource leak + double cmd.Wait()

- `ctx.Done()` path now calls `m.Kill()` ensuring process termination and FD/PID cleanup on gateway shutdown
- Add `waitOnce sync.Once` protecting `cmd.Wait()` across Terminate/Wait/Kill, preventing concurrent calls

### #225 — OCS Wait() crash miss + metadata dispatch + discoverPort

- OCS `Wait()` blocks with 2s grace window instead of immediate non-blocking return, preventing zombie sessions
- Extract `InputMetadataHandler` interface + `DispatchMetadata` to `base/metadata.go`, eliminating ~50 lines of duplicated type-switch logic. Both adapters now consistently call `SetLastIO`.
- Remove redundant internal deadline in `discoverPort` — effective timeout was up to 2x configured value

### #272 — Admin data race + error handling

- `rateLimiter` and `allowedCIDRs` use `atomic.Value` to eliminate data race with Middleware reads
- `HandleStats` returns 503 (was 200 with empty data) when `sm.List()` fails
- `HandleDebugSession` includes `debug.available` field for snapshot status transparency

## Testing

- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass (with -race)
- [x] `make build` — binary builds successfully

## Commits

4 atomic commits: #269 fix → #272 fix → #225 fix → lint fix