### PR TITLE
fix(security): JWT HKDF key derivation docs + Java SDK sync

### DIFF
--- a/docs/guides/enterprise/security-hardening.md
+++ b/docs/guides/enterprise/security-hardening.md
@@ -3,8 +3,8 @@ persona: enterprise
 difficulty: advanced
 title: Security Hardening 企业安全加固指南
 weight: 22
-last_updated: 2026-05-10
-version: v1.10.2
+last_updated: 2026-05-13
+version: v1.11.3
 ---
 
 # Security Hardening 企业安全加固指南

--- a/docs/reference/sdk-java.md
+++ b/docs/reference/sdk-java.md
@@ -285,7 +285,7 @@ public enum SessionState {
 
 ### JwtTokenGenerator
 
-ES256 (ECDSA P-256) 签名，密钥派生逻辑与 Go SDK 完全一致：
+ES256 (ECDSA P-256) 签名，从 `secret` 派生 P-256 密钥对：
 
 ```java
 // 基本用法
@@ -297,6 +297,8 @@ var tokenGen = new JwtTokenGenerator(secret, "hotplex", "my-gateway");
 
 - `secret` — 至少 32 字节的签名字符串
 - 内部通过 BouncyCastle 从 secret 派生 P-256 密钥对
+
+> **兼容性注意**：当前 Java SDK 的密钥派生（`scalar = secret mod (N-1) + 1`）与 v1.11.3 Gateway 的 HKDF 派生**不一致**。使用 Java SDK 生成的 token 将被 Gateway 拒绝。此问题待修复，修复后密钥派生将采用 HKDF (RFC 5869) 与 Go SDK 对齐。
 
 ```java
 // 生成 token

--- a/docs/reference/sdk-java.md
+++ b/docs/reference/sdk-java.md
@@ -296,9 +296,7 @@ var tokenGen = new JwtTokenGenerator(secret, "hotplex", "my-gateway");
 ```
 
 - `secret` — 至少 32 字节的签名字符串
-- 内部通过 BouncyCastle 从 secret 派生 P-256 密钥对
-
-> **兼容性注意**：当前 Java SDK 的密钥派生（`scalar = secret mod (N-1) + 1`）与 v1.11.3 Gateway 的 HKDF 派生**不一致**。使用 Java SDK 生成的 token 将被 Gateway 拒绝。此问题待修复，修复后密钥派生将采用 HKDF (RFC 5869) 与 Go SDK 对齐。
+- 内部通过 BouncyCastle HKDF-SHA256 从 secret 派生 P-256 密钥对，与 Go SDK 完全一致
 
 ```java
 // 生成 token

--- a/docs/reference/security-policies.md
+++ b/docs/reference/security-policies.md
@@ -53,17 +53,24 @@ default:
 | BotID | `bot_id` | string | Bot 标识 |
 | SessionID | `session_id` | string | Session 标识 |
 
-### 密钥派生
+### 密钥派生（HKDF）
 
-当配置为 `[]byte`（原始密钥）时，通过 `deriveECDSAP256Key()` 从字节派生 ECDSA P-256 密钥：
+当配置为 `[]byte`（原始密钥）时，通过 HKDF (RFC 5869) 从字节派生 ECDSA P-256 密钥。info 参数 `"hotplex-ecdsa-p256"` 将派生密钥绑定到特定上下文，防止跨协议密钥复用：
 
 ```go
 func deriveECDSAP256Key(secret []byte) *ecdsa.PrivateKey {
-    // SHA-256 类似的确定性派生
-    // scalar = secret mod (N-1) + 1
-    // 公钥 = scalar * G
+    // HKDF-SHA256 extract-then-expand
+    scalarBytes, _ := hkdf.Key(sha256.New, secret, nil, "hotplex-ecdsa-p256", 32)
+    s := new(big.Int).SetBytes(scalarBytes)
+    N := elliptic.P256().Params().N
+    s.Mod(s, new(big.Int).Sub(N, big.NewInt(1)))
+    s.Add(s, big.NewInt(1))         // scalar ∈ [1, N-1]
+    x, y := elliptic.P256().ScalarBaseMult(s.Bytes())
+    return &ecdsa.PrivateKey{...}
 }
 ```
+
+> **升级注意**：v1.11.3 从 `copy(secret)` 直接截断改为 HKDF。同一个 `HOTPLEX_JWT_SECRET` 会派生出不同的 ECDSA 密钥对，所有旧 token 在升级后立即失效。Go Client SDK 已同步更新。
 
 ### JTI 黑名单
 

--- a/examples/java-client/src/main/java/dev/hotplex/security/JwtTokenGenerator.java
+++ b/examples/java-client/src/main/java/dev/hotplex/security/JwtTokenGenerator.java
@@ -15,15 +15,18 @@ import java.util.List;
 import java.util.UUID;
 
 import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.math.ec.ECPoint;
 
 /**
  * JWT Token Generator for HotPlex Gateway authentication.
- * Uses ES256 (ECDSA P-256) signing method with key derivation from secret.
- * Key derivation algorithm matches the Go implementation:
- * scalar = (secret_bytes mod (N-1)) + 1, where N is the P-256 curve order.
+ * Uses ES256 (ECDSA P-256) signing method with HKDF key derivation from secret.
+ * Key derivation matches the Go implementation (v1.11.3+):
+ * HKDF-SHA256(secret, salt=nil, info="hotplex-ecdsa-p256") → scalar mod (N-1) + 1
  */
 public class JwtTokenGenerator {
 
@@ -61,22 +64,24 @@ public class JwtTokenGenerator {
     }
 
     /**
-     * Derives an ECDSA P-256 key pair from the secret.
-     * Algorithm matches the Go implementation: scalar mod (N-1) + 1
+     * Derives an ECDSA P-256 key pair from the secret using HKDF (RFC 5869).
+     * Matches the Go gateway implementation (v1.11.3+):
+     * HKDF-SHA256(secret, salt=nil, info="hotplex-ecdsa-p256") → 32 bytes
+     * scalar = derived_bytes mod (N-1) + 1
      */
     private KeyPair deriveKeyPair(String secret) {
         try {
-            // Get P-256 curve parameters from BouncyCastle
             X9ECParameters ecParams = org.bouncycastle.asn1.nist.NISTNamedCurves.getByName("P-256");
             org.bouncycastle.math.ec.ECCurve curve = ecParams.getCurve();
             BigInteger n = ecParams.getN();
             BigInteger nMinusOne = n.subtract(BigInteger.ONE);
             ECPoint g = ecParams.getG();
 
-            // Take first 32 bytes of secret
-            byte[] secretBytes = secret.getBytes();
+            // HKDF-SHA256 extract-then-expand, matching Go implementation
+            HKDFBytesGenerator hkdf = new HKDFBytesGenerator(new SHA256Digest());
+            hkdf.init(new HKDFParameters(secret.getBytes(), null, "hotplex-ecdsa-p256".getBytes()));
             byte[] scalarBytes = new byte[32];
-            System.arraycopy(secretBytes, 0, scalarBytes, 0, Math.min(32, secretBytes.length));
+            hkdf.generateBytes(scalarBytes, 0, 32);
 
             // s = (scalar mod (N-1)) + 1
             BigInteger s = new BigInteger(1, scalarBytes);


### PR DESCRIPTION
## Summary

- **docs(security-policies)**: Update JWT key derivation section from stale `copy(secret)` description to HKDF (RFC 5869), add upgrade warning about token invalidation
- **fix(sdk-java)**: Sync `JwtTokenGenerator` key derivation to HKDF-SHA256 with info `"hotplex-ecdsa-p256"`, matching Go gateway + Go client SDK (v1.11.3+). Previous direct-copy derivation produced incompatible keys.
- **docs(sdk-java)**: Remove incompatibility warning, confirm HKDF parity
- **docs(security-hardening)**: Bump version from v1.10.2 to v1.11.3

Refs #391

## Test plan

- [ ] Verify Java SDK `JwtTokenGenerator` compiles with BouncyCastle HKDF imports
- [ ] Verify Java-generated token is accepted by v1.11.3 gateway
- [ ] Verify docs portal renders updated security-policies and sdk-java pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)