### PR TITLE
fix: panic prevention, data race, FD leak, and security hardening

### DIFF
--- a/.agent/arch-analysis/progress.json
+++ b/.agent/arch-analysis/progress.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "last_updated": "2026-05-08T01:13:00+08:00",
-  "total_cycles": 25,
+  "last_updated": "2026-05-08T01:54:00+08:00",
+  "total_cycles": 26,
   "modules": {
     "internal/gateway": {
       "analysis_count": 2,
@@ -107,20 +107,22 @@
       "stats": {"files": 7, "lines": 2743}
     },
     "internal/security": {
-      "analysis_count": 1,
-      "aspects_covered": ["solid", "dry"],
-      "aspects_pending": ["coupling", "error-handling", "concurrency", "resource-mgmt", "performance", "scalability", "security", "observability", "testability", "code-quality"],
-      "issues_created": [208],
-      "findings_total": 3,
+      "analysis_count": 2,
+      "aspects_covered": ["solid", "dry", "coupling", "error-handling"],
+      "aspects_pending": ["concurrency", "resource-mgmt", "performance", "scalability", "security", "observability", "testability", "code-quality"],
+      "issues_created": [208, 290],
+      "findings_total": 5,
       "findings_dropped": [
         {"finding": "command.go has 3 concerns (whitelist, dangerous chars, bash policy)", "reason": "Low ROI — all command-security related, cohesive within the file"},
         {"finding": "ValidateAPIKey placement in jwt.go instead of auth.go", "reason": "Low ROI — just file organization, no functional impact"},
         {"finding": "AllowedTools/AllowedModels hardcoded maps", "reason": "Low ROI — intentional for security, new entries require code review"},
         {"finding": "sensitiveEnvPrefixes redundant entries", "reason": "Low ROI — defense-in-depth, extra entries add safety margin"},
         {"finding": "Platform-specific ConfigureFromConfig duplication", "reason": "Low confidence — build tags require separate files, Windows differs intentionally"},
-        {"finding": "Two parallel worker env construction paths", "reason": "Low ROI — different use cases, both needed"}
+        {"finding": "Two parallel worker env construction paths", "reason": "Low ROI — different use cases, both needed"},
+        {"finding": "Authenticator DIP violation on concrete config.SecurityConfig", "reason": "Medium confidence, Low ROI — common Go pattern, config struct is stable"},
+        {"finding": "mustGenerateJTI silent degradation on crypto/rand failure", "reason": "Medium confidence, Low ROI — extremely rare edge case"}
       ],
-      "last_analyzed": "2026-05-06T11:22:00+08:00",
+      "last_analyzed": "2026-05-08T01:54:00+08:00",
       "stats": {"files": 19, "lines": 4812}
     },
     "internal/agentconfig": {
@@ -272,7 +274,7 @@
       "stats": {"files": 36, "lines": 3697}
     }
   },
-  "issues": [198, 199, 202, 204, 205, 206, 207, 208, 210, 212, 213, 214, 215, 216, 217, 218, 219],
+  "issues": [198, 199, 202, 204, 205, 206, 207, 208, 210, 212, 213, 214, 215, 216, 217, 218, 219, 290],
   "audited_issues": [
     {"number": 198, "verdict": "valid", "action": "confirmed", "audited_at": "2026-05-08T00:35:00+08:00"},
     {"number": 199, "verdict": "valid", "action": "confirmed", "audited_at": "2026-05-08T00:35:00+08:00"},
@@ -319,6 +321,7 @@
     {"cycle": 22, "mode": "audit", "issues_audited": [224, 226, 227, 228, 229], "closed": 0, "updated": 0, "confirmed": 5, "time": "2026-05-08T00:42:00+08:00"},
     {"cycle": 23, "mode": "audit", "issues_audited": [231, 237, 239, 240, 241], "closed": 0, "updated": 1, "confirmed": 4, "time": "2026-05-08T00:53:00+08:00"},
     {"cycle": 24, "mode": "audit", "issues_audited": [242, 243, 244, 245, 246], "closed": 0, "updated": 0, "confirmed": 5, "time": "2026-05-08T01:03:00+08:00"},
-    {"cycle": 25, "module": "internal/config", "aspects": ["coupling", "error-handling"], "issues": [], "time": "2026-05-08T01:13:00+08:00"}
+    {"cycle": 25, "module": "internal/config", "aspects": ["coupling", "error-handling"], "issues": [], "time": "2026-05-08T01:13:00+08:00"},
+    {"cycle": 26, "module": "internal/security", "aspects": ["coupling", "error-handling"], "issues": [290], "time": "2026-05-08T01:54:00+08:00"}
   ]
 }

