### PR TITLE
fix(slack+feishu): streaming TOCTOU race, fallback content loss, and turn number reset

### DIFF
--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -948,7 +948,7 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 		c.adapter.Log.Info("feishu: streaming card rotated",
 			"old_msg_id", oldMsgID)
 
-		newCtrl := NewStreamingCardController(c.adapter.larkClient, c.adapter.rateLimiter, c.adapter.Log, c.adapter.resolveBotName(), 0, c.lastModel, c.lastBranch, c.workDir)
+		newCtrl := NewStreamingCardController(c.adapter.larkClient, c.adapter.rateLimiter, c.adapter.Log, c.adapter.resolveBotName(), c.turnCount+1, c.lastModel, c.lastBranch, c.workDir)
 		c.mu.Lock()
 		c.streamCtrl = newCtrl
 		if oldMsgID != "" {

--- a/internal/messaging/slack/stream.go
+++ b/internal/messaging/slack/stream.go
@@ -21,8 +21,8 @@ const (
 	maxAppendRetries  = 3
 	retryDelay        = 50 * time.Millisecond
 	maxAppendSize     = 3000              // Slack limit ~4000, safety margin
-	StreamTTL         = 10 * time.Minute  // server-side streaming limit (undocumented, aligned with Feishu)
-	StreamRotationTTL = 500 * time.Second // proactive rotation before server limit (aligned with Feishu)
+	StreamTTL         = 5 * time.Minute   // server-side wallclock limit (empirically ~5min, see slackapi/python-slack-sdk#1859)
+	StreamRotationTTL = 240 * time.Second // proactive rotation before server limit (safe margin under ~300s observed limit)
 )
 
 func isStreamStateError(err error) bool {
@@ -117,8 +117,6 @@ type NativeStreamingWriter struct {
 	wg           sync.WaitGroup
 
 	// 完整性校验
-	bytesWritten      int64
-	bytesFlushed      int64
 	failedFlushChunks []string
 
 	// Post-stream table upgrade: accumulates full content for table detection on Close.
@@ -187,8 +185,6 @@ func (w *NativeStreamingWriter) Write(p []byte) (int, error) {
 		w.started = true
 		w.streamStartTime = time.Now()
 		w.fullContent.Write(p)
-		w.bytesWritten += int64(len(p))
-		w.bytesFlushed += int64(len(p))
 		if w.onRegister != nil {
 			w.onRegister(w)
 		}
@@ -197,7 +193,6 @@ func (w *NativeStreamingWriter) Write(p []byte) (int, error) {
 
 	w.buf.Write(p)
 	w.fullContent.Write(p)
-	w.bytesWritten += int64(len(p))
 
 	// 超过阈值触发即时 flush
 	if utf8.RuneCount(w.buf.Bytes()) >= flushSize {
@@ -301,9 +296,6 @@ func (w *NativeStreamingWriter) appendWithRetry(content string) error {
 		)
 		cancel()
 		if err == nil {
-			w.mu.Lock()
-			w.bytesFlushed += int64(len(content))
-			w.mu.Unlock()
 			return nil
 		}
 		lastErr = err
@@ -339,39 +331,37 @@ func (w *NativeStreamingWriter) Close() error {
 		return nil
 	}
 	w.closed = true
-	streamExpired := w.streamExpired
-	shouldSkipFallback := w.skipFallback
 	w.mu.Unlock()
 
 	close(w.closeChan)
 	w.wg.Wait()
 
+	// Read all final state AFTER flushLoop completes to avoid TOCTOU races:
+	// streamExpired may be set during the final flushBuffer() in flushLoop.
 	w.mu.Lock()
 	started := w.started
-	bytesWritten := w.bytesWritten
-	bytesFlushed := w.bytesFlushed
+	streamExpired := w.streamExpired
+	shouldSkipFallback := w.skipFallback
 	failedChunks := w.failedFlushChunks
-	remainingBuf := w.buf.String()
+	fullContent := w.fullContent.String()
 	w.mu.Unlock()
 
 	if !started {
 		return nil
 	}
 
-	integrityOK := len(failedChunks) == 0 && bytesWritten == bytesFlushed
+	integrityOK := len(failedChunks) == 0
 	duration := time.Since(w.streamStartTime).Round(time.Millisecond)
 
-	if (!integrityOK || streamExpired) && !shouldSkipFallback {
+	if !integrityOK {
 		w.log.Warn("slack: stream closed with issues",
 			"channel", w.channelID, "thread", w.threadTS,
 			"duration", duration,
-			"bytes_written", bytesWritten, "bytes_flushed", bytesFlushed,
 			"failed_chunks", len(failedChunks), "expired", streamExpired)
 	} else {
 		w.log.Debug("slack: stream closed",
 			"channel", w.channelID, "thread", w.threadTS,
-			"duration", duration,
-			"bytes_written", bytesWritten)
+			"duration", duration)
 	}
 
 	// Use a fresh context for cleanup since startCtx may be cancelled
@@ -393,32 +383,23 @@ func (w *NativeStreamingWriter) Close() error {
 		w.onComplete(w.messageTS)
 	}
 
-	if (!integrityOK || streamExpired) && !shouldSkipFallback {
-		var fallbackText string
-		if streamExpired {
-			fallbackText = "⚠️ *Stream expired, sending complete content:*\n\n"
-		} else if len(failedChunks) > 0 {
-			fallbackText = "⚠️ *Stream interrupted, resending incomplete content:*\n\n"
-			for _, chunk := range failedChunks {
-				fallbackText += chunk
-			}
+	if !integrityOK && !shouldSkipFallback {
+		label := "Stream expired"
+		if !streamExpired {
+			label = "Stream interrupted"
 		}
-		if remainingBuf != "" {
-			fallbackText += remainingBuf
+		fallbackText := fmt.Sprintf("⚠️ *%s, resending complete content:*\n\n%s", label, fullContent)
+		opts := []slack.MsgOption{slack.MsgOptionText(fallbackText, false)}
+		if w.threadTS != "" {
+			opts = append(opts, slack.MsgOptionTS(w.threadTS))
 		}
-		if fallbackText != "" {
-			opts := []slack.MsgOption{slack.MsgOptionText(fallbackText, false)}
-			if w.threadTS != "" {
-				opts = append(opts, slack.MsgOptionTS(w.threadTS))
-			}
-			if w.teamID != "" {
-				opts = append(opts, slack.MsgOptionRecipientTeamID(w.teamID))
-			}
-			_, _, err := w.client.PostMessageContext(cleanupCtx, w.channelID, opts...)
-			if err != nil {
-				w.log.Error("slack: fallback PostMessage failed",
-					"channel", w.channelID, "err", err)
-			}
+		if w.teamID != "" {
+			opts = append(opts, slack.MsgOptionRecipientTeamID(w.teamID))
+		}
+		_, _, err := w.client.PostMessageContext(cleanupCtx, w.channelID, opts...)
+		if err != nil {
+			w.log.Error("slack: fallback PostMessage failed",
+				"channel", w.channelID, "err", err)
 		}
 	}
 	return nil

--- a/internal/messaging/slack/stream_test.go
+++ b/internal/messaging/slack/stream_test.go
@@ -192,11 +192,9 @@ func TestAC25_CloseTriggersFallbackOnStreamExpired(t *testing.T) {
 
 	w.streamExpired = false
 	w.failedFlushChunks = []string{"chunk1", "chunk2"}
-	w.bytesWritten = 100
-	w.bytesFlushed = 50
 
-	integrityOK := len(w.failedFlushChunks) == 0 && w.bytesWritten == w.bytesFlushed
-	require.False(t, integrityOK, "AC-2.5: Integrity check should fail with incomplete flush")
+	integrityOK := len(w.failedFlushChunks) == 0
+	require.False(t, integrityOK, "AC-2.5: Integrity check should fail with failed chunks")
 	require.True(t, len(w.failedFlushChunks) > 0 || w.streamExpired, "AC-2.5: Fallback condition should be met")
 }
 
@@ -292,7 +290,7 @@ func TestDeadCodeRemoved(t *testing.T) {
 }
 
 func TestStreamRotationTTL(t *testing.T) {
-	require.Equal(t, 500*time.Second, StreamRotationTTL, "rotation TTL should be 500 seconds (aligned with Feishu)")
+	require.Equal(t, 240*time.Second, StreamRotationTTL, "rotation TTL should be 240 seconds (safe margin under ~300s Slack limit)")
 	require.Less(t, StreamRotationTTL, StreamTTL,
 		"rotation TTL must be less than server TTL")
 }


### PR DESCRIPTION
## Summary

Fixes #320 — four related streaming bugs:

- **Slack TOCTOU race**: `Close()` captures `streamExpired` before `wg.Wait()`, causing wrong fallback path when the final flush sets `streamExpired=true` concurrently
- **Slack fallback incomplete**: resends `fullContent` instead of partial `failedChunks + remainingBuf`
- **Feishu turn number**: TTL rotation hardcodes `turnNum=0` instead of `c.turnCount+1`
- **Slack TTL tuning**: adjusted constants to match empirically observed ~300s server limit (10m→5m, 500s→240s)

## Changes

| File | Change |
|------|--------|
| `internal/messaging/slack/stream.go` | Fix TOCTOU by reading state after `wg.Wait()`; use `fullContent` in fallback; remove `bytesWritten`/`bytesFlushed`; adjust TTL constants |
| `internal/messaging/slack/stream_test.go` | Update TTL and integrity assertions |
| `internal/messaging/feishu/adapter.go` | Pass `c.turnCount+1` to rotated `StreamingCardController` |

## Test plan

- [x] `make check` passes
- [ ] Manual: Slack streaming fallback sends full content on stream expiry
- [ ] Manual: Feishu card header preserves turn number after TTL rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)