### PR TITLE
feat(messaging): P2P chat entered event — welcome card, user detection, analytics (#427)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -40,18 +40,19 @@ import (
 )
 
 type GatewayDeps struct {
-	Log            *slog.Logger
-	Config         *config.Config
-	ConfigStore    *config.ConfigStore
-	Hub            *gateway.Hub
-	SessionMgr     *session.Manager
-	EventStore     *eventstore.SQLiteStore
-	EventCollector *eventstore.Collector
-	Auth           *security.Authenticator
-	Handler        *gateway.Handler
-	Bridge         *gateway.Bridge
-	ConfigWatcher  *config.Watcher
-	CronScheduler  *cron.Scheduler
+	Log             *slog.Logger
+	Config          *config.Config
+	ConfigStore     *config.ConfigStore
+	Hub             *gateway.Hub
+	SessionMgr      *session.Manager
+	EventStore      *eventstore.SQLiteStore
+	EventCollector  *eventstore.Collector
+	Auth            *security.Authenticator
+	Handler         *gateway.Handler
+	Bridge          *gateway.Bridge
+	ConfigWatcher   *config.Watcher
+	CronScheduler   *cron.Scheduler
+	ChatAccessStore *messaging.ChatAccessStore
 }
 
 const defaultConfigPath = config.DefaultConfigPath
@@ -303,18 +304,19 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 
 	mux := http.NewServeMux()
 	deps := &GatewayDeps{
-		Log:            log,
-		Config:         cfg,
-		ConfigStore:    cfgStore,
-		Hub:            hub,
-		SessionMgr:     sm,
-		EventStore:     stores.event,
-		EventCollector: stores.collector,
-		Auth:           auth,
-		Handler:        handler,
-		Bridge:         bridge,
-		ConfigWatcher:  configWatcher,
-		CronScheduler:  cronScheduler,
+		Log:             log,
+		Config:          cfg,
+		ConfigStore:     cfgStore,
+		Hub:             hub,
+		SessionMgr:      sm,
+		EventStore:      stores.event,
+		EventCollector:  stores.collector,
+		Auth:            auth,
+		Handler:         handler,
+		Bridge:          bridge,
+		ConfigWatcher:   configWatcher,
+		CronScheduler:   cronScheduler,
+		ChatAccessStore: messaging.NewChatAccessStore(stores.session.DB(), log),
 	}
 
 	// Brain: lightweight LLM layer for TTS summarization (fail-open).

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -173,16 +173,6 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 			}
 			acfg.Extras["turn_summary_enabled"] = appCfg.Messaging.TurnSummaryEnabled
 
-			// Per-bot phrases loading with cascade-append.
-			homeDir, _ := os.UserHomeDir()
-			phrasesDir := filepath.Join(homeDir, ".hotplex", "phrases")
-			phr, err := phrases.Load(phrasesDir, string(entry.Platform), entry.BotID)
-			if err != nil {
-				log.Warn("phrases: load failed, using defaults", "error", err)
-				phr = phrases.Defaults()
-			}
-			acfg.Extras["phrases"] = phr
-
 			// Chat access store (welcome card + analytics).
 			if deps.ChatAccessStore != nil {
 				acfg.Extras["chat_access_store"] = deps.ChatAccessStore
@@ -210,6 +200,24 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 
 			// Update entry with runtime info and register.
 			entry.BotID = adapter.GetBotID()
+
+			// Per-bot phrases loading with cascade-append.
+			// Must happen AFTER adapter.Start() so BotID is resolved from the platform.
+			homeDir, _ := os.UserHomeDir()
+			phrasesDir := filepath.Join(homeDir, ".hotplex", "phrases")
+			phr, phrasesErr := phrases.Load(phrasesDir, string(entry.Platform), entry.BotID)
+			if phrasesErr != nil {
+				log.Warn("phrases: load failed, using defaults", "error", phrasesErr)
+				phr = phrases.Defaults()
+			}
+			if setter, ok := adapter.(interface{ SetPhrases(*phrases.Phrases) }); ok {
+				setter.SetPhrases(phr)
+			} else {
+				acfg.Extras["phrases"] = phr
+				log.Warn("phrases: adapter does not implement SetPhrases, written to Extras only",
+					"platform", pt, "bot", entry.Name)
+			}
+
 			entry.Status = messaging.BotStatusRunning
 			entry.Adapter = adapter
 			entry.Bridge = msgBridge

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -183,6 +183,11 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 			}
 			acfg.Extras["phrases"] = phr
 
