### PR TITLE
feat(config): per-bot configuration with platform-level fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,12 @@ playwright-report/
 __pycache__
 
 # --- Agent & Session State ---
+.agent/skills/*
+!.agent/skills/hotplex-*/
+.agent/skills/hotplex-docs-patrol/.patrol-baseline
+.agents/
+skills/
+skills-lock.json
 .agent/scheduled_tasks.lock
 .agent/source-study-progress.json
 .agent/arch-analysis/progress.json

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -138,13 +138,26 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 				botWorkerType = entry.WorkerType
 			}
 
+			// Per-bot workDir override.
+			botWorkDir := workDir
+			switch pt {
+			case messaging.PlatformSlack:
+				if bc := resolveSlackBot(appCfg, entry.Name); bc != nil && bc.WorkDir != "" {
+					botWorkDir = bc.WorkDir
+				}
+			case messaging.PlatformFeishu:
+				if bc := resolveFeishuBot(appCfg, entry.Name); bc != nil && bc.WorkDir != "" {
+					botWorkDir = bc.WorkDir
+				}
+			}
+
 			adapter, err := messaging.New(pt, log)
 			if err != nil {
 				log.Warn("messaging: skip adapter", "platform", pt, "bot", entry.Name, "err", err)
 				continue
 			}
 
