### PR TITLE
refactor(webchat): unify types, add structured logger and connection state indicator

### DIFF
--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -628,6 +628,19 @@ func (c *FeishuConn) EnableStreaming(ctrl *StreamingCardController) {
 	c.streamCtrl = ctrl
 }
 
+func (c *FeishuConn) getStreamCtrl() *StreamingCardController {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.streamCtrl
+}
+
+func (c *FeishuConn) handleToolReaction(ctx context.Context) {
+	c.mu.RLock()
+	elapsed := time.Since(c.startedAt)
+	c.mu.RUnlock()
+	c.cycleReaction(ctx, timelineEmoji(elapsed))
+}
+
 func (c *FeishuConn) SetTypingReactionID(rid string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -786,11 +799,21 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 			}
 		}
 		return nil
-	case events.ToolCall, events.ToolResult:
-		c.mu.RLock()
-		elapsed := time.Since(c.startedAt)
-		c.mu.RUnlock()
-		c.cycleReaction(ctx, timelineEmoji(elapsed))
+	case events.ToolCall:
+		c.handleToolReaction(ctx)
+		if ctrl := c.getStreamCtrl(); ctrl != nil {
+			if id, text := extractToolCallStatus(env); id != "" {
+				ctrl.WriteToolCall(id, text)
+			}
+		}
+		return nil
+	case events.ToolResult:
+		c.handleToolReaction(ctx)
+		if ctrl := c.getStreamCtrl(); ctrl != nil {
+			if id := extractToolResultID(env); id != "" {
+				ctrl.WriteToolResult(id)
+			}
+		}
 		return nil
 	case events.PermissionRequest:
 		streamCtrl := c.clearActiveIndicators(ctx)

--- a/internal/messaging/feishu/card_template.go
+++ b/internal/messaging/feishu/card_template.go
@@ -81,23 +81,30 @@ func buildCard(header cardHeader, config map[string]any, elements []map[string]a
 	return encodeCard(card)
 }
 
+// toolActivityElementID is the element_id for the tool activity strip.
+const toolActivityElementID = "tool_activity"
+
 // buildStreamingCard constructs a streaming card with streaming_mode, element_id, summary, and optional header.
 func buildStreamingCard(header cardHeader, summary, content string) string {
+	elements := []any{
+		map[string]any{
+			"tag":        "markdown",
+			"element_id": streamingElementID,
+			"content":    content,
+		},
+		map[string]any{
+			"tag":        "markdown",
+			"element_id": toolActivityElementID,
+			"content":    "",
+		},
+	}
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
 			"streaming_mode": true,
 			"summary":        map[string]any{"content": summary},
 		},