+			// Chat access store (welcome card + analytics).
+			if deps.ChatAccessStore != nil {
+				acfg.Extras["chat_access_store"] = deps.ChatAccessStore
+			}
+
 			switch pt {
 			case messaging.PlatformSlack:
 				botCfg := resolveSlackBot(appCfg, entry.Name)

--- a/docs/superpowers/specs/2026-05-15-chat-access-event-design.md
+++ b/docs/superpowers/specs/2026-05-15-chat-access-event-design.md
@@ -1,0 +1,233 @@
+# P2P 聊天进入事件处理设计
+
+**日期**: 2026-05-15
+**状态**: Draft
+**范围**: Feishu + Slack 双平台
+
+---
+
+## 背景与动机
+
+用户打开与 HotPlex bot 的 P2P 聊天窗口时，飞书会发送 `bot_p2p_chat_entered_v1` 事件，但当前 HotPlex 未注册 handler，导致：
+- SDK 日志持续产生 "not found handler" ERROR 噪音
+- 错失在最佳时机（用户刚打开聊天）展示引导的机会
+- 无法追踪"打开聊天 → 发送首条消息"的转化漏斗
+
+Slack 平台虽无完全等价事件，但 `app_home_opened(tab=messages)` 提供了近似能力。
+
+## 目标
+
+1. 注册飞书 `bot_p2p_chat_entered_v1` handler，消除 ERROR 日志
+2. 在用户进入 P2P 聊天时发送欢迎/引导卡片（简洁信息卡）
+3. 区分新用户与冷启动回归用户，发送差异化内容
+4. 记录进入事件到 SQLite，提供转化漏斗数据基础
+5. Slack 端通过 `app_home_opened` 实现等价功能
+
+## 平台事件映射
+
+| 平台 | 事件 | 触发时机 | Bot token 可订阅 | 可用字段 |
+|------|------|---------|-----------------|---------|
+| Feishu | `im.chat.access_event.bot_p2p_chat_entered_v1` | 用户打开 P2P 聊天 | YES | chat_id, operator_id, last_message_id, last_message_create_time |
+| Slack | `app_home_opened` (tab=messages) | 用户打开 App Home 消息 tab | YES | user, channel, tab, view |
+
+**Slack 限制说明**：`im_open` 语义完全匹配但仅支持 user token，bot 无法订阅。`app_home_opened` 是 Slack 平台上最好的可用替代方案。
+
+## 架构
+
+```
+平台事件触发层
+  ├── Feishu: bot_p2p_chat_entered_v1  →  ws.go handler
+  └── Slack:  app_home_opened          →  adapter.go type switch
+        │
+        ▼
+chat_access 公共层（chat_access_store.go）
+  ├── 去重（event_id 唯一约束）
+  ├── 防抖（同 chat_id < 1h 跳过发送）
+  ├── 新老用户判断
+  └── 写入 chat_access_events 表
+        │
+        ▼
+平台消息发送层
+  ├── Feishu: Interactive Card via larkim API
+  └── Slack:  Block Kit via PostMessage API
+```
+
+## 触发策略
+
+### 去重
+
+`chat_access_events.event_id` 列有 UNIQUE 约束，INSERT 失败时静默跳过。
+
+### 防抖
+
+同一 `(platform, chat_id, bot_id)` 组合最近一条记录的 `created_at` 距今 < 1 小时 → 仅写埋点，不发欢迎消息。
+
+### 新老用户判断
+
+**Feishu**：利用事件 payload 中的 `last_message_create_time`：
+- 值为 0 或 nil → 新用户
+- 值距今 > 24h → 冷启动回归用户
+- 值距今 ≤ 24h → 活跃用户
+
+**Slack**：`app_home_opened` 不含历史消息时间，需查 SQLite：
+- 该 `(platform, user_id, bot_id)` 组合无记录 → 新用户
+- 最新记录 `created_at` 距今 > 24h → 冷启动回归用户
+- 最新记录 `created_at` 距今 ≤ 24h → 活跃用户
+
+### 发送规则
+
+| 用户类型 | 发送欢迎 | welcome_sent |
+|---------|---------|-------------|
+| 新用户 | YES | TRUE |
+| 冷启动回归（>24h） | YES（welcome_back 变体） | TRUE |
+| 活跃用户（≤24h） | NO | FALSE |
+
+## 数据模型
+
+### chat_access_events 表
+
+```sql
+CREATE TABLE IF NOT EXISTS chat_access_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    platform TEXT NOT NULL,
+    chat_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    bot_id TEXT NOT NULL,
+    last_message_at INTEGER DEFAULT 0,
+    welcome_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_ca_event ON chat_access_events(event_id);
+CREATE INDEX idx_ca_chat_bot ON chat_access_events(platform, chat_id, bot_id);
+```
+
+`platform` 取值：`"feishu"` | `"slack"`。表由现有 SQLite 连接管理（`internal/session/store.go` 或通过 `sqlutil` 模块），在 gateway 启动时 auto-migrate。
+
+## 欢迎卡片
+
+### 飞书（Interactive Card）
+
+简洁信息卡，包含欢迎语 + 能力概览 + 快捷命令提示。卡片内容模板：
+
+```
+👋 {welcome_text}
+
+我可以帮你：
+• 💻 编写、审查、调试代码
+• 📁 管理项目文件和目录
+• 🔍 搜索代码库和分析架构
+
+快捷命令：/help /reset /cd
+直接发消息即可开始 ✨
+```
+
+通过 phrases 系统的 `welcome` / `welcome_back` category 定制欢迎语，支持三级 fallback（全局 → 平台 → bot）。
+
+### Slack（Block Kit）
+
+等价布局，使用 section + divider + context blocks：
+
+```json
+{
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "👋 {welcome_text}\n\n我可以帮你：\n• 💻 编写、审查、调试代码\n• 📁 管理项目文件和目录\n• 🔍 搜索代码库和分析架构"
+      }
+    },
+    { "type": "divider" },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "mrkdwn",
+          "text": "快捷命令：`/help` `/reset` `/cd`  ·  直接发消息即可开始 ✨"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## phrases 扩展
+
+在 `Phrases` 结构体新增两个 category：
+
+### welcome（新用户）
+
+```
+{Weight: 3, Text: "Hi，我是 {bot_name}，你的 AI 编程助手！"}
+{Weight: 2, Text: "欢迎！直接发消息给我，我们可以开始写代码了。"}
+```
+
+### welcome_back（冷启动回归用户）
+
+```
+{Weight: 3, Text: "好久不见！有什么我可以帮你的？"}
+{Weight: 2, Text: "欢迎回来～随时继续。"}
+```
+
+`{bot_name}` 由各平台 adapter 在发送时替换为实际 bot 名称。
+
+## 文件变更清单
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| `internal/messaging/feishu/ws.go` | 修改 | 在 dispatcher 链追加 `.OnP2ChatAccessEventBotP2pChatEnteredV1()` |
+| `internal/messaging/feishu/chat_access.go` | 新增 | `handleChatEntered()` + 欢迎卡片构建 + 飞书 API 发送 |
+| `internal/messaging/slack/adapter.go` | 修改 | `handleEventsAPI()` 改为 type switch，新增 `AppHomeOpenedEvent` 分支 |
+| `internal/messaging/slack/chat_access.go` | 新增 | `handleAppHomeOpened()` + Block Kit 欢迎消息构建 |
+| `internal/messaging/chat_access_store.go` | 新增 | 公共存储层：表创建、去重查询、记录写入 |
+| `internal/messaging/phrases/phrases.go` | 修改 | 新增 `Welcome` / `WelcomeBack` 字段和默认短语池 |
+
+## 关键实现细节
+
+### 飞书 handler 注册
+
+在 `ws.go` 的 `newEventHandler()` 链末尾追加：
+
+```go
+dispatcher.NewEventDispatcher("", "").
+    // ... 现有 handlers ...
+    OnP2ChatAccessEventBotP2pChatEnteredV1(a.handleChatEntered)
+```
+
+handler 直接调用飞书 `larkim.CreateMessage` API 发送欢迎卡，不经 bridge（因为此时无 session）。adapter 已持有 lark client，可复用。
+
+### Slack handleEventsAPI 改造
+
+当前是硬类型断言：
+
+```go
+msgEvent, ok := event.InnerEvent.Data.(*slackevents.MessageEvent)
+if !ok { return }
+```
+
+改为 type switch：
+
+```go
+switch e := event.InnerEvent.Data.(type) {
+case *slackevents.MessageEvent:
+    a.handleMessageEvent(ctx, e)
+case *slackevents.AppHomeOpenedEvent:
+    a.handleAppHomeOpened(ctx, e)
+}
+```
+
+现有 `handleMessageEvent` 逻辑不变，仅从 `handleEventsAPI` 提取为独立方法。
+
+### 存储层初始化
+
+`chat_access_store.go` 接受 `*sql.DB`（与 session store 共享同一 SQLite 连接）。在 gateway 启动时调用 `EnsureChatAccessSchema(db)` 执行 CREATE TABLE IF NOT EXISTS。
+
+## 风险与边界
+
+- **飞书 API 调用**：handler 中直接调用消息发送 API（绕过 bridge），因为无 session。adapter 已持有 lark client，无新增依赖。
+- **Slack app_home_opened 覆盖率**：部分用户可能直接发消息而不经过 App Home。此场景下首条消息仍走现有流程，欢迎消息不会触发（可接受的退化）。
+- **速率限制**：冷却机制（1h 防抖 + 24h 冷启动判断）规避飞书/Slack 消息发送频率限制。
+- **多 bot 场景**：各 adapter 实例独立注册 handler，bot_id 从 adapter 配置获取，天然隔离。
+- **向后兼容**：纯新增 handler 和存储表，不改任何现有消息处理流程，零回归风险。
+- **SQLite 并发**：与现有 session store 共享连接，已有 WAL 模式和互斥保护，无需额外处理。

--- a/internal/messaging/chat_access_store.go
+++ b/internal/messaging/chat_access_store.go
@@ -1,0 +1,150 @@
+package messaging
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// ChatAccessType classifies why the chat-entered event fired.
+type ChatAccessType int
+
+const (
+	ChatAccessNew       ChatAccessType = iota // No prior record — first contact.
+	ChatAccessReturning                       // Last activity > 24 h ago.
+	ChatAccessActive                          // Last activity ≤ 24 h — suppress welcome.
+)
+
+// ChatAccessRecord is one row in chat_access_events.
+type ChatAccessRecord struct {
+	EventID       string
+	Platform      string
+	ChatID        string
+	UserID        string
+	BotID         string
+	LastMessageAt int64 // ms epoch, 0 = unknown
+	WelcomeSent   bool
+	CreatedAt     int64 // unix epoch
+}
+
+// ChatAccessStore provides dedup + cooldown + persistence for chat-entered events.
+type ChatAccessStore struct {
+	db  *sql.DB
+	log *slog.Logger
+}
+
+// NewChatAccessStore creates a store backed by the shared SQLite connection.
+func NewChatAccessStore(db *sql.DB, log *slog.Logger) *ChatAccessStore {
+	return &ChatAccessStore{db: db, log: log}
+}
+
+// Record inserts the event. Returns false (with nil error) when event_id
+// already exists (duplicate event from the platform).
+func (s *ChatAccessStore) Record(ctx context.Context, r ChatAccessRecord) (inserted bool, err error) {
+	now := time.Now().Unix()
+	r.CreatedAt = now
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO chat_access_events (event_id, platform, chat_id, user_id, bot_id, last_message_at, welcome_sent, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.EventID, r.Platform, r.ChatID, r.UserID, r.BotID, r.LastMessageAt, boolToInt(r.WelcomeSent), r.CreatedAt,
+	)
+	if err != nil {
+		// UNIQUE constraint violation → duplicate event.
+		if isSQLiteUnique(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("chat_access insert: %w", err)
+	}
+	return true, nil
+}
+
+// Classify determines whether a welcome should be sent.
+//
+// Feishu: pass lastMessageAtMs from the event payload.
+// Slack:  pass 0; the function falls back to the DB.
+func (s *ChatAccessStore) Classify(ctx context.Context, platform, chatID, botID, userID string, lastMessageAtMs int64) ChatAccessType {
+	cooldown := int64(3600) // 1 h debounce window in seconds.
+
+	// Check recent row for (platform, chat_id, bot_id).
+	var lastCreatedAt int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT created_at FROM chat_access_events
+		 WHERE platform = ? AND chat_id = ? AND bot_id = ?
+		 ORDER BY created_at DESC LIMIT 1`,
+		platform, chatID, botID,
+	).Scan(&lastCreatedAt)
+
+	if err == nil {
+		now := time.Now().Unix()
+		// Within 1 h cooldown — suppress even if we'd otherwise send.
+		if now-lastCreatedAt < cooldown {
+			return ChatAccessActive
+		}
+	}
+
+	// Feishu fast-path: use event payload timestamp directly.
+	if lastMessageAtMs > 0 {
+		lastSec := lastMessageAtMs / 1000
+		since := time.Now().Unix() - lastSec
+		if since > 24*3600 {
+			return ChatAccessNew // no prior messages in 24 h
+		}
+		return ChatAccessActive
+	}
+
+	// Slack path: check if we've ever seen this user.
+	var cnt int
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chat_access_events
+		 WHERE platform = ? AND user_id = ? AND bot_id = ?`,
+		platform, userID, botID,
+	).Scan(&cnt)
+	if err != nil || cnt == 0 {
+		return ChatAccessNew
+	}
+
+	// Existing user — check last activity.
+	var lastAct int64
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(created_at), 0) FROM chat_access_events
+		 WHERE platform = ? AND user_id = ? AND bot_id = ?`,
+		platform, userID, botID,
+	).Scan(&lastAct)
+	if err != nil {
+		return ChatAccessNew
+	}
+	since := time.Now().Unix() - lastAct
+	if since > 24*3600 {
+		return ChatAccessReturning
+	}
+	return ChatAccessActive
+}
+
+// boolToInt converts bool to SQLite integer.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// isSQLiteUnique returns true for UNIQUE constraint violations.
+func isSQLiteUnique(err error) bool {
+	return err != nil && (err.Error() == "UNIQUE constraint failed: chat_access_events.event_id" ||
+		containsErr(err, "UNIQUE constraint failed"))
+}
+
+func containsErr(err error, sub string) bool {
+	return len(err.Error()) >= len(sub) && containsStr(err.Error(), sub)
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/messaging/chat_access_store.go
+++ b/internal/messaging/chat_access_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -132,19 +133,5 @@ func boolToInt(b bool) int {
 
 // isSQLiteUnique returns true for UNIQUE constraint violations.
 func isSQLiteUnique(err error) bool {
-	return err != nil && (err.Error() == "UNIQUE constraint failed: chat_access_events.event_id" ||
-		containsErr(err, "UNIQUE constraint failed"))
-}
-
-func containsErr(err error, sub string) bool {
-	return len(err.Error()) >= len(sub) && containsStr(err.Error(), sub)
-}
-
-func containsStr(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -42,6 +42,7 @@ type Adapter struct {
 	ttsPipeline        *TTSPipeline
 	phrases            *phrases.Phrases
 	botName            string
+	Extras             map[string]any
 
 	mu          sync.RWMutex
 	chatQueue   *ChatQueue
@@ -80,6 +81,8 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	if p, ok := config.Extras["tts_pipeline"].(*TTSPipeline); ok && p != nil {
 		a.ttsPipeline = p
 	}
+
+	a.Extras = config.Extras
 
 	return nil
 }

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -55,6 +55,12 @@ var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
 
 func (a *Adapter) GetBotID() string { return a.botOpenID }
 
+func (a *Adapter) SetPhrases(p *phrases.Phrases) {
+	if p != nil {
+		a.phrases = p
+	}
+}
+
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	// Call base to set hub/sm/handler/bridge.
 	_ = a.PlatformAdapter.ConfigureWith(config)

--- a/internal/messaging/feishu/chat_access.go
+++ b/internal/messaging/feishu/chat_access.go
@@ -1,0 +1,110 @@
+package feishu
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+)
+
+// handleChatEntered processes the bot_p2p_chat_entered_v1 event.
+// It sends a welcome card to new/returning users and records analytics.
+func (a *Adapter) handleChatEntered(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) error {
+	if event.Event == nil {
+		return nil
+	}
+
+	chatID := ptrStr(event.Event.ChatId)
+	if chatID == "" {
+		return nil
+	}
+	openID := ptrStr(event.Event.OperatorId.OpenId)
+	if openID == "" {
+		return nil
+	}
+	eventID := ""
+	if event.EventV2Base != nil && event.EventV2Base.Header != nil {
+		eventID = event.EventV2Base.Header.EventID
+	}
+	if eventID == "" {
+		return nil
+	}
+
+	var lastMsgMs int64
+	if event.Event.LastMessageCreateTime != nil && *event.Event.LastMessageCreateTime != "" {
+		if v, err := strconv.ParseInt(*event.Event.LastMessageCreateTime, 10, 64); err == nil {
+			lastMsgMs = v
+		}
+	}
+
+	store := a.chatAccessStore()
+	if store == nil {
+		return nil
+	}
+
+	accessType := store.Classify(ctx, string(messaging.PlatformFeishu), chatID, a.botOpenID, openID, lastMsgMs)
+
+	welcomeSent := false
+	if accessType == messaging.ChatAccessNew || accessType == messaging.ChatAccessReturning {
+		if err := a.sendWelcomeCard(ctx, chatID, accessType); err != nil {
+			a.Log.Warn("feishu: welcome card send failed", "chat", chatID, "err", err)
+		} else {
+			welcomeSent = true
+		}
+	}
+
+	inserted, err := store.Record(ctx, messaging.ChatAccessRecord{
+		EventID:       eventID,
+		Platform:      string(messaging.PlatformFeishu),
+		ChatID:        chatID,
+		UserID:        openID,
+		BotID:         a.botOpenID,
+		LastMessageAt: lastMsgMs,
+		WelcomeSent:   welcomeSent,
+	})
+	if err != nil {
+		return fmt.Errorf("feishu: chat access record: %w", err)
+	}
+	if !inserted {
+		a.Log.Debug("feishu: duplicate chat_entered event", "event_id", eventID)
+	}
+	return nil
+}
+
+// sendWelcomeCard builds and sends a welcome card to the chat.
+func (a *Adapter) sendWelcomeCard(ctx context.Context, chatID string, accessType messaging.ChatAccessType) error {
+	category := "welcome"
+	if accessType == messaging.ChatAccessReturning {
+		category = "welcome_back"
+	}
+
+	text := a.phrases.Random(category)
+	if text == "" {
+		text = "Hi，我是 {bot_name}，你的 AI 编程助手！"
+	}
+	text = strings.ReplaceAll(text, "{bot_name}", a.resolveBotName())
+
+	body := fmt.Sprintf("%s\n\n我可以帮你：\n• 💻 编写、审查、调试代码\n• 📁 管理项目文件和目录\n• 🔍 搜索代码库和分析架构\n\n快捷命令：/help /reset /cd\n直接发消息即可开始 ✨", text)
+
+	cardJSON := buildCard(
+		cardHeader{Title: a.resolveBotName(), Template: headerBlue},
+		map[string]any{"wide_screen_mode": true},
+		[]map[string]any{{"tag": "markdown", "content": body}},
+	)
+
+	_, err := larkCreateMessage(ctx, a.larkClient, chatID, cardJSON)
+	return err
+}
+
+// chatAccessStore extracts the ChatAccessStore from the adapter extras.
+func (a *Adapter) chatAccessStore() *messaging.ChatAccessStore {
+	if a.Extras == nil {
+		return nil
+	}
+	s, _ := a.Extras["chat_access_store"].(*messaging.ChatAccessStore)
+	return s
+}

--- a/internal/messaging/feishu/ws.go
+++ b/internal/messaging/feishu/ws.go
@@ -32,6 +32,15 @@ func (a *Adapter) newEventHandler() *dispatcher.EventDispatcher {
 		}).
 		OnP2MessageReactionDeletedV1(func(_ context.Context, _ *larkim.P2MessageReactionDeletedV1) error {
 			return nil
+		}).
+		OnP2ChatAccessEventBotP2pChatEnteredV1(func(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					a.Log.Error("feishu: panic in chat entered handler", "panic", r, "stack", string(debug.Stack()))
+					err = fmt.Errorf("feishu chat entered panic: %v", r)
+				}
+			}()
+			return a.handleChatEntered(ctx, event)
 		})
 }
 

