### PR TITLE
fix: scope .gitignore skills/ to repo root and update MessagingConfig comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ __pycache__
 !.agent/skills/hotplex-*/
 .agent/skills/hotplex-docs-patrol/.patrol-baseline
 .agents/
-skills/
+/skills/
 skills-lock.json
 .agent/scheduled_tasks.lock
 .agent/source-study-progress.json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,7 +166,7 @@ type Config struct {
 // MessagingConfig holds messaging platform adapter settings.
 // Shared defaults (WorkerType, STTConfig, TTSConfig) are set at this level and propagated
 // to each platform config via propagateMessagingDefaults().
-// DMPolicy and GroupPolicy remain platform-level only (different platforms may have different access policies).
+// Access control fields (DMPolicy, GroupPolicy, RequireMention, AllowFrom, AllowDMFrom, AllowGroupFrom) support per-bot overrides with platform-level fallback.
 // Priority: platform-level > messaging-level > Default().
 type MessagingConfig struct {
 	TurnSummaryEnabled bool `mapstructure:"turn_summary_enabled"`


### PR DESCRIPTION
Refs #414

## Summary
- `.gitignore` 中 `skills/` 添加前导 `/` 限定为仓库根目录，避免匹配子目录中的 `skills/` 文件夹，确保 `.agent/skills/hotplex-*/` 的 negation 规则正确生效
- 更新 `MessagingConfig` 注释，反映 per-bot 访问控制字段（DMPolicy, GroupPolicy 等）支持 per-bot 覆盖 + 平台级 fallback 的新架构

## Test plan
- [x] 确认 `skills/` 仅匹配仓库根目录
- [x] 确认 `.agent/skills/hotplex-*/` negation 规则不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)