-		"body": map[string]any{
-			"elements": []any{
-				map[string]any{
-					"tag":        "markdown",
-					"element_id": streamingElementID,
-					"content":    content,
-				},
-			},
-		},
+		"body": map[string]any{"elements": elements},
 	}
 	if hm := header.toMap(); hm != nil {
 		card["header"] = hm

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -90,6 +90,10 @@ type StreamingCardController struct {
 	bufRunes        int // running rune count for flush threshold
 	failedFlushes   int
 
+	// Tool activity strip state.
+	toolEntries []toolEntry // ring buffer, max 2 entries
+	toolDirty   bool        // true when toolEntries changed and needs flush
+
 	chatType     string
 	replyToMsgID string
 	limiter      *FeishuRateLimiter
@@ -143,6 +147,57 @@ func NewStreamingCardController(client *lark.Client, limiter *FeishuRateLimiter,
 // SetCloseMeta injects turn summary data before Close() for header enrichment.
 func (c *StreamingCardController) SetCloseMeta(d messaging.TurnSummaryData) {
 	c.closeMeta.Store(&d)
+}
+
+const maxToolEntries = 2
+
+// WriteToolCall appends a tool activity entry. Oldest entry scrolls out when capacity is exceeded.
+func (c *StreamingCardController) WriteToolCall(id, text string) {
+	if c.getPhase() >= PhaseCompleted {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.toolEntries = append(c.toolEntries, toolEntry{id: id, text: text})
+	if len(c.toolEntries) > maxToolEntries {
+		c.toolEntries = c.toolEntries[len(c.toolEntries)-maxToolEntries:]
+	}
+	c.toolDirty = true
+}
+
+// WriteToolResult marks the matching tool entry as done by ID.
+func (c *StreamingCardController) WriteToolResult(id string) {
+	if c.getPhase() >= PhaseCompleted {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.toolEntries {
+		if c.toolEntries[i].id == id {
+			c.toolEntries[i].done = true
+			c.toolDirty = true
+			return
+		}
+	}
+}
+
+// MarkAllToolsDone marks all tool entries as done. Called on Close/Abort.
+func (c *StreamingCardController) MarkAllToolsDone() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.toolEntries {
+		c.toolEntries[i].done = true
+	}
+	c.toolDirty = true
+}
+
+// toolActivityText returns the rendered tool activity strip content.
+func (c *StreamingCardController) toolActivityText() string {
+	c.mu.Lock()
+	entries := make([]toolEntry, len(c.toolEntries))
+	copy(entries, c.toolEntries)
+	c.mu.Unlock()
+	return renderToolActivity(entries)
 }
 
 // closeTags builds text_tag_list from closeMeta (full Turn/Model/Branch).
@@ -283,6 +338,9 @@ func (c *StreamingCardController) Write(text string) error {
 }
 
 func (c *StreamingCardController) Flush(ctx context.Context) error {
+	// Flush tool activity strip independently of content flush.
+	c.flushToolActivity(ctx)
+
 	c.mu.Lock()
 	content := c.buf.String()
 	c.mu.Unlock()
@@ -354,6 +412,31 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 	return nil
 }
 
+// flushToolActivity flushes the tool activity element via CardKit.
+func (c *StreamingCardController) flushToolActivity(ctx context.Context) {
+	c.mu.Lock()
+	if !c.toolDirty {
+		c.mu.Unlock()
+		return
+	}
+	entries := make([]toolEntry, len(c.toolEntries))
+	copy(entries, c.toolEntries)
+	c.mu.Unlock()
+
+	text := renderToolActivity(entries)
+	if text == "" || !c.cardKitOK || c.cardID == "" || !c.limiter.AllowCardKit(c.cardID) {
+		return
+	}
+	seq := int(c.sequence.Add(1))
+	if err := c.flushCardKitElement(ctx, toolActivityElementID, text, seq); err != nil {
+		c.log.Debug("feishu: tool activity flush failed (non-fatal)", "err", err)
+	} else {
+		c.mu.Lock()
+		c.toolDirty = false
+		c.mu.Unlock()
+	}
+}
+
 // startFlushLoop launches the background flush goroutine.
 // Called once after successful transition to PhaseStreaming.
 func (c *StreamingCardController) startFlushLoop() {
@@ -421,6 +504,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	}
 
 	c.stopFlushLoop()
+	c.MarkAllToolsDone()
 
 	c.mu.Lock()
 	content := c.buf.String()
@@ -438,7 +522,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	finalFlushOK := false
 	if c.cardKitOK && c.cardID != "" {
 		seq := int(c.sequence.Add(1))
-		if err := c.flushCardKit(ctx, content, seq); err != nil {
+		if err := c.flushCardKitElement(ctx, c.elementID, content, seq); err != nil {
 			c.log.Warn("feishu: final cardkit flush failed, attempting IM patch fallback",
 				"err", err)
 			if c.msgID != "" {
@@ -507,6 +591,7 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 	}
 
 	c.stopFlushLoop()
+	c.MarkAllToolsDone()
 
 	c.mu.Lock()
 	cardID := c.cardID
@@ -531,6 +616,20 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 	return nil
 }
 
+// buildFinalElements builds the elements list for the final card (Close/Abort),
+// including both streaming content and tool activity strip.
+func (c *StreamingCardController) buildFinalElements(body string) []map[string]any {
+	elements := []map[string]any{
+		{"tag": "markdown", "element_id": streamingElementID, "content": body},
+	}
+	if toolContent := c.toolActivityText(); toolContent != "" {
+		elements = append(elements, map[string]any{
+			"tag": "markdown", "element_id": toolActivityElementID, "content": toolContent,
+		})
+	}
+	return elements
+}
+
 func (c *StreamingCardController) updateHeader(ctx context.Context, cardID string, header cardHeader, body string) {
 	if cardID == "" {
 		return
@@ -541,9 +640,7 @@ func (c *StreamingCardController) updateHeader(ctx context.Context, cardID strin
 			"streaming_mode": false,
 			"summary":        map[string]any{"content": truncateForSummary(body)},
 		},
-		[]map[string]any{
-			{"tag": "markdown", "element_id": streamingElementID, "content": body},
-		},
+		c.buildFinalElements(body),
 	)
 
 	reqBody := larkcardkit.NewUpdateCardReqBodyBuilder().
@@ -723,7 +820,7 @@ func (c *StreamingCardController) disableStreaming(ctx context.Context) error {
 	return nil
 }
 
-func (c *StreamingCardController) flushCardKit(ctx context.Context, content string, seq int) error {
+func (c *StreamingCardController) flushCardKitElement(ctx context.Context, elementID, content string, seq int) error {
 	uuid := fmt.Sprintf("feishu-stream-%d", time.Now().UnixNano())
 
 	body := larkcardkit.NewContentCardElementReqBodyBuilder().
@@ -734,7 +831,7 @@ func (c *StreamingCardController) flushCardKit(ctx context.Context, content stri
 
 	req := larkcardkit.NewContentCardElementReqBuilder().
 		CardId(c.cardID).
-		ElementId(c.elementID).
+		ElementId(elementID).
 		Body(body).
 		Build()
 
@@ -754,7 +851,7 @@ func (c *StreamingCardController) flushCardKit(ctx context.Context, content stri
 func (c *StreamingCardController) flushCardKitWithRetry(ctx context.Context, content string, seq int) error {
 	var lastErr error
 	for attempt := range 3 {
-		if err := c.flushCardKit(ctx, content, seq); err == nil {
+		if err := c.flushCardKitElement(ctx, c.elementID, content, seq); err == nil {
 			return nil
 		} else {
 			lastErr = err

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -91,8 +91,9 @@ type StreamingCardController struct {
 	failedFlushes   int
 
 	// Tool activity strip state.
-	toolEntries []toolEntry // ring buffer, max 2 entries
-	toolDirty   bool        // true when toolEntries changed and needs flush
+	toolEntries       []toolEntry // ring buffer, max 2 entries
+	toolDirty         bool        // true when toolEntries changed and needs flush
+	failedToolFlushes int         // consecutive flush failures; gives up after 3
 
 	chatType     string
 	replyToMsgID string
@@ -189,15 +190,6 @@ func (c *StreamingCardController) MarkAllToolsDone() {
 		c.toolEntries[i].done = true
 	}
 	c.toolDirty = true
-}
-
-// toolActivityText returns the rendered tool activity strip content.
-func (c *StreamingCardController) toolActivityText() string {
-	c.mu.Lock()
-	entries := make([]toolEntry, len(c.toolEntries))
-	copy(entries, c.toolEntries)
-	c.mu.Unlock()
-	return renderToolActivity(entries)
 }
 
 // closeTags builds text_tag_list from closeMeta (full Turn/Model/Branch).
@@ -429,10 +421,20 @@ func (c *StreamingCardController) flushToolActivity(ctx context.Context) {
 	}
 	seq := int(c.sequence.Add(1))
 	if err := c.flushCardKitElement(ctx, toolActivityElementID, text, seq); err != nil {
-		c.log.Debug("feishu: tool activity flush failed (non-fatal)", "err", err)
+		c.failedToolFlushes++
+		if c.failedToolFlushes >= 3 {
+			c.log.Warn("feishu: tool activity flush repeatedly failed, giving up",
+				"err", err, "failures", c.failedToolFlushes)
+			c.mu.Lock()
+			c.toolDirty = false
+			c.mu.Unlock()
+		} else {
+			c.log.Warn("feishu: tool activity flush failed", "err", err)
+		}
 	} else {
 		c.mu.Lock()
 		c.toolDirty = false
+		c.failedToolFlushes = 0
 		c.mu.Unlock()
 	}
 }
@@ -622,7 +624,11 @@ func (c *StreamingCardController) buildFinalElements(body string) []map[string]a
 	elements := []map[string]any{
 		{"tag": "markdown", "element_id": streamingElementID, "content": body},
 	}
-	if toolContent := c.toolActivityText(); toolContent != "" {
+	c.mu.Lock()
+	entries := make([]toolEntry, len(c.toolEntries))
+	copy(entries, c.toolEntries)
+	c.mu.Unlock()
+	if toolContent := renderToolActivity(entries); toolContent != "" {
 		elements = append(elements, map[string]any{
 			"tag": "markdown", "element_id": toolActivityElementID, "content": toolContent,
 		})
@@ -888,7 +894,8 @@ func (c *StreamingCardController) flushIMPatchWithConfig(ctx context.Context, co
 }
 
 func (c *StreamingCardController) doFlushIMPatch(ctx context.Context, header cardHeader, config map[string]any, content string, final bool) error {
-	contentJSON := buildCard(header, config, []map[string]any{{"tag": "markdown", "content": content}})
+	elements := c.buildFinalElements(content)
+	contentJSON := buildCard(header, config, elements)
 
 	body := larkim.NewPatchMessageReqBodyBuilder().
 		Content(contentJSON).

--- a/internal/messaging/feishu/tool_status.go
+++ b/internal/messaging/feishu/tool_status.go
@@ -1,0 +1,145 @@
+package feishu
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+const toolStatusMaxRunes = 30
+
+// toolEntry tracks a single tool call for the activity strip.
+type toolEntry struct {
+	id   string // matches ToolCallData.ID for result correlation
+	text string // formatted short status, e.g. "📖 Reading(adapter.go)"
+	done bool   // set true when tool_result arrives
+}
+
+// toolFmt defines how a tool name maps to a human-readable status.
+type toolFmt struct {
+	emoji string // e.g. "📖"
+	verb  string // e.g. "Reading"; empty means use just emoji + value
+	key   string // input field to extract, e.g. "file_path"
+}
+
+var toolFmtMap = map[string]toolFmt{
+	"Read":         {"📖", "Reading", "file_path"},
+	"Edit":         {"✏️", "Editing", "file_path"},
+	"Write":        {"📝", "Writing", "file_path"},
+	"NotebookEdit": {"📓", "Editing", "notebook_path"},
+	"Bash":         {"⏳", "", "command"},
+	"Grep":         {"🔍", "", "pattern"},
+	"Glob":         {"📂", "", "pattern"},
+	"WebSearch":    {"🌐", "Searching", "query"},
+	"WebFetch":     {"🌐", "Fetching", "url"},
+	"Agent":        {"🤖", "", "prompt"},
+	"TodoWrite":    {"📋", "", "todos"},
+	"LSP":          {"🔎", "", "text"},
+}
+
+// formatToolCall produces a short status string for a tool_call event.
+func formatToolCall(name string, input map[string]any) string {
+	if f, ok := toolFmtMap[name]; ok {
+		val := extractInputField(input, f.key)
+		val = truncateRunes(shortenPath(val), toolStatusMaxRunes)
+		if f.verb != "" {
+			if val != "" {
+				return f.emoji + " " + f.verb + " " + val
+			}
+			return f.emoji + " " + f.verb
+		}
+		if val != "" {
+			return f.emoji + " " + val
+		}
+		return f.emoji + " " + name
+	}
+	return formatFallbackTool(name, input)
+}
+
+func formatFallbackTool(name string, input map[string]any) string {
+	keys := sortedKeys(input)
+	if len(keys) == 0 {
+		return name
+	}
+	val := fmt.Sprintf("%v", input[keys[0]])
+	val = truncateRunes(shortenPath(val), toolStatusMaxRunes/2)
+	return truncateRunes(name+"("+val+")", toolStatusMaxRunes)
+}
+
+func extractInputField(input map[string]any, key string) string {
+	if input == nil {
+		return ""
+	}
+	v, ok := input[key]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func shortenPath(s string) string {
+	parts := strings.Split(s, "/")
+	if len(parts) <= 1 {
+		return s
+	}
+	return parts[len(parts)-1]
+}
+
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if max > 1 {
+		return string(runes[:max-1]) + "…"
+	}
+	return string(runes[:max])
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// renderToolActivity renders up to 2 tool entries as a single-line markdown string.
+// Returns empty string if no entries.
+// Format: "✅ Reading(main.go) · 🔧 make test"
+func renderToolActivity(entries []toolEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		prefix := "🔧 "
+		if e.done {
+			prefix = "✅ "
+		}
+		parts = append(parts, prefix+e.text)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// extractToolCallStatus extracts a formatted status from a ToolCall envelope.
+func extractToolCallStatus(env *events.Envelope) (id, text string) {
+	data, ok := events.DecodeAs[events.ToolCallData](env.Event.Data)
+	if !ok {
+		return "", ""
+	}
+	return data.ID, formatToolCall(data.Name, data.Input)
+}
+
+// extractToolResultID extracts the tool call ID from a ToolResult envelope.
+func extractToolResultID(env *events.Envelope) string {
+	data, ok := events.DecodeAs[events.ToolResultData](env.Event.Data)
+	if !ok {
+		return ""
+	}
+	return data.ID
+}

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -13,7 +13,7 @@ import { BrandIcon } from '@/components/icons';
 import { SessionPanel } from './SessionPanel';
 import { NewSessionModal } from './NewSessionModal';
 import { MetricsBar } from '@/components/assistant-ui/MetricsBar';
-import { workerType, workDir } from '@/lib/config';
+import { workerType, workDir, type ConnectionState } from '@/lib/config';
 import type { SessionMetrics } from '@/lib/hooks/useMetrics';
 
 function ChatInterface({
@@ -36,7 +36,7 @@ function ChatInterface({
 
   type AdapterExtras = {
     hasMore?: boolean;
-    connectionState?: 'connected' | 'connecting' | 'disconnected';
+    connectionState?: ConnectionState;
     onLoadHistory?: () => Promise<{ hasMore: boolean }>;
     onInteractionRespond?: (toolCallId: string, allowed: boolean) => void;
   };

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -36,18 +36,20 @@ function ChatInterface({
 
   type AdapterExtras = {
     hasMore?: boolean;
+    connectionState?: 'connected' | 'connecting' | 'disconnected';
     onLoadHistory?: () => Promise<{ hasMore: boolean }>;
     onInteractionRespond?: (toolCallId: string, allowed: boolean) => void;
   };
   const extras = adapter.extras as AdapterExtras | undefined;
   const hasMore = extras?.hasMore ?? false;
+  const connectionState = extras?.connectionState;
   const onLoadHistory = extras?.onLoadHistory;
   const onInteractionRespond = extras?.onInteractionRespond;
   const suggestions = adapter.suggestions as readonly { title: string; label: string; prompt: string }[] | undefined;
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <Thread skills={skills} hasMore={hasMore} onLoadHistory={onLoadHistory} onInteractionRespond={onInteractionRespond} suggestions={suggestions} />
+      <Thread skills={skills} hasMore={hasMore} connectionState={connectionState} onLoadHistory={onLoadHistory} onInteractionRespond={onInteractionRespond} suggestions={suggestions} />
     </AssistantRuntimeProvider>
   );
 }

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -24,6 +24,7 @@ import { ListTool } from "./tools/ListTool";
 import { TodoTool } from "./tools/TodoTool";
 import { AgentTool } from "./tools/AgentTool";
 import type { ContextUsageData, TurnSessionStats } from "@/lib/ai-sdk-transport/client/types";
+import type { ConnectionState } from "@/lib/config";
 
 // assistant-ui ThreadMessage doesn't expose status/metadata in public types.
 // Centralize the extension access here to avoid scattered as-any casts.
@@ -154,6 +155,7 @@ function MessageActions({ message, isUser }: { message: any, isUser?: boolean })
 
 const AssistantMessage = memo(function AssistantMessage({ message, onInteractionRespond }: { message: any; onInteractionRespond?: (toolCallId: string, allowed: boolean) => void }) {
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
+  const ext = getExt(message);
 
   return (
     <motion.div className="group msg-assistant flex items-start gap-4 mb-8" variants={messageVariants} initial="hidden" animate="visible">
@@ -170,13 +172,13 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
             {({ part }) => {
               const p = part as Record<string, any>;
               if (!p || !p.type) return null;
-              const isStreaming = getExt(message).status?.type === "running";
+              const isStreaming = ext.status?.type === "running";
 
               if (p.type === "reasoning") return <ReasoningBlock text={p.text || p.reasoning || ""} />;
               if (p.type === "text") return <div className={`prose-hotplex ${isStreaming ? "streaming-cursor" : ""}`}><MarkdownText text={p.text} /></div>;
               
               if (p.type === "tool-call") {
-                const parts = getExt(message).content || [];
+                const parts = ext.content || [];
                 const partIndex = parts.indexOf(p);
                 const isLastPart = partIndex === parts.length - 1;
                 const isComplete = p.status?.type === "complete" || p.status?.type === "error";
@@ -257,11 +259,11 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
               return null;
             }}
           </MessagePrimitive.Parts>
-          {getExt(message).metadata?.contextUsage && (
-            <ContextUsageCard data={getExt(message).metadata!.contextUsage!} />
+          {ext.metadata?.contextUsage && (
+            <ContextUsageCard data={ext.metadata.contextUsage} />
           )}
-          {getExt(message).metadata?.turnSummary && (
-            <TurnSummaryCard data={getExt(message).metadata!.turnSummary!} />
+          {ext.metadata?.turnSummary && (
+            <TurnSummaryCard data={ext.metadata.turnSummary} />
           )}
         </div>
         <MessageActions message={message} />
@@ -398,19 +400,19 @@ function WelcomeScreen({ suggestions, onSuggestionClick }: { suggestions?: reado
 interface ThreadProps {
   skills?: string[];
   hasMore?: boolean;
-  connectionState?: 'connected' | 'connecting' | 'disconnected';
+  connectionState?: ConnectionState;
   onLoadHistory?: () => Promise<{ hasMore: boolean }>;
   onInteractionRespond?: (toolCallId: string, allowed: boolean) => void;
   suggestions?: readonly { title: string; label: string; prompt: string }[];
 }
 
-const connLabel: Record<string, string> = {
+const connLabel: Record<ConnectionState, string> = {
   connected: 'Connected',
   connecting: 'Connecting...',
   disconnected: 'Disconnected',
 };
 
-const connDot: Record<string, string> = {
+const connDot: Record<ConnectionState, string> = {
   connected: 'bg-emerald-400',
   connecting: 'bg-amber-400 animate-pulse',
   disconnected: 'bg-red-400',

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useRef, useState, memo } from "react";
+import { version } from "../../package.json";
 import {
   ThreadPrimitive,
   ComposerPrimitive,
@@ -22,6 +23,22 @@ import { TurnSummaryCard } from "./TurnSummaryCard";
 import { ListTool } from "./tools/ListTool";
 import { TodoTool } from "./tools/TodoTool";
 import { AgentTool } from "./tools/AgentTool";
+import type { ContextUsageData, TurnSessionStats } from "@/lib/ai-sdk-transport/client/types";
+
+// assistant-ui ThreadMessage doesn't expose status/metadata in public types.
+// Centralize the extension access here to avoid scattered as-any casts.
+interface ThreadMessageExtension {
+  status?: { type: string };
+  metadata?: {
+    contextUsage?: ContextUsageData;
+    turnSummary?: TurnSessionStats;
+  };
+  content: unknown[];
+}
+
+function getExt(msg: unknown): ThreadMessageExtension {
+  return msg as ThreadMessageExtension;
+}
 
 /* ============================================================
    Animation & Extraction Logic (Legacy Sync)
@@ -153,13 +170,13 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
             {({ part }) => {
               const p = part as Record<string, any>;
               if (!p || !p.type) return null;
-              const isStreaming = (message as any)?.status?.type === "running";
+              const isStreaming = getExt(message).status?.type === "running";
 
               if (p.type === "reasoning") return <ReasoningBlock text={p.text || p.reasoning || ""} />;
               if (p.type === "text") return <div className={`prose-hotplex ${isStreaming ? "streaming-cursor" : ""}`}><MarkdownText text={p.text} /></div>;
               
               if (p.type === "tool-call") {
-                const parts = (message.content as any[]) || [];
+                const parts = getExt(message).content || [];
                 const partIndex = parts.indexOf(p);
                 const isLastPart = partIndex === parts.length - 1;
                 const isComplete = p.status?.type === "complete" || p.status?.type === "error";
@@ -240,11 +257,11 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
               return null;
             }}
           </MessagePrimitive.Parts>
-          {(message as any)?.metadata?.contextUsage && (
-            <ContextUsageCard data={(message as any).metadata.contextUsage} />
+          {getExt(message).metadata?.contextUsage && (
+            <ContextUsageCard data={getExt(message).metadata!.contextUsage!} />
           )}
-          {(message as any)?.metadata?.turnSummary && (
-            <TurnSummaryCard data={(message as any).metadata.turnSummary} />
+          {getExt(message).metadata?.turnSummary && (
+            <TurnSummaryCard data={getExt(message).metadata!.turnSummary!} />
           )}
         </div>
         <MessageActions message={message} />
@@ -253,7 +270,7 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
   );
 }, (prev, next) => {
   if (prev.message.id !== next.message.id) return false;
-  if ((next.message as any)?.status?.type === 'running') return false;
+  if (getExt(next.message).status?.type === 'running') return false;
   if (prev.onInteractionRespond !== next.onInteractionRespond) return false;
   return prev.message.content === next.message.content;
 });
@@ -381,12 +398,25 @@ function WelcomeScreen({ suggestions, onSuggestionClick }: { suggestions?: reado
 interface ThreadProps {
   skills?: string[];
   hasMore?: boolean;
+  connectionState?: 'connected' | 'connecting' | 'disconnected';
   onLoadHistory?: () => Promise<{ hasMore: boolean }>;
   onInteractionRespond?: (toolCallId: string, allowed: boolean) => void;
   suggestions?: readonly { title: string; label: string; prompt: string }[];
 }
 
-export function Thread({ skills, hasMore, onLoadHistory, onInteractionRespond, suggestions }: ThreadProps) {
+const connLabel: Record<string, string> = {
+  connected: 'Connected',
+  connecting: 'Connecting...',
+  disconnected: 'Disconnected',
+};
+
+const connDot: Record<string, string> = {
+  connected: 'bg-emerald-400',
+  connecting: 'bg-amber-400 animate-pulse',
+  disconnected: 'bg-red-400',
+};
+
+export function Thread({ skills, hasMore, connectionState: conn, onLoadHistory, onInteractionRespond, suggestions }: ThreadProps) {
   const [localText, setLocalText] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -536,8 +566,14 @@ export function Thread({ skills, hasMore, onLoadHistory, onInteractionRespond, s
                 <kbd className="px-1.5 py-0.5 rounded bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[9px]">Shift</kbd> + <kbd className="px-1.5 py-0.5 rounded bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[9px]">Enter</kbd> new line
               </span>
             </div>
-            <span className="text-[10px] text-[var(--text-faint)] font-mono uppercase tracking-widest">
-              v1.1.0-stable
+            <span className="text-[10px] text-[var(--text-faint)] font-mono uppercase tracking-widest flex items-center gap-1.5">
+              {conn && (
+                <>
+                  <span className={`w-1.5 h-1.5 rounded-full ${connDot[conn]}`} title={connLabel[conn]} />
+                  <span className="sr-only">{connLabel[conn]}</span>
+                </>
+              )}
+              v{version}-stable
             </span>
           </div>
         </div>

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -14,6 +14,7 @@ import { wsUrl, workerType, apiKey, workDir, allowedTools } from '@/lib/config';
 import { useMetrics } from '@/lib/hooks/useMetrics';
 import { getSessionHistory, type ConversationRecord } from '@/lib/api/sessions';
 import { conversationTurnsToMessages } from '@/lib/utils/turn-replay';
+import { logger } from '@/lib/logger';
 import type {
   Envelope,
   MessageDeltaData,
@@ -26,8 +27,10 @@ import type {
   ToolResultData,
 } from '@/lib/ai-sdk-transport';
 import type { TextPart, ReasoningPart, ToolCallPart, ToolSummaryPart, ContextUsagePart, TurnSummaryPart, MessagePart } from '@/lib/types/message-parts';
+import type { HotPlexMessage } from '@/lib/types/message';
 
 // Re-export for consumers
+export type { HotPlexMessage };
 export type { TextPart, ReasoningPart, ToolCallPart, ToolSummaryPart, ContextUsagePart, TurnSummaryPart, MessagePart };
 
 // ThreadSuggestion shape — matches @assistant-ui/core ThreadSuggestion
@@ -48,15 +51,6 @@ export interface UseHotPlexRuntimeConfig {
   onSkillsChange?: (skills: string[]) => void;
   /** Custom welcome suggestions shown when thread is empty. */
   suggestions?: readonly ThreadSuggestion[];
-}
-
-// Internal message format for our store
-interface HotPlexMessage {
-  id: string;
-  role: 'user' | 'assistant' | 'system';
-  parts: MessagePart[];
-  createdAt: Date;
-  status?: 'streaming' | 'complete' | 'error';
 }
 
 // ============================================================================
@@ -80,22 +74,25 @@ function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
   // Extract turn summary data for card rendering
   const turnSummaryPart = parts.find((p): p is TurnSummaryPart => p.type === 'turn-summary');
 
-  const result: ThreadMessageLike = {
+  // Extended ThreadMessageLike for HotPlex-specific metadata
+  // (assistant-ui ThreadMessageLike.metadata is typed, but our custom keys need explicit typing)
+  const result = {
     id: message.id,
     role,
     content,
     createdAt: message.createdAt,
-    attachments: [],
+    attachments: [] as const,
     metadata: {
       ...(contextUsagePart ? { contextUsage: contextUsagePart.data } : {}),
       ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
-    } as any,
+    } satisfies Record<string, unknown>,
+  } as ThreadMessageLike & {
+    status?: { type: 'running' } | { type: 'complete'; reason: string };
   };
 
   // Status is only supported for assistant messages
   if (message.role === 'assistant') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (result as any).status = message.status === 'streaming'
+    result.status = message.status === 'streaming'
       ? { type: 'running' }
       : { type: 'complete', reason: 'stop' };
   }
@@ -173,6 +170,7 @@ export function useHotPlexRuntime({
   const [messages, setMessages] = useState<HotPlexMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [historyHasMore, setHistoryHasMore] = useState(true);
+  const [connectionState, setConnectionState] = useState<'connected' | 'connecting' | 'disconnected'>('disconnected');
 
   // One-time cleanup of orphaned localStorage keys from removed message cache
   useEffect(() => {
@@ -273,7 +271,7 @@ export function useHotPlexRuntime({
       })
       .catch(err => {
         if (err instanceof DOMException && err.name === 'AbortError') return;
-        console.warn('HotPlexRuntimeAdapter: failed to load history', err);
+        logger.warn('RuntimeAdapter', 'Failed to load history', { error: String(err) });
         setMessages(prev => [...prev, {
           id: `history-error-${Date.now()}`,
           role: 'assistant' as const,
@@ -289,7 +287,7 @@ export function useHotPlexRuntime({
   // Initialize WebSocket client
   useEffect(() => {
     if (!sessionId) {
-      console.log('HotPlexRuntimeAdapter: No session ID provided, skipping connection.');
+      logger.info('RuntimeAdapter', 'No session ID, skipping connection');
       return;
     }
 
@@ -443,7 +441,7 @@ export function useHotPlexRuntime({
           // Replace previous todo tool-call instead of stacking duplicates
           if (TODO_TOOLS.has(data.name?.toLowerCase())) {
             const lastTodoIdx = lastMessage.parts.findLastIndex(
-              (p) => p.type === 'tool-call' && TODO_TOOLS.has((p as any).toolName?.toLowerCase())
+              (p): p is ToolCallPart => p.type === 'tool-call' && TODO_TOOLS.has(p.toolName.toLowerCase())
             );
             if (lastTodoIdx !== -1) {
               const parts = [...lastMessage.parts];
@@ -524,7 +522,7 @@ export function useHotPlexRuntime({
       // Shutdown errors are transient — gateway is restarting. Don't pollute the
       // chat with error messages; the client will auto-reconnect.
       if (isShutdown) {
-        console.log('HotPlexRuntimeAdapter: gateway shutdown detected, waiting for reconnect');
+        logger.info('RuntimeAdapter', 'Gateway shutdown, waiting for reconnect');
         return;
       }
 
@@ -533,12 +531,12 @@ export function useHotPlexRuntime({
         const detailsStr = data.details ? ` Details: ${JSON.stringify(data.details)}` : '';
         const eventStr = env?.id ? ` EventID: ${env.id}` : '';
         if (isResumeRetry) {
-          console.warn(`HotPlexRuntimeAdapter: worker recovery triggered. Code: ${data.code}, Message: ${data.message}${detailsStr}${eventStr}`);
+          logger.warn('RuntimeAdapter', 'Worker recovery triggered', { code: data.code, message: data.message, details: data.details, eventId: env?.id });
         } else {
-          console.error(`HotPlexRuntimeAdapter: error received. Code: ${data.code || 'unknown'}, Message: ${data.message || 'none'}${detailsStr}${eventStr}`);
+          logger.error('RuntimeAdapter', 'Error received', { code: data.code || 'unknown', message: data.message || 'none', details: data.details, eventId: env?.id });
         }
       } else {
-        console.warn(`HotPlexRuntimeAdapter: empty error event received (no code/message). EventID: ${env?.id}`);
+        logger.warn('RuntimeAdapter', 'Empty error event', { eventId: env?.id });
       }
 
       // If it's a fatal error, stop the run and complete the streaming message
@@ -600,8 +598,9 @@ export function useHotPlexRuntime({
     };
 
     const handleDisconnected = (reason: string) => {
-      console.log('HotPlexRuntimeAdapter: disconnected', reason);
+      logger.info('RuntimeAdapter', 'Disconnected', { reason });
       setIsRunning(false);
+      setConnectionState('disconnected');
     };
 
     // Handle messageStart: if we already created a placeholder message for this env.id
@@ -726,8 +725,12 @@ export function useHotPlexRuntime({
     };
     client.on('elicitationRequest', handleElicitationRequest);
 
-    client.connect(sessionId).catch((err) => {
-      console.error('HotPlexRuntimeAdapter: connection failed', err);
+    setConnectionState('connecting');
+    client.connect(sessionId).then(() => {
+      setConnectionState('connected');
+    }).catch((err) => {
+      setConnectionState('disconnected');
+      logger.error('RuntimeAdapter', 'Connection failed', { error: String(err) });
     });
 
     return () => {
@@ -748,6 +751,7 @@ export function useHotPlexRuntime({
       interactionMapRef.current.clear();
       client.disconnect();
       clientRef.current = null;
+      setConnectionState('disconnected');
     };
   }, [sessionId]);
 
@@ -781,13 +785,13 @@ export function useHotPlexRuntime({
 
     // Handle disconnected state: attempt to reconnect if not already connecting
     if (!client.connected) {
-      console.log('HotPlexRuntimeAdapter: client not connected, attempting to reconnect...');
+      logger.info('RuntimeAdapter', 'Client not connected, attempting reconnect');
       try {
         if (!client.connecting) {
           // Don't pass sessionId here — the client internally tracks the latest session ID,
           // which may have been updated by a SessionNotFound retry in BrowserHotPlexClient.
           client.connect().catch(err => {
-            console.error('HotPlexRuntimeAdapter: auto-connect failed', err);
+            logger.error('RuntimeAdapter', 'Auto-connect failed', { error: String(err) });
           });
         }
 
@@ -867,7 +871,7 @@ export function useHotPlexRuntime({
     try {
       client.sendInput(textContent);
     } catch (err) {
-      console.error('HotPlexRuntimeAdapter: sendInput failed', err);
+      logger.error('RuntimeAdapter', 'sendInput failed', { error: String(err) });
       // Remove BOTH user message and ghost message since send failed
       setMessages((prev) => prev.slice(0, -2));
       throw new Error('Failed to send message. Please check your connection.');
@@ -914,7 +918,7 @@ export function useHotPlexRuntime({
       setHistoryHasMore(res.has_more);
       return { hasMore: res.has_more };
     } catch (err) {
-      console.warn('HotPlexRuntimeAdapter: failed to load earlier messages', err);
+      logger.warn('RuntimeAdapter', 'Failed to load earlier messages', { error: String(err) });
       return { hasMore: false };
     } finally {
       historyLoadingRef.current = false;
@@ -974,13 +978,14 @@ export function useHotPlexRuntime({
     edit: true,
   }), []);
 
-  // Stable extras reference — only changes when metrics or history state change
+  // Stable extras reference — only changes when metrics, history, or connection state change
   const extras = useMemo(() => ({
     metrics: sessionMetrics,
     hasMore: historyHasMore,
+    connectionState,
     onLoadHistory: handleLoadHistory,
     onInteractionRespond: handleInteractionRespond,
-  }), [sessionMetrics, historyHasMore, handleLoadHistory, handleInteractionRespond]);
+  }), [sessionMetrics, historyHasMore, connectionState, handleLoadHistory, handleInteractionRespond]);
 
   // Return ExternalStoreAdapter — memoized to prevent unnecessary setAdapter calls
   return useMemo(() => ({

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -10,7 +10,7 @@ import type { ExternalStoreAdapter, ThreadMessageLike, AppendMessage } from '@as
 import { BrowserHotPlexClient } from '@/lib/ai-sdk-transport';
 import type { InitConfig, ContextUsageData, PermissionRequestData, QuestionRequestData, ElicitationRequestData } from '@/lib/ai-sdk-transport/client/types';
 import { WorkerStdioCommand } from '@/lib/ai-sdk-transport/client/constants';
-import { wsUrl, workerType, apiKey, workDir, allowedTools } from '@/lib/config';
+import { wsUrl, workerType, apiKey, workDir, allowedTools, type ConnectionState } from '@/lib/config';
 import { useMetrics } from '@/lib/hooks/useMetrics';
 import { getSessionHistory, type ConversationRecord } from '@/lib/api/sessions';
 import { conversationTurnsToMessages } from '@/lib/utils/turn-replay';
@@ -52,6 +52,14 @@ export interface UseHotPlexRuntimeConfig {
   /** Custom welcome suggestions shown when thread is empty. */
   suggestions?: readonly ThreadSuggestion[];
 }
+
+const DEFAULT_SUGGESTIONS: readonly ThreadSuggestion[] = [
+  { title: '帮我写一个 React 组件', label: '代码', prompt: '帮我写一个 React 组件' },
+  { title: '解释这段代码的逻辑', label: '学习', prompt: '解释这段代码的逻辑' },
+  { title: '帮我调试这个错误', label: '调试', prompt: '帮我调试这个错误' },
+  { title: '重构这段代码让它更简洁', label: '重构', prompt: '重构这段代码让它更简洁' },
+  { title: '解释系统架构设计', label: '架构', prompt: '解释系统架构设计' },
+];
 
 // ============================================================================
 // Message Converter
@@ -170,7 +178,7 @@ export function useHotPlexRuntime({
   const [messages, setMessages] = useState<HotPlexMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [historyHasMore, setHistoryHasMore] = useState(true);
-  const [connectionState, setConnectionState] = useState<'connected' | 'connecting' | 'disconnected'>('disconnected');
+  const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
 
   // One-time cleanup of orphaned localStorage keys from removed message cache
   useEffect(() => {
@@ -189,14 +197,7 @@ export function useHotPlexRuntime({
   sessionIdRef.current = sessionId;
 
   // Welcome suggestions — shown when thread is empty (use prop or default list)
-  const defaultSuggestions: readonly ThreadSuggestion[] = [
-    { title: '帮我写一个 React 组件', label: '代码', prompt: '帮我写一个 React 组件' },
-    { title: '解释这段代码的逻辑', label: '学习', prompt: '解释这段代码的逻辑' },
-    { title: '帮我调试这个错误', label: '调试', prompt: '帮我调试这个错误' },
-    { title: '重构这段代码让它更简洁', label: '重构', prompt: '重构这段代码让它更简洁' },
-    { title: '解释系统架构设计', label: '架构', prompt: '解释系统架构设计' },
-  ];
-  const suggestions: readonly ThreadSuggestion[] = configSuggestions ?? defaultSuggestions;
+  const suggestions: readonly ThreadSuggestion[] = configSuggestions ?? DEFAULT_SUGGESTIONS;
 
   // Stable ref for skills callback — avoids adding to useEffect deps
   const onSkillsChangeRef = useRef(onSkillsChange);
@@ -751,7 +752,6 @@ export function useHotPlexRuntime({
       interactionMapRef.current.clear();
       client.disconnect();
       clientRef.current = null;
-      setConnectionState('disconnected');
     };
   }, [sessionId]);
 
@@ -978,16 +978,16 @@ export function useHotPlexRuntime({
     edit: true,
   }), []);
 
-  // Stable extras reference — only changes when metrics, history, or connection state change
+  // Stable extras reference — only changes when metrics or history state change
   const extras = useMemo(() => ({
     metrics: sessionMetrics,
     hasMore: historyHasMore,
-    connectionState,
     onLoadHistory: handleLoadHistory,
     onInteractionRespond: handleInteractionRespond,
-  }), [sessionMetrics, historyHasMore, connectionState, handleLoadHistory, handleInteractionRespond]);
+  }), [sessionMetrics, historyHasMore, handleLoadHistory, handleInteractionRespond]);
 
   // Return ExternalStoreAdapter — memoized to prevent unnecessary setAdapter calls
+  // connectionState is returned separately to avoid invalidating the adapter memo on reconnect.
   return useMemo(() => ({
     // State
     isRunning,
@@ -1008,7 +1008,10 @@ export function useHotPlexRuntime({
 
     // Metrics — exposed for session dashboard (spec §4.5)
     extras,
-  } as ExternalStoreAdapter<HotPlexMessage>), [
+
+    // Connection state — separate from adapter to avoid memo churn
+    connectionState,
+  } as ExternalStoreAdapter<HotPlexMessage> & { connectionState: ConnectionState }), [
     isRunning, adapterMessages, threadMessages, suggestions,
     handleSetMessages, handleNew, handleCancel, capabilities, extras,
   ]);

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -6,6 +6,7 @@
  */
 
 import { EventEmitter } from 'eventemitter3';
+import { logger } from '@/lib/logger';
 import {
   EventKind,
   SessionState,
@@ -265,7 +266,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       // Handle handshake-level errors
       if (ackData.error || ackData.code) {
         const errorMsg = ackData.error || `Handshake failed with code: ${ackData.code}`;
-        console.error('BrowserHotPlexClient: handshake error', errorMsg);
+        logger.error('BrowserClient', 'Handshake error', { message: errorMsg });
 
         if (ackData.code === ErrorCode.SessionNotFound) {
           // Session was deleted on server — retry with the original session ID.
@@ -328,7 +329,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       case EventKind.Error:
         const errData = event.data as ErrorData;
         if (!event.data || Object.keys(event.data).length === 0) {
-          console.warn('BrowserHotPlexClient: received empty error data', env);
+          logger.warn('BrowserClient', 'Received empty error data', { envId: env?.id });
         }
         
         // Fatal errors shouldn't trigger reconnect

--- a/webchat/lib/config.ts
+++ b/webchat/lib/config.ts
@@ -45,6 +45,8 @@ export const allowedTools: string[] = rawAllowedTools
 
 // -- Derived -----------------------------------------------------------
 
+export type ConnectionState = 'connected' | 'connecting' | 'disconnected';
+
 export function httpBase(): string {
   return (
     wsUrl

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -18,6 +18,7 @@ import {
   type SessionInfo,
 } from '@/lib/api/sessions';
 import { workerType as defaultWorkerType, workDir as configWorkDir } from '@/lib/config';
+import { logger } from '@/lib/logger';
 
 export interface UseSessionsOptions {
   /** Called when the active session changes (user selects or creates). */
@@ -194,7 +195,7 @@ export function useSessions({
     try {
       await deleteSession(id);
     } catch (e) {
-      console.error('Failed to delete session', e);
+      logger.error('Sessions', 'Failed to delete session', { error: String(e) });
       // Revert optimistic remove on failure
       refreshSessions();
     }

--- a/webchat/lib/logger.ts
+++ b/webchat/lib/logger.ts
@@ -1,0 +1,39 @@
+/**
+ * Structured logger for webchat.
+ *
+ * Replaces raw console calls with JSON-formatted entries containing
+ * module, sessionId, and timestamp. Future-ready for Sentry/error
+ * tracking endpoint integration.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  level: LogLevel;
+  module: string;
+  message: string;
+  sessionId?: string;
+  data?: Record<string, unknown>;
+  timestamp: number;
+}
+
+function emit(entry: LogEntry): void {
+  const args: unknown[] = [JSON.stringify(entry)];
+  switch (entry.level) {
+    case 'error': console.error(...args); break;
+    case 'warn':  console.warn(...args);  break;
+    case 'info':  console.info(...args);  break;
+    default:      console.log(...args);   break;
+  }
+}
+
+function createLog(level: LogLevel, module: string, message: string, data?: Record<string, unknown>) {
+  emit({ level, module, message, data, timestamp: Date.now() });
+}
+
+export const logger = {
+  debug:   (m: string, msg: string, d?: Record<string, unknown>) => createLog('debug', m, msg, d),
+  info:    (m: string, msg: string, d?: Record<string, unknown>) => createLog('info', m, msg, d),
+  warn:    (m: string, msg: string, d?: Record<string, unknown>) => createLog('warn', m, msg, d),
+  error:   (m: string, msg: string, d?: Record<string, unknown>) => createLog('error', m, msg, d),
+};

--- a/webchat/lib/logger.ts
+++ b/webchat/lib/logger.ts
@@ -18,12 +18,12 @@ export interface LogEntry {
 }
 
 function emit(entry: LogEntry): void {
-  const args: unknown[] = [JSON.stringify(entry)];
+  const serialized = JSON.stringify(entry);
   switch (entry.level) {
-    case 'error': console.error(...args); break;
-    case 'warn':  console.warn(...args);  break;
-    case 'info':  console.info(...args);  break;
-    default:      console.log(...args);   break;
+    case 'error': console.error(serialized); break;
+    case 'warn':  console.warn(serialized);  break;
+    case 'info':  console.info(serialized);  break;
+    default:      console.log(serialized);   break;
   }
 }
 

--- a/webchat/lib/types/message.ts
+++ b/webchat/lib/types/message.ts
@@ -1,0 +1,17 @@
+/**
+ * Unified HotPlexMessage type — single source of truth.
+ *
+ * Generic over parts to allow both narrow (history) and wide (live) usage:
+ * - History: HotPlexMessage<TextPart | ToolSummaryPart>
+ * - Live:    HotPlexMessage<MessagePart> (default)
+ */
+
+import type { MessagePart } from './message-parts';
+
+export interface HotPlexMessage<P extends MessagePart = MessagePart> {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  parts: P[];
+  createdAt: Date;
+  status?: 'streaming' | 'complete' | 'error';
+}

--- a/webchat/lib/utils/turn-replay.ts
+++ b/webchat/lib/utils/turn-replay.ts
@@ -8,6 +8,10 @@
  */
 
 import type { TextPart, ToolSummaryPart } from '@/lib/types/message-parts';
+import type { HotPlexMessage } from '@/lib/types/message';
+
+// Re-export for consumers
+export type { HotPlexMessage };
 
 // -- Types --
 
@@ -33,15 +37,8 @@ export interface ConversationTurn {
   created_at: string;
 }
 
-type HistoryMessagePart = TextPart | ToolSummaryPart;
-
-export interface HotPlexMessage {
-  id: string;
-  role: 'user' | 'assistant' | 'system';
-  parts: HistoryMessagePart[];
-  createdAt: Date;
-  status?: 'streaming' | 'complete' | 'error';
-}
+/** History messages only contain text + tool-summary parts */
+type HistoryMessage = HotPlexMessage<TextPart | ToolSummaryPart>;
 
 // -- Conversion --
 
@@ -52,9 +49,9 @@ export interface HotPlexMessage {
  * - Assistant turns become assistant messages with TextPart + optional ToolSummaryPart
  * - Turns are returned in the same order as input (should be ASC by seq)
  */
-export function conversationTurnsToMessages(turns: ConversationTurn[]): HotPlexMessage[] {
+export function conversationTurnsToMessages(turns: ConversationTurn[]): HistoryMessage[] {
   return turns.map((turn) => {
-    const parts: HistoryMessagePart[] = [];
+    const parts: (TextPart | ToolSummaryPart)[] = [];
 
     // Add text content (always present)
     if (turn.content) {

--- a/webchat/package.json
+++ b/webchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotplex-webchat",
-  "version": "1.1.0",
+  "version": "1.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- **Unify `HotPlexMessage` type** — create generic `lib/types/message.ts`, eliminate duplicate interfaces in `turn-replay.ts` and `runtime-adapter.ts`
- **Sync stale version** — `v1.1.0` → `v1.8.1` in `package.json`, dynamic import in `thread.tsx` footer
- **Eliminate all 10 `as any` casts** — typed `getExt()` accessor for assistant-ui interop, type predicate for tool filtering
- **Add structured logger** — `lib/logger.ts` with JSON-formatted entries (module, timestamp, data), replaces 15 raw console calls
- **Add connection state indicator** — WebSocket status (connected/connecting/disconnected) exposed via adapter extras, rendered as color-coded dot in footer
- **Close #305** — localStorage write storm was already fixed in PR #135

Fixes #310
Fixes #309

## Test Plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx next build` — static export succeeds
- [x] `make quality` — fmt + lint + test pass
- [ ] Manual: verify connection state dot changes color when gateway disconnects
- [ ] Manual: verify version string shows `v1.8.1-stable` in footer