### PR TITLE
fix(cron): isolate cron sessions with dedicated UUIDv5 namespace

### DIFF
--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -43,16 +43,7 @@ func NewExecutor(log *slog.Logger, bridge BridgeStarter, sm SessionStateChecker)
 // Returns the session key used for delivery routing.
 // timeout is the execution deadline (from job.TimeoutSec or scheduler default).
 func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Duration) (string, error) {
-	sessionKey := session.DerivePlatformSessionKey(
-		job.OwnerID, worker.TypeClaudeCode,
-		session.PlatformContext{
-			Platform: "cron",
-			BotID:    job.BotID,
-			UserID:   job.OwnerID,
-			WorkDir:  job.WorkDir,
-			ChatID:   job.ID,
-		},
-	)
+	sessionKey := session.DeriveCronSessionKey(job.ID, time.Now().UnixNano())
 
 	platformKey := map[string]string{"cron_job_id": job.ID}
 	title := fmt.Sprintf("cron:%s", job.Name)

--- a/internal/cron/executor_test.go
+++ b/internal/cron/executor_test.go
@@ -23,19 +23,27 @@ func (m *mockBridge) StartSession(_ context.Context, _, _, _ string, _ worker.Wo
 
 // mockSessionStateChecker implements SessionStateChecker for testing.
 type mockSessionStateChecker struct {
-	sessions map[string]*session.SessionInfo
-	workers  map[string]worker.Worker
+	sessions       map[string]*session.SessionInfo
+	workers        map[string]worker.Worker
+	defaultWorker  worker.Worker
+	defaultSession *session.SessionInfo
 }
 
 func (m *mockSessionStateChecker) Get(_ context.Context, id string) (*session.SessionInfo, error) {
 	if si, ok := m.sessions[id]; ok {
 		return si, nil
 	}
+	if m.defaultSession != nil {
+		return m.defaultSession, nil
+	}
 	return nil, errTestNotFound
 }
 
 func (m *mockSessionStateChecker) GetWorker(id string) worker.Worker {
-	return m.workers[id]
+	if w, ok := m.workers[id]; ok {
+		return w
+	}
+	return m.defaultWorker
 }
 
 // mockWorker implements worker.Worker for testing with minimal stubs.
@@ -65,19 +73,6 @@ func (m *mockWorker) LastIO() time.Time                                    { ret
 func (m *mockWorker) ResetContext(_ context.Context) error                 { return nil }
 
 var errTestNotFound = context.DeadlineExceeded
-
-func deriveExpectedKey(job *CronJob) string {
-	return session.DerivePlatformSessionKey(
-		job.OwnerID, worker.TypeClaudeCode,
-		session.PlatformContext{
-			Platform: "cron",
-			BotID:    job.BotID,
-			UserID:   job.OwnerID,
-			WorkDir:  job.WorkDir,
-			ChatID:   job.ID,
-		},
-	)
-}
 
 func testJob() *CronJob {
 	return &CronJob{
@@ -117,18 +112,13 @@ func TestExecutor_Execute_WorkerNotFound(t *testing.T) {
 func TestExecutor_Execute_InputFails(t *testing.T) {
 	t.Parallel()
 
-	job := testJob()
-	key := deriveExpectedKey(job)
-
 	bridge := &mockBridge{}
 	sm := &mockSessionStateChecker{
-		workers: map[string]worker.Worker{
-			key: &mockWorker{inputErr: errTestNotFound},
-		},
+		defaultWorker: &mockWorker{inputErr: errTestNotFound},
 	}
 
 	e := NewExecutor(slog.Default(), bridge, sm)
-	_, err := e.Execute(context.Background(), job, 5*time.Minute)
+	_, err := e.Execute(context.Background(), testJob(), 5*time.Minute)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "input prompt")
 }
@@ -136,21 +126,14 @@ func TestExecutor_Execute_InputFails(t *testing.T) {
 func TestExecutor_Execute_TimeoutWaiting(t *testing.T) {
 	t.Parallel()
 
-	job := testJob()
-	key := deriveExpectedKey(job)
-
 	bridge := &mockBridge{}
 	sm := &mockSessionStateChecker{
-		sessions: map[string]*session.SessionInfo{
-			key: {State: "running"},
-		},
-		workers: map[string]worker.Worker{
-			key: &mockWorker{},
-		},
+		defaultSession: &session.SessionInfo{State: "running"},
+		defaultWorker:  &mockWorker{},
 	}
 
 	e := NewExecutor(slog.Default(), bridge, sm)
-	_, err := e.Execute(context.Background(), job, 100*time.Millisecond)
+	_, err := e.Execute(context.Background(), testJob(), 100*time.Millisecond)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timeout")
 }
@@ -158,23 +141,16 @@ func TestExecutor_Execute_TimeoutWaiting(t *testing.T) {
 func TestExecutor_Execute_Success(t *testing.T) {
 	t.Parallel()
 
-	job := testJob()
-	key := deriveExpectedKey(job)
-
 	bridge := &mockBridge{}
 	// Session already completed (terminated) — waitForCompletion returns immediately.
 	sm := &mockSessionStateChecker{
-		sessions: map[string]*session.SessionInfo{
-			key: {State: "terminated"},
-		},
-		workers: map[string]worker.Worker{
-			key: &mockWorker{},
-		},
+		defaultSession: &session.SessionInfo{State: "terminated"},
+		defaultWorker:  &mockWorker{},
 	}
 
 	e := NewExecutor(slog.Default(), bridge, sm)
 
-	gotKey, err := e.Execute(context.Background(), job, 5*time.Second)
+	gotKey, err := e.Execute(context.Background(), testJob(), 5*time.Second)
 	require.NoError(t, err)
-	require.Equal(t, key, gotKey)
+	require.NotEmpty(t, gotKey)
 }

--- a/internal/session/key.go
+++ b/internal/session/key.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"crypto/sha1"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -12,6 +13,10 @@ import (
 // hotplexNamespace is the HotPlex namespace UUID (RFC 4122 §4.3).
 // Using a fixed value ensures cross-environment consistency.
 var hotplexNamespace = uuid.MustParse("urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+// CronNamespace is a sub-namespace derived from hotplexNamespace for cron session isolation.
+// Cron sessions use this namespace to guarantee they never collide with feishu/slack sessions.
+var CronNamespace = uuid.NewHash(sha1.New(), hotplexNamespace, []byte("cron"), 5)
 
 // DeriveSessionKey generates a deterministic server-side session ID using UUIDv5.
 // Same (ownerID, workerType, clientKey, workDir) always maps to the same session.
@@ -114,4 +119,12 @@ func DerivePlatformSessionKey(ownerID string, wt worker.WorkerType, ctx Platform
 	name := b.String()
 	id := uuid.NewHash(sha1.New(), hotplexNamespace, []byte(name), 5)
 	return id.String()
+}
+
+// DeriveCronSessionKey generates a unique UUIDv5 session key for a single cron execution.
+// Uses CronNamespace for platform isolation, and (jobID + epoch) for per-execution uniqueness.
+// Each invocation with a different epoch produces a different key, ensuring fresh sessions.
+func DeriveCronSessionKey(jobID string, epoch int64) string {
+	name := jobID + "|" + strconv.FormatInt(epoch, 10)
+	return uuid.NewHash(sha1.New(), CronNamespace, []byte(name), 5).String()
 }


### PR DESCRIPTION
## Summary

- All cron jobs for the same (ownerID, botID, userID, workDir) derived the same session key via `DerivePlatformSessionKey`, because the `"cron"` platform had no switch case and `ChatID` (job.ID) was silently ignored
- This caused 100% timeout failures: multiple jobs collided on the same session, `waitForCompletion` polled a session that never went IDLE
- Introduce `CronNamespace` (UUIDv5 sub-namespace of `hotplexNamespace`) and `DeriveCronSessionKey(jobID, epoch)` so each execution gets an isolated, unique session key

## Changes

| File | Change |
|------|--------|
| `internal/session/key.go` | Add `CronNamespace` + `DeriveCronSessionKey(jobID, epoch)` |
| `internal/cron/executor.go` | Replace `DerivePlatformSessionKey` → `DeriveCronSessionKey` |
| `internal/cron/executor_test.go` | Adapt mocks for non-deterministic keys, add defaultWorker/defaultSession fallback |

**架构影响**：
- Channel: N/A
- Worker: CC (cron executor starts Claude Code workers)
- 平台: 跨平台

## Test plan

- [x] `make test` + `make lint` 全通过
- [x] Pre-push hooks (fmt + lint + vet + build + test) all green
- [ ] Manual: deploy and verify cron jobs execute with unique sessions (no collision)

Fixes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)