--- a/.agent/arch-analysis/progress.json
+++ b/.agent/arch-analysis/progress.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "last_updated": "2026-05-08T01:54:00+08:00",
-  "total_cycles": 26,
+  "last_updated": "2026-05-08T01:55:00+08:00",
+  "total_cycles": 27,
   "modules": {
     "internal/gateway": {
       "analysis_count": 2,
@@ -126,17 +126,19 @@
       "stats": {"files": 19, "lines": 4812}
     },
     "internal/agentconfig": {
-      "analysis_count": 1,
-      "aspects_covered": ["solid", "dry"],
-      "aspects_pending": ["coupling", "error-handling", "concurrency", "resource-mgmt", "performance", "scalability", "security", "observability", "testability", "code-quality"],
+      "analysis_count": 2,
+      "aspects_covered": ["solid", "dry", "coupling", "error-handling"],
+      "aspects_pending": ["concurrency", "resource-mgmt", "performance", "scalability", "security", "observability", "testability", "code-quality"],
       "issues_created": [],
       "findings_total": 0,
       "findings_dropped": [
         {"finding": "BuildSystemPrompt repetitive XML wrapping (5 similar blocks)", "reason": "Low ROI — 88-line function, explicit is better than abstract for security-sensitive prompt assembly"},
         {"finding": "configFiles list vs Load hardcoded 5 file names", "reason": "Low ROI — adding config files is rare, current approach is auditable"},
-        {"finding": "B/C channel assembly symmetry", "reason": "Low ROI — symmetry is inherent to the domain"}
+        {"finding": "B/C channel assembly symmetry", "reason": "Low ROI — symmetry is inherent to the domain"},
+        {"finding": "reservedTags list duplicates BuildSystemPrompt tag names", "reason": "Low ROI — 10 entries, adding tags is rare and reviewed, DRY violation was already evaluated in Phase 1"},
+        {"finding": "readFile wraps error with name but not full path", "reason": "Low ROI — caller knows dir, name is always a known config file"}
       ],
-      "last_analyzed": "2026-05-06T11:24:00+08:00",
+      "last_analyzed": "2026-05-08T01:55:00+08:00",
       "stats": {"files": 3, "lines": 651}
     },
     "internal/admin": {
@@ -322,6 +324,7 @@
     {"cycle": 23, "mode": "audit", "issues_audited": [231, 237, 239, 240, 241], "closed": 0, "updated": 1, "confirmed": 4, "time": "2026-05-08T00:53:00+08:00"},
     {"cycle": 24, "mode": "audit", "issues_audited": [242, 243, 244, 245, 246], "closed": 0, "updated": 0, "confirmed": 5, "time": "2026-05-08T01:03:00+08:00"},
     {"cycle": 25, "module": "internal/config", "aspects": ["coupling", "error-handling"], "issues": [], "time": "2026-05-08T01:13:00+08:00"},
-    {"cycle": 26, "module": "internal/security", "aspects": ["coupling", "error-handling"], "issues": [290], "time": "2026-05-08T01:54:00+08:00"}
+    {"cycle": 26, "module": "internal/security", "aspects": ["coupling", "error-handling"], "issues": [290], "time": "2026-05-08T01:54:00+08:00"},
+    {"cycle": 27, "module": "internal/agentconfig", "aspects": ["coupling", "error-handling"], "issues": [], "time": "2026-05-08T01:55:00+08:00"}
   ]
 }

--- a/cmd/hotplex/cmd_test.go
+++ b/cmd/hotplex/cmd_test.go
@@ -81,3 +81,23 @@ func TestLoadEnvFile(t *testing.T) {
 		_ = os.Unsetenv("TEST_VAR_4")
 	})
 }
