### PR TITLE
fix: security + reliability batch — issues #380, #378, #388, #381, #379

### DIFF
--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -63,7 +64,7 @@ func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
@@ -85,7 +86,7 @@ func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}

--- a/internal/brain/config.go
+++ b/internal/brain/config.go
@@ -139,18 +139,19 @@ type MemoryCompressionConfig struct {
 
 // SafetyGuardFeatureConfig configures safety guardrails.
 type SafetyGuardFeatureConfig struct {
-	Enabled            bool          // Enable safety guard
-	InputGuardEnabled  bool          // Enable input validation
-	OutputGuardEnabled bool          // Enable output sanitization
-	Chat2ConfigEnabled bool          // Enable natural language config changes (security risk)
-	MaxInputLength     int           // Maximum input length
-	ScanDepth          int           // Depth for nested context scanning
-	Sensitivity        string        // Detection sensitivity: "low", "medium", "high"
-	AdminUsers         []string      // User IDs with admin privileges
-	AdminChannels      []string      // Channel IDs with admin privileges
-	ResponseTimeout    time.Duration // Timeout for Brain API calls
-	RateLimitRPS       float64       // Requests per second per user (0 = disabled)
-	RateLimitBurst     int           // Burst capacity per user
+	Enabled                bool          // Enable safety guard
+	InputGuardEnabled      bool          // Enable input validation
+	OutputGuardEnabled     bool          // Enable output sanitization
+	Chat2ConfigEnabled     bool          // Enable natural language config changes (security risk)
+	MaxInputLength         int           // Maximum input length
+	ScanDepth              int           // Depth for nested context scanning
+	Sensitivity            string        // Detection sensitivity: "low", "medium", "high"
+	AdminUsers             []string      // User IDs with admin privileges
+	AdminChannels          []string      // Channel IDs with admin privileges
+	ResponseTimeout        time.Duration // Timeout for Brain API calls
+	RateLimitRPS           float64       // Requests per second per user (0 = disabled)
+	RateLimitBurst         int           // Burst capacity per user
+	FailClosedOnBrainError bool          // Block input when deep analysis fails (e.g. LLM down)
 }
 
 // === Main Config ===
@@ -365,18 +366,19 @@ func buildConfig(apiKey, provider, protocol, model, endpoint string) Config {
 			SessionTTL:       getEnv("HOTPLEX_BRAIN_MEMORY_SESSION_TTL", "24h"),
 		},
 		Guard: SafetyGuardFeatureConfig{
-			Enabled:            getBoolEnv("HOTPLEX_BRAIN_GUARD_ENABLED", true),
-			InputGuardEnabled:  getBoolEnv("HOTPLEX_BRAIN_GUARD_INPUT_ENABLED", true),
-			OutputGuardEnabled: getBoolEnv("HOTPLEX_BRAIN_GUARD_OUTPUT_ENABLED", true),
-			Chat2ConfigEnabled: getBoolEnv("HOTPLEX_BRAIN_CHAT2CONFIG_ENABLED", false),
-			MaxInputLength:     getIntEnv("HOTPLEX_BRAIN_GUARD_MAX_INPUT_LENGTH", 100000),
-			ScanDepth:          getIntEnv("HOTPLEX_BRAIN_GUARD_SCAN_DEPTH", 3),
-			Sensitivity:        getEnv("HOTPLEX_BRAIN_GUARD_SENSITIVITY", "medium"),
-			AdminUsers:         parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_USERS", "")),
-			AdminChannels:      parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_CHANNELS", "")),
-			ResponseTimeout:    getDurationEnv("HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT", 10*time.Second),
-			RateLimitRPS:       getFloatEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_RPS", 10.0),
-			RateLimitBurst:     getIntEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_BURST", 20),
+			Enabled:                getBoolEnv("HOTPLEX_BRAIN_GUARD_ENABLED", true),
+			InputGuardEnabled:      getBoolEnv("HOTPLEX_BRAIN_GUARD_INPUT_ENABLED", true),
+			OutputGuardEnabled:     getBoolEnv("HOTPLEX_BRAIN_GUARD_OUTPUT_ENABLED", true),
+			Chat2ConfigEnabled:     getBoolEnv("HOTPLEX_BRAIN_CHAT2CONFIG_ENABLED", false),
+			MaxInputLength:         getIntEnv("HOTPLEX_BRAIN_GUARD_MAX_INPUT_LENGTH", 100000),
+			ScanDepth:              getIntEnv("HOTPLEX_BRAIN_GUARD_SCAN_DEPTH", 3),
+			Sensitivity:            getEnv("HOTPLEX_BRAIN_GUARD_SENSITIVITY", "medium"),
+			AdminUsers:             parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_USERS", "")),
+			AdminChannels:          parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_CHANNELS", "")),
+			ResponseTimeout:        getDurationEnv("HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT", 10*time.Second),
+			RateLimitRPS:           getFloatEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_RPS", 10.0),
+			RateLimitBurst:         getIntEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_BURST", 20),
+			FailClosedOnBrainError: getBoolEnv("HOTPLEX_BRAIN_GUARD_FAIL_CLOSED_ON_BRAIN_ERROR", false),
 		},
 	}
 }