--- a/internal/messaging/phrases/phrases.go
+++ b/internal/messaging/phrases/phrases.go
@@ -15,8 +15,8 @@ type entry struct {
 // Fallback (defaults) all have the same weight → uniform random, no bias.
 const (
 	WeightDefault  = 1 // code defaults (fallback only)
-	WeightPlatform = 2 // ~/.hotplex/phrases/{platform}/PHRASES.md
-	WeightGlobal   = 1 // ~/.hotplex/phrases/PHRASES.md
+	WeightPlatform = 1 // ~/.hotplex/phrases/{platform}/PHRASES.md
+	WeightGlobal   = 2 // ~/.hotplex/phrases/PHRASES.md
 	WeightBot      = 4 // ~/.hotplex/phrases/{platform}/{botID}/PHRASES.md
 )
 

--- a/internal/messaging/phrases/phrases.go
+++ b/internal/messaging/phrases/phrases.go
@@ -121,5 +121,13 @@ func Defaults() *Phrases {
 			{"Composing response...", WeightDefault},
 			{"Processing...", WeightDefault},
 		},
+		"welcome": {
+			{"Hi，我是 {bot_name}，你的 AI 编程助手！", WeightDefault},
+			{"欢迎！直接发消息给我，我们可以开始写代码了。", WeightDefault},
+		},
+		"welcome_back": {
+			{"好久不见！有什么我可以帮你的？", WeightDefault},
+			{"欢迎回来～随时继续。", WeightDefault},
+		},
 	}}
 }

