### PR TITLE
fix: security + reliability batch — config panic, dead validators, ECDSA key derivation, SanitizeArg (#390, #386, #391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Summary
+
+Unreleased 包含跨 **配置、安全、Gateway** 三个模块的安全加固与可靠性改进。配置层消除 env-mapping 拼写错误导致的 reflection panic；Gateway init 握手阶段接入安全白名单验证（tool/model），将定义了但从未执行的死代码安全策略激活；JWT 密钥派生升级为 HKDF (RFC 5869)，并修复 GenerateToken 缺失 audience claim 和 SanitizeArg 截断非 ASCII 字符的问题。
+
+### Fixed
+
+- **Config**: Reflection panic on env-mapping typo — `setField`/`setBoolField`/`setSliceField` 在环境变量映射指向不存在的 struct 字段时不再 panic，而是返回带字段名和目标类型诊断的错误信息。`applyPlatformEnv` 和 `applyMessagingEnv` 通过结构化 warning 日志优雅降级，单个映射失败不阻塞其他环境变量。`runGateway` 启动时调用 `cfg.Validate()`，配置错误（如负 retention_period、零 max_size）在启动阶段输出可见警告。（#390）
+- **Gateway Init**: 死代码安全验证器激活 — `ValidateTools` 和 `ValidateModel` 之前定义了但零生产调用者，tools/models 未经白名单校验直接透传。现在 `ValidateInit` 在 init 握手时对 `allowed_tools` 和 `model` 强制执行白名单校验，不合规的请求返回 `CONFIG_INVALID` 错误。`claudecode/worker.go` 增加 defense-in-depth 模型校验，不在白名单的模型以 warning 记录并静默丢弃。（#386）
+- **Security**: JWT 密钥派生升级至 HKDF (RFC 5869) — `deriveECDSAP256Key` 从直接模约简（`secret bytes mod N`）升级为 `crypto/hkdf.Key` 标准 KDF，info 参数绑定 `"hotplex-ecdsa-p256"` 上下文防止跨协议密钥重用。Go Client SDK (`client/token.go`) 同步更新，消除 Gateway 与 SDK 的密钥派生差异。（#391）
+- **Security**: `GenerateToken`/`GenerateTokenWithJTI` 在 `JWTValidator` 配置 audience 时自动填充 `aud` claim。之前两个函数从不设置 Audience，导致配置 audience 的部署中生成的 token 静默验证失败。（#391）
+- **Security**: `SanitizeArg` 保留非 ASCII 字符 — 过滤条件从 `r < 127` 改为 `r != 127`，CJK/Emoji 等 Unicode 字符不再被截断。`os/exec` 已原生安全，此函数为 defense-in-depth。（#391）
+
+### Changed
+
+- **Config**: `setField`/`setBoolField`/`setSliceField` 签名从 `void` 改为 `error` 返回类型，调用方 `applyPlatformEnv` 和 `applyMessagingEnv` 已同步更新。（#390）
+
+
 ## [1.11.2] - 2026-05-11
 
 ### Summary

--- a/client/token.go
+++ b/client/token.go
@@ -3,6 +3,8 @@ package client
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hkdf"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
@@ -103,12 +105,14 @@ func loadKey(keyOrPath string) (*ecdsa.PrivateKey, error) {
 	return nil, fmt.Errorf("token: unrecognized key format (expected PEM file, 64-char hex, or 44-char base64): %q", keyOrPath)
 }
 
-// deriveECDSAP256Key mirrors internal/security/jwt.go:161-171.
+// deriveECDSAP256Key mirrors internal/security/jwt.go:deriveECDSAP256Key.
 func deriveECDSAP256Key(seed []byte) *ecdsa.PrivateKey {
-	var scalarBytes [32]byte
-	copy(scalarBytes[:], seed)
+	scalarBytes, err := hkdf.Key(sha256.New, seed, nil, "hotplex-ecdsa-p256", 32)
+	if err != nil {
+		panic("hkdf.Key: " + err.Error())
+	}
+	s := new(big.Int).SetBytes(scalarBytes)
 	N := elliptic.P256().Params().N
-	s := new(big.Int).SetBytes(scalarBytes[:])
 	s.Mod(s, new(big.Int).Sub(N, big.NewInt(1)))
 	s.Add(s, big.NewInt(1))
 	x, y := elliptic.P256().ScalarBaseMult(s.Bytes()) //nolint:staticcheck // SA1019: must use deprecated scalar multiplication for deterministic ECDSA key derivation from seed

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -75,6 +75,12 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		return err
 	}
 
+	if validationErrs := cfg.Validate(); len(validationErrs) > 0 {
+		for _, ve := range validationErrs {
+			fmt.Fprintf(os.Stderr, "config validation warning: %s\n", ve)
+		}
+	}
+
 	// Extract embedded Python scripts to ~/.hotplex/scripts
 	scriptsDir := filepath.Join(config.HotplexHome(), "scripts")
 	if err := assets.InstallScripts(scriptsDir); err != nil {

--- a/docs/specs/Gateway-Self-Restart-Spec.md
+++ b/docs/specs/Gateway-Self-Restart-Spec.md
@@ -1,0 +1,385 @@
+---
+type: spec
+tags:
+  - project/HotPlex
+date: 2026-05-12
+status: draft
+progress: 0
+---
+
+# Gateway 自重启能力方案 (AEP-006)
+
+**状态**：草案 (Draft)
+**所有者**：Antigravity
+**更新日期**：2026-05-12
+
+> **目标**：解决 Worker 进程无法成功重启 Gateway 的问题，实现从 Gateway 内部（Worker/Cron）发起的安全自重启。
+
+---
+
+## 1. 问题分析
+
+### 1.1 核心矛盾
+
+Worker 是 Gateway 的子进程。Gateway 停止 = Worker 死亡。`hotplex gateway restart` 的 stop + start 顺序执行中，start 阶段永远不会到达。
+
+### 1.2 死亡链时序
+
+```
+进程树初始状态:
+  Gateway (PID=100, PGID=100)           ← daemon 模式, Setpgid=true
+    └─ Worker (PID=200, PGID=200)       ← proc.Manager.Start() Setpgid=true
+         └─ bash (PID=299, PGID=200)    ← 继承 Worker PGID
+              └─ hotplex gateway restart (PID=300, PGID=200) ← 继承 Worker PGID
+
+时序:
+  T=0    restart CLI → stopGateway() → SIGTERM to Gateway (PGID 100)
+  T=0+   Gateway 收到 SIGTERM → shutdownGateway() 开始
+  T=δ    Gateway: Hub→Skills→Brain→Config→Cron→Messaging→STT/TTS (步骤 1-7)
+  T=δ    restart CLI 在 waitForProcessExit() 中等待 Gateway 退出...
+  T=δ'   Gateway 第 8 步: TerminateAllWorkers() → kill(-200, SIGTERM)
+         ↓ SIGTERM 命中 PGID=200 的所有进程:
+         ↓   Worker (PID 200)   — DEAD
+         ↓   bash   (PID 299)   — DEAD
+         ↓   restart CLI (PID 300) — DEAD  ← start 阶段永远不执行
+  T=30s  Gateway 完全退出
+         新 Gateway 永远不会启动
+```
+
+### 1.3 根因定位
+
+**文件**: `internal/worker/proc/manager.go:194-196`
+
+```go
+if pgid > 0 {
+    _ = GracefulTerminate(pgid)  // syscall.Kill(-pgid, SIGTERM)
+}
+```
+
+`TerminateAllWorkers()` 对每个 Worker 调用 `GracefulTerminate(workerPGID)`，发送 SIGTERM 到整个进程组。restart CLI 作为 Worker 的孙子进程，继承 Worker 的 PGID，被连带杀死。
+
+### 1.4 次要问题：竞态窗口
+
+即使 restart CLI 不被 SIGTERM 杀死，还存在第二个问题：
+
+**文件**: `cmd/hotplex/gateway_cmd.go:111-115`
+
+```go
+if inst.Source == sourcePID {
+    waitForProcessExit(inst.PID, 5*time.Second)  // 只等 5 秒
+}
+```
+
+`waitForProcessExit` 只等 5 秒，但 `shutdownGateway` 有 30 秒超时。随后的 `startDaemon()` 调用 `ensureNotRunning()` 会发现旧 Gateway 仍在 shutdown 中，返回错误。
+
+### 1.5 影响范围
+
+| 触发来源 | 当前结果 | 期望结果 |
+|----------|---------|---------|
+| Worker (Claude Code) 执行 `hotplex gateway restart` | Gateway 停止，不启动 | Gateway 重启成功 |
+| Cron Job 触发 Gateway 重启 | 同上 | Gateway 重启成功 |
+| 终端执行 `hotplex gateway restart` | 正常（CLI 不在 Worker PGID 中） | 保持不变 |
+| `systemctl restart hotplex` | 正常（systemd 原子操作） | 保持不变 |
+
+---
+
+## 2. 设计方案：Detached Restart Helper
+
+### 2.1 核心原理
+
+在杀死 Gateway 之前，fork 一个**独立进程组**的 restart-helper 进程。该进程在 Gateway/Worker 死亡后存活，负责等待旧 Gateway 退出、启动新 Gateway。
+
+### 2.2 进程组隔离验证
+
+Helper 用 `Setpgid: true` + `Process.Release()` 启动，创建独立 PGID：
+
+```
+重启前:
+  Gateway (PID 100, PGID 100)
+    └─ Worker (PID 200, PGID 200)
+         └─ restart CLI (PID 300, PGID 200)
+              └─ restart-helper (PID 301, PGID 301) ← Setpgid=true + Release
+
+CLI 退出后:
+  Gateway (PID 100, PGID 100)
+    └─ Worker (PID 200, PGID 200)
+  restart-helper (PID 301, PGID 301) ← 被 init 收养，存活
+
+Gateway shutdown kill(-200):
+  PID 200 (Worker)    ← DEAD
+  PID 301 (helper)    ← PGID=301 ≠ 200，存活！
+
+Helper 启动新 Gateway:
+  startDaemon() → New Gateway (PID 400, PGID 400)
+  Helper 退出
+```
+
+### 2.3 重启策略
+
+| Gateway 运行方式 | 检测方式 | Helper 行为 |
+|---|---|---|
+| PID 管理 | `gateway.pid` 文件存在 | SIGTERM → 等退出(30s) → startDaemon |
+| systemd 服务 | `systemctl status` | `systemctl --user restart hotplex` (原子) |
+| launchd 服务 | `launchctl list` | `launchctl stop` (KeepAlive 重启) |
+| Windows SCM | SCM 查询 | Stop + Start (SCM 管理) |
+
+---
+
+## 3. 实现规格
+
+### 3.1 新增文件
+
+#### `cmd/hotplex/gateway_restart_helper.go` (Unix)
+
+```go
+//go:build !windows
+
+package main
+
+// restartHelperSysProcAttr returns platform-specific process attributes
+// that ensure the restart helper runs in its own process group.
+func restartHelperSysProcAttr() *syscall.SysProcAttr {
+    return &syscall.SysProcAttr{Setpgid: true}
+}
+```
+
+包含平台无关的核心逻辑：
+
+- `forkRestartHelper()` — fork 独立 PGID 的 helper 进程
+- `runRestartHelper()` — helper 主函数：等待旧 Gateway 退出、启动新 Gateway
+
+#### `cmd/hotplex/gateway_restart_helper_windows.go`
+
+```go
+//go:build windows
+
+func restartHelperSysProcAttr() *syscall.SysProcAttr {
+    return &syscall.SysProcAttr{
+        CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+    }
+}
+```
+
+### 3.2 修改 `cmd/hotplex/gateway_cmd.go`
+
+#### 3.2.1 添加 `--detached` 标志
+
+`newGatewayRestartCmd()` 新增：
+
+```go
+var detached bool
+cmd.Flags().BoolVar(&detached, "detached", false,
+    "spawn detached restart helper (safe when called from Worker)")
+```
+
+当 `--detached` 时，执行 `forkRestartHelper()` 替代 inline stop+start。
+
+当非 `--detached` 时，保持现有逻辑（终端使用场景不受影响）。
+
+#### 3.2.2 注册隐藏的 `_restart-helper` 命令
+
+`newGatewayCmd()` 中添加：
+
+```go
+cmd.AddCommand(newRestartHelperCmd())
+
+func newRestartHelperCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:    "_restart-helper",
+        Hidden: true,
+        RunE:   runRestartHelper,
+    }
+}
+```
+
+### 3.3 修改 `cmd/hotplex/pid.go`
+
+添加冷却标记函数，防重启循环：
+
+```go
+type restartMarker struct {
+    HelperPID int       `json:"helper_pid"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+func restartMarkerPath() string  // ~/.hotplex/.pids/gateway.restart
+func writeRestartMarker() error
+func readRestartMarker() (*restartMarker, error)
+func removeRestartMarker()
+```
+
+---
+
+## 4. 核心函数设计
+
+### 4.1 `forkRestartHelper()`
+
+```
+输入: gatewayInstance, configPath, devMode, daemon
+输出: error
+
+步骤:
+  1. 冷却期检查 — 读标记文件，若 helper 存活则拒绝
+  2. 写入冷却标记文件
+  3. 构造 helper 参数:
+     hotplex gateway _restart-helper \
+       --old-pid <PID> \
+       --source <pid|service> \
+       --config <path> \
+       [--dev] [--daemon] [--level <level>]
+  4. exec.Command(self, args...)
+     - SysProcAttr: restartHelperSysProcAttr() (Setpgid=true)
+     - Stdout/Stderr → ~/.hotplex/logs/gateway-restart.log
+     - Stdin: nil
+  5. cmd.Start()
+  6. cmd.Process.Release() — 脱离父进程
+  7. 验证 helper 存活 (500ms)
+  8. 打印 "gateway: restart helper spawned (PID %d)"
+```
+
+### 4.2 `runRestartHelper()`
+
+```
+输入: cobra 命令参数 (--old-pid, --source, --config, --level, --dev, --daemon)
+输出: error
+
+步骤:
+  1. 解析参数
+  2. 写入冷却标记 (PID + timestamp)
+  3. defer removeRestartMarker()
+  4. 根据 source 分支:
+
+     Service 模式:
+       service.NewManager().Restart("hotplex", level)
+       → systemd: 原子 restart
+       → launchd: stop + start (KeepAlive 保底)
+       → SCM: stop + start
+
+     PID 模式:
+       a. proc.GracefulTerminate(oldPID) — SIGTERM
+       b. waitForProcessExit(oldPID, 30s) — 等待退出
+       c. 若仍存活: proc.ForceKill(oldPID)
+       d. removeGatewayState() — 清理旧 PID 文件
+       e. startDaemon(configPath, devMode) — 启动新 Gateway
+       f. 验证新 Gateway 存活 (1s)
+
+  5. 记录成功日志
+```
+
+### 4.3 冷却期逻辑
+
+```
+冷却检查:
+  1. 读标记文件
+  2. 标记不存在 → 允许重启
+  3. 标记存在，helper 进程存活 → 拒绝: "restart in progress (PID %d)"
+  4. 标记存在，helper 已死且 < 60s → 拒绝: "cooldown active (try again in %s)"
+  5. 标记存在，helper 已死且 ≥ 60s → 清理过期标记，允许重启
+```
+
+---
+
+## 5. 错误处理
+
+| 失败场景 | 处理 |
+|---|---|
+| Helper fork 失败 | CLI 返回错误，不触发重启 |
+| 旧 Gateway 拒绝退出 | Helper 30s 后升级为 ForceKill |
+| 新 Gateway 启动失败 | Helper 记录错误到日志，退出码 1 |
+| Helper 中途死亡 | 标记文件残留，下次尝试检测到过期标记后清理 |
+| Service restart 失败 | Helper 返回错误，旧实例不受影响 |
+| 冷却期冲突 | CLI 返回错误并显示剩余等待时间 |
+
+---
+
+## 6. 使用方式
+
+### Worker (Claude Code) 触发
+
+Worker 通过 bash 工具执行：
+
+```bash
+hotplex gateway restart --detached
+```
+
+CLI 在 ~100ms 内返回，输出 "restart helper spawned"。随后 Gateway shutdown 杀死 Worker。Helper 存活并完成重启。
+
+### 终端使用（不变）
+
+```bash
+hotplex gateway restart          # 保持现有 inline 行为
+hotplex gateway restart -d       # daemon 模式，保持现有行为
+hotplex gateway restart --detached  # 也可以从终端使用 detached 模式
+```
+
+### Cron Job 触发
+
+Cron executor 构造的 prompt 中可以包含 `hotplex gateway restart --detached` 命令。
+
+---
+
+## 7. 文件变更清单
+
+| 文件 | 操作 | 说明 |
+|---|---|---|
+| `cmd/hotplex/gateway_cmd.go` | 修改 | 添加 `--detached` 标志，注册 `_restart-helper` |
+| `cmd/hotplex/gateway_restart_helper.go` | **新建** | Unix: `restartHelperSysProcAttr()` + `forkRestartHelper()` + `runRestartHelper()` |
+| `cmd/hotplex/gateway_restart_helper_windows.go` | **新建** | Windows: `restartHelperSysProcAttr()` |
+| `cmd/hotplex/pid.go` | 修改 | 添加冷却标记读写函数 |
+
+### 复用的现有函数
+
+| 函数 | 文件 | 用途 |
+|---|---|---|
+| `findRunningGateway()` | `pid.go:92` | 发现 Gateway 实例 |
+| `waitForProcessExit()` | `pid.go:128` | 轮询等待进程退出 |
+| `startDaemon()` | `gateway_cmd.go:147` | 启动 daemon Gateway |
+| `daemonSysProcAttr()` | `daemon_unix.go` | 平台 SysProcAttr 参考 |
+| `proc.GracefulTerminate()` | `proc/signal_unix.go` | SIGTERM 到进程组 |
+| `proc.ForceKill()` | `proc/signal_unix.go` | SIGKILL 到进程组 |
+| `proc.IsProcessAlive()` | `proc/signal_unix.go` | 进程存活检查 |
+| `service.NewManager().Restart()` | `service/manager_*.go` | 服务重启 |
+
+---
+
+## 8. 测试策略
+
+### 8.1 手动测试
+
+```bash
+# 1. 启动 Gateway
+make dev
+
+# 2. 从终端测试 --detached
+./hotplex gateway restart --detached
+# 期望: "gateway: restart helper spawned (PID ...)"
+# 验证: 旧 Gateway 停止，新 Gateway 自动启动
+
+# 3. 测试冷却期
+./hotplex gateway restart --detached
+# 期望: "gateway: restart cooldown active (try again in Ns)"
+
+# 4. 测试终端模式不受影响
+./hotplex gateway restart
+# 期望: 现有 inline stop+start 行为不变
+```
+
+### 8.2 从 Worker 测试
+
+```bash
+# 1. 启动 Gateway + 连接 Worker
+# 2. 通过消息平台发送 "重启 Gateway"
+# 3. Worker 执行 hotplex gateway restart --detached
+# 4. 验证: Worker 输出 "restart helper spawned"，然后连接断开
+# 5. 验证: 新 Gateway 在 30s 内启动完成
+# 6. 验证: 新消息可以正常到达 Worker
+```
+
+---
+
+## 9. 后续增强 (Phase 2)
+
+- **Admin API 端点**: `POST /admin/gateway/restart` 提供编程式重启接口
+- **重启通知**: Helper 完成重启后通过消息适配器发送通知
+- **健康检查集成**: Helper 验证新 Gateway 不仅是进程存活，还验证 HTTP ready 端点
+- **指标埋点**: Prometheus counter 记录重启次数和结果

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1073,7 +1073,14 @@ func applyMessagingEnv(cfg *Config) {
 	}
 	for _, m := range msgStrs {
 		if v := os.Getenv(m.env); v != "" {
-			setField(&cfg.Messaging, m.field, v)
+			if err := setField(&cfg.Messaging, m.field, v); err != nil {
+				slog.Warn("config: env mapping skipped",
+					"env", m.env,
+					"field", m.field,
+					"target", "config.Messaging",
+					"error", err,
+				)
+			}
 		}
 	}
 	// Int fields.
@@ -1116,42 +1123,78 @@ type envMapping struct{ env, field string }
 func applyPlatformEnv(target any, strs, bools, slices []envMapping) {
 	for _, m := range strs {
 		if v := os.Getenv(m.env); v != "" {
-			setField(target, m.field, v)
+			if err := setField(target, m.field, v); err != nil {
+				slog.Warn("config: env mapping skipped",
+					"env", m.env,
+					"field", m.field,
+					"target", fmt.Sprintf("%T", target),
+					"error", err,
+				)
+			}
 		}
 	}
 	for _, m := range bools {
 		if v := os.Getenv(m.env); v != "" {
-			setBoolField(target, m.field, strings.EqualFold(v, "true"))
+			if err := setBoolField(target, m.field, strings.EqualFold(v, "true")); err != nil {
+				slog.Warn("config: env mapping skipped",
+					"env", m.env,
+					"field", m.field,
+					"target", fmt.Sprintf("%T", target),
+					"error", err,
+				)
+			}
 		}
 	}
 	for _, m := range slices {
 		if v := os.Getenv(m.env); v != "" {
-			setSliceField(target, m.field, v)
+			if err := setSliceField(target, m.field, v); err != nil {
+				slog.Warn("config: env mapping skipped",
+					"env", m.env,
+					"field", m.field,
+					"target", fmt.Sprintf("%T", target),
+					"error", err,
+				)
+			}
 		}
 	}
 }
 
 // setField sets a string field on a struct by name using reflection.
-func setField(target any, field, value string) {
+func setField(target any, field, value string) error {
 	v := reflect.ValueOf(target).Elem()
-	v.FieldByName(field).SetString(value)
+	f := v.FieldByName(field)
+	if !f.IsValid() {
+		return fmt.Errorf("config: setField: no such field %q on %T", field, target)
+	}
+	f.SetString(value)
+	return nil
 }
 
 // setBoolField sets a bool field on a struct by name using reflection.
-func setBoolField(target any, field string, value bool) {
+func setBoolField(target any, field string, value bool) error {
 	v := reflect.ValueOf(target).Elem()
-	v.FieldByName(field).SetBool(value)
+	f := v.FieldByName(field)
+	if !f.IsValid() {
+		return fmt.Errorf("config: setBoolField: no such field %q on %T", field, target)
+	}
+	f.SetBool(value)
+	return nil
 }
 
 // setSliceField sets a []string field on a struct by name using reflection.
-func setSliceField(target any, field, value string) {
+func setSliceField(target any, field, value string) error {
 	v := reflect.ValueOf(target).Elem()
+	f := v.FieldByName(field)
+	if !f.IsValid() {
+		return fmt.Errorf("config: setSliceField: no such field %q on %T", field, target)
+	}
 	parts := strings.Split(value, ",")
 	slice := make([]string, len(parts))
 	for i, p := range parts {
 		slice[i] = strings.TrimSpace(p)
 	}
-	v.FieldByName(field).Set(reflect.ValueOf(slice))
+	f.Set(reflect.ValueOf(slice))
+	return nil
 }
 
 // decodeJWTSecret decodes a base64-encoded JWT secret.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1199,8 +1199,7 @@ func setSliceField(target any, field, value string) error {
 
 // decodeJWTSecret decodes a base64-encoded JWT secret.
 // It supports both standard base64 and URL-safe base64 (with or without padding).
-// Accepts >= 32 bytes: deriveECDSAP256Key truncates via copy to [32]byte,
-// and RequireSecrets validates len >= 32. Canonical length is 32 bytes.
+// Requires >= 32 bytes (HKDF-derived ECDSA key needs sufficient entropy).
 func decodeJWTSecret(secret string) []byte {
 	if decoded, err := base64.StdEncoding.DecodeString(secret); err == nil && len(decoded) >= 32 {
 		return decoded

--- a/internal/gateway/init.go
+++ b/internal/gateway/init.go
@@ -4,6 +4,7 @@ package gateway
 import (
 	"time"
 
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -85,6 +86,7 @@ var (
 	ErrInitVersionMismatch  = &InitError{Code: events.ErrCodeVersionMismatch, Message: "version mismatch"}
 	ErrInitCapacityExceeded = &InitError{Code: events.ErrCodeRateLimited, Message: "capacity exceeded"}
 	ErrInitSessionNotFound  = &InitError{Code: events.ErrCodeSessionNotFound, Message: "session not found"}
+	ErrInitConfigInvalid    = &InitError{Code: events.ErrCodeConfigInvalid, Message: "invalid config"}
 )
 
 // BuildInitAck builds an init_ack envelope from handshake result.
@@ -175,6 +177,17 @@ func ValidateInit(env *events.Envelope) (InitData, *InitError) {
 		}
 		if workDir, ok := cfgData["work_dir"].(string); ok {
 			cfg.WorkDir = workDir
+		}
+	}
+
+	if len(cfg.AllowedTools) > 0 {
+		if err := security.ValidateTools(cfg.AllowedTools); err != nil {
+			return InitData{}, &InitError{Code: events.ErrCodeConfigInvalid, Message: err.Error()}
+		}
+	}
+	if cfg.Model != "" {
+		if err := security.ValidateModel(cfg.Model); err != nil {
+			return InitData{}, &InitError{Code: events.ErrCodeConfigInvalid, Message: err.Error()}
 		}
 	}
 

--- a/internal/security/command.go
+++ b/internal/security/command.go
@@ -79,11 +79,12 @@ func containsDangerousChars(input string) bool {
 }
 
 // SanitizeArg removes non-printable and control characters from an argument.
+// Keeps ASCII printable (32-126) and all non-ASCII Unicode (>= 128).
 // This is a defense-in-depth measure; os/exec is already safe without it.
 func SanitizeArg(input string) string {
 	var b strings.Builder
 	for _, r := range input {
-		if r >= 32 && r < 127 {
+		if r >= 32 && r != 127 {
 			b.WriteRune(r)
 		}
 	}

--- a/internal/security/jwt.go
+++ b/internal/security/jwt.go
@@ -4,6 +4,8 @@ package security
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hkdf"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math/big"
@@ -124,7 +126,7 @@ func (v *JWTValidator) hasAudience(aud any) bool {
 
 // GenerateToken generates a new JWT token for the given user.
 func (v *JWTValidator) GenerateToken(userID string, scopes []string, ttl time.Duration) (string, error) {
-	return v.GenerateTokenWithClaims(&JWTClaims{
+	claims := &JWTClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -135,7 +137,11 @@ func (v *JWTValidator) GenerateToken(userID string, scopes []string, ttl time.Du
 		},
 		UserID: userID,
 		Scopes: scopes,
-	})
+	}
+	if v.audience != "" {
+		claims.Audience = jwt.ClaimStrings{v.audience}
+	}
+	return v.GenerateTokenWithClaims(claims)
 }
 
 // GenerateTokenWithClaims generates a JWT token with the given claims using ES256.
@@ -160,12 +166,16 @@ func (v *JWTValidator) resolveSigningKey() (any, error) {
 	}
 }
 
-// deriveECDSAP256Key derives an ECDSA P-256 private key from a byte slice.
+// deriveECDSAP256Key derives an ECDSA P-256 private key from a byte slice
+// using HKDF (RFC 5869). The info parameter binds the derived key to the
+// "hotplex-ecdsa-p256" context, preventing cross-protocol key reuse.
 func deriveECDSAP256Key(secret []byte) *ecdsa.PrivateKey {
-	var scalarBytes [32]byte
-	copy(scalarBytes[:], secret)
+	scalarBytes, err := hkdf.Key(sha256.New, secret, nil, "hotplex-ecdsa-p256", 32)
+	if err != nil {
+		panic("hkdf.Key: " + err.Error())
+	}
+	s := new(big.Int).SetBytes(scalarBytes)
 	N := elliptic.P256().Params().N
-	s := new(big.Int).SetBytes(scalarBytes[:])
 	s.Mod(s, new(big.Int).Sub(N, big.NewInt(1)))
 	s.Add(s, big.NewInt(1))
 	x, y := elliptic.P256().ScalarBaseMult(s.Bytes()) //nolint:staticcheck // SA1019: must use deprecated scalar multiplication for deterministic ECDSA key derivation from seed
@@ -186,6 +196,9 @@ func (v *JWTValidator) GenerateTokenWithJTI(userID string, scopes []string, ttl,
 		},
 		UserID: userID,
 		Scopes: scopes,
+	}
+	if v.audience != "" {
+		claims.Audience = jwt.ClaimStrings{v.audience}
 	}
 	var method jwt.SigningMethod
 	var signingKey any

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -788,7 +788,7 @@ func TestSanitizeArg(t *testing.T) {
 		{"tabs removed", "col1\tcol2", "col1col2"},
 		{"null byte removed", "hel\x00lo", "hello"},
 		{"ANSI escape partially kept", "test\x1b[31m", "test[31m"}, // [, ], digits kept; \x1b (27) removed
-		{"unicode removed", "hello\u4e16", "hello"},
+		{"unicode kept", "hello\u4e16", "hello\u4e16"},
 	}
 
 	for _, tt := range tests {

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -279,7 +279,15 @@ func (w *Worker) buildCLIArgs(session worker.SessionInfo, resume bool) ([]string
 	}
 
 	if len(session.AllowedModels) > 0 {
-		args = append(args, "--model", session.AllowedModels[0])
+		if err := security.ValidateModel(session.AllowedModels[0]); err != nil {
+			slog.Warn("claudecode: model rejected by security policy",
+				"model", session.AllowedModels[0],
+				"session_id", session.SessionID,
+				"error", err,
+			)
+		} else {
+			args = append(args, "--model", session.AllowedModels[0])
+		}
 	}
 	if len(session.AllowedTools) > 0 {
 		args = append(args, "--allowed-tools", joinTools(session.AllowedTools))


### PR DESCRIPTION
## Summary

Security and reliability hardening across config, gateway, and security layers. Originally analyzed 4 issues in Phase 1-3; 3 were already fixed in PR #394. This PR delivers the remaining fix plus 2 additional high-ROI security issues identified in the same batch:

- **#390**: config reflection panic + startup validation
- **#386**: wire dead security validators (tool/model) into production paths
- **#391**: ECDSA key derivation hardening, GenerateToken audience, SanitizeArg non-ASCII

Closes #390, #386, #391

## Changes by Issue

### #390 — Prevent reflection panic + add startup validation

**Problem 1**: `setField/setBoolField/setSliceField` in `internal/config/config.go` panicked on env-mapping typos with no diagnostic. **Problem 2**: `runGateway()` never called `cfg.Validate()`.

**Solution**: Add `IsValid()` checks returning errors instead of panics; fire validation at startup.

**Changes**:
- `internal/config/config.go`: 3 setter functions return errors with field/target diagnostics
- `cmd/hotplex/gateway_run.go`: Add `cfg.Validate()` after `loadConfig()`

---

### #386 — Wire dead validators into production paths

**Problem**: `ValidateTools`, `ValidateModel`, `ValidateURL`, `CheckBashCommand` — 4 security validation functions existed in code but had zero production callers. Tools, models, and URLs were never checked against their whitelists.

**Solution**: Wire tool/model validation at the init handshake level (earliest rejection point) with defense-in-depth in the claudecode worker.

**Changes**:
- `internal/gateway/init.go`: Call `security.ValidateTools(cfg.AllowedTools)` and `security.ValidateModel(cfg.Model)` during init parsing; return `CONFIG_INVALID` error to client on rejection
- `internal/worker/claudecode/worker.go`: Add `security.ValidateModel()` before passing `--model` flag; invalid models logged and dropped

---

### #391 — ECDSA key derivation + audience + SanitizeArg

**Problem 1 — Weak ECDSA derivation**: `deriveECDSAP256Key` used direct modular reduction (secret bytes mod N) without any KDF, making keys predictable and subject to collision attacks.

**Problem 2 — Missing audience claim**: `GenerateToken` and `GenerateTokenWithJTI` never set the `Audience` field, causing validation failures when audience is configured.

**Problem 3 — SanitizeArg strips non-ASCII**: The function filtered `r >= 32 && r < 127`, stripping all CJK/Unicode characters from command arguments.

**Solution**:
1. Replace direct modular reduction with `crypto/hkdf.Key` (RFC 5869, Go 1.24+ stdlib) bound to "hotplex-ecdsa-p256" context
2. Set `Audience` claim when `v.audience != ""` in both token generation functions
3. Change filter to `r >= 32 && r != 127` — keep ASCII printable + all non-ASCII Unicode

**Changes**:
- `internal/security/jwt.go`: HKDF-based key derivation, audience claim in `GenerateToken`/`GenerateTokenWithJTI`
- `internal/security/command.go`: `SanitizeArg` now preserves Unicode (CJK, emoji, etc.)
- `internal/security/security_test.go`: Update test expectation for unicode preservation

---

## Also Closed (already fixed in PR #394)

- #378: Missing panic recovery in 3 feishu goroutines
- #379: SafetyGuard fail-open + data race
- #380: Cron handlers missing body size limit
- #381: SafetyGuard blocks silently without logging

## Testing

- [x] Lint passes (golangci-lint: 0 issues)
- [x] Security tests: `go test -race ./internal/security/...` ✅
- [x] Gateway tests: `go test -race ./internal/gateway/...` ✅
- [x] Config tests: `go test -race ./internal/config/...` ✅
- [x] Build succeeds (all platforms)
- [x] Pre-push quality gates: fmt + lint + vet + build + test

## Breaking Changes

- **#391 ECDSA key derivation**: Existing JWTs signed with the old derivation become invalid after upgrade. Deployment must regenerate tokens (`HOTPLEX_JWT_SECRET` unchanged; only the derived key changes).
- **#386 Tool/model validation**: Init requests specifying tools/models outside the whitelist now receive `CONFIG_INVALID` error instead of silent acceptance.
- **#390 SanitizeArg**: Previously stripped CJK/Unicode; now preserved. No negative impact — previously broken non-ASCII arguments now work correctly.