--- a/internal/brain/guard.go
+++ b/internal/brain/guard.go
@@ -48,6 +48,8 @@ type GuardConfig struct {
 	// Rate limiting for CheckInput calls (per-user)
 	RateLimitRPS   float64 `json:"rate_limit_rps"`   // Requests per second per user (0 = disabled)
 	RateLimitBurst int     `json:"rate_limit_burst"` // Burst capacity per user
+	// Fail-closed policy: when true, block input if deep analysis fails (e.g. LLM backend down)
+	FailClosedOnBrainError bool `json:"fail_closed_on_brain_error"`
 }
 
 // DefaultGuardConfig returns default guard configuration.
@@ -302,6 +304,8 @@ func (g *SafetyGuard) CheckInputWithUser(ctx context.Context, input, userID stri
 	for _, pattern := range g.banPatterns {
 		if pattern.MatchString(input) {
 			g.blockedInputs.Add(1)
+			g.logger.Warn("Input blocked by pattern match",
+				"pattern", pattern.String())
 
 			return &GuardResult{
 				Safe:           false,
@@ -398,7 +402,15 @@ Return JSON:
 
 	if err := g.brain.Analyze(ctx, prompt, &analysis); err != nil {
 		g.logger.Warn("Deep input analysis failed", "error", err)
-		// On error, use pattern result (already passed)
+		if g.config.FailClosedOnBrainError {
+			return &GuardResult{
+				Safe:        false,
+				ThreatLevel: ThreatLevelMedium,
+				ThreatType:  "analysis_unavailable",
+				Reason:      "Deep analysis unavailable, fail-closed policy applied",
+				Action:      GuardActionBlock,
+			}
+		}
 		return &GuardResult{
 			Safe:        true,
 			ThreatLevel: ThreatLevelLow,
@@ -408,6 +420,10 @@ Return JSON:
 
 	if !analysis.Safe {
 		g.blockedInputs.Add(1)
+		g.logger.Warn("Input blocked by deep analysis",
+			"threat_level", analysis.ThreatLevel,
+			"threat_type", analysis.ThreatType,
+			"reason", analysis.Reason)
 
 		return &GuardResult{
 			Safe:        false,
@@ -791,61 +807,55 @@ Keep response concise and actionable.`, err, eventContext)
 
 // === Global instance ===
 
-var (
-	globalGuard *SafetyGuard
-	guardOnce   sync.Once
-)
+// globalGuard holds the global SafetyGuard instance.
+// Uses atomic.Pointer for race-free concurrent access.
+var globalGuard atomic.Pointer[SafetyGuard]
 
 // GlobalGuard returns the global SafetyGuard instance.
 func GlobalGuard() *SafetyGuard {
-	return globalGuard
+	return globalGuard.Load()
 }
 
 // InitGuard initializes the global SafetyGuard.
 func InitGuard(config GuardConfig, logger *slog.Logger) error {
-	var initErr error
-	guardOnce.Do(func() {
-		if Global() == nil {
-			initErr = ErrBrainNotConfigured
-			return
-		}
+	if Global() == nil {
+		return ErrBrainNotConfigured
+	}
 
-		guard, err := NewSafetyGuard(Global(), config, logger)
-		if err != nil {
-			initErr = fmt.Errorf("failed to create SafetyGuard: %w", err)
-			return
-		}
+	guard, err := NewSafetyGuard(Global(), config, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create SafetyGuard: %w", err)
+	}
 
-		globalGuard = guard
-		logger.Info("SafetyGuard initialized",
-			"enabled", config.Enabled,
-			"input_guard", config.InputGuardEnabled,
-			"output_guard", config.OutputGuardEnabled,
-			"chat2config", config.Chat2ConfigEnabled)
-	})
-	return initErr
+	globalGuard.Store(guard)
+	logger.Info("SafetyGuard initialized",
+		"enabled", config.Enabled,
+		"input_guard", config.InputGuardEnabled,
+		"output_guard", config.OutputGuardEnabled,
+		"chat2config", config.Chat2ConfigEnabled)
+	return nil
 }
 
 // CheckInputSafe is a convenience function for input checking.
 func CheckInputSafe(ctx context.Context, input string) *GuardResult {
-	if globalGuard == nil {
-		return &GuardResult{Safe: true, ThreatLevel: ThreatLevelNone, Action: GuardActionAllow}
+	if g := globalGuard.Load(); g != nil {
+		return g.CheckInput(ctx, input)
 	}
-	return globalGuard.CheckInput(ctx, input)
+	return &GuardResult{Safe: true, ThreatLevel: ThreatLevelNone, Action: GuardActionAllow}
 }
 
 // CheckOutputSafe is a convenience function for output checking.
 func CheckOutputSafe(output string) *GuardResult {
-	if globalGuard == nil {
-		return &GuardResult{Safe: true, ThreatLevel: ThreatLevelNone, Action: GuardActionAllow}
+	if g := globalGuard.Load(); g != nil {
+		return g.CheckOutput(output)
 	}
-	return globalGuard.CheckOutput(output)
+	return &GuardResult{Safe: true, ThreatLevel: ThreatLevelNone, Action: GuardActionAllow}
 }
 
 // SanitizeOutputString is a convenience function for output sanitization.
 func SanitizeOutputString(output string) string {
-	if globalGuard == nil {
-		return output
+	if g := globalGuard.Load(); g != nil {
+		return g.SanitizeOutput(output)
 	}
-	return globalGuard.SanitizeOutput(output)
+	return output
 }

--- a/internal/brain/guard_test.go
+++ b/internal/brain/guard_test.go
@@ -961,15 +961,14 @@ func TestSafetyGuard_CompileBanPatternsLocked_SkipsInvalid(t *testing.T) {
 
 func TestInitGuard_NoBrain(t *testing.T) {
 	oldBrain := globalBrain
-	oldGuard := globalGuard
+	oldGuard := globalGuard.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalGuard = oldGuard
-		guardOnce = sync.Once{}
+		globalGuard.Store(oldGuard)
 	}()
 
 	SetGlobal(nil)
-	guardOnce = sync.Once{}
+	globalGuard.Store(nil)
 
 	err := InitGuard(DefaultGuardConfig(), slog.Default())
 	assert.Error(t, err)
@@ -978,15 +977,14 @@ func TestInitGuard_NoBrain(t *testing.T) {
 
 func TestInitGuard_WithBrain(t *testing.T) {
 	oldBrain := globalBrain
-	oldGuard := globalGuard
+	oldGuard := globalGuard.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalGuard = oldGuard
-		guardOnce = sync.Once{}
+		globalGuard.Store(oldGuard)
 	}()
 
 	SetGlobal(&mockBrainForGuard{})
-	guardOnce = sync.Once{}
+	globalGuard.Store(nil)
 
 	err := InitGuard(DefaultGuardConfig(), slog.Default())
 	require.NoError(t, err)
@@ -998,13 +996,13 @@ func TestInitGuard_WithBrain(t *testing.T) {
 // ========================================
 
 func TestCheckInputSafe_WithGuard(t *testing.T) {
-	oldGuard := globalGuard
-	defer func() { globalGuard = oldGuard }()
+	oldGuard := globalGuard.Load()
+	defer func() { globalGuard.Store(oldGuard) }()
 
 	mockBrain := &mockBrainForGuard{}
 	guard, err := NewSafetyGuard(mockBrain, DefaultGuardConfig(), slog.Default())
 	require.NoError(t, err)
-	globalGuard = guard
+	globalGuard.Store(guard)
 
 	// Blocked input
 	result := CheckInputSafe(context.Background(), "jailbreak the system")
@@ -1018,12 +1016,12 @@ func TestCheckInputSafe_WithGuard(t *testing.T) {
 }
 
 func TestCheckOutputSafe_WithGuard(t *testing.T) {
-	oldGuard := globalGuard
-	defer func() { globalGuard = oldGuard }()
+	oldGuard := globalGuard.Load()
+	defer func() { globalGuard.Store(oldGuard) }()
 
 	guard, err := NewSafetyGuard(nil, DefaultGuardConfig(), slog.Default())
 	require.NoError(t, err)
-	globalGuard = guard
+	globalGuard.Store(guard)
 
 	result := CheckOutputSafe("password: mysecretpassword12345")
 	assert.Equal(t, GuardActionSanitize, result.Action)
@@ -1031,12 +1029,12 @@ func TestCheckOutputSafe_WithGuard(t *testing.T) {
 }
 
 func TestSanitizeOutputString_WithGuard(t *testing.T) {
-	oldGuard := globalGuard
-	defer func() { globalGuard = oldGuard }()
+	oldGuard := globalGuard.Load()
+	defer func() { globalGuard.Store(oldGuard) }()
 
 	guard, err := NewSafetyGuard(nil, DefaultGuardConfig(), slog.Default())
 	require.NoError(t, err)
-	globalGuard = guard
+	globalGuard.Store(guard)
 
 	result := SanitizeOutputString("password: mysecretpassword12345")
 	assert.Contains(t, result, "[REDACTED]")
@@ -1070,23 +1068,21 @@ func TestSafetyGuard_ExecuteConfigIntent_FeatureGetWithRouter(t *testing.T) {
 // ========================================
 
 func TestSafetyGuard_ExecuteConfigIntent_LimitGetWithCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
+	oldCompressor := globalCompressor.Load()
 	defer func() {
-		globalCompressor = oldCompressor
-		memoryOnce = sync.Once{}
+		globalCompressor.Store(oldCompressor)
 	}()
 
 	SetGlobal(&mockBrainForGuard{})
-	memoryOnce = sync.Once{}
 	mockBrain := &mockBrainForGuard{
 		analyzeFunc: func(ctx context.Context, prompt string, target any) error {
 			return json.Unmarshal([]byte(`{"summary": "compressed"}`), target)
 		},
 	}
-	globalCompressor = NewContextCompressor(mockBrain, CompressionConfig{
+	globalCompressor.Store(NewContextCompressor(mockBrain, CompressionConfig{
 		Enabled:        true,
 		TokenThreshold: 100,
-	}, slog.Default())
+	}, slog.Default()))
 
 	guard := newTestGuard(t, nil, func(c *GuardConfig) {
 		c.Chat2ConfigEnabled = true
@@ -1096,7 +1092,7 @@ func TestSafetyGuard_ExecuteConfigIntent_LimitGetWithCompressor(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, resp, "Token threshold")
 
-	if comp := globalCompressor; comp != nil {
+	if comp := globalCompressor.Load(); comp != nil {
 		comp.Stop()
 	}
 }
@@ -1130,15 +1126,14 @@ func TestSafetyGuard_DiagnoseError_Timeout(t *testing.T) {
 
 func TestInitGuard_NewSafetyGuardError(t *testing.T) {
 	oldBrain := globalBrain
-	oldGuard := globalGuard
+	oldGuard := globalGuard.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalGuard = oldGuard
-		guardOnce = sync.Once{}
+		globalGuard.Store(oldGuard)
 	}()
 
 	SetGlobal(&mockBrainForGuard{})
-	guardOnce = sync.Once{}
+	globalGuard.Store(nil)
 
 	badConfig := GuardConfig{
 		BanPatterns: []string{`[invalid(`},

--- a/internal/brain/init.go
+++ b/internal/brain/init.go
@@ -142,18 +142,19 @@ func Init(logger *slog.Logger) error {
 
 	if config.Guard.Enabled {
 		if err := InitGuard(GuardConfig{
-			Enabled:            config.Guard.Enabled,
-			InputGuardEnabled:  config.Guard.InputGuardEnabled,
-			OutputGuardEnabled: config.Guard.OutputGuardEnabled,
-			Chat2ConfigEnabled: config.Guard.Chat2ConfigEnabled,
-			MaxInputLength:     config.Guard.MaxInputLength,
-			ScanDepth:          config.Guard.ScanDepth,
-			Sensitivity:        config.Guard.Sensitivity,
-			AdminUsers:         config.Guard.AdminUsers,
-			AdminChannels:      config.Guard.AdminChannels,
-			ResponseTimeout:    config.Guard.ResponseTimeout,
-			RateLimitRPS:       config.Guard.RateLimitRPS,
-			RateLimitBurst:     config.Guard.RateLimitBurst,
+			Enabled:                config.Guard.Enabled,
+			InputGuardEnabled:      config.Guard.InputGuardEnabled,
+			OutputGuardEnabled:     config.Guard.OutputGuardEnabled,
+			Chat2ConfigEnabled:     config.Guard.Chat2ConfigEnabled,
+			MaxInputLength:         config.Guard.MaxInputLength,
+			ScanDepth:              config.Guard.ScanDepth,
+			Sensitivity:            config.Guard.Sensitivity,
+			AdminUsers:             config.Guard.AdminUsers,
+			AdminChannels:          config.Guard.AdminChannels,
+			ResponseTimeout:        config.Guard.ResponseTimeout,
+			RateLimitRPS:           config.Guard.RateLimitRPS,
+			RateLimitBurst:         config.Guard.RateLimitBurst,
+			FailClosedOnBrainError: config.Guard.FailClosedOnBrainError,
 		}, logger); err != nil {
 			logger.Warn("Failed to initialize SafetyGuard", "error", err)
 		}

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -599,59 +599,58 @@ func (m *MemoryManager) GetCompressor() *ContextCompressor {
 	return m.compressor
 }
 
-// Global memory manager instance
+// Global memory manager instances.
+// Use atomic.Pointer for race-free concurrent access.
 var (
-	globalCompressor *ContextCompressor
-	globalMemoryMgr  *MemoryManager
-	memoryOnce       sync.Once
+	globalCompressor atomic.Pointer[ContextCompressor]
+	globalMemoryMgr  atomic.Pointer[MemoryManager]
 )
 
 // GlobalCompressor returns the global ContextCompressor instance.
 func GlobalCompressor() *ContextCompressor {
-	return globalCompressor
+	return globalCompressor.Load()
 }
 
 // GlobalMemoryManager returns the global MemoryManager instance.
 func GlobalMemoryManager() *MemoryManager {
-	return globalMemoryMgr
+	return globalMemoryMgr.Load()
 }
 
 // InitMemory initializes the global memory management system.
 func InitMemory(config CompressionConfig, logger *slog.Logger) {
-	memoryOnce.Do(func() {
-		if Global() == nil {
-			logger.Debug("Cannot init Memory: Brain not configured")
-			return
-		}
+	if Global() == nil {
+		logger.Debug("Cannot init Memory: Brain not configured")
+		return
+	}
 
-		globalCompressor = NewContextCompressor(Global(), config, logger)
-		globalMemoryMgr = NewMemoryManager(globalCompressor, Global(), logger)
+	comp := NewContextCompressor(Global(), config, logger)
+	globalCompressor.Store(comp)
+	globalMemoryMgr.Store(NewMemoryManager(comp, Global(), logger))
 
-		logger.Info("Memory management initialized",
-			"enabled", config.Enabled,
-			"token_threshold", config.TokenThreshold)
-	})
+	logger.Info("Memory management initialized",
+		"enabled", config.Enabled,
+		"token_threshold", config.TokenThreshold)
 }
 
 // RecordTurn is a convenience function to record a turn.
 func RecordTurn(sessionID, role, content string, tokenCount int) {
-	if globalCompressor != nil {
-		globalCompressor.RecordTurn(sessionID, role, content, tokenCount)
+	if c := globalCompressor.Load(); c != nil {
+		c.RecordTurn(sessionID, role, content, tokenCount)
 	}
 }
 
 // CheckCompress is a convenience function to check and compress.
 func CheckCompress(ctx context.Context, sessionID string) (*SessionHistory, error) {
-	if globalCompressor == nil {
-		return nil, nil
+	if c := globalCompressor.Load(); c != nil {
+		return c.CheckAndCompress(ctx, sessionID)
 	}
-	return globalCompressor.CheckAndCompress(ctx, sessionID)
+	return nil, nil
 }
 
 // GetSessionSummary is a convenience function to get session summary.
 func GetSessionSummary(sessionID string) string {
-	if globalCompressor == nil {
-		return ""
+	if c := globalCompressor.Load(); c != nil {
+		return c.GetSessionSummary(sessionID)
 	}
-	return globalCompressor.GetSessionSummary(sessionID)
+	return ""
 }

--- a/internal/brain/memory_test.go
+++ b/internal/brain/memory_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sync"
 	"testing"
 	"time"
 
@@ -795,17 +794,15 @@ func TestGetSessionSummary_NilCompressor(t *testing.T) {
 
 func TestInitMemory_NoBrain(t *testing.T) {
 	oldBrain := globalBrain
-	oldCompressor := globalCompressor
-	oldMgr := globalMemoryMgr
+	oldCompressor := globalCompressor.Load()
+	oldMgr := globalMemoryMgr.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalCompressor = oldCompressor
-		globalMemoryMgr = oldMgr
-		memoryOnce = sync.Once{}
+		globalCompressor.Store(oldCompressor)
+		globalMemoryMgr.Store(oldMgr)
 	}()
 
 	SetGlobal(nil)
-	memoryOnce = sync.Once{}
 
 	InitMemory(DefaultCompressionConfig(), slog.Default())
 	// Should not create compressor when brain is nil
@@ -888,17 +885,15 @@ func TestEstimateTokens_MixedContent(t *testing.T) {
 
 func TestInitMemory_WithBrain(t *testing.T) {
 	oldBrain := globalBrain
-	oldCompressor := globalCompressor
-	oldMemoryMgr := globalMemoryMgr
+	oldCompressor := globalCompressor.Load()
+	oldMemoryMgr := globalMemoryMgr.Load()
 	defer func() {
 		globalBrain = oldBrain
-		globalCompressor = oldCompressor
-		globalMemoryMgr = oldMemoryMgr
-		memoryOnce = sync.Once{}
+		globalCompressor.Store(oldCompressor)
+		globalMemoryMgr.Store(oldMemoryMgr)
 	}()
 
 	SetGlobal(&mockBrainForMemory{})
-	memoryOnce = sync.Once{}
 
 	InitMemory(CompressionConfig{Enabled: true}, slog.Default())
 	assert.NotNil(t, GlobalCompressor())
@@ -914,46 +909,54 @@ func TestInitMemory_WithBrain(t *testing.T) {
 // ========================================
 
 func TestRecordTurn_WithGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
 	mockBrain := &mockBrainForMemory{}
-	globalCompressor = NewContextCompressor(mockBrain, CompressionConfig{
+	globalCompressor.Store(NewContextCompressor(mockBrain, CompressionConfig{
 		Enabled:         true,
 		TokenThreshold:  10000,
 		CleanupInterval: 0,
-	}, slog.Default())
-	defer globalCompressor.Stop()
+	}, slog.Default()))
+	defer func() {
+		if c := globalCompressor.Load(); c != nil {
+			c.Stop()
+		}
+	}()
 
 	// Should not panic
 	RecordTurn("session1", "user", "hello", 10)
 
-	history := globalCompressor.GetHistory("session1")
+	history := globalCompressor.Load().GetHistory("session1")
 	require.NotNil(t, history)
 	assert.Len(t, history.Turns, 1)
 }
 
 func TestRecordTurn_NilGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
-	globalCompressor = nil
+	globalCompressor.Store(nil)
 
 	// Should not panic
 	RecordTurn("session1", "user", "hello", 10)
 }
 
 func TestCheckCompress_WithGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
 	mockBrain := &mockBrainForMemory{}
-	globalCompressor = NewContextCompressor(mockBrain, CompressionConfig{
+	globalCompressor.Store(NewContextCompressor(mockBrain, CompressionConfig{
 		Enabled:         true,
 		TokenThreshold:  10000,
 		CleanupInterval: 0,
-	}, slog.Default())
-	defer globalCompressor.Stop()
+	}, slog.Default()))
+	defer func() {
+		if c := globalCompressor.Load(); c != nil {
+			c.Stop()
+		}
+	}()
 
 	result, err := CheckCompress(context.Background(), "session1")
 	assert.NoError(t, err)
@@ -962,10 +965,10 @@ func TestCheckCompress_WithGlobalCompressor(t *testing.T) {
 }
 
 func TestCheckCompress_NilGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
-	globalCompressor = nil
+	globalCompressor.Store(nil)
 
 	result, err := CheckCompress(context.Background(), "session1")
 	assert.NoError(t, err)
@@ -973,26 +976,30 @@ func TestCheckCompress_NilGlobalCompressor(t *testing.T) {
 }
 
 func TestGetSessionSummary_WithGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
 	mockBrain := &mockBrainForMemory{}
-	globalCompressor = NewContextCompressor(mockBrain, CompressionConfig{
+	globalCompressor.Store(NewContextCompressor(mockBrain, CompressionConfig{
 		Enabled:         true,
 		TokenThreshold:  10000,
 		CleanupInterval: 0,
-	}, slog.Default())
-	defer globalCompressor.Stop()
+	}, slog.Default()))
+	defer func() {
+		if c := globalCompressor.Load(); c != nil {
+			c.Stop()
+		}
+	}()
 
 	summary := GetSessionSummary("nonexistent")
 	assert.Empty(t, summary)
 }
 
 func TestGetSessionSummary_NilGlobalCompressor(t *testing.T) {
-	oldCompressor := globalCompressor
-	defer func() { globalCompressor = oldCompressor }()
+	oldCompressor := globalCompressor.Load()
+	defer func() { globalCompressor.Store(oldCompressor) }()
 
-	globalCompressor = nil
+	globalCompressor.Store(nil)
 
 	summary := GetSessionSummary("session1")
 	assert.Empty(t, summary)

--- a/internal/messaging/feishu/chat_queue.go
+++ b/internal/messaging/feishu/chat_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 )
@@ -72,6 +73,13 @@ func (q *ChatQueue) Enqueue(chatID string, task func(ctx context.Context) error)
 // elapses with no new tasks. On exit, it removes itself from the workers map.
 func (q *ChatQueue) runWorker(chatID string, w *chatWorker) {
 	defer q.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			if q.log != nil {
+				q.log.Error("feishu: panic in chat queue worker", "chat_id", chatID, "panic", r, "stack", string(debug.Stack()))
+			}
+		}
+	}()
 
 	idleTimer := time.NewTimer(chatIdleTimeout)
 	defer idleTimer.Stop()

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -3,6 +3,7 @@ package feishu
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -216,7 +217,14 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 		"input_tok", d.TotalInputTok,
 	)
 	if c.adapter.turnSummaryEnabled {
-		go c.sendTurnSummaryCard(d)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					c.adapter.Log.Error("feishu: panic in sendTurnSummaryCard", "panic", r, "stack", string(debug.Stack()))
+				}
+			}()
+			c.sendTurnSummaryCard(d)
+		}()
 	}
 
 	var fullText string
@@ -248,6 +256,11 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 			ttsCtx, ttsCancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 			go func() {
 				defer ttsCancel()
+				defer func() {
+					if r := recover(); r != nil {
+						c.adapter.Log.Error("feishu: panic in TTS process", "panic", r, "stack", string(debug.Stack()))
+					}
+				}()
 				c.adapter.ttsPipeline.Process(ttsCtx, fullText, chatID, replyID)
 			}()
 		}

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -249,7 +249,7 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 }
 
 func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
-	return w.httpPost(ctx, fmt.Sprintf("/question/%s/reply", reqID),
+	return w.httpPost(ctx, fmt.Sprintf("/question/%s/reply", url.PathEscape(reqID)),
 		map[string][][]string{"answers": answersToArrays(answers)})
 }
 
@@ -258,7 +258,7 @@ func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID, action st
 	if content != nil {
 		payload["content"] = content
 	}
-	return w.httpPost(ctx, fmt.Sprintf("/elicitation/%s/reply", reqID), payload)
+	return w.httpPost(ctx, fmt.Sprintf("/elicitation/%s/reply", url.PathEscape(reqID)), payload)
 }
 
 // Resume reconnects to an existing session on the shared OpenCode server.


### PR DESCRIPTION
## Summary

Batch of 5 security and reliability quick fixes identified through ROI-prioritized issue analysis:

- **#380** — Add `io.LimitReader` to cron handler JSON decoding (DoS prevention)
- **#378** — Add panic recovery to 3 unprotected feishu goroutine entries (process crash prevention)
- **#388** — Add `url.PathEscape` to OCS question/elicitation handlers (injection prevention)
- **#381** — Add structured Warn logging when SafetyGuard blocks threats (observability)
- **#379** — Add configurable fail-closed policy + `atomic.Pointer` for global singletons (security + data race fix)

## Changes by Issue

### #380: cron handlers body size limit
**Problem**: `HandleCronCreate` and `HandleCronUpdate` decoded JSON without body size limit.
**Solution**: Added `io.LimitReader(r.Body, 1<<20)` matching existing handlers.

### #378: feishu panic recovery
**Problem**: 3 goroutine entry points (`sendTurnSummaryCard`, TTS `Process`, `ChatQueue.runWorker`) lacked `defer recover()`.
**Solution**: Added panic recovery matching the module's existing pattern.

### #388: OCS URL escaping
**Problem**: `HandleQuestionResponse` and `HandleElicitationResponse` passed raw `reqID` into URL paths.
**Solution**: Added `url.PathEscape(reqID)` matching `HandlePermissionResponse`.

### #381: SafetyGuard silent block
**Problem**: Deep analysis and pattern-based blocks only incremented a counter — no log entry.
**Solution**: Added Warn-level structured logging with threat details.

### #379: fail-closed + data race
**Problem**: (1) `deepInputAnalysis` returned `Safe: true` on Brain errors (fail-open). (2) `globalGuard`/`globalCompressor`/`globalMemoryMgr` used `sync.Once` + direct assignment — data race with concurrent readers.
**Solution**: (1) Added `FailClosedOnBrainError` config (default false). (2) Replaced with `atomic.Pointer` matching IntentRouter pattern from PR #348.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test-short` — all pass
- [x] `go test ./internal/brain/... -race` — no data races
- [x] Pre-commit hooks pass on all 5 commits
- [x] Pre-push validation passes

Fixes #380
Fixes #378
Fixes #388
Fixes #381
Fixes #379