### PR TITLE
fix(cron): executor stdin EOF + auto-disable persistence

### DIFF
--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -81,6 +81,12 @@ func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Durat
 		return "", fmt.Errorf("cron executor: input prompt: %w", err)
 	}
 
+	// Signal EOF so --print mode workers exit after processing instead of
+	// waiting for more streaming input that will never arrive.
+	if ci, ok := w.(interface{ CloseInput() error }); ok {
+		_ = ci.CloseInput()
+	}
+
 	err := e.waitForCompletion(ctx, sessionKey, timeout)
 
 	// Explicitly terminate the session to ensure the worker process exits immediately.

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	GetByName(ctx context.Context, name string) (*CronJob, error)
 	List(ctx context.Context, enabledOnly bool) ([]*CronJob, error)
 	UpdateState(ctx context.Context, id string, state CronJobState) error
+	SetEnabled(ctx context.Context, id string, enabled bool) error
 	UpsertByName(ctx context.Context, job *CronJob) error
 }
 
@@ -189,6 +190,26 @@ func (s *SQLiteStore) UpdateState(ctx context.Context, id string, state CronJobS
 	)
 	if err != nil {
 		return fmt.Errorf("cron store: update state: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("%w: %s", ErrJobNotFound, id)
+	}
+	return nil
+}
+
+// SetEnabled updates the enabled flag for a job without touching other fields.
+func (s *SQLiteStore) SetEnabled(ctx context.Context, id string, enabled bool) error {
+	ctx, cancel := withTimeout(ctx)
+	defer cancel()
+
+	now := time.Now().UnixMilli()
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE cron_jobs SET enabled = ?, updated_at = ? WHERE id = ?`,
+		boolToInt(enabled), now, id,
+	)
+	if err != nil {
+		return fmt.Errorf("cron store: set enabled: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {

--- a/internal/cron/timer.go
+++ b/internal/cron/timer.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -241,6 +242,11 @@ func (s *Scheduler) executeJob(job *CronJob) {
 	}
 
 	s.persistState(job.ID, job.State)
+	if shouldDisable {
+		if err := s.store.SetEnabled(s.persistCtx(), job.ID, false); err != nil {
+			s.log.Error("cron: persist disable", "job_id", job.ID, "err", err)
+		}
+	}
 	s.mergeJobState(job.ID, job.State, shouldDisable)
 }
 
@@ -250,6 +256,10 @@ func (s *Scheduler) persistState(jobID string, state CronJobState) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := s.store.UpdateState(ctx, jobID, state); err != nil {
+		if errors.Is(err, ErrJobNotFound) {
+			s.log.Debug("cron: persist state skipped, job deleted", "job_id", jobID)
+			return
+		}
 		s.log.Error("cron: persist state", "job_id", jobID, "err", err)
 	}
 }

--- a/internal/worker/base/conn.go
+++ b/internal/worker/base/conn.go
@@ -131,6 +131,20 @@ func (c *Conn) WriteMu() *sync.Mutex {
 	return &c.mu
 }
 
+// CloseInput closes the stdin pipe to signal EOF to the worker process.
+// The worker will finish processing buffered input and exit.
+// Safe to call multiple times; sets stdin to nil after close.
+func (c *Conn) CloseInput() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stdin != nil {
+		err := c.stdin.Close()
+		c.stdin = nil
+		return err
+	}
+	return nil
+}
+
 // Close terminates the connection and releases resources.
 func (c *Conn) Close() error {
 	c.mu.Lock()

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -379,6 +379,14 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	return nil
 }
 
+// CloseInput signals EOF on the worker's stdin so it exits after processing.
+func (w *Worker) CloseInput() error {
+	if conn, ok := w.Conn().(*base.Conn); ok {
+		return conn.CloseInput()
+	}
+	return nil
+}
+
 func (w *Worker) HandlePermissionResponse(_ context.Context, reqID string, allowed bool, reason string) error {
 	w.Log.Info("claudecode: sending permission response to stdin",
 		"request_id", reqID,


### PR DESCRIPTION
## Summary

- **Fix executor timeout on completed turns**: Close stdin after writing cron prompt so `--print` mode workers exit after processing instead of waiting for streaming input that never arrives
- **Persist auto-disable to DB**: Call `store.SetEnabled(id, false)` when auto-disabling so `rebuildIndex` doesn't re-enable failed jobs
- **Suppress deleted job persist noise**: Downgrade `ErrJobNotFound` to DEBUG in `persistState`

Closes #371

## Test plan

- [x] `make test` passes (with -race)
- [x] `make lint` passes (0 issues)
- [x] Pre-commit and pre-push hooks pass
- [ ] Manual: trigger cron job, verify completes in seconds not timeout
- [ ] Manual: auto-disable persists across `rebuildIndex` (SIGHUP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)