### PR TITLE
refactor(gateway): DRY — Slack context, auth boilerplate, workdir validation

### DIFF
--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -59,7 +59,7 @@ func respondJSON(w http.ResponseWriter, v any) {
 }
 
 // authorizeSession performs auth + path ID extraction + session lookup + ownership check.
-// Returns (userID, sessionID, sessionInfo, ok). If ok is false, an HTTP error has been written.
+// Returns (sessionID, sessionInfo, ok). If ok is false, an HTTP error has been written.
 func (g *GatewayAPI) authorizeSession(w http.ResponseWriter, r *http.Request) (string, *session.SessionInfo, bool) {
 	userID, _, err := g.auth.AuthenticateRequest(r)
 	if err != nil {

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -58,6 +58,31 @@ func respondJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// authorizeSession performs auth + path ID extraction + session lookup + ownership check.
+// Returns (userID, sessionID, sessionInfo, ok). If ok is false, an HTTP error has been written.
+func (g *GatewayAPI) authorizeSession(w http.ResponseWriter, r *http.Request) (string, *session.SessionInfo, bool) {
+	userID, _, err := g.auth.AuthenticateRequest(r)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return "", nil, false
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "session id required", http.StatusBadRequest)
+		return "", nil, false
+	}
+	si, err := g.sm.Get(r.Context(), id)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return "", nil, false
+	}
+	if si.UserID != userID {
+		http.Error(w, "ownership required", http.StatusForbidden)
+		return "", nil, false
+	}
+	return id, si, true
+}
+
 func (g *GatewayAPI) ListSessions(w http.ResponseWriter, r *http.Request) {
 	userID, _, err := g.auth.AuthenticateRequest(r)
 	if err != nil {
@@ -121,12 +146,8 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 		workDir = g.cfgStore.Load().Worker.DefaultWorkDir
 	}
 	if workDir != "" {
-		expanded, err := config.ExpandAndAbs(workDir)
+		expanded, err := validateAndExpandWorkDir(workDir)
 		if err != nil {
-			http.Error(w, "invalid work_dir: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		if err := security.ValidateWorkDir(expanded); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -163,47 +184,16 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *GatewayAPI) GetSession(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := g.auth.AuthenticateRequest(r)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "session id required", http.StatusBadRequest)
-		return
-	}
-	si, err := g.sm.Get(r.Context(), id)
-	if err != nil {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	}
-	if si.UserID != userID {
-		http.Error(w, "ownership required", http.StatusForbidden)
+	_, si, ok := g.authorizeSession(w, r)
+	if !ok {
 		return
 	}
 	respondJSON(w, si)
 }
 
 func (g *GatewayAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := g.auth.AuthenticateRequest(r)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "session id required", http.StatusBadRequest)
-		return
-	}
-
-	si, err := g.sm.Get(r.Context(), id)
-	if err != nil {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	}
-	if si.UserID != userID {
-		http.Error(w, "ownership required", http.StatusForbidden)
+	id, _, ok := g.authorizeSession(w, r)
+	if !ok {
 		return
 	}
 
@@ -221,17 +211,6 @@ func (g *GatewayAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *GatewayAPI) SwitchWorkDir(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := g.auth.AuthenticateRequest(r)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "session id required", http.StatusBadRequest)
-		return
-	}
-
 	var body struct {
 		WorkDir string `json:"work_dir"`
 	}
@@ -245,23 +224,19 @@ func (g *GatewayAPI) SwitchWorkDir(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Expand ~ and resolve to absolute path.
-	expanded, err := config.ExpandAndAbs(body.WorkDir)
+	expanded, err := validateAndExpandWorkDir(body.WorkDir)
 	if err != nil {
-		http.Error(w, "invalid work_dir: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	body.WorkDir = expanded
 
-	// Ownership check.
-	si, err := g.sm.Get(r.Context(), id)
-	if err != nil {
-		http.Error(w, "session not found", http.StatusNotFound)
+	_, si, ok := g.authorizeSession(w, r)
+	if !ok {
 		return
 	}
-	if si.UserID != userID {
-		http.Error(w, "ownership required", http.StatusForbidden)
-		return
-	}
+	id := r.PathValue("id")
+
 	if !si.State.IsActive() {
 		http.Error(w, "session not active", http.StatusConflict)
 		return
@@ -287,24 +262,8 @@ func (g *GatewayAPI) SwitchWorkDir(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *GatewayAPI) GetHistory(w http.ResponseWriter, r *http.Request) {
-	userID, _, err := g.auth.AuthenticateRequest(r)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "session id required", http.StatusBadRequest)
-		return
-	}
-
-	si, err := g.sm.Get(r.Context(), id)
-	if err != nil {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	}
-	if si.UserID != userID {
-		http.Error(w, "ownership required", http.StatusForbidden)
+	id, _, ok := g.authorizeSession(w, r)
+	if !ok {
 		return
 	}
 
@@ -328,7 +287,10 @@ func (g *GatewayAPI) GetHistory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fetchLimit := limit + 1
-	var records []*eventstore.TurnRecord
+	var (
+		records []*eventstore.TurnRecord
+		err     error
+	)
 
 	if beforeSeq > 0 {
 		records, err = g.turnsStore.QueryTurnsBefore(r.Context(), id, beforeSeq, fetchLimit)
@@ -360,24 +322,8 @@ func (g *GatewayAPI) GetEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, _, err := g.auth.AuthenticateRequest(r)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "session id required", http.StatusBadRequest)
-		return
-	}
-
-	si, err := g.sm.Get(r.Context(), id)
-	if err != nil {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	}
-	if si.UserID != userID {
-		http.Error(w, "ownership required", http.StatusForbidden)
+	id, _, ok := g.authorizeSession(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -119,25 +119,8 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 		return fmt.Errorf("bridge: create session: %w", err)
 	}
 
-	workerInfo := worker.SessionInfo{
-		SessionID:       id,
-		UserID:          userID,
-		ProjectDir:      workDir,
-		AllowedTools:    si.AllowedTools,
-		ConfigEnv:       b.workerEnv,
-		ConfigBlocklist: b.workerEnvBlocklist,
-	}
-
-	// Inject Slack context for CLI subcommand auto-resolution.
-	if chID, ok := platformKey["channel_id"]; ok && chID != "" {
-		if workerInfo.Env == nil {
-			workerInfo.Env = make(map[string]string)
-		}
-		workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
-		if threadTS, ok := platformKey["thread_ts"]; ok && threadTS != "" {
-			workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
-		}
-	}
+	workerInfo := b.buildWorkerInfo(id, userID, workDir, si)
+	injectSlackEnv(&workerInfo, platformKey)
 	workerInfo.Env = injectGatewayContext(workerInfo.Env, platform, botID, userID, platformKey, id, workDir)
 
 	// Inject cron-specific env vars (e.g. admin API creds) only for cron sessions.
@@ -213,29 +196,8 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		b.sm.DetachWorker(id)
 	}
 
-	workerInfo := worker.SessionInfo{
-		SessionID:       si.ID,
-		UserID:          si.UserID,
-		AllowedTools:    si.AllowedTools,
-		WorkerSessionID: si.WorkerSessionID,
-		ProjectDir:      workDir,
-		ConfigEnv:       b.workerEnv,
-		ConfigBlocklist: b.workerEnvBlocklist,
-	}
-
-	// Inject Slack context for CLI subcommand auto-resolution (same as StartSession).
-	if si.PlatformKey != nil {
-		if chID, ok := si.PlatformKey["channel_id"]; ok && chID != "" {
-			if workerInfo.Env == nil {
-				workerInfo.Env = make(map[string]string)
-			}
-			workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
-			if threadTS, ok := si.PlatformKey["thread_ts"]; ok && threadTS != "" {
-				workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
-			}
-		}
-	}
-
+	workerInfo := b.buildWorkerInfo(si.ID, si.UserID, workDir, si)
+	injectSlackEnv(&workerInfo, si.PlatformKey)
 	workerInfo.Env = injectGatewayContext(workerInfo.Env, si.Platform, si.BotID, si.UserID, si.PlatformKey, id, workDir)
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:         ctx,
@@ -436,11 +398,8 @@ func (b *Bridge) SwitchWorkDir(ctx context.Context, oldSessionID, newWorkDir str
 		return nil, fmt.Errorf("switch-workdir: session not active (state: %s)", si.State)
 	}
 
-	expanded, err := config.ExpandAndAbs(newWorkDir)
+	expanded, err := validateAndExpandWorkDir(newWorkDir)
 	if err != nil {
-		return nil, fmt.Errorf("switch-workdir: expand work dir: %w", err)
-	}
-	if err := security.ValidateWorkDir(expanded); err != nil {
 		return nil, fmt.Errorf("switch-workdir: %w", err)
 	}
 
@@ -570,6 +529,51 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// buildWorkerInfo constructs a worker.SessionInfo from session metadata,
+// carrying over bridge-level config (workerEnv, blocklist).
+func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.SessionInfo) worker.SessionInfo {
+	return worker.SessionInfo{
+		SessionID:       sessionID,
+		UserID:          userID,
+		ProjectDir:      workDir,
+		AllowedTools:    si.AllowedTools,
+		WorkerSessionID: si.WorkerSessionID,
+		ConfigEnv:       b.workerEnv,
+		ConfigBlocklist: b.workerEnvBlocklist,
+	}
+}
+
+// injectSlackEnv injects HOTPLEX_SLACK_CHANNEL_ID and HOTPLEX_SLACK_THREAD_TS
+// into the worker env map for CLI subcommand auto-resolution.
+func injectSlackEnv(info *worker.SessionInfo, platformKey map[string]string) {
+	if platformKey == nil {
+		return
+	}
+	if chID := platformKey["channel_id"]; chID != "" {
+		if info.Env == nil {
+			info.Env = make(map[string]string)
+		}
+		info.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
+		if threadTS := platformKey["thread_ts"]; threadTS != "" {
+			info.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
+		}
+	}
+}
+
+// validateAndExpandWorkDir expands a work directory path and validates it for safety.
+// Combines config.ExpandAndAbs + security.ValidateWorkDir into a single call to prevent
+// accidental omission of the security check at call sites.
+func validateAndExpandWorkDir(input string) (string, error) {
+	expanded, err := config.ExpandAndAbs(input)
+	if err != nil {
+		return "", fmt.Errorf("expand work dir: %w", err)
+	}
+	if err := security.ValidateWorkDir(expanded); err != nil {
+		return "", fmt.Errorf("unsafe work dir: %w", err)
+	}
+	return expanded, nil
 }
 
 // injectGatewayContext injects unified GATEWAY_* environment variables into

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -357,12 +357,12 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	// 1. Session completed normally: "done" received with no pending turn text.
 	// 2. Worker was intentionally terminated: SIGTERM (exit 143) is always
 	//    bridge/handler/GC-initiated, never an unexpected crash.
-	suppressError := (p.doneReceived && p.turnTextLen == 0) || exitCode == 143
-
-	if suppressError {
-		b.log.Debug("bridge: worker exit not reported (normal completion or intentional termination)",
-			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode,
-			"done_received", p.doneReceived, "turn_text_len", p.turnTextLen)
+	if p.doneReceived && p.turnTextLen == 0 {
+		b.log.Info("bridge: worker exit clean (done received, no pending output)",
+			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode)
+	} else if exitCode == 143 {
+		b.log.Info("bridge: worker exit intentional (SIGTERM)",
+			"session_id", p.sessionID, "worker_type", workerType)
 	} else if exitCode != 0 && exitCode != -1 {
 		acc := b.getOrInitAccum(p.sessionID, "", p.startTime)
 		b.log.Warn("bridge: worker exited with non-zero code, sending crash error",

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -148,28 +148,8 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		return false
 	}
 
-	workerInfo := worker.SessionInfo{
-		SessionID:       si.ID,
-		UserID:          si.UserID,
-		AllowedTools:    si.AllowedTools,
-		WorkerSessionID: si.WorkerSessionID,
-		ProjectDir:      p.workDir,
-		ConfigEnv:       b.workerEnv,
-		ConfigBlocklist: b.workerEnvBlocklist,
-	}
-
-	// Inject Slack context for CLI subcommand auto-resolution (same as StartSession).
-	if si.PlatformKey != nil {
-		if chID, ok := si.PlatformKey["channel_id"]; ok && chID != "" {
-			if workerInfo.Env == nil {
-				workerInfo.Env = make(map[string]string)
-			}
-			workerInfo.Env["HOTPLEX_SLACK_CHANNEL_ID"] = chID
-			if threadTS, ok := si.PlatformKey["thread_ts"]; ok && threadTS != "" {
-				workerInfo.Env["HOTPLEX_SLACK_THREAD_TS"] = threadTS
-			}
-		}
-	}
+	workerInfo := b.buildWorkerInfo(si.ID, si.UserID, p.workDir, si)
+	injectSlackEnv(&workerInfo, si.PlatformKey)
 	workerInfo.Env = injectGatewayContext(workerInfo.Env, si.Platform, si.BotID, si.UserID, si.PlatformKey, si.ID, p.workDir)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -13,9 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
-	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/metrics"
-	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/tracing"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -293,13 +291,8 @@ func (c *Conn) performInit(handler *Handler) error {
 	if workDir == "" {
 		workDir = c.hub.cfgStore.Load().Worker.DefaultWorkDir
 	}
-	expanded, err := config.ExpandAndAbs(workDir)
+	expanded, err := validateAndExpandWorkDir(workDir)
 	if err != nil {
-		c.sendInitError(events.ErrCodeInvalidMessage, "invalid work_dir: "+err.Error())
-		metrics.GatewayErrorsTotal.WithLabelValues(string(events.ErrCodeInvalidMessage)).Inc()
-		return err
-	}
-	if err := security.ValidateWorkDir(expanded); err != nil {
 		c.sendInitError(events.ErrCodeInvalidMessage, err.Error())
 		metrics.GatewayErrorsTotal.WithLabelValues(string(events.ErrCodeInvalidMessage)).Inc()
 		return err


### PR DESCRIPTION
## Summary

- Extract `buildWorkerInfo` + `injectSlackEnv` helpers: 3x Slack context injection → single source of truth
- Extract `authorizeSession` helper: 5x auth+ownership check boilerplate → single helper
- Extract `validateAndExpandWorkDir` helper: 4x expand+validate → single helper (prevents security validation omission)
- Upgrade worker exit logging from Debug → Info with explicit reason (clean completion vs SIGTERM)

## Impact

5 files changed, **-77 lines** net reduction. Zero behavioral change — pure structural DRY.

### Call site changes

| Helper | Before | After |
|--------|--------|-------|
| `buildWorkerInfo` | 3x worker.SessionInfo construction | 1 helper, 3 call sites |
| `injectSlackEnv` | 3x 8-line Slack env block | 1 helper, 3 call sites |
| `authorizeSession` | 5x 15-line auth+ownership sequence | 1 helper, 5 call sites |
| `validateAndExpandWorkDir` | 4x expand+validate pair | 1 helper, 4 call sites |

## Test plan

- [x] `make quality` (fmt + lint + test) passes
- [x] `make build` succeeds
- [x] All existing gateway tests pass (including `TestSwitchWorkDir_*`)
- [x] Pre-commit hooks pass (gofmt + golangci-lint)
- [x] Pre-push validation passes (lint + vet + build + test)

Fixes #242
Fixes #255