### PR TITLE
fix+refactor: init safety + lifecycle DRY (#339, #344, #258)

### DIFF
--- a/internal/brain/guard_test.go
+++ b/internal/brain/guard_test.go
@@ -1048,15 +1048,13 @@ func TestSanitizeOutputString_WithGuard(t *testing.T) {
 // ========================================
 
 func TestSafetyGuard_ExecuteConfigIntent_FeatureGetWithRouter(t *testing.T) {
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 	}()
 
 	SetGlobal(&mockBrainForGuard{})
-	globalRouterOnce = sync.Once{}
-	globalIntentRouter = NewIntentRouter(&mockBrainForGuard{}, IntentRouterConfig{Enabled: true}, slog.Default())
+	globalIntentRouter.Store(NewIntentRouter(&mockBrainForGuard{}, IntentRouterConfig{Enabled: true}, slog.Default()))
 
 	guard := newTestGuard(t, nil, func(c *GuardConfig) {
 		c.Chat2ConfigEnabled = true

--- a/internal/brain/router.go
+++ b/internal/brain/router.go
@@ -545,21 +545,26 @@ func DefaultIntentRouterConfig() IntentRouterConfig {
 	}
 }
 
-// GlobalIntentRouter returns the global IntentRouter instance.
-// It uses the global Brain if available.
-func GlobalIntentRouter() *IntentRouter {
-	globalRouterOnce.Do(func() {
-		if Global() != nil {
-			globalIntentRouter = NewIntentRouter(Global(), DefaultIntentRouterConfig(), slog.Default())
-		}
-	})
-	return globalIntentRouter
-}
+// globalIntentRouter holds the global IntentRouter instance.
+// Uses atomic.Pointer for race-free concurrent access — eliminates the
+// previous sync.Once + direct-assignment pattern that caused a data race
+// when GlobalIntentRouter() and InitIntentRouter() were called concurrently.
+var globalIntentRouter atomic.Pointer[IntentRouter]
 
-var (
-	globalIntentRouter *IntentRouter
-	globalRouterOnce   sync.Once
-)
+// GlobalIntentRouter returns the global IntentRouter instance.
+// If no router has been set via InitIntentRouter, it lazily creates one
+// with default config using CompareAndSwap to avoid overwriting a concurrent
+// InitIntentRouter call.
+func GlobalIntentRouter() *IntentRouter {
+	if r := globalIntentRouter.Load(); r != nil {
+		return r
+	}
+	if Global() != nil {
+		r := NewIntentRouter(Global(), DefaultIntentRouterConfig(), slog.Default())
+		globalIntentRouter.CompareAndSwap(nil, r)
+	}
+	return globalIntentRouter.Load()
+}
 
 // InitIntentRouter initializes the global intent router.
 func InitIntentRouter(config IntentRouterConfig, logger *slog.Logger) {
@@ -567,7 +572,7 @@ func InitIntentRouter(config IntentRouterConfig, logger *slog.Logger) {
 		logger.Debug("Cannot init IntentRouter: Brain not configured")
 		return
 	}
-	globalIntentRouter = NewIntentRouter(Global(), config, logger)
+	globalIntentRouter.Store(NewIntentRouter(Global(), config, logger))
 	logger.Info("IntentRouter initialized", "enabled", config.Enabled)
 }
 

--- a/internal/brain/router_test.go
+++ b/internal/brain/router_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -644,17 +643,15 @@ func TestDefaultIntentRouterConfig(t *testing.T) {
 // ========================================
 
 func TestRoute_NilRouter(t *testing.T) {
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	oldBrain := globalBrain
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 		globalBrain = oldBrain
 	}()
 
 	globalBrain = nil
-	globalIntentRouter = nil
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(nil)
 
 	result := Route(context.Background(), "hello")
 	assert.Equal(t, IntentTypeTask, result.Type)
@@ -663,16 +660,14 @@ func TestRoute_NilRouter(t *testing.T) {
 
 func TestIsRelevant_NilRouter(t *testing.T) {
 	// Save and restore all global state
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	oldBrain := globalBrain
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 		globalBrain = oldBrain
 	}()
 	globalBrain = nil
-	globalIntentRouter = nil
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(nil)
 
 	assert.True(t, IsRelevant(context.Background(), "hello", true))
 	assert.False(t, IsRelevant(context.Background(), "hello", false))
@@ -680,16 +675,14 @@ func TestIsRelevant_NilRouter(t *testing.T) {
 
 func TestQuickResponse_NilRouter(t *testing.T) {
 	oldBrain := globalBrain
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 	}()
 
 	SetGlobal(nil)
-	globalIntentRouter = nil
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(nil)
 
 	// Pass a non-nil intent to avoid nil pointer dereference in GenerateResponse
 	_, err := QuickResponse(context.Background(), "hello", &IntentResult{Response: "hi"})
@@ -793,14 +786,14 @@ func TestIntentRouter_ConcurrentRoute(t *testing.T) {
 func TestInitIntentRouter_NoBrain(t *testing.T) {
 	// Save and restore
 	oldBrain := globalBrain
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalIntentRouter = oldRouter
+		globalIntentRouter.Store(oldRouter)
 	}()
 
 	SetGlobal(nil)
-	globalIntentRouter = nil
+	globalIntentRouter.Store(nil)
 
 	InitIntentRouter(IntentRouterConfig{Enabled: true}, slog.Default())
 	// Should not create router when brain is nil
@@ -839,10 +832,9 @@ func TestLengthConstants(t *testing.T) {
 // ========================================
 
 func TestRoute_WithRouter(t *testing.T) {
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 	}()
 
 	mockBrain := &mockBrainForRouter{
@@ -850,8 +842,7 @@ func TestRoute_WithRouter(t *testing.T) {
 			return json.Unmarshal([]byte(`{"intent": "task", "confidence": 0.9, "reason": "code question"}`), target)
 		},
 	}
-	globalIntentRouter = NewIntentRouter(mockBrain, IntentRouterConfig{Enabled: true}, slog.Default())
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(NewIntentRouter(mockBrain, IntentRouterConfig{Enabled: true}, slog.Default()))
 
 	result := Route(context.Background(), "write a function to sort an array")
 	assert.NotNil(t, result)
@@ -915,11 +906,10 @@ func TestIsRelevant_DisabledRouter(t *testing.T) {
 }
 
 func TestQuickResponse_WithRouter(t *testing.T) {
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	oldBrain := globalBrain
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 		globalBrain = oldBrain
 	}()
 
@@ -930,8 +920,7 @@ func TestQuickResponse_WithRouter(t *testing.T) {
 		},
 	}
 	SetGlobal(mockBrain)
-	globalIntentRouter = nil
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(nil)
 
 	intent := &IntentResult{Type: IntentTypeChat}
 	resp, err := QuickResponse(context.Background(), "hello", intent)
@@ -940,18 +929,16 @@ func TestQuickResponse_WithRouter(t *testing.T) {
 }
 
 func TestQuickResponse_WithPrecomputedResponse(t *testing.T) {
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	oldBrain := globalBrain
 	defer func() {
-		globalIntentRouter = oldRouter
-		globalRouterOnce = sync.Once{}
+		globalIntentRouter.Store(oldRouter)
 		globalBrain = oldBrain
 	}()
 
 	mockBrain := &mockBrainForRouter{}
 	SetGlobal(mockBrain)
-	globalIntentRouter = nil
-	globalRouterOnce = sync.Once{}
+	globalIntentRouter.Store(nil)
 
 	intent := &IntentResult{Type: IntentTypeChat, Response: "Pong!"}
 	resp, err := QuickResponse(context.Background(), "ping", intent)
@@ -961,14 +948,14 @@ func TestQuickResponse_WithPrecomputedResponse(t *testing.T) {
 
 func TestInitIntentRouter_WithBrain(t *testing.T) {
 	oldBrain := globalBrain
-	oldRouter := globalIntentRouter
+	oldRouter := globalIntentRouter.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalIntentRouter = oldRouter
+		globalIntentRouter.Store(oldRouter)
 	}()
 
 	SetGlobal(&mockBrainForRouter{})
-	globalIntentRouter = nil
+	globalIntentRouter.Store(nil)
 
 	InitIntentRouter(IntentRouterConfig{Enabled: true}, slog.Default())
 	assert.NotNil(t, GlobalIntentRouter())

--- a/internal/worker/base/worker.go
+++ b/internal/worker/base/worker.go
@@ -21,7 +21,9 @@ var (
 )
 
 // Grace period for graceful worker shutdown.
-const GracefulShutdownTimeout = 5 * time.Second
+// Canonical constant lives in proc.DefaultGracePeriod; referenced here for
+// backward compatibility with existing callers.
+const GracefulShutdownTimeout = proc.DefaultGracePeriod
 
 // BaseWorker provides shared lifecycle methods for CLI-based worker adapters.
 // Embed this struct to get Terminate/Kill/Wait/Health/LastIO/Conn for free.

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -180,27 +180,14 @@ func (w *Worker) Modalities() []string    { return []string{"text", "code"} }
 // Start acquires the singleton server, creates a new HTTP session, and starts
 // the SSE reader goroutine.
 func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
-	if w.singleton == nil {
-		return fmt.Errorf("opencodeserver: singleton not initialized (call InitSingleton first)")
+	if err := w.checkNotStarted(); err != nil {
+		return err
 	}
-
-	// Prevent double-start
-	w.Mu.Lock()
-	if w.httpConn != nil {
-		w.Mu.Unlock()
-		return fmt.Errorf("opencodeserver: already started")
-	}
-	w.Mu.Unlock()
 
 	// Acquire ref from singleton (starts process if first session)
-	httpAddr, client, sseClient, crashSub, err := w.singleton.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("opencodeserver: acquire server: %w", err)
+	if err := w.acquireServer(ctx); err != nil {
+		return err
 	}
-	w.httpAddr = httpAddr
-	w.client = client
-	w.sseClient = sseClient
-	w.crashSub = crashSub
 
 	// Create new session via HTTP API
 	sessionID, err := w.createSession(ctx, session.ProjectDir)
@@ -210,14 +197,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	}
 
 	w.initSessionConn(ctx, sessionID, session)
-
-	// Create cancellable context for SSE request
-	sseCtx, sseCancel := context.WithCancel(context.Background())
-	w.Mu.Lock()
-	w.sseCancel = sseCancel
-	w.Mu.Unlock()
-
-	go w.readSSE(sseCtx, sessionID)
+	w.startSSE(sessionID)
 	return nil
 }
 
@@ -283,93 +263,30 @@ func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID, action st
 
 // Resume reconnects to an existing session on the shared OpenCode server.
 func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
-	if w.singleton == nil {
-		return fmt.Errorf("opencodeserver: singleton not initialized (call InitSingleton first)")
+	if err := w.checkNotStarted(); err != nil {
+		return err
 	}
 
-	w.Mu.Lock()
-	if w.httpConn != nil {
-		w.Mu.Unlock()
-		return fmt.Errorf("opencodeserver: already started")
+	if err := w.acquireServer(ctx); err != nil {
+		return err
 	}
-	w.Mu.Unlock()
-
-	httpAddr, client, sseClient, crashSub, err := w.singleton.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("opencodeserver: acquire server: %w", err)
-	}
-	w.httpAddr = httpAddr
-	w.client = client
-	w.sseClient = sseClient
-	w.crashSub = crashSub
 
 	w.initSessionConn(ctx, session.SessionID, session)
-
-	// Create cancellable context for SSE request
-	sseCtx, sseCancel := context.WithCancel(context.Background())
-	w.Mu.Lock()
-	w.sseCancel = sseCancel
-	w.Mu.Unlock()
-
-	go w.readSSE(sseCtx, session.SessionID)
+	w.startSSE(session.SessionID)
 	return nil
 }
 
 // Terminate closes the SSE connection and releases the singleton ref.
 // Does NOT kill the shared server process.
 func (w *Worker) Terminate(_ context.Context) error {
-	w.Mu.Lock()
-	sseCancel := w.sseCancel
-	w.Mu.Unlock()
-
-	// Cancel SSE request to unblock readSSE goroutine
-	if sseCancel != nil {
-		sseCancel()
-	}
-
-	w.releaseOnce.Do(func() {
-		if w.singleton != nil {
-			w.singleton.Release()
-		}
-	})
-
-	w.Mu.Lock()
-	conn := w.httpConn
-	w.httpConn = nil
-	w.Mu.Unlock()
-
-	if conn != nil {
-		_ = conn.Close()
-	}
+	w.release()
 	return nil
 }
 
 // Kill closes the SSE connection and releases the singleton ref.
 // Does NOT kill the shared server process.
 func (w *Worker) Kill() error {
-	w.Mu.Lock()
-	sseCancel := w.sseCancel
-	w.Mu.Unlock()
-
-	// Cancel SSE request to unblock readSSE goroutine
-	if sseCancel != nil {
-		sseCancel()
-	}
-
-	w.releaseOnce.Do(func() {
-		if w.singleton != nil {
-			w.singleton.Release()
-		}
-	})
-
-	w.Mu.Lock()
-	conn := w.httpConn
-	w.httpConn = nil
-	w.Mu.Unlock()
-
-	if conn != nil {
-		_ = conn.Close()
-	}
+	w.release()
 	return nil
 }
 
@@ -575,6 +492,73 @@ func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, se
 	w.StartTime = time.Now()
 	w.SetLastIO(w.StartTime)
 	w.Mu.Unlock()
+}
+
+// ─── Shared Lifecycle Helpers ──────────────────────────────────────────────────
+
+// checkNotStarted validates the singleton is ready and the worker is not
+// already running. Shared by Start and Resume.
+func (w *Worker) checkNotStarted() error {
+	if w.singleton == nil {
+		return fmt.Errorf("opencodeserver: singleton not initialized (call InitSingleton first)")
+	}
+	w.Mu.Lock()
+	started := w.httpConn != nil
+	w.Mu.Unlock()
+	if started {
+		return fmt.Errorf("opencodeserver: already started")
+	}
+	return nil
+}
+
+// acquireServer acquires a ref from the singleton process manager.
+func (w *Worker) acquireServer(ctx context.Context) error {
+	httpAddr, client, sseClient, crashSub, err := w.singleton.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("opencodeserver: acquire server: %w", err)
+	}
+	w.httpAddr = httpAddr
+	w.client = client
+	w.sseClient = sseClient
+	w.crashSub = crashSub
+	return nil
+}
+
+// startSSE creates a cancellable SSE context and starts the reader goroutine.
+func (w *Worker) startSSE(sessionID string) {
+	sseCtx, sseCancel := context.WithCancel(context.Background())
+	w.Mu.Lock()
+	w.sseCancel = sseCancel
+	w.Mu.Unlock()
+	go w.readSSE(sseCtx, sessionID)
+}
+
+// release closes the SSE connection and releases the singleton ref.
+// Shared by Terminate and Kill — they are semantically identical for OCS
+// workers since the shared server process is never killed by individual sessions.
+func (w *Worker) release() {
+	w.Mu.Lock()
+	sseCancel := w.sseCancel
+	w.Mu.Unlock()
+
+	if sseCancel != nil {
+		sseCancel()
+	}
+
+	w.releaseOnce.Do(func() {
+		if w.singleton != nil {
+			w.singleton.Release()
+		}
+	})
+
+	w.Mu.Lock()
+	conn := w.httpConn
+	w.httpConn = nil
+	w.Mu.Unlock()
+
+	if conn != nil {
+		_ = conn.Close()
+	}
 }
 
 func (w *Worker) readSSE(ctx context.Context, sessionID string) {

--- a/internal/worker/proc/pidfile.go
+++ b/internal/worker/proc/pidfile.go
@@ -306,7 +306,7 @@ func (t *Tracker) cleanupSingle(ctx context.Context, match string) CleanupResult
 	}
 
 	// Wait for graceful shutdown.
-	graceTimer := time.NewTimer(5 * time.Second)
+	graceTimer := time.NewTimer(DefaultGracePeriod)
 	defer graceTimer.Stop()
 
 	select {

--- a/internal/worker/proc/signal_unix.go
+++ b/internal/worker/proc/signal_unix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 // SetSysProcAttr configures the command to create a new process group (POSIX).
@@ -22,6 +23,11 @@ func GracefulTerminate(pgid int) error {
 func ForceKill(pgid int) error {
 	return syscall.Kill(-pgid, syscall.SIGKILL)
 }
+
+// DefaultGracePeriod is the default time to wait after SIGTERM before
+// escalating to SIGKILL. Shared across proc/manager, proc/pidfile, and
+// base/worker to avoid magic number duplication.
+const DefaultGracePeriod = 5 * time.Second
 
 // IsProcessAlive checks if a process exists by sending signal 0.
 func IsProcessAlive(pid int) error {

--- a/internal/worker/proc/signal_windows.go
+++ b/internal/worker/proc/signal_windows.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -61,3 +62,7 @@ func IsProcessNotExist(err error) bool {
 	}
 	return errors.Is(err, windows.ERROR_INVALID_PARAMETER)
 }
+
+// DefaultGracePeriod is the default time to wait after graceful termination
+// before escalating to force kill. Must match signal_unix.go value.
+const DefaultGracePeriod = 5 * time.Second


### PR DESCRIPTION
## Summary

Batch fix of 3 issues focused on init safety and lifecycle DRY:

- **#339** — Eliminate dual-init data race in global IntentRouter: `sync.Once` + direct assignment pattern replaced with `atomic.Pointer[IntentRouter]`. `GlobalIntentRouter()` and `InitIntentRouter()` can now safely be called concurrently; `CompareAndSwap` ensures the configured router always wins.
- **#344** — Extract 4 shared lifecycle helpers in OCS worker: `checkNotStarted()`, `acquireServer()`, `startSSE()`, `release()`. Terminate/Kill were 25 lines of byte-for-byte identical code; Start/Resume shared ~80% duplication. Net reduction: ~55 lines.
- **#258** — Unify grace period constant: extract `proc.DefaultGracePeriod` as canonical 5s constant, replace hardcoded `5 * time.Second` in `pidfile.go`, reference from `base.GracefulShutdownTimeout`.

## Changes

| File | Issue | Change |
|------|-------|--------|
| `internal/brain/router.go` | #339 | `*IntentRouter` + `sync.Once` → `atomic.Pointer[IntentRouter]` + `CompareAndSwap` |
| `internal/brain/router_test.go` | #339 | Test global state cleanup uses `Store`/`Load` instead of direct assignment |
| `internal/brain/guard_test.go` | #339 | Same test cleanup pattern |
| `internal/worker/opencodeserver/worker.go` | #344 | Extract `checkNotStarted`, `acquireServer`, `startSSE`, `release` helpers |
| `internal/worker/proc/signal_unix.go` | #258 | Add `DefaultGracePeriod` constant |
| `internal/worker/proc/signal_windows.go` | #258 | Add `DefaultGracePeriod` constant |
| `internal/worker/proc/pidfile.go` | #258 | Use `DefaultGracePeriod` instead of hardcoded `5 * time.Second` |
| `internal/worker/base/worker.go` | #258 | `GracefulShutdownTimeout` references `proc.DefaultGracePeriod` |

## Test plan

- [x] `make check` passes (fmt + lint + test -race + build)
- [x] `go test -race ./internal/brain/...` — zero data races (confirms #339 fix)
- [x] `go test -race ./internal/worker/opencodeserver/...` — all pass
- [x] `go test -race ./internal/worker/proc/...` — all pass
- [x] Cross-platform build: `signal_unix.go` + `signal_windows.go` both define `DefaultGracePeriod`

Fixes #339
Fixes #344
Fixes #258