### PR TITLE
perf+refactor: brain lock-dropping (#385) + cron admin DRY (#384)

### DIFF
--- a/cmd/hotplex/cron_admin_adapter.go
+++ b/cmd/hotplex/cron_admin_adapter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/gateway"
 	"github.com/hrygo/hotplex/internal/session"
-	"github.com/hrygo/hotplex/internal/worker"
 )
 
 // cronAdminAdapter bridges cron.Scheduler to admin.CronSchedulerProvider.
@@ -36,69 +35,28 @@ func (a *cronAdminAdapter) UpdateJob(ctx context.Context, id string, updates map
 		return err
 	}
 
-	// Apply selective updates.
-	if v, ok := updates["name"].(string); ok {
-		job.Name = v
+	// Marshal current job, overlay updates, unmarshal back.
+	base, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("marshal job: %w", err)
 	}
-	if v, ok := updates["description"].(string); ok {
-		job.Description = v
+	var merged map[string]any
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return fmt.Errorf("unmarshal job: %w", err)
 	}
-	if v, ok := updates["enabled"].(bool); ok {
-		job.Enabled = v
+	for k, v := range updates {
+		merged[k] = v
 	}
-	if v, ok := updates["timeout_sec"].(float64); ok {
-		job.TimeoutSec = int(v)
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("re-marshal: %w", err)
 	}
-	if v, ok := updates["delete_after_run"].(bool); ok {
-		job.DeleteAfterRun = v
-	}
-	if v, ok := updates["silent"].(bool); ok {
-		job.Silent = v
-	}
-	if v, ok := updates["max_retries"].(float64); ok {
-		job.MaxRetries = int(v)
-	}
-	if v, ok := updates["max_runs"].(float64); ok {
-		job.MaxRuns = int(v)
-	}
-	if v, ok := updates["expires_at"].(string); ok {
-		job.ExpiresAt = v
+	var updated cron.CronJob
+	if err := json.Unmarshal(data, &updated); err != nil {
+		return fmt.Errorf("unmarshal updated: %w", err)
 	}
 
-	if sched, ok := updates["schedule"].(map[string]any); ok {
-		if kind, ok := sched["kind"].(string); ok {
-			job.Schedule.Kind = cron.ScheduleKind(kind)
-		}
-		if at, ok := sched["at"].(string); ok {
-			job.Schedule.At = at
-		}
-		if every, ok := sched["every_ms"].(float64); ok {
-			job.Schedule.EveryMs = int64(every)
-		}
-		if expr, ok := sched["expr"].(string); ok {
-			job.Schedule.Expr = expr
-		}
-		if tz, ok := sched["tz"].(string); ok {
-			job.Schedule.TZ = tz
-		}
-	}
-
-	if payload, ok := updates["payload"].(map[string]any); ok {
-		if msg, ok := payload["message"].(string); ok {
-			job.Payload.Message = msg
-		}
-		if tools, ok := payload["allowed_tools"].([]any); ok {
-			var t []string
-			for _, tool := range tools {
-				if s, ok := tool.(string); ok {
-					t = append(t, s)
-				}
-			}
-			job.Payload.AllowedTools = t
-		}
-	}
-
-	return a.scheduler.UpdateJob(ctx, job)
+	return a.scheduler.UpdateJob(ctx, &updated)
 }
 
 func (a *cronAdminAdapter) DeleteJob(ctx context.Context, id string) error {
@@ -127,21 +85,10 @@ func (a *cronAdminAdapter) RunHistory(ctx context.Context, id string) (any, erro
 		return nil, err
 	}
 
-	sessionKey := session.DerivePlatformSessionKey(
-		job.OwnerID, worker.TypeClaudeCode,
-		session.PlatformContext{
-			Platform: "cron",
-			BotID:    job.BotID,
-			UserID:   job.OwnerID,
-			WorkDir:  job.WorkDir,
-			ChatID:   job.ID,
-		},
-	)
-
 	if a.turnsStore == nil {
 		return nil, fmt.Errorf("eventstore not available")
 	}
-	return a.turnsStore.QueryTurnStats(ctx, sessionKey)
+	return a.turnsStore.QueryTurnStats(ctx, job.SessionKey())
 }
 
 // cronAttachedRouter implements cron.AttachedSessionRouter using Bridge + SessionManager.

--- a/cmd/hotplex/cron_admin_adapter.go
+++ b/cmd/hotplex/cron_admin_adapter.go
@@ -17,6 +17,14 @@ type cronAdminAdapter struct {
 	turnsStore *eventstore.SQLiteStore
 }
 
+// Fields that must not be overwritten via admin API UpdateJob.
+var protectedFields = map[string]struct{}{
+	"id":            {},
+	"created_at_ms": {},
+	"updated_at_ms": {},
+	"state":         {},
+}
+
 func (a *cronAdminAdapter) CreateJob(ctx context.Context, raw any) error {
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -45,6 +53,10 @@ func (a *cronAdminAdapter) UpdateJob(ctx context.Context, id string, updates map
 		return fmt.Errorf("unmarshal job: %w", err)
 	}
 	for k, v := range updates {
+		// Protect internal fields from external injection.
+		if _, ok := protectedFields[k]; ok {
+			continue
+		}
 		merged[k] = v
 	}
 	data, err := json.Marshal(merged)

--- a/cmd/hotplex/cron_admin_adapter.go
+++ b/cmd/hotplex/cron_admin_adapter.go
@@ -43,17 +43,26 @@ func (a *cronAdminAdapter) UpdateJob(ctx context.Context, id string, updates map
 		return err
 	}
 
-	// Marshal current job, overlay updates, unmarshal back.
+	updated, err := mergeJobUpdates(job, updates)
+	if err != nil {
+		return err
+	}
+	return a.scheduler.UpdateJob(ctx, updated)
+}
+
+// mergeJobUpdates overlays user-supplied updates onto a CronJob via JSON merge.
+// Nested objects (schedule, payload) are replaced entirely, not deep-merged.
+// Protected fields (id, created_at_ms, updated_at_ms, state) are silently dropped.
+func mergeJobUpdates(job *cron.CronJob, updates map[string]any) (*cron.CronJob, error) {
 	base, err := json.Marshal(job)
 	if err != nil {
-		return fmt.Errorf("marshal job: %w", err)
+		return nil, fmt.Errorf("marshal job: %w", err)
 	}
 	var merged map[string]any
 	if err := json.Unmarshal(base, &merged); err != nil {
-		return fmt.Errorf("unmarshal job: %w", err)
+		return nil, fmt.Errorf("unmarshal job: %w", err)
 	}
 	for k, v := range updates {
-		// Protect internal fields from external injection.
 		if _, ok := protectedFields[k]; ok {
 			continue
 		}
@@ -61,14 +70,13 @@ func (a *cronAdminAdapter) UpdateJob(ctx context.Context, id string, updates map
 	}
 	data, err := json.Marshal(merged)
 	if err != nil {
-		return fmt.Errorf("re-marshal: %w", err)
+		return nil, fmt.Errorf("re-marshal: %w", err)
 	}
 	var updated cron.CronJob
 	if err := json.Unmarshal(data, &updated); err != nil {
-		return fmt.Errorf("unmarshal updated: %w", err)
+		return nil, fmt.Errorf("unmarshal updated: %w", err)
 	}
-
-	return a.scheduler.UpdateJob(ctx, &updated)
+	return &updated, nil
 }
 
 func (a *cronAdminAdapter) DeleteJob(ctx context.Context, id string) error {

--- a/cmd/hotplex/cron_admin_adapter_test.go
+++ b/cmd/hotplex/cron_admin_adapter_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cron"
+)
+
+func TestMergeJobUpdates_NormalFields(t *testing.T) {
+	t.Parallel()
+	job := &cron.CronJob{
+		ID:          "job-123",
+		Name:        "old-name",
+		Description: "old-desc",
+		Enabled:     true,
+		TimeoutSec:  30,
+	}
+
+	updated, err := mergeJobUpdates(job, map[string]any{
+		"name":        "new-name",
+		"description": "new-desc",
+		"enabled":     false,
+		"timeout_sec": 60,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", updated.Name)
+	assert.Equal(t, "new-desc", updated.Description)
+	assert.False(t, updated.Enabled)
+	assert.Equal(t, 60, updated.TimeoutSec)
+	assert.Equal(t, "job-123", updated.ID)
+}
+
+func TestMergeJobUpdates_ProtectedFieldsIgnored(t *testing.T) {
+	t.Parallel()
+	job := &cron.CronJob{
+		ID:   "job-123",
+		Name: "original",
+		State: cron.CronJobState{
+			RunCount:    5,
+			NextRunAtMs: 999,
+		},
+	}
+
+	updated, err := mergeJobUpdates(job, map[string]any{
+		"id":            "hacked-id",
+		"state":         map[string]any{"run_count": 0, "next_run_at_ms": 0},
+		"created_at_ms": 0.0,
+		"updated_at_ms": 0.0,
+		"name":          "legit-update",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "job-123", updated.ID, "id must not be injectable")
+	assert.Equal(t, int64(999), updated.State.NextRunAtMs, "state must not be injectable")
+	assert.Equal(t, 5, updated.State.RunCount, "state.run_count must not be reset")
+	assert.Equal(t, "legit-update", updated.Name)
+}
+
+func TestMergeJobUpdates_UnknownFieldsIgnored(t *testing.T) {
+	t.Parallel()
+	job := &cron.CronJob{
+		ID:   "job-123",
+		Name: "original",
+	}
+
+	updated, err := mergeJobUpdates(job, map[string]any{
+		"unknown_field": "value",
+		"fake":          42,
+		"name":          "updated",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", updated.Name)
+	// Unknown fields are silently dropped by JSON unmarshal into typed struct.
+}

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -227,55 +227,69 @@ func (c *ContextCompressor) CheckAndCompress(ctx context.Context, sessionID stri
 }
 
 // compress performs the actual compression of session history.
+// Uses lock-dropping to avoid blocking all sessions during the LLM call.
 func (c *ContextCompressor) compress(ctx context.Context, sessionID string) (*SessionHistory, error) {
+	// Phase 1: Extract turns to compress under lock (fast).
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	history, exists := c.sessions[sessionID]
 	if !exists {
+		c.mu.Unlock()
 		return nil, fmt.Errorf("session %s not found", sessionID)
 	}
-
-	// Identify turns to compress (all except preserved)
 	if len(history.Turns) <= c.config.PreserveTurns*2 {
-		return nil, nil // Not enough turns to compress
+		c.mu.Unlock()
+		return nil, nil
 	}
-
 	preserveStart := len(history.Turns) - c.config.PreserveTurns*2
-	toCompress := history.Turns[:preserveStart]
-	preserved := history.Turns[preserveStart:]
+	toCompress := make([]Turn, preserveStart)
+	copy(toCompress, history.Turns[:preserveStart])
+	totalTokens := history.TotalTokens
+	c.mu.Unlock()
 
-	// Generate summary of old turns
+	// Phase 2: Generate summary outside lock (slow LLM call, 5-30s).
 	summary, err := c.generateSummary(ctx, toCompress)
 	if err != nil {
 		c.logger.Warn("Failed to generate summary", "session_id", sessionID, "error", err)
 		return nil, fmt.Errorf("generate summary: %w", err)
 	}
 
-	// Calculate tokens saved
+	// Phase 3: Apply summary under lock (fast).
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	history, exists = c.sessions[sessionID]
+	if !exists {
+		return nil, fmt.Errorf("session %s not found after compression", sessionID)
+	}
+
+	// Recalculate: turns may have been added during the LLM call.
+	if len(history.Turns) <= c.config.PreserveTurns*2 {
+		return nil, nil
+	}
+	preserveStart = len(history.Turns) - c.config.PreserveTurns*2
+	// Only drop turns up to what we compressed — newly added turns are preserved.
+	dropCount := min(preserveStart, len(toCompress))
 	oldTokens := 0
-	for _, t := range toCompress {
+	for _, t := range history.Turns[:dropCount] {
 		oldTokens += t.TokenCount
 	}
-	summaryTokens := llm.EstimateTokens(summary)
 
-	// Update history
-	history.Turns = preserved
+	summaryTokens := llm.EstimateTokens(summary)
+	history.Turns = history.Turns[dropCount:]
 	history.Summary = summary
 	history.Compressed = true
 	history.TotalTokens = history.TotalTokens - oldTokens + summaryTokens
 
-	// Update metrics
 	c.totalCompressions++
 	c.totalTokensSaved += int64(oldTokens - summaryTokens)
-	c.updateCompressionRatio(float64(history.TotalTokens) / float64(oldTokens+history.TotalTokens))
+	c.updateCompressionRatio(float64(history.TotalTokens) / float64(oldTokens+totalTokens))
 
 	c.logger.Info("Context compressed",
 		"session_id", sessionID,
 		"old_tokens", oldTokens,
 		"summary_tokens", summaryTokens,
 		"tokens_saved", oldTokens-summaryTokens,
-		"preserved_turns", len(preserved))
+		"preserved_turns", len(history.Turns))
 
 	return history, nil
 }

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -134,6 +134,9 @@ type ContextCompressor struct {
 	totalCompressions       int64   // Total compression operations performed
 	totalTokensSaved        int64   // Tokens saved by compression
 	averageCompressionRatio float64 // Running average of compression ratios
+
+	// In-flight guard prevents redundant LLM calls for the same session.
+	compressing sync.Map // sessionID → struct{}
 }
 
 // NewContextCompressor creates a new ContextCompressor.
@@ -228,7 +231,13 @@ func (c *ContextCompressor) CheckAndCompress(ctx context.Context, sessionID stri
 
 // compress performs the actual compression of session history.
 // Uses lock-dropping to avoid blocking all sessions during the LLM call.
+// An in-flight guard prevents redundant LLM calls for the same session.
 func (c *ContextCompressor) compress(ctx context.Context, sessionID string) (*SessionHistory, error) {
+	if _, loaded := c.compressing.LoadOrStore(sessionID, struct{}{}); loaded {
+		return nil, nil // another compression already in progress
+	}
+	defer c.compressing.Delete(sessionID)
+
 	// Phase 1: Extract turns to compress under lock (fast).
 	c.mu.Lock()
 	history, exists := c.sessions[sessionID]

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -403,17 +403,16 @@ func (c *ContextCompressor) ClearExpired() int {
 // Stats returns compressor statistics.
 func (c *ContextCompressor) Stats() map[string]interface{} {
 	c.mu.RLock()
-	sessionCount := len(c.sessions)
-	c.mu.RUnlock()
-
-	return map[string]interface{}{
+	stats := map[string]interface{}{
 		"enabled":                   c.enabled.Load(),
-		"session_count":             sessionCount,
+		"session_count":             len(c.sessions),
 		"total_compressions":        c.totalCompressions,
 		"total_tokens_saved":        c.totalTokensSaved,
 		"average_compression_ratio": c.averageCompressionRatio,
 		"token_threshold":           c.config.TokenThreshold,
 	}
+	c.mu.RUnlock()
+	return stats
 }
 
 // Context compression limits.

--- a/internal/brain/memory_test.go
+++ b/internal/brain/memory_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1070,4 +1072,169 @@ func TestGenerateSummary_BrainError(t *testing.T) {
 	// This should fail because generateSummary calls brain.Chat which returns error
 	_, err := c.ForceCompress(context.Background(), "session1")
 	assert.Error(t, err)
+}
+
+// ========================================
+// Lock-Dropping Concurrency Tests
+// ========================================
+
+func TestContextCompressor_ConcurrentRecordDuringCompress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent test in short mode")
+	}
+
+	slowBrain := &mockBrainForMemory{
+		chatFn: func(ctx context.Context, prompt string) (string, error) {
+			time.Sleep(100 * time.Millisecond) // simulate slow LLM
+			return "summary of conversation", nil
+		},
+	}
+	config := DefaultCompressionConfig()
+	config.CleanupInterval = 0
+	config.TokenThreshold = 500
+	config.PreserveTurns = 2
+
+	c := NewContextCompressor(slowBrain, config, slog.Default())
+	defer c.Stop()
+
+	// Add initial turns to exceed threshold.
+	for i := 0; i < 6; i++ {
+		c.RecordTurn("s1", "user", fmt.Sprintf("msg %d", i), 100)
+		c.RecordTurn("s1", "assistant", fmt.Sprintf("resp %d", i), 100)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Goroutine 1: compress.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, err := c.CheckAndCompress(context.Background(), "s1")
+		require.NoError(t, err)
+	}()
+
+	// Goroutine 2: add turns during compression (Phase 2).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		time.Sleep(50 * time.Millisecond)
+		c.RecordTurn("s1", "user", "new msg during compress", 100)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	history := c.GetHistory("s1")
+	require.NotNil(t, history)
+
+	// The turn added during compression must be preserved.
+	found := false
+	for _, turn := range history.Turns {
+		if turn.Content == "new msg during compress" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "turn added during compression should be preserved")
+}
+
+func TestContextCompressor_ConcurrentClearDuringCompress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent test in short mode")
+	}
+
+	slowBrain := &mockBrainForMemory{
+		chatFn: func(ctx context.Context, prompt string) (string, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "summary", nil
+		},
+	}
+	config := DefaultCompressionConfig()
+	config.CleanupInterval = 0
+	config.TokenThreshold = 500
+	config.PreserveTurns = 2
+
+	c := NewContextCompressor(slowBrain, config, slog.Default())
+	defer c.Stop()
+
+	for i := 0; i < 6; i++ {
+		c.RecordTurn("s1", "user", fmt.Sprintf("msg %d", i), 100)
+		c.RecordTurn("s1", "assistant", fmt.Sprintf("resp %d", i), 100)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Goroutine 1: compress.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		c.CheckAndCompress(context.Background(), "s1") // may return error, that's ok
+	}()
+
+	// Goroutine 2: clear session during Phase 2.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		time.Sleep(50 * time.Millisecond)
+		c.ClearSession("s1")
+	}()
+
+	close(start)
+	wg.Wait()
+
+	// Session should be gone after ClearSession.
+	assert.Nil(t, c.GetHistory("s1"))
+}
+
+func TestContextCompressor_InflightDedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent test in short mode")
+	}
+
+	var chatCount int64
+	slowBrain := &mockBrainForMemory{
+		chatFn: func(ctx context.Context, prompt string) (string, error) {
+			atomic.AddInt64(&chatCount, 1)
+			time.Sleep(150 * time.Millisecond)
+			return "summary", nil
+		},
+	}
+	config := DefaultCompressionConfig()
+	config.CleanupInterval = 0
+	config.TokenThreshold = 500
+	config.PreserveTurns = 2
+
+	c := NewContextCompressor(slowBrain, config, slog.Default())
+	defer c.Stop()
+
+	for i := 0; i < 6; i++ {
+		c.RecordTurn("s1", "user", fmt.Sprintf("msg %d", i), 100)
+		c.RecordTurn("s1", "assistant", fmt.Sprintf("resp %d", i), 100)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Launch 3 concurrent compressions — only 1 should call the LLM.
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			c.CheckAndCompress(context.Background(), "s1")
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	// In-flight dedup should ensure only 1 LLM call was made.
+	assert.Equal(t, int64(1), atomic.LoadInt64(&chatCount),
+		"in-flight dedup should prevent redundant LLM calls")
 }

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
-	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/internal/worker/proc"
 )
 
@@ -284,18 +283,7 @@ func QueryHistory(ctx context.Context, store cron.Store, evStore *eventstore.SQL
 		return nil, err
 	}
 
-	sessionKey := session.DerivePlatformSessionKey(
-		job.OwnerID, worker.TypeClaudeCode,
-		session.PlatformContext{
-			Platform: "cron",
-			BotID:    job.BotID,
-			UserID:   job.OwnerID,
-			WorkDir:  job.WorkDir,
-			ChatID:   job.ID,
-		},
-	)
-
-	return evStore.QueryTurnStats(ctx, sessionKey)
+	return evStore.QueryTurnStats(ctx, job.SessionKey())
 }
 
 // NotifyGateway sends SIGHUP to the running gateway to reload the cron index.

--- a/internal/cron/types.go
+++ b/internal/cron/types.go
@@ -1,5 +1,10 @@
 package cron
 
+import (
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
 // Schedule kinds.
 type ScheduleKind string
 
@@ -56,6 +61,20 @@ type CronJobState struct {
 	RetryCount      int       `json:"retry_count,omitempty"`
 	LastRunID       string    `json:"last_run_id,omitempty"`
 	RunCount        int       `json:"run_count,omitempty"`
+}
+
+// SessionKey derives the deterministic session key for this cron job's execution history.
+func (j *CronJob) SessionKey() string {
+	return session.DerivePlatformSessionKey(
+		j.OwnerID, worker.TypeClaudeCode,
+		session.PlatformContext{
+			Platform: "cron",
+			BotID:    j.BotID,
+			UserID:   j.OwnerID,
+			WorkDir:  j.WorkDir,
+			ChatID:   j.ID,
+		},
+	)
 }
 
 // Clone returns a deep copy of the job, including reference-type fields

--- a/internal/cron/types_test.go
+++ b/internal/cron/types_test.go
@@ -1,0 +1,92 @@
+package cron
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCronJob_SessionKey_Deterministic(t *testing.T) {
+	t.Parallel()
+	job := &CronJob{
+		ID:      "job-123",
+		OwnerID: "user-abc",
+		BotID:   "bot-xyz",
+		WorkDir: "/home/user/project",
+	}
+
+	key1 := job.SessionKey()
+	key2 := job.SessionKey()
+	assert.Equal(t, key1, key2, "SessionKey must be deterministic")
+	assert.NotEmpty(t, key1)
+}
+
+func TestCronJob_SessionKey_DifferentForDifferentWorkDirs(t *testing.T) {
+	t.Parallel()
+	job1 := &CronJob{
+		ID:      "job-123",
+		OwnerID: "user-abc",
+		BotID:   "bot-xyz",
+		WorkDir: "/home/user/project-a",
+	}
+	job2 := &CronJob{
+		ID:      "job-456",
+		OwnerID: "user-abc",
+		BotID:   "bot-xyz",
+		WorkDir: "/home/user/project-b",
+	}
+
+	assert.NotEqual(t, job1.SessionKey(), job2.SessionKey(),
+		"different WorkDirs must produce different session keys")
+}
+
+func TestCronJob_SessionKey_DifferentForDifferentOwners(t *testing.T) {
+	t.Parallel()
+	job1 := &CronJob{
+		ID:      "job-123",
+		OwnerID: "user-aaa",
+		BotID:   "bot-xyz",
+		WorkDir: "/home/user/project",
+	}
+	job2 := &CronJob{
+		ID:      "job-123",
+		OwnerID: "user-bbb",
+		BotID:   "bot-xyz",
+		WorkDir: "/home/user/project",
+	}
+
+	assert.NotEqual(t, job1.SessionKey(), job2.SessionKey(),
+		"different owners must produce different session keys")
+}
+
+func TestCronJob_Clone(t *testing.T) {
+	t.Parallel()
+	original := &CronJob{
+		ID:          "job-123",
+		Name:        "test-job",
+		OwnerID:     "user-abc",
+		BotID:       "bot-xyz",
+		Enabled:     true,
+		PlatformKey: map[string]string{"chat_id": "oc_123"},
+		Payload: CronPayload{
+			Message:      "hello",
+			AllowedTools: []string{"tool1", "tool2"},
+		},
+	}
+
+	cloned := original.Clone()
+
+	require.NotNil(t, cloned)
+	assert.Equal(t, original.ID, cloned.ID)
+	assert.Equal(t, original.Name, cloned.Name)
+	assert.Equal(t, original.Enabled, cloned.Enabled)
+
+	// Verify deep copy of maps and slices.
+	cloned.PlatformKey["chat_id"] = "modified"
+	cloned.Payload.AllowedTools[0] = "modified"
+	assert.Equal(t, "oc_123", original.PlatformKey["chat_id"],
+		"modifying clone must not affect original map")
+	assert.Equal(t, "tool1", original.Payload.AllowedTools[0],
+		"modifying clone must not affect original slice")
+}


### PR DESCRIPTION
## Summary

Batch PR addressing 2 issues:

- **#385**: Lock-dropping in `brain.compress()` to unblock all sessions during LLM call (5-30s)
- **#384**: DRY refactor of cron admin adapter `UpdateJob` + session key derivation

**Note**: #389 was originally in this batch but already has a dedicated PR (#408), so it was excluded.

## Changes by Issue

### #385 — perf(brain): compress() lock-dropping

**Problem**: `compress()` held `c.mu.Lock()` through the entire function including the LLM API call via `generateSummary()`, blocking all sessions' `RecordTurn()` / `GetHistory()` for 5-30 seconds.

**Solution**: Three-phase lock-dropping:
1. Lock → extract turns to compress → unlock
2. LLM summary generation (slow, no lock)
3. Lock → apply summary with re-validation → unlock

**Impact**: All sessions can record turns and read history concurrently during compression.

### #384 — refactor(cmd): cron admin adapter DRY

**Problem**: `UpdateJob` had 70 lines of type assertion cascade; session key derivation was duplicated in `cron_admin_adapter.go` and `cron/client.go`.

**Solution**:
- Replace type assertions with `json.Marshal` baseline + selective merge (consistent with `CreateJob` pattern)
- Extract `CronJob.SessionKey()` method to eliminate duplication

**Impact**: -83 lines, +37 lines; adding new `CronJob` fields no longer requires manual type assertions.

## Testing

- [x] `make test` — all packages pass
- [x] `make lint` — 0 issues
- [x] `make build` — successful
- [x] brain package tests pass with lock-dropping changes
- [x] cron package tests pass with DRY changes

Fixes #385, Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)