### PR TITLE
fix+refactor: reliability and correctness fixes (#347, #346, #345, #334)

### DIFF
--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"net"
 	"net/http"
 	"net/netip"
 	"slices"
@@ -24,7 +25,10 @@ func hasScope(r *http.Request, required string) bool {
 // It uses r.RemoteAddr directly to prevent IP spoofing via X-Forwarded-For.
 // Deploy behind a reverse proxy that strips untrusted XFF headers.
 func clientIP(r *http.Request) string {
-	host, _, _ := strings.Cut(r.RemoteAddr, ":")
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
 	return host
 }
 

--- a/internal/admin/middleware_test.go
+++ b/internal/admin/middleware_test.go
@@ -21,6 +21,9 @@ func TestClientIP(t *testing.T) {
 		{"xff ignored", "10.0.0.1", "1.2.3.4:8080", "1.2.3.4"},
 		{"xff multiple ignored", "10.0.0.1, 10.0.0.2", "1.2.3.4:8080", "1.2.3.4"},
 		{"no port", "", "1.2.3.4", "1.2.3.4"},
+		{"ipv6 loopback", "", "[::1]:8080", "::1"},
+		{"ipv6 full", "", "[2001:db8::1]:9090", "2001:db8::1"},
+		{"ipv6 no port", "", "2001:db8::1", "2001:db8::1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/brain/guard.go
+++ b/internal/brain/guard.go
@@ -143,6 +143,7 @@ type SafetyGuard struct {
 
 	// Background cleanup for unbounded maps
 	cleanupStop context.CancelFunc
+	cleanupWg   sync.WaitGroup
 
 	// Metrics for monitoring (lock-free via atomic)
 	totalChecks      atomic.Int64 // Total number of CheckInput calls
@@ -178,6 +179,7 @@ func NewSafetyGuard(brain Brain, config GuardConfig, logger *slog.Logger) (*Safe
 	// Initialize sensitive patterns for output filtering
 	guard.initSensitivePatterns()
 
+	guard.cleanupWg.Add(1)
 	go guard.runCleanup(ctx, 10*time.Minute)
 
 	return guard, nil
@@ -188,9 +190,11 @@ func (g *SafetyGuard) Close() {
 	if g.cleanupStop != nil {
 		g.cleanupStop()
 	}
+	g.cleanupWg.Wait()
 }
 
 func (g *SafetyGuard) runCleanup(ctx context.Context, interval time.Duration) {
+	defer g.cleanupWg.Done()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -454,7 +454,9 @@ func (c *ContextCompressor) ForceCompress(ctx context.Context, sessionID string)
 
 // SetEnabled enables or disables compression at runtime.
 func (c *ContextCompressor) SetEnabled(enabled bool) {
+	c.mu.Lock()
 	c.config.Enabled = enabled
+	c.mu.Unlock()
 }
 
 // UpdateConfig updates the compression configuration.

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -51,6 +51,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/text/cases"
@@ -114,9 +115,10 @@ func DefaultCompressionConfig() CompressionConfig {
 //  3. Check compression with CheckAndCompress()
 //  4. Stop background cleanup with Stop()
 type ContextCompressor struct {
-	brain  Brain
-	config CompressionConfig
-	logger *slog.Logger
+	brain   Brain
+	config  CompressionConfig
+	logger  *slog.Logger
+	enabled atomic.Bool // source of truth for Enabled, avoids locking on hot-path reads
 
 	// Session storage (protected by mu)
 	// Key: sessionID, Value: conversation history
@@ -145,6 +147,7 @@ func NewContextCompressor(brain Brain, config CompressionConfig, logger *slog.Lo
 		ctx:      ctx,
 		cancel:   cancel,
 	}
+	compressor.enabled.Store(config.Enabled)
 
 	// Start background cleanup daemon
 	if config.CleanupInterval > 0 {
@@ -156,7 +159,7 @@ func NewContextCompressor(brain Brain, config CompressionConfig, logger *slog.Lo
 
 // RecordTurn records a conversation turn in session history.
 func (c *ContextCompressor) RecordTurn(sessionID, role, content string, tokenCount int) {
-	if !c.config.Enabled {
+	if !c.enabled.Load() {
 		return
 	}
 
@@ -195,7 +198,7 @@ func (c *ContextCompressor) RecordTurn(sessionID, role, content string, tokenCou
 //   - (nil, nil): No compression needed (below threshold)
 //   - (nil, error): Compression failed
 func (c *ContextCompressor) CheckAndCompress(ctx context.Context, sessionID string) (*SessionHistory, error) {
-	if !c.config.Enabled || c.brain == nil {
+	if !c.enabled.Load() || c.brain == nil {
 		return nil, nil
 	}
 
@@ -390,7 +393,7 @@ func (c *ContextCompressor) Stats() map[string]interface{} {
 	c.mu.RUnlock()
 
 	return map[string]interface{}{
-		"enabled":                   c.config.Enabled,
+		"enabled":                   c.enabled.Load(),
 		"session_count":             sessionCount,
 		"total_compressions":        c.totalCompressions,
 		"total_tokens_saved":        c.totalTokensSaved,
@@ -446,7 +449,7 @@ func (c *ContextCompressor) Stop() {
 
 // ForceCompress forces compression of a session regardless of threshold.
 func (c *ContextCompressor) ForceCompress(ctx context.Context, sessionID string) (*SessionHistory, error) {
-	if !c.config.Enabled || c.brain == nil {
+	if !c.enabled.Load() || c.brain == nil {
 		return nil, fmt.Errorf("compression not enabled")
 	}
 	return c.compress(ctx, sessionID)
@@ -454,9 +457,7 @@ func (c *ContextCompressor) ForceCompress(ctx context.Context, sessionID string)
 
 // SetEnabled enables or disables compression at runtime.
 func (c *ContextCompressor) SetEnabled(enabled bool) {
-	c.mu.Lock()
-	c.config.Enabled = enabled
-	c.mu.Unlock()
+	c.enabled.Store(enabled)
 }
 
 // UpdateConfig updates the compression configuration.
@@ -464,6 +465,7 @@ func (c *ContextCompressor) UpdateConfig(config CompressionConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.config = config
+	c.enabled.Store(config.Enabled)
 }
 
 // MemoryManager provides high-level memory management capabilities.

--- a/internal/brain/memory_test.go
+++ b/internal/brain/memory_test.go
@@ -439,10 +439,10 @@ func TestContextCompressor_SetEnabled(t *testing.T) {
 	compressor := NewContextCompressor(mockBrain, config, slog.Default())
 
 	compressor.SetEnabled(false)
-	assert.False(t, compressor.config.Enabled)
+	assert.False(t, compressor.enabled.Load())
 
 	compressor.SetEnabled(true)
-	assert.True(t, compressor.config.Enabled)
+	assert.True(t, compressor.enabled.Load())
 }
 
 // ========================================

--- a/internal/brain/router.go
+++ b/internal/brain/router.go
@@ -90,9 +90,9 @@ type IntentRouter struct {
 	logger *slog.Logger // Structured logger for routing decisions
 
 	// Configuration
-	enabled             bool    // Master switch (disabled → all messages go to Engine)
-	confidenceThreshold float64 // Minimum confidence for Brain classification (0.0-1.0)
-	cacheSize           int     // Maximum cached intent results
+	enabled             atomic.Bool // Master switch (disabled → all messages go to Engine)
+	confidenceThreshold float64     // Minimum confidence for Brain classification (0.0-1.0)
+	cacheSize           int         // Maximum cached intent results
 
 	// LRU Cache for recent intent results
 	// Key: SHA256 hash of normalized message, Value: IntentResult
@@ -121,16 +121,17 @@ func NewIntentRouter(brain Brain, config IntentRouterConfig, logger *slog.Logger
 		config.CacheSize = 1000
 	}
 
-	return &IntentRouter{
+	router := &IntentRouter{
 		brain:               brain,
 		logger:              logger,
-		enabled:             config.Enabled,
 		confidenceThreshold: config.ConfidenceThreshold,
 		cacheSize:           config.CacheSize,
 		cache:               make(map[string]*IntentResult),
 		lruList:             list.New(),
 		lruIndex:            make(map[string]*list.Element),
 	}
+	router.enabled.Store(config.Enabled)
+	return router
 }
 
 // Route determines the intent of a message and returns the routing decision.
@@ -145,7 +146,7 @@ func NewIntentRouter(brain Brain, config IntentRouterConfig, logger *slog.Logger
 // If the Brain is disabled or unavailable, returns IntentTypeTask to ensure
 // the message is processed by the Engine (safe default).
 func (r *IntentRouter) Route(ctx context.Context, msg string) *IntentResult {
-	if !r.enabled || r.brain == nil {
+	if !r.enabled.Load() || r.brain == nil {
 		return &IntentResult{
 			Type:       IntentTypeTask,
 			Confidence: 1.0,
@@ -172,7 +173,7 @@ func (r *IntentRouter) Route(ctx context.Context, msg string) *IntentResult {
 
 // RouteWithHistory determines intent considering conversation history.
 func (r *IntentRouter) RouteWithHistory(ctx context.Context, msg string, history []string) *IntentResult {
-	if !r.enabled || r.brain == nil {
+	if !r.enabled.Load() || r.brain == nil {
 		return &IntentResult{
 			Type:       IntentTypeTask,
 			Confidence: 1.0,
@@ -419,7 +420,7 @@ func (r *IntentRouter) addToCache(key string, result *IntentResult) {
 // IsRelevant checks if a message in a group chat is relevant to the bot.
 // This is used for noise filtering in group channels.
 func (r *IntentRouter) IsRelevant(ctx context.Context, msg string, botMentioned bool) bool {
-	if !r.enabled || r.brain == nil {
+	if !r.enabled.Load() || r.brain == nil {
 		// Without brain, only process if bot is explicitly mentioned
 		return botMentioned
 	}
@@ -460,7 +461,7 @@ Return JSON:
 
 // GenerateResponse generates a quick response for chat/command intents.
 func (r *IntentRouter) GenerateResponse(ctx context.Context, msg string, intent *IntentResult) (string, error) {
-	if !r.enabled || r.brain == nil {
+	if !r.enabled.Load() || r.brain == nil {
 		return "", fmt.Errorf("brain not available")
 	}
 
@@ -495,7 +496,7 @@ func (r *IntentRouter) Stats() map[string]interface{} {
 	r.cacheMu.RUnlock()
 
 	return map[string]interface{}{
-		"enabled":         r.enabled,
+		"enabled":         r.enabled.Load(),
 		"total_processed": r.totalProcessed.Load(),
 		"cache_hits":      r.cacheHits.Load(),
 		"cache_size":      cacheLen,
@@ -518,12 +519,12 @@ func (r *IntentRouter) ShouldUseEngine(result *IntentResult) bool {
 
 // SetEnabled enables or disables the router at runtime.
 func (r *IntentRouter) SetEnabled(enabled bool) {
-	r.enabled = enabled
+	r.enabled.Store(enabled)
 }
 
 // GetEnabled returns whether the router is enabled.
 func (r *IntentRouter) GetEnabled() bool {
-	return r.enabled
+	return r.enabled.Load()
 }
 
 // ClearCache clears the intent cache.

--- a/internal/brain/router_test.go
+++ b/internal/brain/router_test.go
@@ -55,7 +55,7 @@ func TestNewIntentRouter_Defaults(t *testing.T) {
 	}, slog.Default())
 
 	assert.NotNil(t, router)
-	assert.True(t, router.enabled)
+	assert.True(t, router.enabled.Load())
 	assert.Equal(t, 0.7, router.confidenceThreshold)
 	assert.Equal(t, 1000, router.cacheSize)
 }

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -231,6 +231,15 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		}
 	}
 
+	// Flush buffered error that never reached a retry decision point.
+	if pendingError != nil {
+		if err := b.hub.SendToSession(context.Background(), pendingError); err != nil {
+			b.log.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+		}
+		b.captureEvent(sessionID, pendingError.Seq, pendingError.Event.Type, pendingError.Event.Data)
+		pendingError = nil
+	}
+
 	b.handleWorkerExit(w, workerExitParams{
 		sessionID:      sessionID,
 		workerType:     workerType,

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -238,6 +238,10 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 	b.accumMu.Lock()
 	delete(b.accum, sessionID)
 	b.accumMu.Unlock()
+
+	b.crashTrackerMu.Lock()
+	delete(b.crashTracker, sessionID)
+	b.crashTrackerMu.Unlock()
 }
 
 // injectAgentConfig loads agent config files and injects the unified system

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -469,7 +469,9 @@ func (h *Handler) handleReset(ctx context.Context, env *events.Envelope) error {
 		State:   events.StateRunning,
 		Message: "context_reset",
 	})
-	_ = h.hub.SendToSession(ctx, stateEvt)
+	if err := h.hub.SendToSession(ctx, stateEvt); err != nil {
+		h.log.Warn("gateway: state notification send failed", "session_id", env.SessionID, "err", err)
+	}
 
 	h.log.Info("gateway: session reset", "session_id", env.SessionID)
 	return nil
@@ -509,7 +511,9 @@ func (h *Handler) handleGC(ctx context.Context, env *events.Envelope) error {
 		State:   events.StateTerminated,
 		Message: "session_archived",
 	})
-	_ = h.hub.SendToSession(ctx, stateEvt)
+	if err := h.hub.SendToSession(ctx, stateEvt); err != nil {
+		h.log.Warn("gateway: state notification send failed", "session_id", env.SessionID, "err", err)
+	}
 
 	h.log.Info("gateway: session gc'd", "session_id", env.SessionID)
 	return nil
@@ -571,7 +575,9 @@ func (h *Handler) handleCD(ctx context.Context, env *events.Envelope) error {
 		aep.NewID(), env.SessionID, h.hub.NextSeq(env.SessionID),
 		events.Message, events.MessageData{Content: msg},
 	)
-	_ = h.hub.SendToSession(ctx, msgEnv)
+	if err := h.hub.SendToSession(ctx, msgEnv); err != nil {
+		h.log.Warn("gateway: state notification send failed", "session_id", env.SessionID, "err", err)
+	}
 
 	return nil
 }

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -290,6 +290,13 @@ export function useHotPlexRuntime({
 
   // Initialize WebSocket client
   useEffect(() => {
+    // Guard: disconnect any lingering client from a previous effect run
+    // (e.g., React Strict Mode double-render or stale closure from async reconnect)
+    if (clientRef.current) {
+      clientRef.current.disconnect();
+      clientRef.current = null;
+    }
+
     if (!sessionId) {
       logger.info('RuntimeAdapter', 'No session ID, skipping connection');
       return;


### PR DESCRIPTION
## Summary

Batch reliability and correctness fixes across 4 modules:

- **#347** — `clientIP` breaks IPv6 addresses: `strings.Cut` splits on first colon, corrupting `[::1]:8080` → `"[::"`. Fixed with `net.SplitHostPort`.
- **#346** — Data races in `IntentRouter.enabled` (plain bool → `atomic.Bool`), `ContextCompressor.SetEnabled` (added mutex), `SafetyGuard.Close()` (added `sync.WaitGroup`).
- **#345** — `crashTracker` map leak (added cleanup in `cleanupCrashedWorker`), `pendingError` lost on worker exit (flush before `handleWorkerExit`), state notification errors silently swallowed (added warn logging).
- **#334** — Duplicate `BrowserHotPlexClient` instances causing heartbeat ping anomaly (9-11s vs 20s). Added useEffect guard to disconnect lingering client before creating new one.

## Changes

| File | Issue | Change |
|------|-------|--------|
| `internal/admin/middleware.go` | #347 | `net.SplitHostPort` replaces `strings.Cut` |
| `internal/admin/middleware_test.go` | #347 | IPv6 test cases |
| `internal/brain/router.go` | #346 | `enabled bool` → `atomic.Bool` |
| `internal/brain/memory.go` | #346 | `SetEnabled` acquires mutex |
| `internal/brain/guard.go` | #346 | `cleanupWg` WaitGroup for goroutine lifecycle |
| `internal/brain/router_test.go` | #346 | Updated field access to `.Load()` |
| `internal/gateway/bridge_worker.go` | #345 | `delete(crashTracker)` in cleanup |
| `internal/gateway/bridge_forward.go` | #345 | Flush `pendingError` on recv channel close |
| `internal/gateway/handler.go` | #345 | Warn log on state notification send failure |
| `webchat/lib/adapters/hotplex-runtime-adapter.ts` | #334 | Disconnect guard in useEffect |

## Test plan

- [x] `make check` passes (fmt + lint + test -race + build)
- [x] `go test -race ./internal/brain/...` — zero data races
- [x] `go test -race ./internal/gateway/...` — all pass
- [x] `npx tsc --noEmit` in webchat — zero type errors
- [x] IPv6: `TestClientIP/ipv6_loopback` + `TestClientIP/ipv6_full` pass

Fixes #347
Fixes #346
Fixes #345
Partial fix for #334 (server-side gap tolerance tracked in #325)