+
+func TestLoadEnvFile_ProtectedVars(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", originalHome) })
+
+	envPath := tmpDir + "/.env"
+	content := "HOME=/evil\nCLAUDECODE=/evil\nTEST_UNPROTECTED=yes\n"
+	err := os.WriteFile(envPath, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	loadEnvFile(tmpDir)
+
+	// Protected vars must NOT be overwritten.
+	require.Equal(t, originalHome, os.Getenv("HOME"), "HOME should not be overwritten by .env")
+	require.NotEqual(t, "/evil", os.Getenv("CLAUDECODE"), "CLAUDECODE should not be overwritten by .env")
+	// Non-protected vars should be loaded normally.
+	require.Equal(t, "yes", os.Getenv("TEST_UNPROTECTED"))
+	t.Cleanup(func() { _ = os.Unsetenv("TEST_UNPROTECTED") })
+}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -531,7 +531,7 @@ func loadEnvFile(dir string) {
 		key := strings.TrimSpace(line[:idx])
 		val := strings.TrimSpace(line[idx+1:])
 		val = strings.Trim(val, `"'`)
-		if os.Getenv(key) == "" {
+		if os.Getenv(key) == "" && !security.IsProtected(key) {
 			_ = os.Setenv(key, val)
 			loaded++
 		}

--- a/cmd/hotplex/security.go
+++ b/cmd/hotplex/security.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -167,16 +167,8 @@ func checkSSRFConfig(_ context.Context, cfgPath string) cli.Diagnostic {
 // isLocalAddr returns true for localhost/127.0.0.1/::1 or empty address.
 func isLocalAddr(addr string) bool {
 	host := addr
-	if h, _, err := splitHostPort(addr); err == nil {
+	if h, _, err := net.SplitHostPort(addr); err == nil {
 		host = h
 	}
 	return host == "" || host == "localhost" || host == "127.0.0.1" || host == "::1"
-}
-
-func splitHostPort(addr string) (string, string, error) {
-	i := strings.LastIndex(addr, ":")
-	if i < 0 {
-		return addr, "", fmt.Errorf("no port")
-	}
-	return addr[:i], addr[i+1:], nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,7 +128,11 @@ func (c *Config) Validate() []string {
 func (c *Config) RequireSecrets() error {
 	var missing []string
 	if len(c.Security.JWTSecret) == 0 {
-		missing = append(missing, "security.jwt_secret")
+		if os.Getenv("HOTPLEX_JWT_SECRET") != "" {
+			missing = append(missing, "security.jwt_secret (set but invalid: must be 32-byte raw or base64-encoded)")
+		} else {
+			missing = append(missing, "security.jwt_secret")
+		}
 	} else if len(c.Security.JWTSecret) < 32 {
 		missing = append(missing, "security.jwt_secret (must decode to exactly 32 bytes for ES256)")
 	}
@@ -726,6 +730,9 @@ func loadRecursive(filePath string, opts LoadOptions, visited []string) (*Config
 	// This matches the client token generator's key loading behavior.
 	if secret := sp.Get("HOTPLEX_JWT_SECRET"); secret != "" {
 		cfg.Security.JWTSecret = decodeJWTSecret(secret)
+		if cfg.Security.JWTSecret == nil {
+			slog.Warn("config: HOTPLEX_JWT_SECRET set but invalid format (must be 32-byte raw or base64-encoded 32 bytes)", "length", len(secret))
+		}
 	}
 
 	// Numbered environment variables for slices (e.g. HOTPLEX_ADMIN_TOKEN_1..N)

--- a/internal/messaging/dedup.go
+++ b/internal/messaging/dedup.go
@@ -15,6 +15,7 @@ type Dedup struct {
 	maxEntries int
 	ttl        time.Duration
 	done       chan struct{}
+	closeOnce  sync.Once
 }
 
 // NewDedup creates a new bounded dedup map.
@@ -99,9 +100,11 @@ func (d *Dedup) Len() int {
 
 // Close stops the cleanup goroutine started by StartCleanup.
 func (d *Dedup) Close() {
-	if d.done != nil {
-		close(d.done)
-	}
+	d.closeOnce.Do(func() {
+		if d.done != nil {
+			close(d.done)
+		}
+	})
 }
 
 func (d *Dedup) cleanupLoop() {

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -706,7 +706,9 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		c.adapter.Interactions.CancelAll(env.SessionID)
 		if streamCtrl != nil && streamCtrl.IsCreated() {
 			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_ = streamCtrl.Close(closeCtx)
+			if err := streamCtrl.Close(closeCtx); err != nil {
+				c.adapter.Log.Warn("feishu: failed to close streaming card on error", "err", err)
+			}
 			closeCancel()
 		}
 		// Extract error text and send as simple message

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -679,7 +679,9 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 
 		var closeErr error
 		if streamCtrl != nil && streamCtrl.IsCreated() {
-			closeErr = streamCtrl.Close(ctx)
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			closeErr = streamCtrl.Close(closeCtx)
+			closeCancel()
 		}
 
 		if c.adapter.ttsPipeline != nil && c.voiceTriggered.Load() {
@@ -703,7 +705,9 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 		streamCtrl := c.clearActiveIndicators(ctx)
 		c.adapter.Interactions.CancelAll(env.SessionID)
 		if streamCtrl != nil && streamCtrl.IsCreated() {
-			_ = streamCtrl.Close(ctx)
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = streamCtrl.Close(closeCtx)
+			closeCancel()
 		}
 		// Extract error text and send as simple message
 		if errMsg := messaging.ExtractErrorMessage(env); errMsg != "" {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -242,6 +242,7 @@ func (a *Adapter) runSocketMode(ctx context.Context) {
 				// Channel closed — Run() exited. The reconnect goroutine above will
 				// detect this and restart the connection.
 				a.Log.Warn("slack: events channel closed, waiting for reconnect")
+				time.Sleep(500 * time.Millisecond)
 				continue
 			}
 			switch evt.Type {

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -44,6 +44,7 @@ var ErrUnauthorized = errors.New("security: unauthorized")
 // Returns the user ID, bot ID (from JWT BotID claim), and any error.
 // botID may be empty when no JWT Bearer token is present.
 func (a *Authenticator) AuthenticateRequest(r *http.Request) (string, string, error) {
+	a.mu.RLock()
 	header := a.cfg.APIKeyHeader
 	if header == "" {
 		header = "X-API-Key"
@@ -55,11 +56,11 @@ func (a *Authenticator) AuthenticateRequest(r *http.Request) (string, string, er
 		key = r.URL.Query().Get(apiKeyQueryParam)
 	}
 	if key == "" {
+		a.mu.RUnlock()
 		return "", "", ErrUnauthorized
 	}
 
 	// Constant-time comparison to prevent timing attacks.
-	a.mu.RLock()
 	defer a.mu.RUnlock()
 
 	if len(a.validKey) == 0 {

--- a/internal/security/jwt.go
+++ b/internal/security/jwt.go
@@ -239,8 +239,9 @@ func ValidateAPIKey(provided, expected string) error {
 // ─── JTI Blacklist ────────────────────────────────────────────────────────────
 
 type jtiBlacklist struct {
-	entries sync.Map
-	stopCh  chan struct{}
+	entries  sync.Map
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 func newJTIBlacklist() *jtiBlacklist {
@@ -295,7 +296,9 @@ func (b *jtiBlacklist) sweep(interval time.Duration) {
 }
 
 func (b *jtiBlacklist) Stop() {
-	close(b.stopCh)
+	b.stopOnce.Do(func() {
+		close(b.stopCh)
+	})
 }
 
 // Size returns the approximate number of entries in the blacklist.

--- a/internal/security/jwt_test.go
+++ b/internal/security/jwt_test.go
@@ -604,9 +604,16 @@ func TestJTIBlacklist(t *testing.T) {
 		require.NotPanics(t, func() {
 			b.Stop()
 		})
+	})
 
-		// Double stop should not panic (channel already closed)
-		// Note: this will panic, but that's expected behavior
+	t.Run("double Stop does not panic", func(t *testing.T) {
+		t.Parallel()
+		b := newJTIBlacklist()
+
+		require.NotPanics(t, func() {
+			b.Stop()
+			b.Stop()
+		})
 	})
 
 	t.Run("concurrent access", func(t *testing.T) {

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -257,6 +257,7 @@ func (m *Manager) Wait() (int, error) {
 
 	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 	m.captureExitCodeLocked()
+	_ = m.closeLocked()
 	return m.exitCode, m.waitErr
 }
 
@@ -397,22 +398,29 @@ func (m *Manager) drainStderr() {
 func (m *Manager) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.closeLocked()
+}
 
+// closeLocked closes pipe FDs. Caller must hold m.mu.
+func (m *Manager) closeLocked() error {
 	var errs []error
 	if m.stdin != nil {
-		if err := m.stdin.Close(); err != nil {
+		if err := m.stdin.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			errs = append(errs, err)
 		}
+		m.stdin = nil
 	}
 	if m.stdout != nil {
-		if err := m.stdout.Close(); err != nil {
+		if err := m.stdout.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			errs = append(errs, err)
 		}
+		m.stdout = nil
 	}
 	if m.stderr != nil {
-		if err := m.stderr.Close(); err != nil {
+		if err := m.stderr.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			errs = append(errs, err)
 		}
+		m.stderr = nil
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("proc: close: %v", errs)

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -257,7 +257,9 @@ func (m *Manager) Wait() (int, error) {
 
 	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 	m.captureExitCodeLocked()
-	_ = m.closeLocked()
+	if closeErr := m.closeLocked(); closeErr != nil {
+		m.log.Warn("proc: pipe close after wait", "err", closeErr)
+	}
 	return m.exitCode, m.waitErr
 }
 

--- a/internal/worker/proc/manager_test.go
+++ b/internal/worker/proc/manager_test.go
@@ -194,7 +194,7 @@ func TestManager_Close(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("多文件关闭收集错误", func(t *testing.T) {
+	t.Run("幂等关闭 nil-out 已关闭 FD", func(t *testing.T) {
 		// 使用临时文件，关闭后再次关闭会返回错误
 		tmp1, err := os.CreateTemp("", "proc-close-*.tmp")
 		require.NoError(t, err)
@@ -216,11 +216,10 @@ func TestManager_Close(t *testing.T) {
 		require.NoError(t, f1.Close())
 		require.NoError(t, f2.Close())
 
-		// 第二次关闭返回错误
+		// 第二次关闭幂等 — os.ErrClosed 被忽略
 		m := &Manager{stdin: f1, stdout: f2}
 		err = m.Close()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "proc: close")
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## Summary

Batch fix for 5 reliability and security issues (9 individual fixes) across 5 modules.

### #271 — Security: double-close panic + data race
- **jtiBlacklist.Stop()**: Added `sync.Once` to prevent panic on double-close during shutdown retry
- **Authenticator.AuthenticateRequest()**: Moved `cfg.APIKeyHeader` read under `RLock` to fix data race with `ReloadKeys`

### #268 — Messaging: Dedup double-close + context leak + CPU spin
- **Dedup.Close()**: Added `sync.Once` to prevent panic on double-close
- **Feishu streaming card**: Done/Error paths now use `context.Background()` + 5s timeout instead of caller context, preventing flush failure during session teardown
- **Slack event loop**: Added 500ms backoff on closed events channel to prevent CPU spin during reconnect

### #231 — Cmd: loadEnvFile security gap + IPv6 mishandling
- **loadEnvFile()**: Added `security.IsProtected()` guard to filter protected env vars (e.g. `CLAUDECODE`, `GATEWAY_*`)
- **splitHostPort()**: Replaced hand-rolled `strings.LastIndex` with `net.SplitHostPort` for correct IPv6 handling

### #237 — Worker: proc.Manager FD leak
- **Wait()**: Now calls `closeLocked()` after process exit to close stdin/stdout/stderr pipes
- **closeLocked()**: Made `Close()` idempotent — nil-out pointers after close, ignore `os.ErrClosed`

### #270 — Config: decodeJWTSecret silent nil
- **loadRecursive()**: Added `slog.Warn` when `HOTPLEX_JWT_SECRET` is set but format is invalid
- **RequireSecrets()**: Error message now distinguishes "not set" vs "set but invalid format"

## Test plan
- [x] `make build` — compiles clean
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass with `-race`
- [x] Pre-push hooks: fmt + lint + vet + build + test all green
- [ ] Verify `go test -race ./internal/security/...` reports no data races
- [ ] Verify Feishu streaming card correctly finalizes on rapid session teardown

Fixes #271
Fixes #268
Fixes #231
Fixes #237
Fixes #270