-			msgBridge := messaging.NewBridge(log, pt, hub, sm, handler, gwBridge, botWorkerType, workDir)
+			msgBridge := messaging.NewBridge(log, pt, hub, sm, handler, gwBridge, botWorkerType, botWorkDir)
 
 			acfg := messaging.AdapterConfig{
 				Hub:     hub,
@@ -232,15 +245,7 @@ func resolveFeishuBot(cfg *config.Config, name string) *config.FeishuBotConfig {
 // fillSlackExtras populates AdapterConfig.Extras for a Slack bot.
 func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCfg *config.SlackBotConfig, log *slog.Logger) {
 	platformCfg := appCfg.Messaging.Slack
-	gate := messaging.NewGate(
-		platformCfg.DMPolicy,
-		platformCfg.GroupPolicy,
-		platformCfg.RequireMention,
-		platformCfg.AllowFrom,
-		platformCfg.AllowDMFrom,
-		platformCfg.AllowGroupFrom,
-	)
-	acfg.Gate = gate
+	acfg.Gate = resolveSlackGate(platformCfg, botCfg)
 
 	// Use bot-specific credentials, falling back to platform-level.
 	botToken := platformCfg.BotToken
@@ -276,15 +281,7 @@ func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCf
 // fillFeishuExtras populates AdapterConfig.Extras for a Feishu bot.
 func fillFeishuExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCfg *config.FeishuBotConfig, log *slog.Logger) {
 	platformCfg := appCfg.Messaging.Feishu
-	gate := messaging.NewGate(
-		platformCfg.DMPolicy,
-		platformCfg.GroupPolicy,
-		platformCfg.RequireMention,
-		platformCfg.AllowFrom,
-		platformCfg.AllowDMFrom,
-		platformCfg.AllowGroupFrom,
-	)
-	acfg.Gate = gate
+	acfg.Gate = resolveFeishuGate(platformCfg, botCfg)
 
 	// Use bot-specific credentials, falling back to platform-level.
 	appID := platformCfg.AppID
@@ -482,4 +479,70 @@ func buildTTSSynthesizer(ttsCfg config.TTSConfig, log *slog.Logger) tts.Synthesi
 	shared := tts.NewSharedSynthesizer(synth)
 	ttsCache[cacheKey] = shared
 	return shared
+}
+
+// resolveSlackGate builds a Gate for a Slack bot, using per-bot fields
+// with platform-level fallback for any unset values.
+func resolveSlackGate(platformCfg config.SlackConfig, botCfg *config.SlackBotConfig) *messaging.Gate {
+	dm := platformCfg.DMPolicy
+	group := platformCfg.GroupPolicy
+	mention := platformCfg.RequireMention
+	from := platformCfg.AllowFrom
+	dmFrom := platformCfg.AllowDMFrom
+	groupFrom := platformCfg.AllowGroupFrom
+
+	if botCfg != nil {
+		if botCfg.DMPolicy != "" {
+			dm = botCfg.DMPolicy
+		}
+		if botCfg.GroupPolicy != "" {
+			group = botCfg.GroupPolicy
+		}
+		if botCfg.RequireMention != nil {
+			mention = *botCfg.RequireMention
+		}
+		if len(botCfg.AllowFrom) > 0 {
+			from = botCfg.AllowFrom
+		}
+		if len(botCfg.AllowDMFrom) > 0 {
+			dmFrom = botCfg.AllowDMFrom
+		}
+		if len(botCfg.AllowGroupFrom) > 0 {
+			groupFrom = botCfg.AllowGroupFrom
+		}
+	}
+	return messaging.NewGate(dm, group, mention, from, dmFrom, groupFrom)
+}
+
+// resolveFeishuGate builds a Gate for a Feishu bot, using per-bot fields
+// with platform-level fallback for any unset values.
+func resolveFeishuGate(platformCfg config.FeishuConfig, botCfg *config.FeishuBotConfig) *messaging.Gate {
+	dm := platformCfg.DMPolicy
+	group := platformCfg.GroupPolicy
+	mention := platformCfg.RequireMention
+	from := platformCfg.AllowFrom
+	dmFrom := platformCfg.AllowDMFrom
+	groupFrom := platformCfg.AllowGroupFrom
+
+	if botCfg != nil {
+		if botCfg.DMPolicy != "" {
+			dm = botCfg.DMPolicy
+		}
+		if botCfg.GroupPolicy != "" {
+			group = botCfg.GroupPolicy
+		}
+		if botCfg.RequireMention != nil {
+			mention = *botCfg.RequireMention
+		}
+		if len(botCfg.AllowFrom) > 0 {
+			from = botCfg.AllowFrom
+		}
+		if len(botCfg.AllowDMFrom) > 0 {
+			dmFrom = botCfg.AllowDMFrom
+		}
+		if len(botCfg.AllowGroupFrom) > 0 {
+			groupFrom = botCfg.AllowGroupFrom
+		}
+	}
+	return messaging.NewGate(dm, group, mention, from, dmFrom, groupFrom)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -318,6 +318,15 @@ type SlackBotConfig struct {
 	AppToken   string `mapstructure:"app_token"`
 	Soul       string `mapstructure:"soul,omitempty"`
 	WorkerType string `mapstructure:"worker_type,omitempty"`
+	WorkDir    string `mapstructure:"work_dir,omitempty"`
+
+	// Per-bot access control (falls back to platform-level when empty).
+	DMPolicy       string   `mapstructure:"dm_policy,omitempty"`
+	GroupPolicy    string   `mapstructure:"group_policy,omitempty"`
+	RequireMention *bool    `mapstructure:"require_mention,omitempty"`
+	AllowFrom      []string `mapstructure:"allow_from,omitempty"`
+	AllowDMFrom    []string `mapstructure:"allow_dm_from,omitempty"`
+	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
 
 	STTConfig `mapstructure:",squash"`
 	TTSConfig `mapstructure:",squash"`
@@ -344,6 +353,15 @@ type FeishuBotConfig struct {
 	AppSecret  string `mapstructure:"app_secret"`
 	Soul       string `mapstructure:"soul,omitempty"`
 	WorkerType string `mapstructure:"worker_type,omitempty"`
+	WorkDir    string `mapstructure:"work_dir,omitempty"`
+
+	// Per-bot access control (falls back to platform-level when empty).
+	DMPolicy       string   `mapstructure:"dm_policy,omitempty"`
+	GroupPolicy    string   `mapstructure:"group_policy,omitempty"`
+	RequireMention *bool    `mapstructure:"require_mention,omitempty"`
+	AllowFrom      []string `mapstructure:"allow_from,omitempty"`
+	AllowDMFrom    []string `mapstructure:"allow_dm_from,omitempty"`
+	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
 
 	STTConfig `mapstructure:",squash"`
 	TTSConfig `mapstructure:",squash"`
@@ -1013,13 +1031,25 @@ func (c *Config) normalizePaths() {
 			*ef = ExpandEnv(*ef)
 		}
 	}
-	// Per-bot env expansion.
+	// Per-bot env expansion (credentials + paths).
 	var botFields []*string
 	for i := range c.Messaging.Slack.Bots {
-		botFields = append(botFields, &c.Messaging.Slack.Bots[i].LocalCmd, &c.Messaging.Slack.Bots[i].MossModelDir)
+		botFields = append(botFields,
+			&c.Messaging.Slack.Bots[i].BotToken,
+			&c.Messaging.Slack.Bots[i].AppToken,
+			&c.Messaging.Slack.Bots[i].WorkDir,
+			&c.Messaging.Slack.Bots[i].LocalCmd,
+			&c.Messaging.Slack.Bots[i].MossModelDir,
+		)
 	}
 	for i := range c.Messaging.Feishu.Bots {
-		botFields = append(botFields, &c.Messaging.Feishu.Bots[i].LocalCmd, &c.Messaging.Feishu.Bots[i].MossModelDir)
+		botFields = append(botFields,
+			&c.Messaging.Feishu.Bots[i].AppID,
+			&c.Messaging.Feishu.Bots[i].AppSecret,
+			&c.Messaging.Feishu.Bots[i].WorkDir,
+			&c.Messaging.Feishu.Bots[i].LocalCmd,
+			&c.Messaging.Feishu.Bots[i].MossModelDir,
+		)
 	}
 	expandStringFields(botFields...)
 
@@ -1046,15 +1076,15 @@ func (c *Config) normalizePaths() {
 			*pf = absPath
 		}
 	}
-	// Per-bot MossModelDir path normalization.
-	var mossDirs []*string
+	// Per-bot WorkDir and MossModelDir path normalization.
+	var botPaths []*string
 	for i := range c.Messaging.Slack.Bots {
-		mossDirs = append(mossDirs, &c.Messaging.Slack.Bots[i].MossModelDir)
+		botPaths = append(botPaths, &c.Messaging.Slack.Bots[i].WorkDir, &c.Messaging.Slack.Bots[i].MossModelDir)
 	}
 	for i := range c.Messaging.Feishu.Bots {
-		mossDirs = append(mossDirs, &c.Messaging.Feishu.Bots[i].MossModelDir)
+		botPaths = append(botPaths, &c.Messaging.Feishu.Bots[i].WorkDir, &c.Messaging.Feishu.Bots[i].MossModelDir)
 	}
-	normalizePathFields(mossDirs...)
+	normalizePathFields(botPaths...)
 }
 
 // ExpandAndAbs returns an absolute path, resolving ~ and relative paths.


### PR DESCRIPTION
## Summary

- **Bug fix**: Per-bot credential `${VAR}` env expansion was missing in `normalizePaths()`, causing `app secret invalid` errors when using environment variable references in `bots[].app_secret`
- **Feature**: Per-bot `work_dir` override with platform-level fallback
- **Feature**: Per-bot access control (Gate) with `dm_policy`, `group_policy`, `require_mention`, `allow_from`, `allow_dm_from`, `allow_group_from`

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Added fields to bot configs; expanded per-bot env expansion + path normalization |
| `cmd/hotplex/messaging_init.go` | Per-bot workDir resolution; `resolveSlackGate`/`resolveFeishuGate` helpers |

## Fallback Rules

- `string`: empty string → platform-level
- `*bool`: nil pointer → platform-level
- `[]string`: nil/empty → platform-level

## Test Plan

- [x] `make build` + `go test` passes
- [x] Deployed: `feishu ✓ feishu ✓ slack ✓`
- [x] Code review: no high-confidence issues
- [x] Backward compatible: single-bot mode unaffected

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)