### PR TITLE
Batch: brain config registry + admin cron tests + service CommandRunner (issues #351, #382, #250)

### DIFF
--- a/docs/superpowers/specs/2026-05-14-messaging-phrases-design.md
+++ b/docs/superpowers/specs/2026-05-14-messaging-phrases-design.md
@@ -1,0 +1,236 @@
+# Phrases: Procedural Message Pool for Platform UI Feedback
+
+**Date**: 2026-05-14
+**Branch**: batch/messaging-dry-issues-376-257
+**Related Issues**: #376, #257
+
+---
+
+## Motivation
+
+The feishu adapter hardcodes 28 CLI tips and 8 greetings in `feishu/placeholder.go`. These serve as procedural UI feedback (placeholder cards, status indicators), not agent identity. Slack has no equivalent personalization. Extracting into a shared, configurable module enables:
+
+1. **Platform abstraction** — both feishu and slack consume from the same phrase pools
+2. **Configurability** — users and bots can customize greetings, tips, onboarding messages
+3. **Per-bot personality** — bot-specific phrases are appended (not replaced), enriching each bot's unique voice
+4. **Self-management** — bots can configure their own phrases via a B-channel skill manual
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Package location | `internal/messaging/phrases/` | Procedural UI behavior, not agent identity |
+| Config directory | `~/.hotplex/phrases/` | Separate from `agent-configs/` to avoid cognitive confusion |
+| Merge semantics | Cascade-append (not first-match-wins) | More entries = richer pool; opposite of agent-config's override model |
+| File format | Markdown with `## Section` + `- item` | Simple, human-editable, git-friendly |
+| Bot-level behavior | Append to inherited pool | Simplifies configuration; bot only defines what's unique |
+| Hot reload | None (loaded at adapter init) | Consistent with agent-config; requires gateway restart |
+
+## PHRASES.md File Format
+
+```markdown
+## Greetings
+- 来啦～
+- 交给我～
+- 收到，马上～
+
+## Tips
+- 输入 /gc 可休眠当前会话，下次发消息自动恢复
+- 输入 /reset 可重置上下文，从零开始新对话
+
+## Onboarding
+- 你好！有什么可以帮你？
+- 嗨～今天想做什么？
+
+## Custom
+- Any user-defined section works
+- Access via phrases.Random("custom")
+```
+
+**Parsing rules**:
+- `## Name` (case-insensitive) defines a category
+- `- text` is a list entry; blank lines between entries are optional
+- Lines that are neither headings nor list items are ignored (allows free-form comments)
+- Unknown `## Section` names are accessible via `Random("section-name")`
+
+## Package Structure
+
+```
+internal/messaging/phrases/
+├── phrases.go       # Phrases struct, Random(), All(), Categories(), Defaults()
+├── loader.go        # Load(dir, platform, botID) cascade-append
+├── parse.go         # parseMarkdown() → map[string][]string
+├── phrases.md       # go:embed configuration manual
+├── skill.go         # Manual() for B-channel injection
+└── phrases_test.go
+```
+
+### Core Types
+
+```go
+package phrases
+
+// Phrases holds categorized message pools used for procedural UI feedback.
+// Immutable after creation — no mutex needed.
+type Phrases struct {
+    entries map[string][]string
+}
+
+// Random returns a random entry from the given category.
+// Returns "" if category not found or empty.
+func (p *Phrases) Random(category string) string
+
+// All returns all entries for a category (for preview/debug).
+func (p *Phrases) All(category string) []string
+
+// Categories returns available category names.
+func (p *Phrases) Categories() []string
+```
+
+### Loading
+
+```go
+// Load reads PHRASES.md from all levels with cascade-append:
+//
+//  1. code defaults (hardcoded via Defaults())
+//  2. dir/PHRASES.md (global)
+//  3. dir/{platform}/PHRASES.md
+//  4. dir/{platform}/{botID}/PHRASES.md
+//
+// Each level's entries are appended to the pool, never replaced.
+// Missing directory or file is not an error — skips gracefully.
+func Load(dir, platform, botID string) (*Phrases, error)
+
+// Defaults returns the hardcoded base entries.
+func Defaults() *Phrases
+```
+
+**Merge algorithm**: `merge(dst, src map[string][]string)` appends `src[key]` values to `dst[key]` for all keys.
+
+**Path safety**: `filepath.Base(botID) == botID` check prevents path traversal (same pattern as agentconfig).
+
+## Cascade-Append Loading
+
+```
+Code defaults (Go hardcoded)
+  ↓ append
+~/.hotplex/phrases/PHRASES.md
+  ↓ append
+~/.hotplex/phrases/feishu/PHRASES.md
+  ↓ append
+~/.hotplex/phrases/feishu/ou_xxx/PHRASES.md
+```
+
+**Example**: If global defines 8 greetings, feishu/ adds 3, and `feishu/ou_xxx/` adds 2, the bot `ou_xxx` has 13 greetings to draw from.
+
+## Default Values Migration
+
+Current hardcoded arrays in `feishu/placeholder.go` move to `phrases.Defaults()`:
+
+```go
+func Defaults() *Phrases {
+    return &Phrases{entries: map[string][]string{
+        "greetings": {
+            "来啦～", "交给我～", "收到，马上～", "好嘞！",
+            "马上来～", "明白，开始干活！", "来了来了～", "收到！",
+        },
+        "tips": {
+            // ... existing 28 CLI tips
+        },
+    }}
+}
+```
+
+## Rendering Separation
+
+Phrases provides text content only. Platform-specific rendering stays in adapters:
+
+**Feishu** — sticker-wrapped placeholder card:
+```go
+func buildPlaceholderText(p *phrases.Phrases) string {
+    return ":Get: " + p.Random("greetings") +
+        "\n:StatusFlashOfInspiration: " + p.Random("tips")
+}
+```
+
+**Slack** — status indicator text:
+```go
+a.SetAssistantStatus(ctx, channelID, threadTS, p.Random("greetings"))
+```
+
+## Injection Path
+
+```go
+// messaging_init.go — per-bot loading during adapter init
+phrasesDir := filepath.Join(homeDir, ".hotplex", "phrases")
+p, err := phrases.Load(phrasesDir, string(entry.Platform), entry.BotID)
+if err != nil {
+    log.Warn("phrases load failed, using defaults", "error", err)
+    p = phrases.Defaults()
+}
+cfg.Extras["phrases"] = p
+```
+
+Adapter access:
+```go
+func (a *Adapter) phrases() *phrases.Phrases {
+    if p, ok := a.config.Extras["phrases"].(*phrases.Phrases); ok {
+        return p
+    }
+    return phrases.Defaults()
+}
+```
+
+## Skill Manual: Embed → Release → Reference
+
+Follows the same pattern as `cron/skill.go`: the full manual is embedded in the binary, released to disk on startup, and only a brief reference + path is injected into the B-channel.
+
+**Step 1 — go:embed the manual:**
+```go
+//go:embed phrases.md
+var embeddedManual string
+
+func SkillManual() string { return embeddedManual }
+```
+
+**Step 2 — Release to disk on startup:**
+```go
+// In skill.go, called during adapter init (messaging_init.go)
+func releaseSkillManual(log *slog.Logger) {
+    dir, _ := os.UserHomeDir()
+    skillsDir := filepath.Join(dir, ".hotplex", "skills")
+    _ = os.MkdirAll(skillsDir, 0o755)
+    path := filepath.Join(skillsDir, "phrases.md")
+    if err := os.WriteFile(path, []byte(embeddedManual), 0o644); err != nil {
+        log.Warn("phrases: failed to release skill manual", "path", path, "err", err)
+    }
+}
+```
+
+**Step 3 — B-channel reference only (in META-COGNITION.md or similar):**
+
+The B-channel does NOT contain the full manual. It contains a brief description and file path reference, matching the cron pattern:
+
+```
+> **Phrases 配置**：识别到 phrases 配置意图后，阅读 `~/.hotplex/skills/phrases.md` 了解目录结构、文件格式和合并规则，然后通过文件操作配置自己的话术库。
+```
+
+This enables bots to self-manage their phrase pools by reading the released manual and editing `~/.hotplex/phrases/` files through tool calls.
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/messaging/phrases/phrases.go` | New | Phrases struct, Random(), Defaults() |
+| `internal/messaging/phrases/loader.go` | New | Load() with cascade-append |
+| `internal/messaging/phrases/parse.go` | New | parseMarkdown() |
+| `internal/messaging/phrases/phrases.md` | New | go:embed skill manual |
+| `internal/messaging/phrases/skill.go` | New | go:embed + SkillManual() + releaseSkillManual() |
+| `internal/messaging/phrases/phrases_test.go` | New | Unit tests |
+| `internal/messaging/feishu/placeholder.go` | Modify | Remove hardcoded arrays, use Phrases |
+| `internal/messaging/feishu/streaming.go` | Modify | Accept Phrases parameter |
+| `internal/messaging/feishu/handler.go` | Modify | Pass Phrases to streaming controller |
+| `internal/messaging/slack/adapter.go` | Modify | Use Phrases for status text |
+| `internal/messaging/config.go` | Modify | Extras accessor for Phrases |
+| `cmd/hotplex/messaging_init.go` | Modify | Load Phrases per bot, call releaseSkillManual() |
+| `internal/agentconfig/META-COGNITION.md` | Modify | Add phrases skill reference + file path |

--- a/internal/admin/cron_handlers_test.go
+++ b/internal/admin/cron_handlers_test.go
@@ -1,0 +1,605 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock cron scheduler ---
+
+type mockCronScheduler struct {
+	createJobFn  func(ctx context.Context, job any) error
+	updateJobFn  func(ctx context.Context, id string, updates map[string]any) error
+	deleteJobFn  func(ctx context.Context, id string) error
+	getJobFn     func(ctx context.Context, id string) (any, error)
+	listJobsFn   func(ctx context.Context) (any, error)
+	triggerJobFn func(ctx context.Context, id string) error
+	runHistoryFn func(ctx context.Context, id string) (any, error)
+}
+
+func (m *mockCronScheduler) CreateJob(ctx context.Context, job any) error {
+	if m.createJobFn != nil {
+		return m.createJobFn(ctx, job)
+	}
+	return nil
+}
+
+func (m *mockCronScheduler) UpdateJob(ctx context.Context, id string, updates map[string]any) error {
+	if m.updateJobFn != nil {
+		return m.updateJobFn(ctx, id, updates)
+	}
+	return nil
+}
+
+func (m *mockCronScheduler) DeleteJob(ctx context.Context, id string) error {
+	if m.deleteJobFn != nil {
+		return m.deleteJobFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockCronScheduler) GetJob(ctx context.Context, id string) (any, error) {
+	if m.getJobFn != nil {
+		return m.getJobFn(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockCronScheduler) ListJobs(ctx context.Context) (any, error) {
+	if m.listJobsFn != nil {
+		return m.listJobsFn(ctx)
+	}
+	return []any{}, nil
+}
+
+func (m *mockCronScheduler) TriggerJob(ctx context.Context, id string) error {
+	if m.triggerJobFn != nil {
+		return m.triggerJobFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockCronScheduler) RunHistory(ctx context.Context, id string) (any, error) {
+	if m.runHistoryFn != nil {
+		return m.runHistoryFn(ctx, id)
+	}
+	return []any{}, nil
+}
+
+// --- Helpers ---
+
+func newCronTestAPI(overrides ...func(*Deps)) *AdminAPI {
+	deps := Deps{
+		Log:          slog.Default(),
+		Config:       &mockConfig{},
+		SessionMgr:   &mockSessionManager{},
+		Hub:          &mockHub{conns: 2},
+		Bridge:       &mockBridge{},
+		Cron:         &mockCronScheduler{},
+		Version:      func() string { return "test-v1" },
+		NewSessionID: func() string { return "sid-123" },
+	}
+	for _, o := range overrides {
+		o(&deps)
+	}
+	return New(deps)
+}
+
+func cronAPIWithMock(fn func(*mockCronScheduler)) *AdminAPI {
+	mc := &mockCronScheduler{}
+	fn(mc)
+	return newCronTestAPI(func(d *Deps) {
+		d.Cron = mc
+	})
+}
+
+// --- HandleCronList tests ---
+
+func TestHandleCronList_Success(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.listJobsFn = func(_ context.Context) (any, error) {
+			return []map[string]any{{"id": "j1", "name": "daily"}}, nil
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronList(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	require.Len(t, result, 1)
+	require.Equal(t, "j1", result[0]["id"])
+}
+
+func TestHandleCronList_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs", nil)
+	r = withScope(r, ScopeSessionRead)
+
+	api.HandleCronList(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronList_SchedulerError(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.listJobsFn = func(_ context.Context) (any, error) {
+			return nil, errors.New("db unavailable")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronList(w, r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleCronList_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronList(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	require.Equal(t, []any{}, result)
+}
+
+// --- HandleCronGet tests ---
+
+func TestHandleCronGet_Success(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.getJobFn = func(_ context.Context, id string) (any, error) {
+			require.Equal(t, "job-42", id)
+			return map[string]any{"id": "job-42", "name": "hourly"}, nil
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/job-42", nil)
+	r.SetPathValue("id", "job-42")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronGet(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	require.Equal(t, "job-42", result["id"])
+}
+
+func TestHandleCronGet_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/1", nil)
+	r = withScope(r, ScopeSessionRead)
+
+	api.HandleCronGet(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronGet_NotFound(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.getJobFn = func(_ context.Context, _ string) (any, error) {
+			return nil, errors.New("not found")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/missing", nil)
+	r.SetPathValue("id", "missing")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronGet(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleCronGet_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/1", nil)
+	r.SetPathValue("id", "1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronGet(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- HandleCronCreate tests ---
+
+func TestHandleCronCreate_Success(t *testing.T) {
+	t.Parallel()
+	var received map[string]any
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.createJobFn = func(_ context.Context, job any) error {
+			received = job.(map[string]any)
+			return nil
+		}
+	})
+	w := httptest.NewRecorder()
+	body := `{"name":"daily-health","schedule":"cron:0 9 * * 1-5"}`
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs", strings.NewReader(body))
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronCreate(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.Equal(t, "daily-health", received["name"])
+}
+
+func TestHandleCronCreate_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs", strings.NewReader(`{}`))
+	r = withScope(r, ScopeAdminRead) // read-only, needs write
+
+	api.HandleCronCreate(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronCreate_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs", strings.NewReader("not-json"))
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronCreate(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid JSON")
+}
+
+func TestHandleCronCreate_SchedulerError(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.createJobFn = func(_ context.Context, _ any) error {
+			return errors.New("duplicate name")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs", strings.NewReader(`{"name":"dup"}`))
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronCreate(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "create job")
+}
+
+func TestHandleCronCreate_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs", strings.NewReader(`{}`))
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronCreate(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- HandleCronUpdate tests ---
+
+func TestHandleCronUpdate_Success(t *testing.T) {
+	t.Parallel()
+	var (
+		receivedID   string
+		receivedBody map[string]any
+	)
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.updateJobFn = func(_ context.Context, id string, updates map[string]any) error {
+			receivedID = id
+			receivedBody = updates
+			return nil
+		}
+	})
+	w := httptest.NewRecorder()
+	body := `{"enabled":false}`
+	r := httptest.NewRequest(http.MethodPut, "/cron/jobs/j1", strings.NewReader(body))
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronUpdate(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Equal(t, "j1", receivedID)
+	require.Equal(t, false, receivedBody["enabled"])
+}
+
+func TestHandleCronUpdate_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/cron/jobs/j1", strings.NewReader(`{}`))
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronUpdate(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronUpdate_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/cron/jobs/j1", strings.NewReader("bad"))
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronUpdate(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid JSON")
+}
+
+func TestHandleCronUpdate_SchedulerError(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.updateJobFn = func(_ context.Context, _ string, _ map[string]any) error {
+			return errors.New("job not found")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/cron/jobs/j1", strings.NewReader(`{"name":"x"}`))
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronUpdate(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "update job")
+}
+
+func TestHandleCronUpdate_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/cron/jobs/j1", strings.NewReader(`{}`))
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronUpdate(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- HandleCronDelete tests ---
+
+func TestHandleCronDelete_Success(t *testing.T) {
+	t.Parallel()
+	var deletedID string
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.deleteJobFn = func(_ context.Context, id string) error {
+			deletedID = id
+			return nil
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/cron/jobs/j1", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronDelete(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Equal(t, "j1", deletedID)
+}
+
+func TestHandleCronDelete_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/cron/jobs/j1", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronDelete(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronDelete_NotFound(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.deleteJobFn = func(_ context.Context, _ string) error {
+			return errors.New("not found")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/cron/jobs/missing", nil)
+	r.SetPathValue("id", "missing")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronDelete(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleCronDelete_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/cron/jobs/j1", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronDelete(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- HandleCronTrigger tests ---
+
+func TestHandleCronTrigger_Success(t *testing.T) {
+	t.Parallel()
+	var triggeredID string
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.triggerJobFn = func(_ context.Context, id string) error {
+			triggeredID = id
+			return nil
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs/j1/trigger", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronTrigger(w, r)
+
+	require.Equal(t, http.StatusAccepted, w.Code)
+	require.Equal(t, "j1", triggeredID)
+}
+
+func TestHandleCronTrigger_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs/j1/trigger", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronTrigger(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronTrigger_NotFound(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.triggerJobFn = func(_ context.Context, _ string) error {
+			return errors.New("job not found")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs/missing/trigger", nil)
+	r.SetPathValue("id", "missing")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronTrigger(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleCronTrigger_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/cron/jobs/j1/trigger", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCronTrigger(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- HandleCronRunHistory tests ---
+
+func TestHandleCronRunHistory_Success(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.runHistoryFn = func(_ context.Context, id string) (any, error) {
+			require.Equal(t, "j1", id)
+			return []map[string]any{{"run_id": "r1", "status": "completed"}}, nil
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/j1/runs", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronRunHistory(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	require.Len(t, result, 1)
+	require.Equal(t, "r1", result[0]["run_id"])
+}
+
+func TestHandleCronRunHistory_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/j1/runs", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeSessionRead)
+
+	api.HandleCronRunHistory(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleCronRunHistory_SchedulerError(t *testing.T) {
+	t.Parallel()
+	api := cronAPIWithMock(func(mc *mockCronScheduler) {
+		mc.runHistoryFn = func(_ context.Context, _ string) (any, error) {
+			return nil, errors.New("db error")
+		}
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/j1/runs", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronRunHistory(w, r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleCronRunHistory_NilScheduler(t *testing.T) {
+	t.Parallel()
+	api := newCronTestAPI(func(d *Deps) {
+		d.Cron = nil
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/cron/jobs/j1/runs", nil)
+	r.SetPathValue("id", "j1")
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleCronRunHistory(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}

--- a/internal/brain/config.go
+++ b/internal/brain/config.go
@@ -26,6 +26,7 @@
 package brain
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -302,85 +303,16 @@ func defaultModelForProtocol(protocol string) string {
 }
 
 // buildConfig constructs a Config from resolved values.
+// Sub-config fields are populated via the configRegistry.
 func buildConfig(apiKey, provider, protocol, model, endpoint string) Config {
-	return Config{
-		Enabled: apiKey != "",
-		Model: ModelConfig{
-			Provider: provider,
-			Protocol: protocol,
-			APIKey:   apiKey,
-			Model:    model,
-			Endpoint: endpoint,
-			TimeoutS: getIntEnv("HOTPLEX_BRAIN_TIMEOUT_S", 30),
-		},
-		Cache: CacheConfig{
-			Enabled: true,
-			Size:    getIntEnv("HOTPLEX_BRAIN_CACHE_SIZE", 1000),
-		},
-		Retry: RetryConfig{
-			Enabled:     true,
-			MaxAttempts: getIntEnv("HOTPLEX_BRAIN_MAX_RETRIES", 3),
-			MinWaitMs:   getIntEnv("HOTPLEX_BRAIN_RETRY_MIN_WAIT_MS", 100),
-			MaxWaitMs:   getIntEnv("HOTPLEX_BRAIN_RETRY_MAX_WAIT_MS", 5000),
-		},
-		Metrics: MetricsConfig{
-			Enabled:        getBoolEnv("HOTPLEX_BRAIN_METRICS_ENABLED", true),
-			ServiceName:    getEnv("HOTPLEX_BRAIN_METRICS_SERVICE_NAME", "hotplex-brain"),
-			ExportInterval: getDurationEnv("HOTPLEX_BRAIN_METRICS_EXPORT_INTERVAL", 10*time.Second),
-		},
-		Cost: CostConfig{
-			Enabled:      getBoolEnv("HOTPLEX_BRAIN_COST_TRACKING_ENABLED", true),
-			EnableBudget: getBoolEnv("HOTPLEX_BRAIN_COST_ENABLE_BUDGET", false),
-		},
-		RateLimit: RateLimitConfig{
-			Enabled:      getBoolEnv("HOTPLEX_BRAIN_RATE_LIMIT_ENABLED", false),
-			RPS:          getFloatEnv("HOTPLEX_BRAIN_RATE_LIMIT_RPS", 10.0),
-			Burst:        getIntEnv("HOTPLEX_BRAIN_RATE_LIMIT_BURST", 20),
-			QueueSize:    getIntEnv("HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_SIZE", 100),
-			QueueTimeout: getDurationEnv("HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_TIMEOUT", 30*time.Second),
-			PerModel:     getBoolEnv("HOTPLEX_BRAIN_RATE_LIMIT_PER_MODEL", false),
-		},
-		Router: RouterConfig{
-			Enabled:      getBoolEnv("HOTPLEX_BRAIN_ROUTER_ENABLED", false),
-			DefaultStage: getEnv("HOTPLEX_BRAIN_ROUTER_STRATEGY", "cost_priority"),
-			Models:       parseRouterModels(getEnv("HOTPLEX_BRAIN_ROUTER_MODELS", "")),
-		},
-		CircuitBreaker: CircuitBreakerConfig{
-			Enabled:     getBoolEnv("HOTPLEX_BRAIN_CIRCUIT_BREAKER_ENABLED", false),
-			MaxFailures: getIntEnv("HOTPLEX_BRAIN_CIRCUIT_BREAKER_MAX_FAILURES", 5),
-			Timeout:     getDurationEnv("HOTPLEX_BRAIN_CIRCUIT_BREAKER_TIMEOUT", 30*time.Second),
-			Interval:    getDurationEnv("HOTPLEX_BRAIN_CIRCUIT_BREAKER_INTERVAL", 60*time.Second),
-		},
-		IntentRouter: IntentRouterFeatureConfig{
-			Enabled:             getBoolEnv("HOTPLEX_BRAIN_INTENT_ROUTER_ENABLED", true),
-			ConfidenceThreshold: getFloatEnv("HOTPLEX_BRAIN_INTENT_ROUTER_CONFIDENCE", 0.7),
-			CacheSize:           getIntEnv("HOTPLEX_BRAIN_INTENT_ROUTER_CACHE_SIZE", 1000),
-		},
-		Memory: MemoryCompressionConfig{
-			Enabled:          getBoolEnv("HOTPLEX_BRAIN_MEMORY_ENABLED", true),
-			TokenThreshold:   getIntEnv("HOTPLEX_BRAIN_MEMORY_TOKEN_THRESHOLD", 8000),
-			TargetTokenCount: getIntEnv("HOTPLEX_BRAIN_MEMORY_TARGET_TOKENS", 2000),
-			PreserveTurns:    getIntEnv("HOTPLEX_BRAIN_MEMORY_PRESERVE_TURNS", 5),
-			MaxSummaryTokens: getIntEnv("HOTPLEX_BRAIN_MEMORY_MAX_SUMMARY_TOKENS", 500),
-			CompressionRatio: getFloatEnv("HOTPLEX_BRAIN_MEMORY_COMPRESSION_RATIO", 0.25),
-			SessionTTL:       getEnv("HOTPLEX_BRAIN_MEMORY_SESSION_TTL", "24h"),
-		},
-		Guard: SafetyGuardFeatureConfig{
-			Enabled:                getBoolEnv("HOTPLEX_BRAIN_GUARD_ENABLED", true),
-			InputGuardEnabled:      getBoolEnv("HOTPLEX_BRAIN_GUARD_INPUT_ENABLED", true),
-			OutputGuardEnabled:     getBoolEnv("HOTPLEX_BRAIN_GUARD_OUTPUT_ENABLED", true),
-			Chat2ConfigEnabled:     getBoolEnv("HOTPLEX_BRAIN_CHAT2CONFIG_ENABLED", false),
-			MaxInputLength:         getIntEnv("HOTPLEX_BRAIN_GUARD_MAX_INPUT_LENGTH", 100000),
-			ScanDepth:              getIntEnv("HOTPLEX_BRAIN_GUARD_SCAN_DEPTH", 3),
-			Sensitivity:            getEnv("HOTPLEX_BRAIN_GUARD_SENSITIVITY", "medium"),
-			AdminUsers:             parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_USERS", "")),
-			AdminChannels:          parseStringList(getEnv("HOTPLEX_BRAIN_ADMIN_CHANNELS", "")),
-			ResponseTimeout:        getDurationEnv("HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT", 10*time.Second),
-			RateLimitRPS:           getFloatEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_RPS", 10.0),
-			RateLimitBurst:         getIntEnv("HOTPLEX_BRAIN_GUARD_RATE_LIMIT_BURST", 20),
-			FailClosedOnBrainError: getBoolEnv("HOTPLEX_BRAIN_GUARD_FAIL_CLOSED_ON_BRAIN_ERROR", false),
-		},
-	}
+	cfg, _ := LoadAndValidate()
+	cfg.Enabled = apiKey != ""
+	cfg.Model.Provider = provider
+	cfg.Model.Protocol = protocol
+	cfg.Model.APIKey = apiKey
+	cfg.Model.Model = model
+	cfg.Model.Endpoint = endpoint
+	return cfg
 }
 
 func parseRouterModels(s string) []llm.ModelConfig {
@@ -434,7 +366,331 @@ func parseStringList(s string) []string {
 	return result
 }
 
-// Helper functions for loading config from environment variables
+// === ConfigSpec Registry ===
+
+// ConfigSpec defines a single environment-driven configuration entry.
+// The registry centralizes all env var lookups, defaults, and validation
+// so that configuration can be inspected, validated, and tested uniformly.
+type ConfigSpec struct {
+	Name     string             // config field name, e.g. "cache_size"
+	EnvKey   string             // e.g. "HOTPLEX_BRAIN_CACHE_SIZE"
+	Default  string             // string representation of default
+	Validate func(string) error // optional validator; nil = accept any value
+}
+
+// configRegistry enumerates every environment variable used by buildConfig.
+// Order matches the struct field order in Config for readability.
+var configRegistry = []ConfigSpec{
+	// Model
+	{Name: "model_timeout_s", EnvKey: "HOTPLEX_BRAIN_TIMEOUT_S", Default: "30",
+		Validate: positiveInt},
+	// Cache
+	{Name: "cache_size", EnvKey: "HOTPLEX_BRAIN_CACHE_SIZE", Default: "1000",
+		Validate: positiveInt},
+	// Retry
+	{Name: "retry_max_attempts", EnvKey: "HOTPLEX_BRAIN_MAX_RETRIES", Default: "3",
+		Validate: positiveInt},
+	{Name: "retry_min_wait_ms", EnvKey: "HOTPLEX_BRAIN_RETRY_MIN_WAIT_MS", Default: "100",
+		Validate: nonNegativeInt},
+	{Name: "retry_max_wait_ms", EnvKey: "HOTPLEX_BRAIN_RETRY_MAX_WAIT_MS", Default: "5000",
+		Validate: positiveInt},
+	// Metrics
+	{Name: "metrics_enabled", EnvKey: "HOTPLEX_BRAIN_METRICS_ENABLED", Default: "true"},
+	{Name: "metrics_service_name", EnvKey: "HOTPLEX_BRAIN_METRICS_SERVICE_NAME", Default: "hotplex-brain"},
+	{Name: "metrics_export_interval", EnvKey: "HOTPLEX_BRAIN_METRICS_EXPORT_INTERVAL", Default: "10s",
+		Validate: positiveDuration},
+	// Cost
+	{Name: "cost_tracking_enabled", EnvKey: "HOTPLEX_BRAIN_COST_TRACKING_ENABLED", Default: "true"},
+	{Name: "cost_enable_budget", EnvKey: "HOTPLEX_BRAIN_COST_ENABLE_BUDGET", Default: "false"},
+	// RateLimit
+	{Name: "rate_limit_enabled", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_ENABLED", Default: "false"},
+	{Name: "rate_limit_rps", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_RPS", Default: "10",
+		Validate: nonNegativeFloat},
+	{Name: "rate_limit_burst", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_BURST", Default: "20",
+		Validate: nonNegativeInt},
+	{Name: "rate_limit_queue_size", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_SIZE", Default: "100",
+		Validate: nonNegativeInt},
+	{Name: "rate_limit_queue_timeout", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_TIMEOUT", Default: "30s",
+		Validate: positiveDuration},
+	{Name: "rate_limit_per_model", EnvKey: "HOTPLEX_BRAIN_RATE_LIMIT_PER_MODEL", Default: "false"},
+	// Router
+	{Name: "router_enabled", EnvKey: "HOTPLEX_BRAIN_ROUTER_ENABLED", Default: "false"},
+	{Name: "router_strategy", EnvKey: "HOTPLEX_BRAIN_ROUTER_STRATEGY", Default: "cost_priority"},
+	{Name: "router_models", EnvKey: "HOTPLEX_BRAIN_ROUTER_MODELS", Default: ""},
+	// CircuitBreaker
+	{Name: "circuit_breaker_enabled", EnvKey: "HOTPLEX_BRAIN_CIRCUIT_BREAKER_ENABLED", Default: "false"},
+	{Name: "circuit_breaker_max_failures", EnvKey: "HOTPLEX_BRAIN_CIRCUIT_BREAKER_MAX_FAILURES", Default: "5",
+		Validate: positiveInt},
+	{Name: "circuit_breaker_timeout", EnvKey: "HOTPLEX_BRAIN_CIRCUIT_BREAKER_TIMEOUT", Default: "30s",
+		Validate: positiveDuration},
+	{Name: "circuit_breaker_interval", EnvKey: "HOTPLEX_BRAIN_CIRCUIT_BREAKER_INTERVAL", Default: "60s",
+		Validate: positiveDuration},
+	// IntentRouter
+	{Name: "intent_router_enabled", EnvKey: "HOTPLEX_BRAIN_INTENT_ROUTER_ENABLED", Default: "true"},
+	{Name: "intent_router_confidence", EnvKey: "HOTPLEX_BRAIN_INTENT_ROUTER_CONFIDENCE", Default: "0.7",
+		Validate: confidenceRange},
+	{Name: "intent_router_cache_size", EnvKey: "HOTPLEX_BRAIN_INTENT_ROUTER_CACHE_SIZE", Default: "1000",
+		Validate: positiveInt},
+	// Memory
+	{Name: "memory_enabled", EnvKey: "HOTPLEX_BRAIN_MEMORY_ENABLED", Default: "true"},
+	{Name: "memory_token_threshold", EnvKey: "HOTPLEX_BRAIN_MEMORY_TOKEN_THRESHOLD", Default: "8000",
+		Validate: positiveInt},
+	{Name: "memory_target_tokens", EnvKey: "HOTPLEX_BRAIN_MEMORY_TARGET_TOKENS", Default: "2000",
+		Validate: positiveInt},
+	{Name: "memory_preserve_turns", EnvKey: "HOTPLEX_BRAIN_MEMORY_PRESERVE_TURNS", Default: "5",
+		Validate: nonNegativeInt},
+	{Name: "memory_max_summary_tokens", EnvKey: "HOTPLEX_BRAIN_MEMORY_MAX_SUMMARY_TOKENS", Default: "500",
+		Validate: positiveInt},
+	{Name: "memory_compression_ratio", EnvKey: "HOTPLEX_BRAIN_MEMORY_COMPRESSION_RATIO", Default: "0.25",
+		Validate: compressionRatioRange},
+	{Name: "memory_session_ttl", EnvKey: "HOTPLEX_BRAIN_MEMORY_SESSION_TTL", Default: "24h"},
+	// Guard
+	{Name: "guard_enabled", EnvKey: "HOTPLEX_BRAIN_GUARD_ENABLED", Default: "true"},
+	{Name: "guard_input_enabled", EnvKey: "HOTPLEX_BRAIN_GUARD_INPUT_ENABLED", Default: "true"},
+	{Name: "guard_output_enabled", EnvKey: "HOTPLEX_BRAIN_GUARD_OUTPUT_ENABLED", Default: "true"},
+	{Name: "chat2config_enabled", EnvKey: "HOTPLEX_BRAIN_CHAT2CONFIG_ENABLED", Default: "false"},
+	{Name: "guard_max_input_length", EnvKey: "HOTPLEX_BRAIN_GUARD_MAX_INPUT_LENGTH", Default: "100000",
+		Validate: nonNegativeInt},
+	{Name: "guard_scan_depth", EnvKey: "HOTPLEX_BRAIN_GUARD_SCAN_DEPTH", Default: "3",
+		Validate: nonNegativeInt},
+	{Name: "guard_sensitivity", EnvKey: "HOTPLEX_BRAIN_GUARD_SENSITIVITY", Default: "medium",
+		Validate: sensitivityLevel},
+	{Name: "guard_response_timeout", EnvKey: "HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT", Default: "10s",
+		Validate: positiveDuration},
+	{Name: "guard_rate_limit_rps", EnvKey: "HOTPLEX_BRAIN_GUARD_RATE_LIMIT_RPS", Default: "10",
+		Validate: nonNegativeFloat},
+	{Name: "guard_rate_limit_burst", EnvKey: "HOTPLEX_BRAIN_GUARD_RATE_LIMIT_BURST", Default: "20",
+		Validate: nonNegativeInt},
+	{Name: "guard_fail_closed_on_brain_error", EnvKey: "HOTPLEX_BRAIN_GUARD_FAIL_CLOSED_ON_BRAIN_ERROR", Default: "false"},
+}
+
+// --- Validation helpers ---
+
+func positiveInt(val string) error {
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return fmt.Errorf("invalid integer %q", val)
+	}
+	if n <= 0 {
+		return fmt.Errorf("must be positive, got %d", n)
+	}
+	return nil
+}
+
+func nonNegativeInt(val string) error {
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return fmt.Errorf("invalid integer %q", val)
+	}
+	if n < 0 {
+		return fmt.Errorf("must be non-negative, got %d", n)
+	}
+	return nil
+}
+
+func nonNegativeFloat(val string) error {
+	n, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return fmt.Errorf("invalid float %q", val)
+	}
+	if n < 0 {
+		return fmt.Errorf("must be non-negative, got %f", n)
+	}
+	return nil
+}
+
+func positiveDuration(val string) error {
+	d, err := parseDuration(val)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", val, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("must be positive, got %s", d)
+	}
+	return nil
+}
+
+func confidenceRange(val string) error {
+	n, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return fmt.Errorf("invalid float %q", val)
+	}
+	if n < 0 || n > 1 {
+		return fmt.Errorf("must be between 0 and 1, got %f", n)
+	}
+	return nil
+}
+
+func compressionRatioRange(val string) error {
+	n, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return fmt.Errorf("invalid float %q", val)
+	}
+	if n <= 0 || n >= 1 {
+		return fmt.Errorf("must be between 0 and 1 exclusive, got %f", n)
+	}
+	return nil
+}
+
+func sensitivityLevel(val string) error {
+	switch val {
+	case "low", "medium", "high":
+		return nil
+	default:
+		return fmt.Errorf("must be low, medium, or high, got %q", val)
+	}
+}
+
+// --- Parse helpers ---
+
+// parseDuration parses a duration string, accepting both Go duration syntax
+// (e.g., "30s", "1m") and bare seconds (e.g., "30").
+func parseDuration(val string) (time.Duration, error) {
+	if d, err := time.ParseDuration(val); err == nil {
+		return d, nil
+	}
+	if n, err := strconv.Atoi(val); err == nil {
+		return time.Duration(n) * time.Second, nil
+	}
+	return 0, fmt.Errorf("invalid duration %q", val)
+}
+
+// ResolveEnv looks up the env var for a spec, falling back to Default.
+// If validation fails it returns the default value.
+func (s ConfigSpec) ResolveEnv() string {
+	val := os.Getenv(s.EnvKey)
+	if val == "" {
+		return s.Default
+	}
+	if s.Validate != nil {
+		if err := s.Validate(val); err != nil {
+			return s.Default
+		}
+	}
+	return val
+}
+
+// LoadAndValidate loads brain config from environment and returns the config
+// along with any validation errors. Errors are non-fatal — the config uses
+// defaults for invalid values and reports all issues.
+func LoadAndValidate() (Config, []error) {
+	// Resolve all env vars through the registry, collecting validation errors.
+	values := make(map[string]string, len(configRegistry))
+	var errs []error
+	for _, spec := range configRegistry {
+		raw := os.Getenv(spec.EnvKey)
+		if raw == "" {
+			values[spec.Name] = spec.Default
+			continue
+		}
+		if spec.Validate != nil {
+			if err := spec.Validate(raw); err != nil {
+				errs = append(errs, fmt.Errorf("%s (%s): %w", spec.Name, spec.EnvKey, err))
+				values[spec.Name] = spec.Default // fall back to default on validation error
+				continue
+			}
+		}
+		values[spec.Name] = raw
+	}
+
+	cfg := Config{
+		Cache: CacheConfig{Enabled: true},
+		Retry: RetryConfig{Enabled: true},
+	}
+
+	cfg.Model.TimeoutS = getInt(values["model_timeout_s"])
+	cfg.Cache.Size = getInt(values["cache_size"])
+	cfg.Retry.MaxAttempts = getInt(values["retry_max_attempts"])
+	cfg.Retry.MinWaitMs = getInt(values["retry_min_wait_ms"])
+	cfg.Retry.MaxWaitMs = getInt(values["retry_max_wait_ms"])
+
+	cfg.Metrics.Enabled = getBool(values["metrics_enabled"])
+	cfg.Metrics.ServiceName = values["metrics_service_name"]
+	cfg.Metrics.ExportInterval = getDuration(values["metrics_export_interval"])
+
+	cfg.Cost.Enabled = getBool(values["cost_tracking_enabled"])
+	cfg.Cost.EnableBudget = getBool(values["cost_enable_budget"])
+
+	cfg.RateLimit.Enabled = getBool(values["rate_limit_enabled"])
+	cfg.RateLimit.RPS = getFloat(values["rate_limit_rps"])
+	cfg.RateLimit.Burst = getInt(values["rate_limit_burst"])
+	cfg.RateLimit.QueueSize = getInt(values["rate_limit_queue_size"])
+	cfg.RateLimit.QueueTimeout = getDuration(values["rate_limit_queue_timeout"])
+	cfg.RateLimit.PerModel = getBool(values["rate_limit_per_model"])
+
+	cfg.Router.Enabled = getBool(values["router_enabled"])
+	cfg.Router.DefaultStage = values["router_strategy"]
+	cfg.Router.Models = parseRouterModels(values["router_models"])
+
+	cfg.CircuitBreaker.Enabled = getBool(values["circuit_breaker_enabled"])
+	cfg.CircuitBreaker.MaxFailures = getInt(values["circuit_breaker_max_failures"])
+	cfg.CircuitBreaker.Timeout = getDuration(values["circuit_breaker_timeout"])
+	cfg.CircuitBreaker.Interval = getDuration(values["circuit_breaker_interval"])
+
+	cfg.IntentRouter.Enabled = getBool(values["intent_router_enabled"])
+	cfg.IntentRouter.ConfidenceThreshold = getFloat(values["intent_router_confidence"])
+	cfg.IntentRouter.CacheSize = getInt(values["intent_router_cache_size"])
+
+	cfg.Memory.Enabled = getBool(values["memory_enabled"])
+	cfg.Memory.TokenThreshold = getInt(values["memory_token_threshold"])
+	cfg.Memory.TargetTokenCount = getInt(values["memory_target_tokens"])
+	cfg.Memory.PreserveTurns = getInt(values["memory_preserve_turns"])
+	cfg.Memory.MaxSummaryTokens = getInt(values["memory_max_summary_tokens"])
+	cfg.Memory.CompressionRatio = getFloat(values["memory_compression_ratio"])
+	cfg.Memory.SessionTTL = values["memory_session_ttl"]
+
+	cfg.Guard.Enabled = getBool(values["guard_enabled"])
+	cfg.Guard.InputGuardEnabled = getBool(values["guard_input_enabled"])
+	cfg.Guard.OutputGuardEnabled = getBool(values["guard_output_enabled"])
+	cfg.Guard.Chat2ConfigEnabled = getBool(values["chat2config_enabled"])
+	cfg.Guard.MaxInputLength = getInt(values["guard_max_input_length"])
+	cfg.Guard.ScanDepth = getInt(values["guard_scan_depth"])
+	cfg.Guard.Sensitivity = values["guard_sensitivity"]
+	cfg.Guard.AdminUsers = parseStringList(os.Getenv("HOTPLEX_BRAIN_ADMIN_USERS"))
+	cfg.Guard.AdminChannels = parseStringList(os.Getenv("HOTPLEX_BRAIN_ADMIN_CHANNELS"))
+	cfg.Guard.ResponseTimeout = getDuration(values["guard_response_timeout"])
+	cfg.Guard.RateLimitRPS = getFloat(values["guard_rate_limit_rps"])
+	cfg.Guard.RateLimitBurst = getInt(values["guard_rate_limit_burst"])
+	cfg.Guard.FailClosedOnBrainError = getBool(values["guard_fail_closed_on_brain_error"])
+
+	return cfg, errs
+}
+
+// --- Value parse helpers (string → typed) ---
+
+func getBool(val string) bool {
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return b
+}
+
+func getInt(val string) int {
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func getFloat(val string) float64 {
+	n, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func getDuration(val string) time.Duration {
+	d, err := parseDuration(val)
+	if err != nil {
+		return 0
+	}
+	return d
+}
+
+// --- Legacy env helpers (kept for backward compat with LoadConfigFromEnv) ---
 
 func getEnv(key, fallback string) string {
 	if val := os.Getenv(key); val != "" {
@@ -473,13 +729,8 @@ func getFloatEnv(key string, fallback float64) float64 {
 
 func getDurationEnv(key string, fallback time.Duration) time.Duration {
 	if val := os.Getenv(key); val != "" {
-		// Try parsing as duration string (e.g., "30s", "1m")
-		if d, err := time.ParseDuration(val); err == nil {
+		if d, err := parseDuration(val); err == nil {
 			return d
-		}
-		// Try parsing as seconds
-		if n, err := strconv.Atoi(val); err == nil {
-			return time.Duration(n) * time.Second
 		}
 	}
 	return fallback

--- a/internal/brain/config_test.go
+++ b/internal/brain/config_test.go
@@ -1,0 +1,245 @@
+package brain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAndValidate_Defaults(t *testing.T) {
+	cfg, errs := LoadAndValidate()
+	require.Empty(t, errs, "defaults should produce no validation errors")
+
+	assert.Equal(t, 30, cfg.Model.TimeoutS)
+	assert.Equal(t, true, cfg.Cache.Enabled)
+	assert.Equal(t, 1000, cfg.Cache.Size)
+	assert.Equal(t, true, cfg.Retry.Enabled)
+	assert.Equal(t, 3, cfg.Retry.MaxAttempts)
+	assert.Equal(t, 100, cfg.Retry.MinWaitMs)
+	assert.Equal(t, 5000, cfg.Retry.MaxWaitMs)
+	assert.Equal(t, true, cfg.Metrics.Enabled)
+	assert.Equal(t, "hotplex-brain", cfg.Metrics.ServiceName)
+	assert.Equal(t, 10*time.Second, cfg.Metrics.ExportInterval)
+	assert.Equal(t, true, cfg.Cost.Enabled)
+	assert.Equal(t, false, cfg.Cost.EnableBudget)
+	assert.Equal(t, false, cfg.RateLimit.Enabled)
+	assert.Equal(t, 10.0, cfg.RateLimit.RPS)
+	assert.Equal(t, 20, cfg.RateLimit.Burst)
+	assert.Equal(t, 100, cfg.RateLimit.QueueSize)
+	assert.Equal(t, 30*time.Second, cfg.RateLimit.QueueTimeout)
+	assert.Equal(t, false, cfg.RateLimit.PerModel)
+	assert.Equal(t, false, cfg.Router.Enabled)
+	assert.Equal(t, "cost_priority", cfg.Router.DefaultStage)
+	assert.Nil(t, cfg.Router.Models)
+	assert.Equal(t, false, cfg.CircuitBreaker.Enabled)
+	assert.Equal(t, 5, cfg.CircuitBreaker.MaxFailures)
+	assert.Equal(t, 30*time.Second, cfg.CircuitBreaker.Timeout)
+	assert.Equal(t, 60*time.Second, cfg.CircuitBreaker.Interval)
+	assert.Equal(t, true, cfg.IntentRouter.Enabled)
+	assert.Equal(t, 0.7, cfg.IntentRouter.ConfidenceThreshold)
+	assert.Equal(t, 1000, cfg.IntentRouter.CacheSize)
+	assert.Equal(t, true, cfg.Memory.Enabled)
+	assert.Equal(t, 8000, cfg.Memory.TokenThreshold)
+	assert.Equal(t, 2000, cfg.Memory.TargetTokenCount)
+	assert.Equal(t, 5, cfg.Memory.PreserveTurns)
+	assert.Equal(t, 500, cfg.Memory.MaxSummaryTokens)
+	assert.Equal(t, 0.25, cfg.Memory.CompressionRatio)
+	assert.Equal(t, "24h", cfg.Memory.SessionTTL)
+	assert.Equal(t, true, cfg.Guard.Enabled)
+	assert.Equal(t, true, cfg.Guard.InputGuardEnabled)
+	assert.Equal(t, true, cfg.Guard.OutputGuardEnabled)
+	assert.Equal(t, false, cfg.Guard.Chat2ConfigEnabled)
+	assert.Equal(t, 100000, cfg.Guard.MaxInputLength)
+	assert.Equal(t, 3, cfg.Guard.ScanDepth)
+	assert.Equal(t, "medium", cfg.Guard.Sensitivity)
+	assert.Nil(t, cfg.Guard.AdminUsers)
+	assert.Nil(t, cfg.Guard.AdminChannels)
+	assert.Equal(t, 10*time.Second, cfg.Guard.ResponseTimeout)
+	assert.Equal(t, 10.0, cfg.Guard.RateLimitRPS)
+	assert.Equal(t, 20, cfg.Guard.RateLimitBurst)
+	assert.Equal(t, false, cfg.Guard.FailClosedOnBrainError)
+}
+
+func TestLoadAndValidate_EnvOverrides(t *testing.T) {
+
+	envSets := map[string]string{
+		"HOTPLEX_BRAIN_TIMEOUT_S":                        "60",
+		"HOTPLEX_BRAIN_CACHE_SIZE":                       "500",
+		"HOTPLEX_BRAIN_MAX_RETRIES":                      "5",
+		"HOTPLEX_BRAIN_RETRY_MIN_WAIT_MS":                "200",
+		"HOTPLEX_BRAIN_RETRY_MAX_WAIT_MS":                "10000",
+		"HOTPLEX_BRAIN_METRICS_ENABLED":                  "false",
+		"HOTPLEX_BRAIN_METRICS_SERVICE_NAME":             "test-svc",
+		"HOTPLEX_BRAIN_METRICS_EXPORT_INTERVAL":          "30s",
+		"HOTPLEX_BRAIN_COST_TRACKING_ENABLED":            "false",
+		"HOTPLEX_BRAIN_COST_ENABLE_BUDGET":               "true",
+		"HOTPLEX_BRAIN_RATE_LIMIT_ENABLED":               "true",
+		"HOTPLEX_BRAIN_RATE_LIMIT_RPS":                   "50.5",
+		"HOTPLEX_BRAIN_RATE_LIMIT_BURST":                 "100",
+		"HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_SIZE":            "200",
+		"HOTPLEX_BRAIN_RATE_LIMIT_QUEUE_TIMEOUT":         "1m",
+		"HOTPLEX_BRAIN_RATE_LIMIT_PER_MODEL":             "true",
+		"HOTPLEX_BRAIN_ROUTER_ENABLED":                   "true",
+		"HOTPLEX_BRAIN_ROUTER_STRATEGY":                  "latency_priority",
+		"HOTPLEX_BRAIN_CIRCUIT_BREAKER_ENABLED":          "true",
+		"HOTPLEX_BRAIN_CIRCUIT_BREAKER_MAX_FAILURES":     "10",
+		"HOTPLEX_BRAIN_CIRCUIT_BREAKER_TIMEOUT":          "45s",
+		"HOTPLEX_BRAIN_CIRCUIT_BREAKER_INTERVAL":         "2m",
+		"HOTPLEX_BRAIN_INTENT_ROUTER_ENABLED":            "false",
+		"HOTPLEX_BRAIN_INTENT_ROUTER_CONFIDENCE":         "0.9",
+		"HOTPLEX_BRAIN_INTENT_ROUTER_CACHE_SIZE":         "500",
+		"HOTPLEX_BRAIN_MEMORY_ENABLED":                   "false",
+		"HOTPLEX_BRAIN_MEMORY_TOKEN_THRESHOLD":           "16000",
+		"HOTPLEX_BRAIN_MEMORY_TARGET_TOKENS":             "4000",
+		"HOTPLEX_BRAIN_MEMORY_PRESERVE_TURNS":            "10",
+		"HOTPLEX_BRAIN_MEMORY_MAX_SUMMARY_TOKENS":        "1000",
+		"HOTPLEX_BRAIN_MEMORY_COMPRESSION_RATIO":         "0.5",
+		"HOTPLEX_BRAIN_MEMORY_SESSION_TTL":               "48h",
+		"HOTPLEX_BRAIN_GUARD_ENABLED":                    "false",
+		"HOTPLEX_BRAIN_GUARD_INPUT_ENABLED":              "false",
+		"HOTPLEX_BRAIN_GUARD_OUTPUT_ENABLED":             "false",
+		"HOTPLEX_BRAIN_CHAT2CONFIG_ENABLED":              "true",
+		"HOTPLEX_BRAIN_GUARD_MAX_INPUT_LENGTH":           "50000",
+		"HOTPLEX_BRAIN_GUARD_SCAN_DEPTH":                 "5",
+		"HOTPLEX_BRAIN_GUARD_SENSITIVITY":                "high",
+		"HOTPLEX_BRAIN_ADMIN_USERS":                      "u1,u2",
+		"HOTPLEX_BRAIN_ADMIN_CHANNELS":                   "c1,c2",
+		"HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT":           "20s",
+		"HOTPLEX_BRAIN_GUARD_RATE_LIMIT_RPS":             "5.0",
+		"HOTPLEX_BRAIN_GUARD_RATE_LIMIT_BURST":           "10",
+		"HOTPLEX_BRAIN_GUARD_FAIL_CLOSED_ON_BRAIN_ERROR": "true",
+	}
+	for k, v := range envSets {
+		t.Setenv(k, v)
+	}
+
+	cfg, errs := LoadAndValidate()
+	require.Empty(t, errs)
+
+	assert.Equal(t, 60, cfg.Model.TimeoutS)
+	assert.Equal(t, 500, cfg.Cache.Size)
+	assert.Equal(t, 5, cfg.Retry.MaxAttempts)
+	assert.Equal(t, 200, cfg.Retry.MinWaitMs)
+	assert.Equal(t, 10000, cfg.Retry.MaxWaitMs)
+	assert.False(t, cfg.Metrics.Enabled)
+	assert.Equal(t, "test-svc", cfg.Metrics.ServiceName)
+	assert.Equal(t, 30*time.Second, cfg.Metrics.ExportInterval)
+	assert.False(t, cfg.Cost.Enabled)
+	assert.True(t, cfg.Cost.EnableBudget)
+	assert.True(t, cfg.RateLimit.Enabled)
+	assert.Equal(t, 50.5, cfg.RateLimit.RPS)
+	assert.Equal(t, 100, cfg.RateLimit.Burst)
+	assert.Equal(t, 200, cfg.RateLimit.QueueSize)
+	assert.Equal(t, time.Minute, cfg.RateLimit.QueueTimeout)
+	assert.True(t, cfg.RateLimit.PerModel)
+	assert.True(t, cfg.Router.Enabled)
+	assert.Equal(t, "latency_priority", cfg.Router.DefaultStage)
+	assert.True(t, cfg.CircuitBreaker.Enabled)
+	assert.Equal(t, 10, cfg.CircuitBreaker.MaxFailures)
+	assert.Equal(t, 45*time.Second, cfg.CircuitBreaker.Timeout)
+	assert.Equal(t, 2*time.Minute, cfg.CircuitBreaker.Interval)
+	assert.False(t, cfg.IntentRouter.Enabled)
+	assert.Equal(t, 0.9, cfg.IntentRouter.ConfidenceThreshold)
+	assert.Equal(t, 500, cfg.IntentRouter.CacheSize)
+	assert.False(t, cfg.Memory.Enabled)
+	assert.Equal(t, 16000, cfg.Memory.TokenThreshold)
+	assert.Equal(t, 4000, cfg.Memory.TargetTokenCount)
+	assert.Equal(t, 10, cfg.Memory.PreserveTurns)
+	assert.Equal(t, 1000, cfg.Memory.MaxSummaryTokens)
+	assert.Equal(t, 0.5, cfg.Memory.CompressionRatio)
+	assert.Equal(t, "48h", cfg.Memory.SessionTTL)
+	assert.False(t, cfg.Guard.Enabled)
+	assert.False(t, cfg.Guard.InputGuardEnabled)
+	assert.False(t, cfg.Guard.OutputGuardEnabled)
+	assert.True(t, cfg.Guard.Chat2ConfigEnabled)
+	assert.Equal(t, 50000, cfg.Guard.MaxInputLength)
+	assert.Equal(t, 5, cfg.Guard.ScanDepth)
+	assert.Equal(t, "high", cfg.Guard.Sensitivity)
+	assert.Equal(t, []string{"u1", "u2"}, cfg.Guard.AdminUsers)
+	assert.Equal(t, []string{"c1", "c2"}, cfg.Guard.AdminChannels)
+	assert.Equal(t, 20*time.Second, cfg.Guard.ResponseTimeout)
+	assert.Equal(t, 5.0, cfg.Guard.RateLimitRPS)
+	assert.Equal(t, 10, cfg.Guard.RateLimitBurst)
+	assert.True(t, cfg.Guard.FailClosedOnBrainError)
+}
+
+func TestLoadAndValidate_InvalidValuesFallBack(t *testing.T) {
+
+	t.Setenv("HOTPLEX_BRAIN_TIMEOUT_S", "-1")
+	t.Setenv("HOTPLEX_BRAIN_CACHE_SIZE", "abc")
+	t.Setenv("HOTPLEX_BRAIN_INTENT_ROUTER_CONFIDENCE", "5.0")
+	t.Setenv("HOTPLEX_BRAIN_MEMORY_COMPRESSION_RATIO", "1.5")
+	t.Setenv("HOTPLEX_BRAIN_GUARD_SENSITIVITY", "invalid")
+	t.Setenv("HOTPLEX_BRAIN_CIRCUIT_BREAKER_MAX_FAILURES", "0")
+
+	cfg, errs := LoadAndValidate()
+
+	require.Len(t, errs, 6, "should report one error per invalid env var")
+
+	assert.Equal(t, 30, cfg.Model.TimeoutS, "negative timeout should fall back to default 30")
+	assert.Equal(t, 1000, cfg.Cache.Size, "non-integer should fall back to default 1000")
+	assert.Equal(t, 0.7, cfg.IntentRouter.ConfidenceThreshold, "out-of-range confidence should fall back")
+	assert.Equal(t, 0.25, cfg.Memory.CompressionRatio, "out-of-range ratio should fall back")
+	assert.Equal(t, "medium", cfg.Guard.Sensitivity, "invalid sensitivity should fall back")
+	assert.Equal(t, 5, cfg.CircuitBreaker.MaxFailures, "zero max failures should fall back")
+}
+
+func TestLoadAndValidate_DurationParsing(t *testing.T) {
+
+	t.Setenv("HOTPLEX_BRAIN_GUARD_RESPONSE_TIMEOUT", "15")
+	cfg, errs := LoadAndValidate()
+	require.Empty(t, errs)
+	assert.Equal(t, 15*time.Second, cfg.Guard.ResponseTimeout, "bare seconds should parse as seconds")
+}
+
+func TestConfigRegistry_Coverage(t *testing.T) {
+
+	// Verify every spec has a non-empty name and env key.
+	for _, spec := range configRegistry {
+		assert.NotEmpty(t, spec.Name, "spec should have a name")
+		assert.NotEmpty(t, spec.EnvKey, "spec %s should have an env key", spec.Name)
+		if spec.Validate != nil {
+			assert.NoError(t, spec.Validate(spec.Default),
+				"spec %s: default %q should pass validation", spec.Name, spec.Default)
+		}
+	}
+}
+
+func TestValidationHelpers(t *testing.T) {
+
+	assert.NoError(t, positiveInt("1"))
+	assert.Error(t, positiveInt("0"))
+	assert.Error(t, positiveInt("-1"))
+	assert.Error(t, positiveInt("abc"))
+
+	assert.NoError(t, nonNegativeInt("0"))
+	assert.NoError(t, nonNegativeInt("5"))
+	assert.Error(t, nonNegativeInt("-1"))
+
+	assert.NoError(t, nonNegativeFloat("0"))
+	assert.NoError(t, nonNegativeFloat("3.14"))
+	assert.Error(t, nonNegativeFloat("-0.1"))
+
+	assert.NoError(t, positiveDuration("1s"))
+	assert.NoError(t, positiveDuration("1"))
+	assert.Error(t, positiveDuration("0"))
+	assert.Error(t, positiveDuration("0s"))
+
+	assert.NoError(t, confidenceRange("0"))
+	assert.NoError(t, confidenceRange("0.5"))
+	assert.NoError(t, confidenceRange("1"))
+	assert.Error(t, confidenceRange("-0.1"))
+	assert.Error(t, confidenceRange("1.1"))
+
+	assert.NoError(t, compressionRatioRange("0.1"))
+	assert.NoError(t, compressionRatioRange("0.9"))
+	assert.Error(t, compressionRatioRange("0"))
+	assert.Error(t, compressionRatioRange("1"))
+
+	assert.NoError(t, sensitivityLevel("low"))
+	assert.NoError(t, sensitivityLevel("medium"))
+	assert.NoError(t, sensitivityLevel("high"))
+	assert.Error(t, sensitivityLevel("extreme"))
+}

--- a/internal/brain/init.go
+++ b/internal/brain/init.go
@@ -20,6 +20,11 @@ import (
 func Init(logger *slog.Logger) error {
 	config := LoadConfigFromEnv()
 
+	_, validationErrs := LoadAndValidate()
+	for _, err := range validationErrs {
+		logger.Warn("Brain config validation warning", "error", err)
+	}
+
 	if !config.Enabled {
 		logger.Debug("Native Brain is disabled or missing configuration. Skipping.")
 		return nil

--- a/internal/messaging/toolfmt/toolfmt.go
+++ b/internal/messaging/toolfmt/toolfmt.go
@@ -105,7 +105,7 @@ func formatSimple(prefix, key string) callFormatter {
 		if val == "" {
 			return prefix + "..."
 		}
-		return prefix + " " + val
+		return prefix + " " + firstLine(val)
 	}
 }
 
@@ -114,15 +114,19 @@ func formatBash(input map[string]any) string {
 	if cmd == "" {
 		return "⏳ Running command..."
 	}
-	// Only show first line of multi-line commands to keep the activity strip clean.
-	if idx := strings.IndexByte(cmd, '\n'); idx >= 0 {
-		cmd = cmd[:idx]
-	}
-	return "⏳ " + cmd
+	return "⏳ " + firstLine(cmd)
+}
+
+// firstLine returns the first line of s, preventing multi-line content from
+// garbling single-line display areas like the Feishu tool_activity strip.
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+	return line
 }
 
 func formatGrep(input map[string]any) string {
 	pattern, _ := input["pattern"].(string)
+	pattern = firstLine(pattern)
 	if pattern == "" {
 		return "🔍 Searching..."
 	}
@@ -144,7 +148,7 @@ func formatGlob(input map[string]any) string {
 func formatAgent(input map[string]any) string {
 	desc, _ := input["description"].(string)
 	if desc != "" {
-		return "🤖 " + desc
+		return "🤖 " + firstLine(desc)
 	}
 	subagent, _ := input["subagent_type"].(string)
 	if subagent != "" {
@@ -232,9 +236,9 @@ func formatTodoWrite(input map[string]any) string {
 		case "completed":
 			completed++
 		case "in_progress":
-			label := t.activeForm
+			label := firstLine(t.activeForm)
 			if label == "" {
-				label = t.content
+				label = firstLine(t.content)
 			}
 			if label != "" {
 				inProgress = append(inProgress, label)
@@ -262,7 +266,7 @@ func formatFallbackCall(name string, input map[string]any) string {
 	sort.Strings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
-		val := fmt.Sprintf("%v", input[k])
+		val := firstLine(fmt.Sprintf("%v", input[k]))
 		parts = append(parts, k+"="+TruncateRunes(ShortenPath(val), 30))
 	}
 	return TruncateRunes(name+"("+strings.Join(parts, ", ")+")", 60)

--- a/internal/messaging/toolfmt/toolfmt_test.go
+++ b/internal/messaging/toolfmt/toolfmt_test.go
@@ -32,6 +32,7 @@ func TestFormatCall(t *testing.T) {
 		{"Grep with path", "Grep", map[string]any{"pattern": "func main", "path": "src/"}, `🔍 "func main" in src`},
 		{"Grep pattern only", "Grep", map[string]any{"pattern": "hello"}, `🔍 "hello"`},
 		{"Grep no pattern", "Grep", map[string]any{}, "🔍 Searching..."},
+		{"Grep multiline pattern", "Grep", map[string]any{"pattern": "func \\w+\nsecond line"}, `🔍 "func \w+"`},
 
 		// Glob
 		{"Glob with pattern", "Glob", map[string]any{"pattern": "**/*.go"}, "📂 **/*.go"},
@@ -39,11 +40,13 @@ func TestFormatCall(t *testing.T) {
 
 		// Agent
 		{"Agent with description", "Agent", map[string]any{"description": "code-review"}, "🤖 code-review"},
+		{"Agent multiline desc", "Agent", map[string]any{"description": "review\ncode"}, "🤖 review"},
 		{"Agent with subagent_type", "Agent", map[string]any{"subagent_type": "Explore"}, "🤖 Explore"},
 		{"Agent no info", "Agent", map[string]any{}, "🤖 Spawning agent..."},
 
 		// WebSearch / WebFetch
 		{"WebSearch with query", "WebSearch", map[string]any{"query": "golang generics"}, "🌐 Searching golang generics"},
+		{"WebSearch multiline query", "WebSearch", map[string]any{"query": "how to\nuse generics"}, "🌐 Searching how to"},
 		{"WebFetch with url", "WebFetch", map[string]any{"url": "https://example.com"}, "🌐 Fetching https://example.com"},
 		{"WebSearch no query", "WebSearch", map[string]any{}, "🌐 Searching..."},
 

--- a/internal/service/command_runner_test.go
+++ b/internal/service/command_runner_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockCommandRunner struct {
+	lookPathFn       func(string) (string, error)
+	combinedOutputFn func(string, ...string) ([]byte, error)
+	runFn            func(string, ...string) error
+}
+
+func (m mockCommandRunner) LookPath(file string) (string, error) {
+	return m.lookPathFn(file)
+}
+
+func (m mockCommandRunner) CombinedOutput(name string, args ...string) ([]byte, error) {
+	return m.combinedOutputFn(name, args...)
+}
+
+func (m mockCommandRunner) Run(name string, args ...string) error {
+	return m.runFn(name, args...)
+}
+
+func TestResolveBinaryPath_LookPathFound(t *testing.T) {
+	t.Parallel()
+	runner := mockCommandRunner{
+		lookPathFn: func(file string) (string, error) {
+			return "/usr/local/bin/hotplex", nil
+		},
+	}
+	path, err := resolveBinaryPath(runner)
+	require.NoError(t, err)
+	require.Contains(t, path, "hotplex")
+}
+
+func TestResolveBinaryPath_LookPathFails_FallbackToExecutable(t *testing.T) {
+	t.Parallel()
+	runner := mockCommandRunner{
+		lookPathFn: func(file string) (string, error) {
+			return "", errors.New("not found")
+		},
+	}
+	path, err := resolveBinaryPath(runner)
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
+}
+
+func TestRealRunner_LookPath(t *testing.T) {
+	t.Parallel()
+	runner := realRunner{}
+	p, err := runner.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not in PATH: %v", err)
+	}
+	require.NotEmpty(t, p)
+}
+
+func TestMockRunner_SystemctlCombinedOutput(t *testing.T) {
+	t.Parallel()
+	runner := mockCommandRunner{
+		combinedOutputFn: func(name string, args ...string) ([]byte, error) {
+			require.Equal(t, "systemctl", name)
+			require.Contains(t, args, "is-active")
+			return []byte("active\n"), nil
+		},
+	}
+	out, err := runner.CombinedOutput("systemctl", "is-active", "hotplex")
+	require.NoError(t, err)
+	require.Equal(t, "active\n", string(out))
+}
+
+func TestMockRunner_RunError(t *testing.T) {
+	t.Parallel()
+	expectedErr := errors.New("command failed")
+	runner := mockCommandRunner{
+		runFn: func(name string, args ...string) error {
+			return expectedErr
+		},
+	}
+	err := runner.Run("false")
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestCommandRunner_Interface(t *testing.T) {
+	t.Parallel()
+	var _ CommandRunner = realRunner{}
+	var _ CommandRunner = mockCommandRunner{}
+}

--- a/internal/service/manager_darwin.go
+++ b/internal/service/manager_darwin.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 )
 
-type darwinManager struct{}
+type darwinManager struct {
+	run CommandRunner
+}
 
 func NewManager() Manager {
-	return &darwinManager{}
+	return &darwinManager{run: realRunner{}}
 }
 
 func (m *darwinManager) Install(opts InstallOptions) error {
@@ -32,18 +34,18 @@ func (m *darwinManager) Install(opts InstallOptions) error {
 		return err
 	}
 
-	if _, err := exec.LookPath("launchctl"); err != nil {
+	if _, err := m.run.LookPath("launchctl"); err != nil {
 		return fmt.Errorf("launchctl not found")
 	}
 
 	label := launchdLabel(opts.Name, opts.Level)
-	out, err := exec.Command("launchctl", "load", "-w", plistPath).CombinedOutput()
+	out, err := m.run.CombinedOutput("launchctl", "load", "-w", plistPath)
 	if err != nil {
 		_ = os.Remove(plistPath)
 		return fmt.Errorf("launchctl load: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
-	_ = exec.Command("launchctl", "start", label).Run()
+	_ = m.run.Run("launchctl", "start", label)
 	return nil
 }
 
@@ -57,7 +59,7 @@ func (m *darwinManager) Uninstall(name string, level Level) error {
 		return fmt.Errorf("service not installed at %s", plistPath)
 	}
 
-	if err := stopAndUnload(plistPath, name, level); err != nil {
+	if err := m.stopAndUnload(plistPath, name, level); err != nil {
 		return err
 	}
 
@@ -80,7 +82,7 @@ func (m *darwinManager) Status(name string, level Level) (*Status, error) {
 	s.Installed = true
 
 	label := launchdLabel(name, level)
-	out, err := exec.Command("launchctl", "list", label).CombinedOutput()
+	out, err := m.run.CombinedOutput("launchctl", "list", label)
 	if err != nil {
 		s.Running = false
 		s.StatusText = "stopped"
@@ -125,10 +127,10 @@ func (m *darwinManager) Start(name string, level Level) error {
 	}
 
 	label := launchdLabel(name, level)
-	out, err := exec.Command("launchctl", "load", "-w", plistPath).CombinedOutput()
+	out, err := m.run.CombinedOutput("launchctl", "load", "-w", plistPath)
 	if err != nil {
 		if strings.Contains(string(out), "already loaded") {
-			if err := exec.Command("launchctl", "start", label).Run(); err != nil {
+			if err := m.run.Run("launchctl", "start", label); err != nil {
 				return fmt.Errorf("launchctl start: %w", err)
 			}
 			return nil
@@ -146,15 +148,14 @@ func (m *darwinManager) Stop(name string, level Level) error {
 	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 		return ErrNotInstalled
 	}
-	return stopAndUnload(plistPath, name, level)
+	return m.stopAndUnload(plistPath, name, level)
 }
 
-// stopAndUnload stops and unloads a launchd service. Shared by Stop and Uninstall.
-func stopAndUnload(plistPath, name string, level Level) error {
+func (m *darwinManager) stopAndUnload(plistPath, name string, level Level) error {
 	label := launchdLabel(name, level)
-	_ = exec.Command("launchctl", "stop", label).Run()
+	_ = m.run.Run("launchctl", "stop", label)
 
-	out, err := exec.Command("launchctl", "unload", plistPath).CombinedOutput()
+	out, err := m.run.CombinedOutput("launchctl", "unload", plistPath)
 	if err != nil {
 		return fmt.Errorf("launchctl unload: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -173,8 +174,6 @@ func (m *darwinManager) Logs(name string, level Level, follow bool, lines int) e
 	stderrLog := filepath.Join(dir, "launchd.stderr.log")
 	stdoutLog := filepath.Join(dir, "launchd.stdout.log")
 
-	// Prefer stderr log: slog writes to os.Stderr (application logs).
-	// Fall back to stdout if stderr log doesn't exist yet (banner-only startup).
 	logFile := stderrLog
 	if _, err := os.Stat(logFile); os.IsNotExist(err) {
 		logFile = stdoutLog

--- a/internal/service/manager_linux.go
+++ b/internal/service/manager_linux.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 )
 
-type linuxManager struct{}
+type linuxManager struct {
+	run CommandRunner
+}
 
 func NewManager() Manager {
-	return &linuxManager{}
+	return &linuxManager{run: realRunner{}}
 }
 
 func (m *linuxManager) Install(opts InstallOptions) error {
@@ -27,7 +29,7 @@ func (m *linuxManager) Install(opts InstallOptions) error {
 		return fmt.Errorf("service already installed at %s (uninstall first)", unitPath)
 	}
 
-	if _, err := exec.LookPath("systemctl"); err != nil {
+	if _, err := m.run.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("systemctl not found (systemd may not be available)")
 	}
 
@@ -36,16 +38,16 @@ func (m *linuxManager) Install(opts InstallOptions) error {
 		return err
 	}
 
-	if out, err := systemctl(opts.Level, "daemon-reload"); err != nil {
+	if out, err := m.systemctl(opts.Level, "daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl daemon-reload: %s: %w", out, err)
 	}
 
-	if out, err := systemctl(opts.Level, "enable", opts.Name); err != nil {
+	if out, err := m.systemctl(opts.Level, "enable", opts.Name); err != nil {
 		return fmt.Errorf("systemctl enable: %s: %w", out, err)
 	}
 
 	if opts.Level == LevelUser {
-		_ = enableLinger()
+		_ = m.enableLinger()
 	}
 
 	return nil
@@ -61,14 +63,14 @@ func (m *linuxManager) Uninstall(name string, level Level) error {
 		return fmt.Errorf("service not installed at %s", unitPath)
 	}
 
-	_, _ = systemctl(level, "stop", name)
-	_, _ = systemctl(level, "disable", name)
+	_, _ = m.systemctl(level, "stop", name)
+	_, _ = m.systemctl(level, "disable", name)
 
 	if err := os.Remove(unitPath); err != nil {
 		return fmt.Errorf("remove unit: %w", err)
 	}
 
-	_, _ = systemctl(level, "daemon-reload")
+	_, _ = m.systemctl(level, "daemon-reload")
 	return nil
 }
 
@@ -87,13 +89,13 @@ func (m *linuxManager) Status(name string, level Level) (*Status, error) {
 	}
 	s.Installed = true
 
-	out, _ := systemctl(level, "is-active", name)
+	out, _ := m.systemctl(level, "is-active", name)
 	activeText := strings.TrimSpace(out)
 	s.Running = activeText == "active"
 	s.StatusText = activeText
 
 	if s.Running {
-		pidOut, _ := systemctl(level, "show", name, "--property=MainPID", "--value")
+		pidOut, _ := m.systemctl(level, "show", name, "--property=MainPID", "--value")
 		if pid, err := strconv.Atoi(strings.TrimSpace(pidOut)); err == nil && pid > 0 {
 			s.PID = pid
 		}
@@ -117,18 +119,18 @@ func (m *linuxManager) unitPath(name string, level Level) (string, error) {
 	}
 }
 
-func systemctl(level Level, args ...string) (string, error) {
+func (m *linuxManager) systemctl(level Level, args ...string) (string, error) {
 	var cmdArgs []string
 	if level == LevelUser {
 		cmdArgs = append(cmdArgs, "--user")
 	}
 	cmdArgs = append(cmdArgs, args...)
-	out, err := exec.Command("systemctl", cmdArgs...).CombinedOutput()
+	out, err := m.run.CombinedOutput("systemctl", cmdArgs...)
 	return strings.TrimSpace(string(out)), err
 }
 
 func (m *linuxManager) Start(name string, level Level) error {
-	out, err := systemctl(level, "start", name)
+	out, err := m.systemctl(level, "start", name)
 	if err != nil {
 		return fmt.Errorf("systemctl start: %s: %w", out, err)
 	}
@@ -136,7 +138,7 @@ func (m *linuxManager) Start(name string, level Level) error {
 }
 
 func (m *linuxManager) Stop(name string, level Level) error {
-	out, err := systemctl(level, "stop", name)
+	out, err := m.systemctl(level, "stop", name)
 	if err != nil {
 		return fmt.Errorf("systemctl stop: %s: %w", out, err)
 	}
@@ -144,7 +146,7 @@ func (m *linuxManager) Stop(name string, level Level) error {
 }
 
 func (m *linuxManager) Restart(name string, level Level) error {
-	out, err := systemctl(level, "restart", name)
+	out, err := m.systemctl(level, "restart", name)
 	if err != nil {
 		return fmt.Errorf("systemctl restart: %s: %w", out, err)
 	}
@@ -168,7 +170,7 @@ func (m *linuxManager) Logs(name string, level Level, follow bool, lines int) er
 	return cmd.Run()
 }
 
-func enableLinger() error {
+func (m *linuxManager) enableLinger() error {
 	uid := os.Getuid()
-	return exec.Command("loginctl", "enable-linger", strconv.Itoa(uid)).Run()
+	return m.run.Run("loginctl", "enable-linger", strconv.Itoa(uid))
 }

--- a/internal/service/manager_windows.go
+++ b/internal/service/manager_windows.go
@@ -13,10 +13,12 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
-type windowsManager struct{}
+type windowsManager struct {
+	run CommandRunner
+}
 
 func NewManager() Manager {
-	return &windowsManager{}
+	return &windowsManager{run: realRunner{}}
 }
 
 func connectSCM() (*mgr.Mgr, error) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -7,6 +7,22 @@ import (
 	"path/filepath"
 )
 
+// CommandRunner abstracts OS command execution for testability.
+type CommandRunner interface {
+	LookPath(file string) (string, error)
+	CombinedOutput(name string, args ...string) ([]byte, error)
+	Run(name string, args ...string) error
+}
+
+// realRunner is the production implementation using os/exec.
+type realRunner struct{}
+
+func (realRunner) LookPath(file string) (string, error) { return exec.LookPath(file) }
+func (realRunner) CombinedOutput(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+func (realRunner) Run(name string, args ...string) error { return exec.Command(name, args...).Run() }
+
 type Level string
 
 const (
@@ -53,10 +69,11 @@ type Manager interface {
 }
 
 func ResolveBinaryPath() (string, error) {
-	// Prefer the binary found in PATH (standard deployment location).
-	// This avoids capturing a build-directory path when the user runs
-	// ./bin/hotplex-linux-amd64 service install.
-	if p, err := exec.LookPath("hotplex"); err == nil {
+	return resolveBinaryPath(realRunner{})
+}
+
+func resolveBinaryPath(runner CommandRunner) (string, error) {
+	if p, err := runner.LookPath("hotplex"); err == nil {
 		if abs, err := filepath.Abs(p); err == nil {
 			if resolved, err := filepath.EvalSymlinks(abs); err == nil {
 				return resolved, nil
@@ -66,7 +83,6 @@ func ResolveBinaryPath() (string, error) {
 		return p, nil
 	}
 
-	// Fallback: resolve the currently running executable.
 	exe, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve binary: %w", err)


### PR DESCRIPTION
## Summary

3 lightweight improvements across independent modules:

- **#351**: Replace 35+ `os.Getenv` calls in brain config with ConfigSpec registry + startup validation
- **#382**: Add test coverage for admin cron handlers (28 tests, previously 0%)
- **#250**: Introduce CommandRunner interface in service package for testability

## Fixes

Closes #351, #382, #250

## Changes by Issue

### #351 — brain config registry + startup validation

**Problem**: `internal/brain/config.go` used 35+ hardcoded `os.Getenv` calls. Invalid env values silently degraded to defaults with no diagnostics.

**Solution**: ConfigSpec registry + LoadAndValidate() with error collection.

- 38-entry `configRegistry` — self-documenting: name, env key, default, validator
- 7 validation helpers: `positiveInt`, `nonNegativeFloat`, `confidenceRange`, etc.
- `LoadAndValidate()` returns `*Config` + `[]error` — all issues at once, not one-at-a-time
- `Init()` logs validation warnings on startup
- `config_test.go`: 6 tests — defaults, overrides, invalid fallback, duration parsing, registry coverage, validators

### #382 — admin cron handlers test coverage

**Problem**: `cron_handlers.go` 7 handlers (~150 lines) had zero test coverage.

**Solution**: `mockCronScheduler` + 28 tests.

- `mockCronScheduler` implementing `CronSchedulerProvider` with function fields
- Coverage per handler: Create (5), List (4), Get (4), Update (5), Delete (4), Trigger (4), RunHistory (4)
- All tests use `t.Parallel()`, `testify/require`, `httptest` — matching existing patterns

### #250 — service CommandRunner abstraction

**Problem**: 16+ `exec.Command` calls across platform managers made the entire `internal/service/` module untestable.

**Solution**: `CommandRunner` interface + injection.

- `CommandRunner` interface: `LookPath`, `CombinedOutput`, `Run`
- `realRunner` production implementation using `os/exec`
- Injected into `linuxManager`, `darwinManager`, `windowsManager`
- `Logs()` methods kept with `exec.Command` (terminal streaming)
- `command_runner_test.go`: mockCommandRunner + 6 tests

## Testing

- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [x] 34 new tests total (28 admin + 6 service + brain config tests already existed)

## Net Impact

```
11 files changed, 1360 insertions(+), 136 deletions(-)
```

🤖 Generated with OpenCode