### PR TITLE
fix+refactor: security + testability — cron auth, security DRY, session/admin/updater testability

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
-var startTime = time.Now()
-
 const (
 	ScopeSessionRead  = "session:read"
 	ScopeSessionWrite = "session:write"
@@ -75,10 +73,12 @@ type AdminAPI struct {
 	bridge        BridgeProvider
 	configWatcher ConfigWatcherProvider
 	cron          CronSchedulerProvider
+	logCollector  LogCollector
 	rateLimiter   atomic.Value // *simpleRateLimiter
 	allowedCIDRs  atomic.Value // []string
 	version       func() string
 	newSessionID  func() string
+	startedAt     time.Time
 }
 
 type Deps struct {
@@ -90,11 +90,16 @@ type Deps struct {
 	Bridge        BridgeProvider
 	ConfigWatcher ConfigWatcherProvider
 	Cron          CronSchedulerProvider
+	LogCollector  LogCollector
 	Version       func() string
 	NewSessionID  func() string
 }
 
 func New(deps Deps) *AdminAPI {
+	lc := deps.LogCollector
+	if lc == nil {
+		lc = LogRing
+	}
 	a := &AdminAPI{
 		log:           deps.Log,
 		cfg:           deps.Config,
@@ -104,8 +109,10 @@ func New(deps Deps) *AdminAPI {
 		bridge:        deps.Bridge,
 		configWatcher: deps.ConfigWatcher,
 		cron:          deps.Cron,
+		logCollector:  lc,
 		version:       deps.Version,
 		newSessionID:  deps.NewSessionID,
+		startedAt:     time.Now(),
 	}
 	return a
 }

--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -20,6 +20,10 @@ type CronSchedulerProvider interface {
 
 // HandleCronList returns all cron jobs.
 func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminRead) {
+		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		respondJSON(w, []any{})
 		return
@@ -34,6 +38,10 @@ func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronGet returns a single cron job.
 func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminRead) {
+		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return
@@ -49,6 +57,10 @@ func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronCreate creates a new cron job.
 func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return
@@ -67,6 +79,10 @@ func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronUpdate updates an existing cron job.
 func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return
@@ -86,6 +102,10 @@ func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronDelete deletes a cron job.
 func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return
@@ -100,6 +120,10 @@ func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronTrigger manually triggers a cron job run.
 func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return
@@ -114,6 +138,10 @@ func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronRunHistory returns the turn history for a cron job's latest run.
 func (a *AdminAPI) HandleCronRunHistory(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminRead) {
+		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+		return
+	}
 	if a.cron == nil {
 		http.Error(w, "cron scheduler not enabled", http.StatusServiceUnavailable)
 		return

--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -20,8 +20,7 @@ type CronSchedulerProvider interface {
 
 // HandleCronList returns all cron jobs.
 func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminRead) {
-		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminRead) {
 		return
 	}
 	if a.cron == nil {
@@ -38,8 +37,7 @@ func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronGet returns a single cron job.
 func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminRead) {
-		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminRead) {
 		return
 	}
 	if a.cron == nil {
@@ -57,8 +55,7 @@ func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronCreate creates a new cron job.
 func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminWrite) {
-		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminWrite) {
 		return
 	}
 	if a.cron == nil {
@@ -79,8 +76,7 @@ func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronUpdate updates an existing cron job.
 func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminWrite) {
-		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminWrite) {
 		return
 	}
 	if a.cron == nil {
@@ -102,8 +98,7 @@ func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronDelete deletes a cron job.
 func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminWrite) {
-		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminWrite) {
 		return
 	}
 	if a.cron == nil {
@@ -120,8 +115,7 @@ func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronTrigger manually triggers a cron job run.
 func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminWrite) {
-		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminWrite) {
 		return
 	}
 	if a.cron == nil {
@@ -138,8 +132,7 @@ func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
 
 // HandleCronRunHistory returns the turn history for a cron job's latest run.
 func (a *AdminAPI) HandleCronRunHistory(w http.ResponseWriter, r *http.Request) {
-	if !hasScope(r, ScopeAdminRead) {
-		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
+	if !requireScope(w, r, ScopeAdminRead) {
 		return
 	}
 	if a.cron == nil {

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -132,13 +132,13 @@ func (a *AdminAPI) HandleLogs(w http.ResponseWriter, r *http.Request) {
 			limit = v
 		}
 	}
-	logs := a.logCollector.Recent(limit)
+	logs, total := a.logCollector.Recent(limit)
 	if logs == nil {
 		logs = []logEntry{}
 	}
 	respondJSON(w, map[string]any{
 		"logs":  logs,
-		"total": a.logCollector.Total(),
+		"total": total,
 		"limit": limit,
 	})
 }

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -41,7 +41,7 @@ func (a *AdminAPI) HandleStats(w http.ResponseWriter, r *http.Request) {
 
 	respondJSON(w, map[string]any{
 		"gateway": map[string]any{
-			"uptime_seconds":        int(time.Since(startTime).Seconds()),
+			"uptime_seconds":        int(time.Since(a.startedAt).Seconds()),
 			"websocket_connections": a.hub.ConnectionsOpen(),
 			"sessions_active":       total,
 			"sessions_total":        len(sessions),
@@ -83,7 +83,7 @@ func (a *AdminAPI) HandleHealth(w http.ResponseWriter, r *http.Request) {
 		"checks": map[string]any{
 			"gateway": map[string]any{
 				"status":         "healthy",
-				"uptime_seconds": int(time.Since(startTime).Seconds()),
+				"uptime_seconds": int(time.Since(a.startedAt).Seconds()),
 			},
 			"database": dbCheck,
 			"workers": map[string]any{
@@ -132,13 +132,13 @@ func (a *AdminAPI) HandleLogs(w http.ResponseWriter, r *http.Request) {
 			limit = v
 		}
 	}
-	logs := LogRing.Recent(limit)
+	logs := a.logCollector.Recent(limit)
 	if logs == nil {
 		logs = []logEntry{}
 	}
 	respondJSON(w, map[string]any{
 		"logs":  logs,
-		"total": LogRing.Total(),
+		"total": a.logCollector.Total(),
 		"limit": limit,
 	})
 }

--- a/internal/admin/logbuf.go
+++ b/internal/admin/logbuf.go
@@ -65,6 +65,7 @@ func (r *logRingBuffer) Recent(limit int) []logEntry {
 
 type LogCollector interface {
 	Recent(limit int) []logEntry
+	Total() int
 }
 
 var LogRing = newLogRing(100)

--- a/internal/admin/logbuf.go
+++ b/internal/admin/logbuf.go
@@ -42,11 +42,11 @@ func (r *logRingBuffer) Total() int {
 	return r.n
 }
 
-func (r *logRingBuffer) Recent(limit int) []logEntry {
+func (r *logRingBuffer) Recent(limit int) ([]logEntry, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.n == 0 {
-		return nil
+		return nil, 0
 	}
 	size := len(r.ent)
 	size = min(r.n, size)
@@ -60,12 +60,11 @@ func (r *logRingBuffer) Recent(limit int) []logEntry {
 		idx := (start + i) % len(r.ent)
 		out = append(out, r.ent[idx])
 	}
-	return out
+	return out, r.n
 }
 
 type LogCollector interface {
-	Recent(limit int) []logEntry
-	Total() int
+	Recent(limit int) ([]logEntry, int)
 }
 
 var LogRing = newLogRing(100)

--- a/internal/admin/logbuf_test.go
+++ b/internal/admin/logbuf_test.go
@@ -13,8 +13,8 @@ func TestLogRingBuffer_Add(t *testing.T) {
 	r.Add("warn", "msg2", "sess2")
 	r.Add("error", "msg3", "sess3")
 
-	require.Equal(t, 3, r.Total())
-	entries := r.Recent(0)
+	entries, total := r.Recent(0)
+	require.Equal(t, 3, total)
 	require.Len(t, entries, 3)
 	require.Equal(t, "msg1", entries[0].Msg)
 	require.Equal(t, "msg2", entries[1].Msg)
@@ -29,8 +29,8 @@ func TestLogRingBuffer_Wraparound(t *testing.T) {
 	r.Add("info", "msg3", "")
 	r.Add("info", "msg4", "") // overwrites msg1
 
-	require.Equal(t, 4, r.Total())
-	entries := r.Recent(0)
+	entries, total := r.Recent(0)
+	require.Equal(t, 4, total)
 	require.Len(t, entries, 3)
 	require.Equal(t, "msg2", entries[0].Msg)
 	require.Equal(t, "msg3", entries[1].Msg)
@@ -43,13 +43,14 @@ func TestLogRingBuffer_RecentLimit(t *testing.T) {
 		r.Add("info", "msg", "")
 	}
 
-	entries := r.Recent(3)
+	entries, total := r.Recent(3)
 	require.Len(t, entries, 3)
-	require.Equal(t, 5, r.Total())
+	require.Equal(t, 5, total)
 }
 
 func TestLogRingBuffer_Empty(t *testing.T) {
 	r := newLogRing(5)
-	require.Equal(t, 0, r.Total())
-	require.Nil(t, r.Recent(0))
+	entries, total := r.Recent(0)
+	require.Equal(t, 0, total)
+	require.Nil(t, entries)
 }

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -21,6 +21,16 @@ func hasScope(r *http.Request, required string) bool {
 	return slices.Contains(getScopes(r), required)
 }
 
+// requireScope checks that the request has the required scope.
+// Returns false and writes 403 if not.
+func requireScope(w http.ResponseWriter, r *http.Request, scope string) bool {
+	if !hasScope(r, scope) {
+		http.Error(w, "insufficient scope: need "+scope, http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 // clientIP extracts the client IP from the request.
 // It uses r.RemoteAddr directly to prevent IP spoofing via X-Forwarded-For.
 // Deploy behind a reverse proxy that strips untrusted XFF headers.

--- a/internal/security/jwt.go
+++ b/internal/security/jwt.go
@@ -4,7 +4,6 @@ package security
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/subtle"
 	"errors"
 	"fmt"
 	"math/big"
@@ -228,14 +227,6 @@ func (v *JWTValidator) Stop() {
 	}
 }
 
-// ValidateAPIKey performs constant-time comparison of an API key.
-func ValidateAPIKey(provided, expected string) error {
-	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
-		return ErrUnauthorized
-	}
-	return nil
-}
-
 // ─── JTI Blacklist ────────────────────────────────────────────────────────────
 
 type jtiBlacklist struct {
@@ -321,7 +312,7 @@ func GenerateJTI() (string, error) {
 func mustGenerateJTI() string {
 	jti, err := GenerateJTI()
 	if err != nil {
-		return "" // crypto/rand should never fail on a healthy system
+		panic(fmt.Sprintf("security: failed to generate JTI: %v", err))
 	}
 	return jti
 }

--- a/internal/security/jwt_test.go
+++ b/internal/security/jwt_test.go
@@ -477,41 +477,6 @@ func TestRevokeTokenAndIsRevoked(t *testing.T) {
 	validator.RevokeToken("", 10*time.Minute)
 }
 
-// ─── ValidateAPIKey ──────────────────────────────────────────────────────────────
-
-func TestValidateAPIKey(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		provided string
-		expected string
-		wantErr  bool
-	}{
-		{"valid key", "secret-api-key-123", "secret-api-key-123", false},
-		{"invalid key", "wrong-key", "secret-api-key-123", true},
-		{"empty provided", "", "secret-api-key-123", true},
-		{"empty expected", "secret-api-key-123", "", true},
-		{"both empty", "", "", false}, // ConstantTimeCompare returns 1 for equal byte slices (both empty)
-		{"case sensitive", "Secret-Key", "secret-key", true},
-		{"different length", "short", "much-longer-secret-key", true},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			err := ValidateAPIKey(tt.provided, tt.expected)
-			if tt.wantErr {
-				require.Error(t, err)
-				require.Equal(t, ErrUnauthorized, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 // ─── JTI Blacklist ──────────────────────────────────────────────────────────────
 
 func TestJTIBlacklist(t *testing.T) {

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -14,8 +14,7 @@ func ValidateBaseDir(baseDir string) error {
 	return nil
 }
 
-// GetAllowedBaseDirs returns a copy of the current allowed base directories map.
-// Used for testing and diagnostics.
+// GetAllowedBaseDirs returns a defensive copy for testing.
 func GetAllowedBaseDirs() map[string]bool {
 	securityConfigMutex.RLock()
 	defer securityConfigMutex.RUnlock()
@@ -27,8 +26,7 @@ func GetAllowedBaseDirs() map[string]bool {
 	return result
 }
 
-// GetForbiddenWorkDirs returns a copy of the current forbidden work directories slice.
-// Used for testing and diagnostics.
+// GetForbiddenWorkDirs returns a defensive copy for testing.
 func GetForbiddenWorkDirs() []string {
 	securityConfigMutex.RLock()
 	defer securityConfigMutex.RUnlock()

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -14,6 +14,30 @@ func ValidateBaseDir(baseDir string) error {
 	return nil
 }
 
+// GetAllowedBaseDirs returns a copy of the current allowed base directories map.
+// Used for testing and diagnostics.
+func GetAllowedBaseDirs() map[string]bool {
+	securityConfigMutex.RLock()
+	defer securityConfigMutex.RUnlock()
+
+	result := make(map[string]bool, len(allowedBaseDirs))
+	for k, v := range allowedBaseDirs {
+		result[k] = v
+	}
+	return result
+}
+
+// GetForbiddenWorkDirs returns a copy of the current forbidden work directories slice.
+// Used for testing and diagnostics.
+func GetForbiddenWorkDirs() []string {
+	securityConfigMutex.RLock()
+	defer securityConfigMutex.RUnlock()
+
+	result := make([]string, len(forbiddenWorkDirs))
+	copy(result, forbiddenWorkDirs)
+	return result
+}
+
 // ValidateWorkDir validates that a work directory is safe for worker execution.
 //
 // Rules:

--- a/internal/security/path_unix.go
+++ b/internal/security/path_unix.go
@@ -106,27 +106,3 @@ func ConfigureFromConfig(cfg *config.SecurityConfig) {
 		}
 	}
 }
-
-// GetAllowedBaseDirs returns a copy of the current allowed base directories map.
-// Used for testing and diagnostics.
-func GetAllowedBaseDirs() map[string]bool {
-	securityConfigMutex.RLock()
-	defer securityConfigMutex.RUnlock()
-
-	result := make(map[string]bool, len(allowedBaseDirs))
-	for k, v := range allowedBaseDirs {
-		result[k] = v
-	}
-	return result
-}
-
-// GetForbiddenWorkDirs returns a copy of the current forbidden work directories slice.
-// Used for testing and diagnostics.
-func GetForbiddenWorkDirs() []string {
-	securityConfigMutex.RLock()
-	defer securityConfigMutex.RUnlock()
-
-	result := make([]string, len(forbiddenWorkDirs))
-	copy(result, forbiddenWorkDirs)
-	return result
-}

--- a/internal/security/path_windows.go
+++ b/internal/security/path_windows.go
@@ -34,28 +34,6 @@ func init() {
 	}
 }
 
-// GetAllowedBaseDirs returns a copy of the current allowed base directories map.
-func GetAllowedBaseDirs() map[string]bool {
-	securityConfigMutex.RLock()
-	defer securityConfigMutex.RUnlock()
-
-	result := make(map[string]bool, len(allowedBaseDirs))
-	for k, v := range allowedBaseDirs {
-		result[k] = v
-	}
-	return result
-}
-
-// GetForbiddenWorkDirs returns a copy of the current forbidden work directories slice.
-func GetForbiddenWorkDirs() []string {
-	securityConfigMutex.RLock()
-	defer securityConfigMutex.RUnlock()
-
-	result := make([]string, len(forbiddenWorkDirs))
-	copy(result, forbiddenWorkDirs)
-	return result
-}
-
 // ConfigureFromConfig applies security settings from the configuration file.
 func ConfigureFromConfig(cfg *config.SecurityConfig) {
 	securityConfigMutex.Lock()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -588,7 +588,10 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 	m.mu.Unlock()
 
 	if workerToKill != nil {
-		_ = workerToKill.Kill()
+		if err := workerToKill.Kill(); err != nil {
+			m.log.Warn("session: worker kill failed during physical delete",
+				"session_id", id, "err", err)
+		}
 	}
 
 	return m.store.DeletePhysical(ctx, id)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -64,11 +64,6 @@ func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {
 	return args.Error(0)
 }
 
-func (m *mockStore) DeleteExpiredEvents(ctx context.Context, cutoff time.Time) (int64, error) {
-	args := m.Called(ctx, cutoff)
-	return args.Get(0).(int64), args.Error(1)
-}
-
 func (m *mockStore) Compact(ctx context.Context, threshold float64) error {
 	args := m.Called(ctx, threshold)
 	return args.Error(0)
@@ -1437,7 +1432,6 @@ func TestManager_GC_ZombieDetection(t *testing.T) {
 	store.On("Upsert", mock.Anything, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
 	store.On("GetExpiredMaxLifetime", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
 
 	m.gc(ctx)
@@ -1480,7 +1474,6 @@ func TestManager_GC_NoZombieWhenRecentIO(t *testing.T) {
 
 	store.On("GetExpiredMaxLifetime", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time")).Return(nil)
 
 	m.gc(ctx)
@@ -1505,7 +1498,6 @@ func TestManager_GC_ExpiredMaxLifetime(t *testing.T) {
 		Return([]string{"sess_maxlife"}, nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string(nil), nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(nil)
 	store.On("Close").Return(nil)
@@ -1547,7 +1539,6 @@ func TestManager_GC_ExpiredIdleTimeout(t *testing.T) {
 		Return([]string(nil), nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string{"sess_idle_exp"}, nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(nil)
 	store.On("Close").Return(nil)
@@ -1588,7 +1579,6 @@ func TestManager_GC_NoRetentionCleanup(t *testing.T) {
 		Return([]string(nil), nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string(nil), nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	// DeleteTerminated is NOT expected — retention cleanup is intentionally
 	// removed so that TERMINATED records serve as "resume decision flags".
 	store.On("Close").Return(nil)
@@ -1611,7 +1601,6 @@ func TestManager_GC_TerminatedSessionPreserved(t *testing.T) {
 		Return([]string(nil), nil)
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string(nil), nil)
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("Close").Return(nil)
 
 	m, err := NewManager(ctx, nil, cfg, nil, store)
@@ -1661,7 +1650,6 @@ func TestManager_GC_TerminatedSession_DBError_NoImpact(t *testing.T) {
 		Return([]string(nil), errors.New("db error"))
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string(nil), errors.New("db error"))
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	store.On("Close").Return(nil)
 
 	m, err := NewManager(ctx, nil, cfg, nil, store)
@@ -1704,7 +1692,6 @@ func TestManager_GC_NoPanicOnStoreErrors(t *testing.T) {
 		Return([]string(nil), errors.New("db error"))
 	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]string(nil), errors.New("db error"))
-	store.On("DeleteExpiredEvents", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil)
 	// DeleteTerminated no longer called — retention cleanup removed.
 	store.On("Close").Return(nil)
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -131,7 +131,7 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 // Download fetches the binary to a temp file and returns its path.
 // Caller is responsible for cleaning up the temp file.
 func (u *Updater) Download(ctx context.Context, url string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -136,9 +136,12 @@ func (u *Updater) Download(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("create request: %w", err)
 	}
 
-	// Use a longer timeout for binary download.
-	dlClient := &http.Client{Timeout: 3 * time.Minute}
-	resp, err := dlClient.Do(req)
+	// Use a longer timeout for binary download via context.
+	dlCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	req = req.WithContext(dlCtx)
+
+	resp, err := u.Client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("download binary: %w", err)
 	}


### PR DESCRIPTION
## Summary

Batch of 5 issues addressing a critical security vulnerability and testability improvements:

- **#259**: Add scope checks to all 7 cron handler endpoints — any authenticated request could create/delete/trigger cron jobs regardless of token scope (auth bypass)
- **#341**: Remove dead `ValidateAPIKey`, fix `mustGenerateJTI` silent failure, DRY `GetAllowedBaseDirs`/`GetForbiddenWorkDirs` from platform files to `path.go`
- **#243**: Remove phantom `DeleteExpiredEvents` mock (method not in Store interface) + 8 dead stubs, log `Kill()` error instead of silently discarding
- **#251**: Fix `Download()` bypassing injected `u.Client` with hardcoded `http.Client`
- **#246**: Move `startTime` to `AdminAPI.startedAt` field, inject `LogCollector` into `AdminAPI`

Fixes #259, Fixes #341, Fixes #243, Fixes #251, Fixes #246

## Changes by commit

| Commit | Issue | Files | Change |
|--------|-------|-------|--------|
| `27653e0` | #259 | `internal/admin/cron_handlers.go` | Add `admin:read`/`admin:write` scope checks to 7 handlers |
| `231600f` | #341 | `jwt.go`, `jwt_test.go`, `path.go`, `path_unix.go`, `path_windows.go` | Delete dead `ValidateAPIKey`, fix `mustGenerateJTI`, DRY path getters |
| `ad12fbb` | #243 | `manager.go`, `manager_test.go` | Remove phantom mock + stubs, log Kill error |
| `b9bed9f` | #251 | `updater.go` | Use injected client + context deadline |
| `89a8462` | #246 | `admin.go`, `handlers.go`, `logbuf.go` | Inject startTime + LogCollector |

## Test plan

- [x] `make check` passes (quality + build)
- [x] All 5 commits are atomic with `Fixes #XX` footers
- [x] `internal/security` tests pass (ValidateAPIKey removal verified)
- [x] `internal/session` tests pass (phantom mock removal verified)
- [x] `internal/admin` tests pass (startTime/LogCollector injection verified)
- [x] `internal/updater` tests pass (Download client fix verified)