### PR TITLE
refactor(messaging/slack): extract SlackAPI interface for testability

### DIFF
--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -74,7 +74,7 @@ type Adapter struct {
 
 	botToken           string
 	appToken           string
-	client             *slack.Client
+	client             SlackAPI
 	socketMode         *socketmode.Client
 	botID              string
 	teamID             string
@@ -139,8 +139,9 @@ func (a *Adapter) Start(ctx context.Context) error {
 		return fmt.Errorf("slack: botToken and appToken required")
 	}
 
-	a.client = slack.New(a.botToken, slack.OptionAppLevelToken(a.appToken))
-	a.socketMode = socketmode.New(a.client)
+	client := slack.New(a.botToken, slack.OptionAppLevelToken(a.appToken))
+	a.client = client
+	a.socketMode = socketmode.New(client)
 
 	// Fetch bot identity
 	authTest, err := a.client.AuthTestContext(ctx)

--- a/internal/messaging/slack/api.go
+++ b/internal/messaging/slack/api.go
@@ -1,0 +1,29 @@
+package slack
+
+import (
+	"context"
+	"io"
+
+	"github.com/slack-go/slack"
+)
+
+// SlackAPI abstracts the subset of slack.Client methods used by the adapter.
+// *slack.Client satisfies this interface implicitly — no wrapper needed.
+type SlackAPI interface {
+	PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error)
+	AuthTestContext(ctx context.Context) (*slack.AuthTestResponse, error)
+	GetUserInfoContext(ctx context.Context, user string) (*slack.User, error)
+	UploadFileContext(ctx context.Context, params slack.UploadFileParameters) (*slack.FileSummary, error)
+	StartStreamContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error)
+	AppendStreamContext(ctx context.Context, channelID, timestamp string, options ...slack.MsgOption) (string, string, error)
+	StopStreamContext(ctx context.Context, channelID, timestamp string, options ...slack.MsgOption) (string, string, error)
+	UpdateMessageContext(ctx context.Context, channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error)
+	PostEphemeralContext(ctx context.Context, channelID, userID string, options ...slack.MsgOption) (string, error)
+	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
+	AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error
+	RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error
+	SetAssistantThreadsStatusContext(ctx context.Context, params slack.AssistantThreadsSetStatusParameters) error
+}
+
+// Compile-time verification that *slack.Client satisfies SlackAPI.
+var _ SlackAPI = (*slack.Client)(nil)

--- a/internal/messaging/slack/mention.go
+++ b/internal/messaging/slack/mention.go
@@ -17,7 +17,6 @@ const (
 var mentionPattern = regexp.MustCompile(`<@([A-Z0-9]+)(?:\|([^>]*))?>`)
 
 // UserCache resolves Slack user IDs to display names.
-// Uses slack.Client.GetUserInfoContext for resolution.
 // Evicts entries older than 30 minutes and caps at 500 entries.
 type UserCache struct {
 	client SlackAPI

--- a/internal/messaging/slack/mention.go
+++ b/internal/messaging/slack/mention.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/slack-go/slack"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -21,12 +20,12 @@ var mentionPattern = regexp.MustCompile(`<@([A-Z0-9]+)(?:\|([^>]*))?>`)
 // Uses slack.Client.GetUserInfoContext for resolution.
 // Evicts entries older than 30 minutes and caps at 500 entries.
 type UserCache struct {
-	client *slack.Client
+	client SlackAPI
 	cache  *TTLCache[string, string]
 }
 
 // NewUserCache creates a new user mention resolver with bounded TTL and size.
-func NewUserCache(client *slack.Client) *UserCache {
+func NewUserCache(client SlackAPI) *UserCache {
 	return &UserCache{
 		client: client,
 		cache:  NewTTLCache[string, string](userCacheTTL, userCacheSweepInt),

--- a/internal/messaging/slack/stream.go
+++ b/internal/messaging/slack/stream.go
@@ -96,7 +96,7 @@ type NativeStreamingWriter struct {
 	// appendWithRetry) must NOT reference this — the caller (pcEntry.writeOne)
 	// cancels its context as soon as Write() returns.
 	startCtx  context.Context
-	client    *slack.Client
+	client    SlackAPI
 	channelID string
 	threadTS  string
 	teamID    string
@@ -129,7 +129,7 @@ type NativeStreamingWriter struct {
 }
 
 // NewNativeStreamingWriter creates a new streaming writer for Slack.
-func NewNativeStreamingWriter(ctx context.Context, client *slack.Client, channelID, threadTS, teamID string,
+func NewNativeStreamingWriter(ctx context.Context, client SlackAPI, channelID, threadTS, teamID string,
 	rateLimiter *ChannelRateLimiter, log *slog.Logger, onComplete func(string), onRegister func(*NativeStreamingWriter)) *NativeStreamingWriter {
 	w := &NativeStreamingWriter{
 		startCtx:     ctx,

--- a/internal/messaging/slack/tts.go
+++ b/internal/messaging/slack/tts.go
@@ -18,13 +18,13 @@ import (
 // Slack natively supports MP3 inline playback.
 type TTSPipeline struct {
 	synthesizer tts.Synthesizer
-	client      *slack.Client
+	client      SlackAPI
 	maxChars    int
 	sem         *semaphore.Weighted
 	log         *slog.Logger
 }
 
-func NewTTSPipeline(synthesizer tts.Synthesizer, client *slack.Client, maxChars int, log *slog.Logger) *TTSPipeline {
+func NewTTSPipeline(synthesizer tts.Synthesizer, client SlackAPI, maxChars int, log *slog.Logger) *TTSPipeline {
 	if maxChars <= 0 {
 		maxChars = 150
 	}


### PR DESCRIPTION
## Summary

- Extract `SlackAPI` interface covering the 13 `slack.Client` methods actually used by the adapter (Context variants only)
- `*slack.Client` satisfies the interface implicitly — no wrapper, no behavior change
- 4 struct fields (`Adapter`, `UserCache`, `NativeStreamingWriter`, `TTSPipeline`) and 3 constructors now depend on `SlackAPI` instead of the concrete type
- Enables mock injection for unit tests going forward

Closes #359

## Test plan

- [x] `make check` passes (fmt + lint + test + build, zero regressions)
- [x] Compile-time `var _ SlackAPI = (*slack.Client)(nil)` verified
- [x] All existing tests pass with nil literal and `slack.New("x-test-token")` patterns unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)