### PR TITLE
refactor(cron): promote silent from magic [SILENT] text prefix to structural Silent field

### DIFF
--- a/cmd/hotplex/cron_admin_adapter.go
+++ b/cmd/hotplex/cron_admin_adapter.go
@@ -51,6 +51,9 @@ func (a *cronAdminAdapter) UpdateJob(ctx context.Context, id string, updates map
 	if v, ok := updates["delete_after_run"].(bool); ok {
 		job.DeleteAfterRun = v
 	}
+	if v, ok := updates["silent"].(bool); ok {
+		job.Silent = v
+	}
 	if v, ok := updates["max_retries"].(float64); ok {
 		job.MaxRetries = int(v)
 	}

--- a/cmd/hotplex/cron_create.go
+++ b/cmd/hotplex/cron_create.go
@@ -24,6 +24,7 @@ func newCronCreateCmd() *cobra.Command {
 		timeoutSec     int
 		allowedTools   string
 		deleteAfterRun bool
+		silent         bool
 		maxRetries     int
 		maxRuns        int
 		expiresAt      string
@@ -57,6 +58,7 @@ Schedule format:
 
 				job, err := croncli.PrepareJobForCreate(name, schedule, message, description, workDir, botID, ownerID, timeoutSec, tools, croncli.JobCreateOptions{
 					DeleteAfterRun: deleteAfterRun,
+					Silent:         silent,
 					MaxRetries:     maxRetries,
 					MaxRuns:        maxRuns,
 					ExpiresAt:      expiresAt,
@@ -91,6 +93,7 @@ Schedule format:
 	cmd.Flags().IntVar(&timeoutSec, "timeout", 0, "execution timeout in seconds")
 	cmd.Flags().StringVar(&allowedTools, "allowed-tools", "", "comma-separated tool list")
 	cmd.Flags().BoolVar(&deleteAfterRun, "delete-after-run", false, "delete one-shot job after execution")
+	cmd.Flags().BoolVar(&silent, "silent", false, "suppress result delivery (self-maintenance tasks)")
 	cmd.Flags().IntVar(&maxRetries, "max-retries", 0, "max retries for failed one-shot jobs")
 	cmd.Flags().IntVar(&maxRuns, "max-runs", 0, "max executions before auto-disable (0=unlimited)")
 	cmd.Flags().StringVar(&expiresAt, "expires-at", "", "auto-disable after this time (RFC3339)")

--- a/cmd/hotplex/cron_get.go
+++ b/cmd/hotplex/cron_get.go
@@ -48,6 +48,9 @@ func newCronGetCmd() *cobra.Command {
 				if job.TimeoutSec > 0 {
 					_, _ = fmt.Fprintf(tw, "Timeout:\t%ds\n", job.TimeoutSec)
 				}
+				if job.DeleteAfterRun {
+					_, _ = fmt.Fprintf(tw, "Delete After Run:\t%v\n", job.DeleteAfterRun)
+				}
 				if job.Silent {
 					_, _ = fmt.Fprintf(tw, "Silent:\t%v\n", job.Silent)
 				}

--- a/cmd/hotplex/cron_get.go
+++ b/cmd/hotplex/cron_get.go
@@ -48,6 +48,9 @@ func newCronGetCmd() *cobra.Command {
 				if job.TimeoutSec > 0 {
 					_, _ = fmt.Fprintf(tw, "Timeout:\t%ds\n", job.TimeoutSec)
 				}
+				if job.Silent {
+					_, _ = fmt.Fprintf(tw, "Silent:\t%v\n", job.Silent)
+				}
 				_, _ = fmt.Fprintf(tw, "Next Run:\t%s\n", croncli.FormatTimeMs(job.State.NextRunAtMs))
 				_, _ = fmt.Fprintf(tw, "Last Run:\t%s\n", croncli.FormatTimeMs(job.State.LastRunAtMs))
 				if job.State.LastStatus != "" {

--- a/cmd/hotplex/cron_update.go
+++ b/cmd/hotplex/cron_update.go
@@ -70,6 +70,7 @@ Schedule format:
 	cmd.Flags().String("allowed-tools", "", "comma-separated tool list")
 	cmd.Flags().Bool("enabled", true, "enable or disable the job")
 	cmd.Flags().Bool("delete-after-run", false, "delete one-shot job after execution")
+	cmd.Flags().Bool("silent", false, "suppress result delivery (self-maintenance tasks)")
 	cmd.Flags().Int("max-retries", 0, "max retries for failed one-shot jobs")
 	cmd.Flags().Int("max-runs", 0, "max executions before auto-disable (0=unlimited)")
 	cmd.Flags().String("expires-at", "", "auto-disable after this time (RFC3339)")
@@ -122,6 +123,10 @@ func applyFlags(cmd *cobra.Command, job *cron.CronJob) bool {
 	}
 	if cmd.Flags().Changed("delete-after-run") {
 		job.DeleteAfterRun, _ = cmd.Flags().GetBool("delete-after-run")
+		changed = true
+	}
+	if cmd.Flags().Changed("silent") {
+		job.Silent, _ = cmd.Flags().GetBool("silent")
 		changed = true
 	}
 	if cmd.Flags().Changed("max-retries") {

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -113,6 +113,7 @@ func parseDurationMs(s string) (int64, error) {
 // JobCreateOptions groups lifecycle and optional parameters for job creation.
 type JobCreateOptions struct {
 	DeleteAfterRun bool
+	Silent         bool
 	MaxRetries     int
 	MaxRuns        int
 	ExpiresAt      string
@@ -173,6 +174,7 @@ func PrepareJobForCreate(name, scheduleRaw, message, description, workDir, botID
 		PlatformKey:    platformKey,
 		TimeoutSec:     timeoutSec,
 		DeleteAfterRun: opts.DeleteAfterRun,
+		Silent:         opts.Silent,
 		MaxRetries:     opts.MaxRetries,
 		MaxRuns:        opts.MaxRuns,
 		ExpiresAt:      opts.ExpiresAt,

--- a/internal/cron/cron-skill-manual.md
+++ b/internal/cron/cron-skill-manual.md
@@ -4,7 +4,7 @@
 
 HotPlex Gateway 内置 AI-native 定时任务系统。载荷为自然语言 Prompt，由 Worker 执行（等同一次 AI 对话），结果自动回传至创建者的平台（飞书卡片 / Slack 消息）。
 
-Prompt 以 `[SILENT]` 开头则不投递结果（用于自维护任务）。
+`--silent` 标志（CLI）或 `silent: true`（YAML/API）标记静默任务，结果不投递（用于自维护任务）。
 
 **操作方式**：`hotplex cron` CLI（本机直接操作 SQLite，自动通知 gateway 刷新索引）。Admin API 仅用于远程场景。
 
@@ -20,6 +20,7 @@ Prompt 以 `[SILENT]` 开头则不投递结果（用于自维护任务）。
 | X 点(提醒我) / 每天/每周 | `cron` | `cron:0 9 * * *` |
 | X 分钟后 / 过一会儿 / 稍后 | `at` | `at:ISO timestamp` |
 | 提醒我 | `at` | `at:ISO timestamp` |
+| 静默 / 悄悄 / 别发 / 不用报告 / 无需通知 | `--silent` | `--silent` |
 
 **禁止**：用 `sleep` 循环、系统 crontab、Claude CronCreate、后台脚本等替代方案。
 
@@ -65,6 +66,7 @@ hotplex cron create \
   [--timeout <秒>] \
   [--allowed-tools <逗号分隔>] \
   [--delete-after-run] \
+  [--silent] \
   [--max-retries <次数>] \
   [--max-runs <次数>] \
   [--expires-at <RFC3339>]
@@ -187,7 +189,16 @@ hotplex cron history <id|name> [--json]
 
 ### 静默自维护
 
-需要定期清理但不需要看到结果 → Prompt 以 `[SILENT]` 开头，结果不投递。
+需要定期清理但不需要看到结果 → 使用 `--silent` 标志，结果不投递。
+
+```bash
+hotplex cron create \
+  --name "silent-cleanup" \
+  --schedule "every:6h" \
+  -m "清理临时文件" \
+  --bot-id "$GATEWAY_BOT_ID" --owner-id "$GATEWAY_USER_ID" \
+  --silent
+```
 
 ## 字段速查
 
@@ -203,6 +214,7 @@ hotplex cron history <id|name> [--json]
 | `timeout_sec` | `--timeout` | 否 | 单次超时（秒），默认 5min |
 | `allowed_tools` | `--allowed-tools` | 否 | 逗号分隔 |
 | `delete_after_run` | `--delete-after-run` | 否 | 执行后自动删除（one-shot 适用） |
+| `silent` | `--silent` | 否 | 静默模式，不投递结果 |
 | `max_retries` | `--max-retries` | 否 | 失败最大重试次数，默认 0 |
 | `max_runs` | `--max-runs` | 否 | 成功执行 N 次后自动 disable，默认 0（无限） |
 | `expires_at` | `--expires-at` | 否 | 过期时间（RFC3339），到期自动 disable |
@@ -236,6 +248,7 @@ hotplex cron history <id|name> [--json]
   "work_dir": "/path",
   "timeout_sec": 300,
   "delete_after_run": false,
+  "silent": false,
   "max_retries": 0,
   "max_runs": 0,
   "expires_at": ""

--- a/internal/cron/delivery.go
+++ b/internal/cron/delivery.go
@@ -3,7 +3,6 @@ package cron
 import (
 	"context"
 	"log/slog"
-	"strings"
 	"sync"
 )
 
@@ -42,12 +41,6 @@ func (d *Delivery) Deliver(ctx context.Context, job *CronJob, sessionKey string)
 		return
 	}
 	if response == "" {
-		return
-	}
-
-	// [SILENT] suppression.
-	if strings.HasPrefix(strings.TrimSpace(response), "[SILENT]") {
-		d.log.Debug("cron delivery: suppressed [SILENT] response", "job_id", job.ID)
 		return
 	}
 

--- a/internal/cron/delivery_test.go
+++ b/internal/cron/delivery_test.go
@@ -37,50 +37,6 @@ func TestDelivery_Deliver_EmptyResponse(t *testing.T) {
 	require.False(t, delivered)
 }
 
-func TestDelivery_Deliver_SilentSuppression(t *testing.T) {
-	t.Parallel()
-
-	var delivered bool
-	d := NewDelivery(slog.Default(),
-		func(_ context.Context, _ string) (string, error) {
-			return "[SILENT] this output should be suppressed", nil
-		},
-		func(_ context.Context, _ string, _ map[string]string, _ string) error {
-			delivered = true
-			return nil
-		},
-	)
-
-	d.Deliver(context.Background(), &CronJob{
-		ID:       "test",
-		Platform: "feishu",
-	}, "session-key")
-
-	require.False(t, delivered)
-}
-
-func TestDelivery_Deliver_SilentWithLeadingWhitespace(t *testing.T) {
-	t.Parallel()
-
-	var delivered bool
-	d := NewDelivery(slog.Default(),
-		func(_ context.Context, _ string) (string, error) {
-			return "  [SILENT] suppressed with whitespace", nil
-		},
-		func(_ context.Context, _ string, _ map[string]string, _ string) error {
-			delivered = true
-			return nil
-		},
-	)
-
-	d.Deliver(context.Background(), &CronJob{
-		ID:       "test",
-		Platform: "feishu",
-	}, "session-key")
-
-	require.False(t, delivered)
-}
-
 func TestDelivery_Deliver_NoPlatform(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/session"
@@ -112,10 +111,10 @@ func HasCLIDelivery(job *CronJob) bool {
 
 // buildDeliverySuffix appends CLI delivery instructions to the cron prompt.
 func buildDeliverySuffix(job *CronJob) string {
-	if job.Platform == "" || job.Platform == "cron" {
+	if job.Silent {
 		return ""
 	}
-	if strings.HasPrefix(strings.TrimSpace(job.Payload.Message), "[SILENT]") {
+	if job.Platform == "" || job.Platform == "cron" {
 		return ""
 	}
 	switch job.Platform {

--- a/internal/cron/executor_test.go
+++ b/internal/cron/executor_test.go
@@ -154,3 +154,22 @@ func TestExecutor_Execute_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, gotKey)
 }
+
+func TestBuildDeliverySuffix_SilentJob(t *testing.T) {
+	t.Parallel()
+
+	job := testJob()
+	job.Silent = true
+	job.Platform = "feishu"
+	job.PlatformKey = map[string]string{"chat_id": "oc_123"}
+	require.Empty(t, buildDeliverySuffix(job))
+}
+
+func TestBuildDeliverySuffix_NonSilentWithPlatform(t *testing.T) {
+	t.Parallel()
+
+	job := testJob()
+	job.Platform = "feishu"
+	job.PlatformKey = map[string]string{"chat_id": "oc_123"}
+	require.NotEmpty(t, buildDeliverySuffix(job))
+}

--- a/internal/cron/loader.go
+++ b/internal/cron/loader.go
@@ -20,6 +20,7 @@ type YAMLJobDef struct {
 	Platform       string   `mapstructure:"platform" yaml:"platform"`
 	TimeoutSec     int      `mapstructure:"timeout_sec" yaml:"timeout_sec"`
 	DeleteAfterRun bool     `mapstructure:"delete_after_run" yaml:"delete_after_run"`
+	Silent         bool     `mapstructure:"silent" yaml:"silent"`
 	MaxRetries     int      `mapstructure:"max_retries" yaml:"max_retries"`
 	MaxRuns        int      `mapstructure:"max_runs" yaml:"max_runs"`
 	ExpiresAt      string   `mapstructure:"expires_at" yaml:"expires_at"`
@@ -103,6 +104,7 @@ func yamlDefToJob(def YAMLJobDef) (*CronJob, error) {
 		PlatformKey:    map[string]string{},
 		TimeoutSec:     def.TimeoutSec,
 		DeleteAfterRun: def.DeleteAfterRun,
+		Silent:         def.Silent,
 		MaxRetries:     def.MaxRetries,
 		MaxRuns:        def.MaxRuns,
 		ExpiresAt:      def.ExpiresAt,

--- a/internal/cron/loader_test.go
+++ b/internal/cron/loader_test.go
@@ -92,6 +92,7 @@ func TestYAMLDefToJob(t *testing.T) {
 		Platform:      "feishu",
 		TimeoutSec:    120,
 		MaxRetries:    3,
+		Silent:        true,
 		AllowedTools:  []string{"Read", "Bash"},
 	}
 
@@ -112,6 +113,7 @@ func TestYAMLDefToJob(t *testing.T) {
 	require.Equal(t, "feishu", job.Platform)
 	require.Equal(t, 120, job.TimeoutSec)
 	require.Equal(t, 3, job.MaxRetries)
+	require.True(t, job.Silent)
 	require.NotZero(t, job.State.NextRunAtMs)
 	require.NotZero(t, job.CreatedAtMs)
 }

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -48,7 +48,7 @@ func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 const jobColumns = `id, name, description, enabled,
 	schedule_kind, schedule_data, payload_kind, payload_data,
 	work_dir, bot_id, owner_id, platform, platform_key,
-	timeout_sec, delete_after_run, max_retries, max_runs, expires_at,
+	timeout_sec, delete_after_run, silent, max_retries, max_runs, expires_at,
 	state, created_at, updated_at`
 
 func (s *SQLiteStore) Create(ctx context.Context, job *CronJob) error {
@@ -66,11 +66,11 @@ func (s *SQLiteStore) Create(ctx context.Context, job *CronJob) error {
 
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO cron_jobs (`+jobColumns+`)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		job.ID, job.Name, job.Description, boolToInt(job.Enabled),
 		job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
 		job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
-		job.TimeoutSec, boolToInt(job.DeleteAfterRun), job.MaxRetries, job.MaxRuns, job.ExpiresAt,
+		job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries, job.MaxRuns, job.ExpiresAt,
 		stateData, job.CreatedAtMs, job.UpdatedAtMs,
 	)
 	if err != nil {
@@ -93,14 +93,14 @@ func (s *SQLiteStore) Update(ctx context.Context, job *CronJob) error {
 			name = ?, description = ?, enabled = ?,
 			schedule_kind = ?, schedule_data = ?, payload_kind = ?, payload_data = ?,
 			work_dir = ?, bot_id = ?, owner_id = ?, platform = ?, platform_key = ?,
-			timeout_sec = ?, delete_after_run = ?, max_retries = ?,
+			timeout_sec = ?, delete_after_run = ?, silent = ?, max_retries = ?,
 			max_runs = ?, expires_at = ?,
 			state = ?, updated_at = ?
 		WHERE id = ?`,
 		job.Name, job.Description, boolToInt(job.Enabled),
 		job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
 		job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
-		job.TimeoutSec, boolToInt(job.DeleteAfterRun), job.MaxRetries,
+		job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries,
 		job.MaxRuns, job.ExpiresAt,
 		stateData, job.UpdatedAtMs,
 		job.ID,
@@ -224,20 +224,20 @@ type scanner interface{ Scan(...any) error }
 
 func scanJobRow(s scanner) (*CronJob, error) {
 	job := &CronJob{}
-	var enabled, deleteAfterRun int
+	var enabled, deleteAfterRun, silent int
 	var schedData, payloadData, platformKeyData, stateData string
 
 	err := s.Scan(
 		&job.ID, &job.Name, &job.Description, &enabled,
 		&job.Schedule.Kind, &schedData, &job.Payload.Kind, &payloadData,
 		&job.WorkDir, &job.BotID, &job.OwnerID, &job.Platform, &platformKeyData,
-		&job.TimeoutSec, &deleteAfterRun, &job.MaxRetries, &job.MaxRuns, &job.ExpiresAt,
+		&job.TimeoutSec, &deleteAfterRun, &silent, &job.MaxRetries, &job.MaxRuns, &job.ExpiresAt,
 		&stateData, &job.CreatedAtMs, &job.UpdatedAtMs,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cron store: scan job: %w", err)
 	}
-	if err := decodeJobFields(job, enabled, deleteAfterRun, schedData, payloadData, platformKeyData, stateData); err != nil {
+	if err := decodeJobFields(job, enabled, deleteAfterRun, silent, schedData, payloadData, platformKeyData, stateData); err != nil {
 		return nil, err
 	}
 	return job, nil
@@ -263,6 +263,7 @@ func copyJobDefinition(dst, src *CronJob) {
 	dst.PlatformKey = src.PlatformKey
 	dst.TimeoutSec = src.TimeoutSec
 	dst.DeleteAfterRun = src.DeleteAfterRun
+	dst.Silent = src.Silent
 	dst.MaxRetries = src.MaxRetries
 	dst.MaxRuns = src.MaxRuns
 	dst.ExpiresAt = src.ExpiresAt
@@ -270,9 +271,10 @@ func copyJobDefinition(dst, src *CronJob) {
 	dst.UpdatedAtMs = time.Now().UnixMilli()
 }
 
-func decodeJobFields(job *CronJob, enabled, deleteAfterRun int, schedData, payloadData, platformKeyData, stateData string) error {
+func decodeJobFields(job *CronJob, enabled, deleteAfterRun, silent int, schedData, payloadData, platformKeyData, stateData string) error {
 	job.Enabled = enabled == 1
 	job.DeleteAfterRun = deleteAfterRun == 1
+	job.Silent = silent == 1
 	if err := json.Unmarshal([]byte(schedData), &job.Schedule); err != nil {
 		return fmt.Errorf("cron store: unmarshal schedule: %w", err)
 	}

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -48,6 +48,7 @@ func newTestStore(t *testing.T) *SQLiteStore {
 			platform_key     TEXT NOT NULL DEFAULT '{}',
 			timeout_sec      INTEGER NOT NULL DEFAULT 0,
 			delete_after_run INTEGER NOT NULL DEFAULT 0 CHECK(delete_after_run IN (0, 1)),
+			silent           INTEGER NOT NULL DEFAULT 0 CHECK(silent IN (0, 1)),
 			max_retries      INTEGER NOT NULL DEFAULT 0,
 			max_runs         INTEGER NOT NULL DEFAULT 0,
 			expires_at       TEXT    NOT NULL DEFAULT '',
@@ -278,6 +279,7 @@ func TestSQLiteStore_FieldsRoundtrip(t *testing.T) {
 		PlatformKey:    map[string]string{"chat_id": "oc_abc", "user_id": "ou_xyz"},
 		TimeoutSec:     300,
 		DeleteAfterRun: true,
+		Silent:         true,
 		MaxRetries:     5,
 		State: CronJobState{
 			NextRunAtMs:     now + 60_000,
@@ -312,6 +314,7 @@ func TestSQLiteStore_FieldsRoundtrip(t *testing.T) {
 	require.Equal(t, job.PlatformKey, got.PlatformKey)
 	require.Equal(t, job.TimeoutSec, got.TimeoutSec)
 	require.Equal(t, job.DeleteAfterRun, got.DeleteAfterRun)
+	require.Equal(t, job.Silent, got.Silent)
 	require.Equal(t, job.MaxRetries, got.MaxRetries)
 	require.Equal(t, job.State, got.State)
 	require.Equal(t, job.CreatedAtMs, got.CreatedAtMs)

--- a/internal/cron/timer.go
+++ b/internal/cron/timer.go
@@ -180,7 +180,7 @@ func (s *Scheduler) executeJob(job *CronJob) {
 		job.State.ConsecutiveErrs = 0
 		job.State.RunCount++
 		resetRetry(job)
-		if s.delivery != nil && !HasCLIDelivery(job) {
+		if s.delivery != nil && !job.Silent && !HasCLIDelivery(job) {
 			s.delivery.Deliver(s.ctx, job, sessionKey)
 		}
 	}

--- a/internal/cron/types.go
+++ b/internal/cron/types.go
@@ -86,6 +86,7 @@ type CronJob struct {
 	PlatformKey    map[string]string `json:"platform_key,omitempty"`
 	TimeoutSec     int               `json:"timeout_sec,omitempty"`
 	DeleteAfterRun bool              `json:"delete_after_run,omitempty"`
+	Silent         bool              `json:"silent,omitempty"`
 	MaxRetries     int               `json:"max_retries,omitempty"`
 	MaxRuns        int               `json:"max_runs,omitempty"`
 	ExpiresAt      string            `json:"expires_at,omitempty"`

--- a/internal/session/sql/migrations/007_cron_job_silent.sql
+++ b/internal/session/sql/migrations/007_cron_job_silent.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE cron_jobs ADD COLUMN silent INTEGER NOT NULL DEFAULT 0 CHECK(silent IN (0, 1));
+
+-- +goose Down
+-- SQLite DROP COLUMN requires 3.35.0+; no-op for safety.


### PR DESCRIPTION
Closes #365

## Summary

- Promote `silent` from a magic `[SILENT]` text prefix in prompt messages to a first-class `Silent bool` field on `CronJob`
- Replace unreliable response-prefix detection in `delivery.go` with deterministic `job.Silent` checks
- Add `--silent` CLI flag (create + update), YAML loader support, and Admin API handling
- Update cron-skill-manual.md with intent mapping table and usage examples

## Changes

| Area | Files | Change |
|------|-------|--------|
| Schema | `007_cron_job_silent.sql` | `ALTER TABLE ADD COLUMN silent` |
| Types | `types.go` | `Silent bool` on CronJob |
| Store | `store.go` | Full column persistence chain |
| Executor | `executor.go` | `buildDeliverySuffix` uses `job.Silent` |
| Delivery | `delivery.go` | Remove `[SILENT]` response detection |
| Timer | `timer.go` | `!job.Silent` guard before delivery |
| CLI | `cron_create.go`, `cron_update.go`, `client.go` | `--silent` flag |
| Loader | `loader.go` | `Silent` in YAMLJobDef |
| Admin | `cron_admin_adapter.go` | `silent` in UpdateJob |
| Docs | `cron-skill-manual.md` | Flag docs + intent mapping |
| Tests | `*_test.go` | Coverage for new field and behavior |

## Test plan

- [x] `make check` passes (lint 0 issues + all tests + build)
- [x] `TestBuildDeliverySuffix_SilentJob` verifies empty suffix for silent jobs
- [x] `TestBuildDeliverySuffix_NonSilentWithPlatform` verifies non-empty suffix for normal jobs
- [x] `TestSQLiteStore_FieldsRoundtrip` covers `Silent` field persistence
- [x] `TestYAMLDefToJob` covers `Silent` in YAML loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)