### PR TITLE
feat(gateway): detached restart helper for worker-initiated restart

### DIFF
--- a/cmd/hotplex/gateway_cmd.go
+++ b/cmd/hotplex/gateway_cmd.go
@@ -31,6 +31,7 @@ func newGatewayCmd() *cobra.Command {
 		newGatewayStartCmd(),
 		newGatewayStopCmd(),
 		newGatewayRestartCmd(),
+		newRestartHelperCmd(),
 	)
 	return cmd
 }
@@ -89,15 +90,24 @@ func newGatewayStopCmd() *cobra.Command {
 
 func newGatewayRestartCmd() *cobra.Command {
 	var configPath string
-	var devMode, daemon bool
+	var devMode, daemon, detached bool
 
 	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "Restart the gateway server",
 		Long: `Restart the gateway server by stopping the current instance and starting a new one.
 Preserves the same configuration file and mode.
-Use -d to restart as a background daemon.`,
+Use -d to restart as a background daemon.
+Use --detached to spawn a helper process that survives worker shutdown.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if detached {
+				inst, err := findRunningGateway()
+				if err != nil {
+					return fmt.Errorf("gateway: %w", err)
+				}
+				return forkRestartHelper(inst, configPath, devMode, daemon)
+			}
+
 			inst, err := findRunningGateway()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "gateway: %s (proceeding with start)\n", err)
@@ -139,6 +149,7 @@ Use -d to restart as a background daemon.`,
 	configFlag(cmd, &configPath)
 	cmd.Flags().BoolVar(&devMode, "dev", false, "development mode")
 	cmd.Flags().BoolVarP(&daemon, "daemon", "d", false, "run as background daemon")
+	cmd.Flags().BoolVar(&detached, "detached", false, "spawn detached restart helper (safe when called from worker)")
 	return cmd
 }
 

--- a/cmd/hotplex/gateway_restart_helper.go
+++ b/cmd/hotplex/gateway_restart_helper.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/service"
+	"github.com/hrygo/hotplex/internal/worker/proc"
+)
+
+func newRestartHelperCmd() *cobra.Command {
+	var oldPID int
+	var source string
+	var configPath string
+	var level string
+	var devMode, daemon bool
+
+	cmd := &cobra.Command{
+		Use:    "_restart-helper",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRestartHelper(oldPID, source, configPath, level, devMode, daemon)
+		},
+	}
+	cmd.Flags().IntVar(&oldPID, "old-pid", 0, "PID of the old gateway process")
+	cmd.Flags().StringVar(&source, "source", "pid", "discovery source (pid|service)")
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
+	cmd.Flags().StringVar(&level, "level", "", "service level (user|system)")
+	cmd.Flags().BoolVar(&devMode, "dev", false, "development mode")
+	cmd.Flags().BoolVarP(&daemon, "daemon", "d", false, "restart as daemon")
+	return cmd
+}
+
+func forkRestartHelper(inst *gatewayInstance, configPath string, devMode, daemon bool) error {
+	if err := checkRestartCooldown(); err != nil {
+		return err
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+
+	args := []string{
+		"gateway", "_restart-helper",
+		"--old-pid", fmt.Sprintf("%d", inst.PID),
+		"--source", string(inst.Source),
+	}
+	if configPath != "" {
+		args = append(args, "--config", configPath)
+	}
+	if inst.Level != "" {
+		args = append(args, "--level", string(inst.Level))
+	}
+	if devMode {
+		args = append(args, "--dev")
+	}
+	if daemon {
+		args = append(args, "-d")
+	}
+
+	logDir := filepath.Join(config.HotplexHome(), "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logPath := filepath.Join(logDir, "gateway-restart.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open restart log: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	helperCmd := exec.Command(self, args...)
+	helperCmd.Stdout = logFile
+	helperCmd.Stderr = logFile
+	helperCmd.Stdin = nil
+	helperCmd.SysProcAttr = restartHelperSysProcAttr()
+
+	if err := helperCmd.Start(); err != nil {
+		return fmt.Errorf("spawn restart helper: %w", err)
+	}
+
+	helperPID := helperCmd.Process.Pid
+	if err := writeRestartMarker(helperPID); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not write restart marker: %s\n", err)
+	}
+
+	_ = helperCmd.Process.Release()
+
+	time.Sleep(500 * time.Millisecond)
+	if err := proc.IsProcessAlive(helperPID); err != nil {
+		removeRestartMarker()
+		return fmt.Errorf("restart helper exited unexpectedly; check %s", logPath)
+	}
+
+	fmt.Fprintf(os.Stderr, "gateway: restart helper spawned (PID %d, log: %s)\n", helperPID, logPath)
+	return nil
+}
+
+func runRestartHelper(oldPID int, source, configPath, levelStr string, devMode, daemon bool) error {
+	defer removeRestartMarker()
+
+	logDir := filepath.Join(config.HotplexHome(), "logs")
+	logPath := filepath.Join(logDir, "gateway-restart.log")
+
+	switch source {
+	case "service":
+		var lvl service.Level
+		switch levelStr {
+		case "system":
+			lvl = service.LevelSystem
+		default:
+			lvl = service.LevelUser
+		}
+		if err := service.NewManager().Restart("hotplex", lvl); err != nil {
+			appendRestartLog(logPath, "service restart failed: %s\n", err)
+			return fmt.Errorf("service restart: %w", err)
+		}
+		appendRestartLog(logPath, "service restart completed\n")
+
+	default: // "pid"
+		appendRestartLog(logPath, "stopping old gateway (PID %d)\n", oldPID)
+
+		if err := proc.GracefulTerminate(oldPID); err != nil {
+			appendRestartLog(logPath, "graceful terminate failed: %s, force killing\n", err)
+			_ = proc.ForceKill(oldPID)
+		}
+		waitForProcessExit(oldPID, 30*time.Second)
+
+		if proc.IsProcessAlive(oldPID) == nil {
+			appendRestartLog(logPath, "process %d still alive after timeout, force killing\n", oldPID)
+			_ = proc.ForceKill(oldPID)
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		removeGatewayState()
+		appendRestartLog(logPath, "old gateway stopped, starting new instance\n")
+
+		if daemon {
+			if err := startDaemon(configPath, devMode); err != nil {
+				appendRestartLog(logPath, "daemon start failed: %s\n", err)
+				return err
+			}
+			appendRestartLog(logPath, "new gateway started as daemon\n")
+			return nil
+		}
+
+		if err := writeGatewayState(configPath, devMode); err != nil {
+			appendRestartLog(logPath, "warning: could not write PID file: %s\n", err)
+		}
+		if err := runGateway(configPath, devMode, nil); err != nil {
+			removeGatewayState()
+			appendRestartLog(logPath, "gateway run failed: %s\n", err)
+			return err
+		}
+		appendRestartLog(logPath, "new gateway started\n")
+	}
+
+	return nil
+}
+
+func appendRestartLog(path, format string, args ...interface{}) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "[%s] ", time.Now().Format(time.RFC3339))
+	_, _ = fmt.Fprintf(f, format, args...)
+}

--- a/cmd/hotplex/gateway_restart_helper_unix.go
+++ b/cmd/hotplex/gateway_restart_helper_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func restartHelperSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/cmd/hotplex/gateway_restart_helper_windows.go
+++ b/cmd/hotplex/gateway_restart_helper_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func restartHelperSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
+}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -60,7 +60,7 @@ func configFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVarP(target, "config", "c", defaultConfigPath, "config file path")
 }
 
-func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err error) {
+func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err error) { //nolint:unparam // stopCh used by Windows service wrapper
 	defer func() {
 		if err != nil {
 			removeGatewayState()

--- a/cmd/hotplex/pid.go
+++ b/cmd/hotplex/pid.go
@@ -134,3 +134,58 @@ func waitForProcessExit(pid int, timeout time.Duration) {
 		time.Sleep(100 * time.Millisecond)
 	}
 }
+
+// ─── Restart Cooldown Marker ──────────────────────────────────────────────────
+
+type restartMarker struct {
+	HelperPID int       `json:"helper_pid"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func restartMarkerPath() string {
+	return filepath.Join(config.HotplexHome(), ".pids", "gateway.restart")
+}
+
+func writeRestartMarker(helperPID int) error {
+	p := restartMarkerPath()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	data, _ := json.Marshal(restartMarker{HelperPID: helperPID, CreatedAt: time.Now()})
+	return os.WriteFile(p, data, 0o644)
+}
+
+func readRestartMarker() (*restartMarker, error) {
+	data, err := os.ReadFile(restartMarkerPath())
+	if err != nil {
+		return nil, err
+	}
+	var m restartMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("invalid restart marker: %w", err)
+	}
+	return &m, nil
+}
+
+func removeRestartMarker() {
+	_ = os.Remove(restartMarkerPath())
+}
+
+const restartCooldownPeriod = 60 * time.Second
+
+func checkRestartCooldown() error {
+	m, err := readRestartMarker()
+	if err != nil {
+		return nil // no marker = no cooldown
+	}
+	if proc.IsProcessAlive(m.HelperPID) == nil {
+		return fmt.Errorf("gateway: restart in progress (helper PID %d)", m.HelperPID)
+	}
+	elapsed := time.Since(m.CreatedAt)
+	if elapsed < restartCooldownPeriod {
+		remaining := restartCooldownPeriod - elapsed
+		return fmt.Errorf("gateway: restart cooldown active (try again in %s)", remaining.Round(time.Second))
+	}
+	removeRestartMarker()
+	return nil
+}


