### PR TITLE
fix(cron): resolve platform from env/flags so cron results deliver to Slack/Feishu

### DIFF
--- a/cmd/hotplex/cron_create.go
+++ b/cmd/hotplex/cron_create.go
@@ -48,13 +48,20 @@ Schedule format:
 					tools = strings.Split(allowedTools, ",")
 				}
 
+				var platformKeyMap map[string]string
+				if platformKey != "" {
+					if err := json.Unmarshal([]byte(platformKey), &platformKeyMap); err != nil {
+						return fmt.Errorf("invalid --platform-key: expected JSON object, got %q", platformKey)
+					}
+				}
+
 				job, err := croncli.PrepareJobForCreate(name, schedule, message, description, workDir, botID, ownerID, timeoutSec, tools, croncli.JobCreateOptions{
 					DeleteAfterRun: deleteAfterRun,
 					MaxRetries:     maxRetries,
 					MaxRuns:        maxRuns,
 					ExpiresAt:      expiresAt,
 					Platform:       platform,
-					PlatformKey:    parsePlatformKey(platformKey),
+					PlatformKey:    platformKeyMap,
 				})
 				if err != nil {
 					return err
@@ -95,17 +102,4 @@ Schedule format:
 	_ = cmd.MarkFlagRequired("bot-id")
 	_ = cmd.MarkFlagRequired("owner-id")
 	return cmd
-}
-
-// parsePlatformKey parses a JSON object string into a map[string]string.
-// Returns nil for empty input.
-func parsePlatformKey(raw string) map[string]string {
-	if raw == "" {
-		return nil
-	}
-	var m map[string]string
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		return nil
-	}
-	return m
 }

--- a/cmd/hotplex/cron_create.go
+++ b/cmd/hotplex/cron_create.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,8 @@ func newCronCreateCmd() *cobra.Command {
 		maxRetries     int
 		maxRuns        int
 		expiresAt      string
+		platform       string
+		platformKey    string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -50,6 +53,8 @@ Schedule format:
 					MaxRetries:     maxRetries,
 					MaxRuns:        maxRuns,
 					ExpiresAt:      expiresAt,
+					Platform:       platform,
+					PlatformKey:    parsePlatformKey(platformKey),
 				})
 				if err != nil {
 					return err
@@ -82,10 +87,25 @@ Schedule format:
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 0, "max retries for failed one-shot jobs")
 	cmd.Flags().IntVar(&maxRuns, "max-runs", 0, "max executions before auto-disable (0=unlimited)")
 	cmd.Flags().StringVar(&expiresAt, "expires-at", "", "auto-disable after this time (RFC3339)")
+	cmd.Flags().StringVar(&platform, "platform", "", "target delivery platform (slack|feishu|cron), auto-detected from env if unset")
+	cmd.Flags().StringVar(&platformKey, "platform-key", "", "platform routing key as JSON, e.g. '{\"channel_id\":\"C123\"}'")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("schedule")
 	_ = cmd.MarkFlagRequired("message")
 	_ = cmd.MarkFlagRequired("bot-id")
 	_ = cmd.MarkFlagRequired("owner-id")
 	return cmd
+}
+
+// parsePlatformKey parses a JSON object string into a map[string]string.
+// Returns nil for empty input.
+func parsePlatformKey(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil
+	}
+	return m
 }

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -116,6 +116,39 @@ type JobCreateOptions struct {
 	MaxRetries     int
 	MaxRuns        int
 	ExpiresAt      string
+	Platform       string
+	PlatformKey    map[string]string
+}
+
+// resolvePlatform resolves the target platform and routing key with three-level priority:
+// 1. CLI flags (explicit --platform / --platform-key)
+// 2. Environment variables (GATEWAY_PLATFORM, GATEWAY_CHANNEL_ID, GATEWAY_THREAD_ID)
+// 3. Default "cron" (backward compatible)
+func resolvePlatform(cliPlatform string, cliPlatformKey map[string]string) (string, map[string]string) {
+	if cliPlatform != "" {
+		return cliPlatform, cliPlatformKey
+	}
+
+	envPlatform := os.Getenv("GATEWAY_PLATFORM")
+	switch envPlatform {
+	case "slack":
+		key := map[string]string{}
+		if ch := os.Getenv("GATEWAY_CHANNEL_ID"); ch != "" {
+			key["channel_id"] = ch
+		}
+		if ts := os.Getenv("GATEWAY_THREAD_ID"); ts != "" {
+			key["thread_ts"] = ts
+		}
+		return "slack", key
+	case "feishu":
+		key := map[string]string{}
+		if chatID := os.Getenv("GATEWAY_CHANNEL_ID"); chatID != "" {
+			key["chat_id"] = chatID
+		}
+		return "feishu", key
+	}
+
+	return "cron", nil
 }
 
 // PrepareJobForCreate builds a CronJob from CLI flags.
@@ -124,6 +157,9 @@ func PrepareJobForCreate(name, scheduleRaw, message, description, workDir, botID
 	if err != nil {
 		return nil, err
 	}
+
+	platform, platformKey := resolvePlatform(opts.Platform, opts.PlatformKey)
+
 	job := &cron.CronJob{
 		Name:           name,
 		Description:    description,
@@ -133,7 +169,8 @@ func PrepareJobForCreate(name, scheduleRaw, message, description, workDir, botID
 		WorkDir:        workDir,
 		BotID:          botID,
 		OwnerID:        ownerID,
-		Platform:       "cron",
+		Platform:       platform,
+		PlatformKey:    platformKey,
 		TimeoutSec:     timeoutSec,
 		DeleteAfterRun: opts.DeleteAfterRun,
 		MaxRetries:     opts.MaxRetries,


### PR DESCRIPTION
## Summary

- CLI 创建的 cron job 硬编码 `Platform="cron"`，导致 `buildDeliverySuffix()` 和 `Deliver()` 两条投递路径均跳过，执行结果无法送达 Slack/飞书
- 新增三级 platform 解析：CLI flags (`--platform`/`--platform-key`) > 环境变量 (`GATEWAY_PLATFORM`/`GATEWAY_CHANNEL_ID`/`GATEWAY_THREAD_ID`) > 默认值 `"cron"`
- 纯增量修改，默认值保持向后兼容

Closes #358

## Test plan

- [ ] Worker 进程内通过 Slack 创建 cron job → `GATEWAY_PLATFORM=slack` 环境变量自动注入，结果投递到 Slack channel
- [ ] 纯 CLI 直接执行 `hotplex cron create`（无环境变量）→ `Platform="cron"` 行为不变
- [ ] `--platform slack --platform-key '{"channel_id":"C123"}'` 显式指定 → 正确投递
- [ ] `make check` 通过 ✓