--- a/internal/messaging/phrases/phrases.go
+++ b/internal/messaging/phrases/phrases.go
@@ -15,8 +15,8 @@ type entry struct {
 // Fallback (defaults) all have the same weight → uniform random, no bias.
 const (
 	WeightDefault  = 1 // code defaults (fallback only)
-	WeightPlatform = 1 // ~/.hotplex/phrases/{platform}/PHRASES.md
-	WeightGlobal   = 2 // ~/.hotplex/phrases/PHRASES.md
+	WeightPlatform = 2 // ~/.hotplex/phrases/{platform}/PHRASES.md
+	WeightGlobal   = 1 // ~/.hotplex/phrases/PHRASES.md
 	WeightBot      = 4 // ~/.hotplex/phrases/{platform}/{botID}/PHRASES.md
 )
 

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -100,6 +100,12 @@ var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
 
 func (a *Adapter) GetBotID() string { return a.botID }
 
+func (a *Adapter) SetPhrases(p *phrases.Phrases) {
+	if p != nil {
+		a.phrases = p
+	}
+}
+
 func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	// Call base to set hub/sm/handler/bridge.
 	_ = a.PlatformAdapter.ConfigureWith(config)

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -87,6 +87,7 @@ type Adapter struct {
 	turnSummaryEnabled bool
 	ttsPipeline        *TTSPipeline
 	phrases            *phrases.Phrases
+	Extras             map[string]any
 
 	rateLimiter   *ChannelRateLimiter
 	slashLimiter  *SlashRateLimiter
@@ -133,6 +134,8 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	if p, ok := config.Extras["tts_pipeline"].(*TTSPipeline); ok && p != nil {
 		a.ttsPipeline = p
 	}
+
+	a.Extras = config.Extras
 
 	return nil
 }
@@ -320,11 +323,15 @@ func (a *Adapter) runSocketMode(ctx context.Context) {
 }
 
 func (a *Adapter) handleEventsAPI(ctx context.Context, event slackevents.EventsAPIEvent) {
-	msgEvent, ok := event.InnerEvent.Data.(*slackevents.MessageEvent)
-	if !ok {
-		return
+	switch e := event.InnerEvent.Data.(type) {
+	case *slackevents.MessageEvent:
+		a.handleMessageEvent(ctx, e, event.TeamID)
+	case *slackevents.AppHomeOpenedEvent:
+		a.handleAppHomeOpened(ctx, e)
 	}
+}
 
+func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.MessageEvent, teamID string) {
 	if msgEvent.BotID != "" {
 		a.Log.Debug("slack: skipping bot message", "bot_id", msgEvent.BotID)
 		return
@@ -351,7 +358,6 @@ func (a *Adapter) handleEventsAPI(ctx context.Context, event slackevents.EventsA
 		return
 	}
 	text = messaging.SanitizeText(text)
-	teamID := event.TeamID
 
 	channelType := ChannelGroup
 	if channelID != "" && channelID[0] == 'D' {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -88,6 +88,7 @@ type Adapter struct {
 	ttsPipeline        *TTSPipeline
 	phrases            *phrases.Phrases
 	Extras             map[string]any
+	botName            string
 
 	rateLimiter   *ChannelRateLimiter
 	slashLimiter  *SlashRateLimiter
@@ -142,6 +143,10 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	}
 
 	a.Extras = config.Extras
+
+	if config.BotName != "" {
+		a.botName = config.BotName
+	}
 
 	return nil
 }

--- a/internal/messaging/slack/chat_access.go
+++ b/internal/messaging/slack/chat_access.go
@@ -1,0 +1,98 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+)
+
+// handleAppHomeOpened processes the app_home_opened event.
+// When tab=="messages" it mirrors Feishu's bot_p2p_chat_entered_v1.
+func (a *Adapter) handleAppHomeOpened(ctx context.Context, event *slackevents.AppHomeOpenedEvent) {
+	if event.User == "" || event.Channel == "" {
+		return
+	}
+
+	// Only trigger on the messages tab (the DM conversation view).
+	if event.Tab != "messages" {
+		return
+	}
+
+	store := a.chatAccessStore()
+	if store == nil {
+		return
+	}
+
+	eventID := fmt.Sprintf("app_home_opened_%s_%s_%s", event.User, event.Channel, event.EventTimeStamp)
+	accessType := store.Classify(ctx, string(messaging.PlatformSlack), event.Channel, a.botID, event.User, 0)
+
+	welcomeSent := false
+	if accessType == messaging.ChatAccessNew || accessType == messaging.ChatAccessReturning {
+		if err := a.sendWelcomeMessage(ctx, event.Channel, accessType); err != nil {
+			a.Log.Warn("slack: welcome message send failed", "channel", event.Channel, "err", err)
+		} else {
+			welcomeSent = true
+		}
+	}
+
+	inserted, err := store.Record(ctx, messaging.ChatAccessRecord{
+		EventID:     eventID,
+		Platform:    string(messaging.PlatformSlack),
+		ChatID:      event.Channel,
+		UserID:      event.User,
+		BotID:       a.botID,
+		WelcomeSent: welcomeSent,
+	})
+	if err != nil {
+		a.Log.Warn("slack: chat access record failed", "err", err)
+	}
+	if !inserted {
+		a.Log.Debug("slack: duplicate app_home_opened event", "event_id", eventID)
+	}
+}
+
+// sendWelcomeMessage posts a Block Kit welcome message to the DM channel.
+func (a *Adapter) sendWelcomeMessage(ctx context.Context, channelID string, accessType messaging.ChatAccessType) error {
+	category := "welcome"
+	if accessType == messaging.ChatAccessReturning {
+		category = "welcome_back"
+	}
+
+	text := a.phrases.Random(category)
+	if text == "" {
+		text = "Hi，我是 {bot_name}，你的 AI 编程助手！"
+	}
+	botName := "HotPlex"
+	text = strings.ReplaceAll(text, "{bot_name}", botName)
+
+	body := fmt.Sprintf("%s\n\n我可以帮你：\n• 💻 编写、审查、调试代码\n• 📁 管理项目文件和目录\n• 🔍 搜索代码库和分析架构", text)
+
+	blocks := []slack.Block{
+		&slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{Type: "mrkdwn", Text: body},
+		},
+		slack.NewDividerBlock(),
+		slack.NewContextBlock("", &slack.TextBlockObject{Type: "mrkdwn", Text: "快捷命令：`/help` `/reset` `/cd`  ·  直接发消息即可开始 ✨"}),
+	}
+
+	_, _, err := a.client.PostMessageContext(ctx, channelID,
+		slack.MsgOptionBlocks(blocks...),
+		slack.MsgOptionText(text, false),
+	)
+	return err
+}
+
+// chatAccessStore extracts the ChatAccessStore from the adapter extras.
+func (a *Adapter) chatAccessStore() *messaging.ChatAccessStore {
+	if a.Extras == nil {
+		return nil
+	}
+	s, _ := a.Extras["chat_access_store"].(*messaging.ChatAccessStore)
+	return s
+}

--- a/internal/messaging/slack/chat_access.go
+++ b/internal/messaging/slack/chat_access.go
@@ -67,7 +67,10 @@ func (a *Adapter) sendWelcomeMessage(ctx context.Context, channelID string, acce
 	if text == "" {
 		text = "Hi，我是 {bot_name}，你的 AI 编程助手！"
 	}
-	botName := "HotPlex"
+	botName := a.botName
+	if botName == "" {
+		botName = "HotPlex"
+	}
 	text = strings.ReplaceAll(text, "{bot_name}", botName)
 
 	body := fmt.Sprintf("%s\n\n我可以帮你：\n• 💻 编写、审查、调试代码\n• 📁 管理项目文件和目录\n• 🔍 搜索代码库和分析架构", text)

--- a/internal/session/sql/migrations/007_chat_access_events.sql
+++ b/internal/session/sql/migrations/007_chat_access_events.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS chat_access_events (
 
 CREATE INDEX IF NOT EXISTS idx_ca_event ON chat_access_events(event_id);
 CREATE INDEX IF NOT EXISTS idx_ca_chat_bot ON chat_access_events(platform, chat_id, bot_id);
+CREATE INDEX IF NOT EXISTS idx_ca_user_bot ON chat_access_events(platform, user_id, bot_id);
 
 -- +goose Down
 

--- a/internal/session/sql/migrations/007_chat_access_events.sql
+++ b/internal/session/sql/migrations/007_chat_access_events.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS chat_access_events (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id          TEXT NOT NULL UNIQUE,
+    platform          TEXT NOT NULL CHECK(platform IN ('feishu', 'slack')),
+    chat_id           TEXT NOT NULL,
+    user_id           TEXT NOT NULL,
+    bot_id            TEXT NOT NULL DEFAULT '',
+    last_message_at   INTEGER NOT NULL DEFAULT 0,
+    welcome_sent      INTEGER NOT NULL DEFAULT 0 CHECK(welcome_sent IN (0, 1)),
+    created_at        INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ca_event ON chat_access_events(event_id);
+CREATE INDEX IF NOT EXISTS idx_ca_chat_bot ON chat_access_events(platform, chat_id, bot_id);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS chat_access_events;


### PR DESCRIPTION
## Summary

- Register Feishu `bot_p2p_chat_entered_v1` handler to eliminate SDK "not found handler" ERROR logs
- Register Slack `app_home_opened(tab=messages)` handler for equivalent behavior
- Send welcome/guidance cards to new and returning users (>24h cold start)
- Record chat access analytics in SQLite for conversion funnel tracking

## Changes

### New Files
- `internal/session/sql/migrations/007_chat_access_events.sql` — SQLite table schema
- `internal/messaging/chat_access_store.go` — Shared store: dedup, cooldown, new/returning/active classification
- `internal/messaging/feishu/chat_access.go` — Feishu handler + Interactive Card welcome message
- `internal/messaging/slack/chat_access.go` — Slack handler + Block Kit welcome message

### Modified Files
- `internal/messaging/feishu/ws.go` — Register `OnP2ChatAccessEventBotP2pChatEnteredV1` in dispatcher chain
- `internal/messaging/slack/adapter.go` — Refactor `handleEventsAPI` to type switch for extensibility
- `internal/messaging/phrases/phrases.go` — Add `welcome` / `welcome_back` phrase categories
- `cmd/hotplex/gateway_run.go` — Add `ChatAccessStore` to GatewayDeps
- `cmd/hotplex/messaging_init.go` — Inject ChatAccessStore via AdapterConfig Extras

## Trigger Strategy

| User Type | Condition | Action |
|-----------|-----------|--------|
| New | No prior record / no messages | Send welcome card |
| Returning | Last activity > 24h | Send welcome_back card |
| Active | Last activity ≤ 24h | Silent (record only) |
| Debounce | Same chat < 1h | Silent (skip card) |

## Test Plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [x] `go test -short ./internal/messaging/... ./internal/session/...` — all pass
- [x] Pre-commit hooks pass (gofmt + golangci-lint + go vet + build + tests)
- [ ] Manual: deploy and verify Feishu bot sends welcome card on P2P chat enter
- [ ] Manual: verify Slack bot sends welcome on app_home_opened
- [ ] Manual: verify no duplicate welcome cards within 1h
- [ ] Manual: verify `bot_p2p_chat_entered_v1` ERROR no longer appears in logs

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)