### PR DESCRIPTION
## Summary

- Worker 进程执行 `hotplex gateway restart` 时，CLI 继承 Worker 的 PGID，Gateway shutdown 的 `TerminateAllWorkers()` 用 `kill(-pgid, SIGTERM)` 杀整个进程组，CLI 被连带杀死，`startDaemon()` 永远不执行
- 新增 `--detached` flag，fork 一个独立 PGID 的 restart-helper 进程，在 Gateway/Worker 死亡后存活并完成重启
- 60s 冷却期 + marker 文件防止重启循环
- 跨平台支持：Unix (`Setpgid: true`) / Windows (`CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`)

## Changes

| File | Change |
|------|--------|
| `cmd/hotplex/gateway_restart_helper.go` | 新增：`forkRestartHelper()`, `runRestartHelper()`, `newRestartHelperCmd()` 核心逻辑 |
| `cmd/hotplex/gateway_restart_helper_unix.go` | 新增：Unix 平台 `Setpgid: true` |
| `cmd/hotplex/gateway_restart_helper_windows.go` | 新增：Windows 平台进程组隔离 |
| `cmd/hotplex/pid.go` | 新增：`restartMarker` 冷却期标记基础设施 |
| `cmd/hotplex/gateway_cmd.go` | 修改：注册 `_restart-helper` 子命令 + `--detached` flag |
| `cmd/hotplex/gateway_run.go` | 修改：`runGateway` 添加 `//nolint:unparam` 注释（stopCh 由 Windows 服务使用） |

Refs #396

## Test plan

- [x] `make build` 编译通过
- [x] `make test-short` 所有测试通过
- [x] `make lint` lint 通过（0 issues）
- [ ] 从终端执行 `hotplex gateway restart --detached` 验证 helper fork → 旧 Gateway 停止 → 新 Gateway 启动
- [ ] 连续执行两次 `--detached` 验证第二次被冷却期拒绝
- [ ] `hotplex gateway restart`（不带 --detached）原有行为不变
- [ ] 从 Worker 通过消息平台触发重启验证完整流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)