### PR TITLE
fix(worker/ocs): update Converter for OCS 1.15+ message.part.delta

### DIFF
--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -10,20 +10,18 @@ import (
 
 // OCS event type constants — used by Converter and singleton dispatch filter.
 const (
-	ocsStepStarted    = "session.next.step.started"
-	ocsStepEnded      = "session.next.step.ended"
-	ocsStepFailed     = "session.next.step.failed"
-	ocsTextDelta      = "session.next.text.delta"
-	ocsReasoningDelta = "session.next.reasoning.delta"
-	ocsReasoningEnded = "session.next.reasoning.ended"
-	ocsToolCalled     = "session.next.tool.called"
-	ocsToolSuccess    = "session.next.tool.success"
-	ocsToolFailed     = "session.next.tool.failed"
-	ocsSessionStatus  = "session.status"
-	ocsSessionIdle    = "session.idle"
-	ocsSessionError   = "session.error"
-	ocsPermAsked      = "permission.asked"
-	ocsQuestionAsked  = "question.asked"
+	ocsStepStarted   = "session.next.step.started"
+	ocsStepEnded     = "session.next.step.ended"
+	ocsStepFailed    = "session.next.step.failed"
+	ocsPartDelta     = "message.part.delta" // OCS 1.15+: unified text/reasoning delta
+	ocsToolCalled    = "session.next.tool.called"
+	ocsToolSuccess   = "session.next.tool.success"
+	ocsToolFailed    = "session.next.tool.failed"
+	ocsSessionStatus = "session.status"
+	ocsSessionIdle   = "session.idle"
+	ocsSessionError  = "session.error"
+	ocsPermAsked     = "permission.asked"
+	ocsQuestionAsked = "question.asked"
 )
 
 // Converter maps OCS BusEvents to AEP envelopes.
@@ -59,12 +57,14 @@ func NewConverter() *Converter {
 // Convert maps an OCS BusEvent to zero or more AEP envelopes.
 // eventType is payload.type, props is payload.properties (raw JSON).
 func (c *Converter) Convert(sessionID, eventType string, props json.RawMessage) []*events.Envelope {
-	// V2 events: session.next.* prefix
-	if strings.HasPrefix(eventType, "session.next.") {
+	switch {
+	case eventType == ocsPartDelta:
+		return c.handlePartDelta(sessionID, props)
+	case strings.HasPrefix(eventType, "session.next."):
 		return c.convertV2(sessionID, eventType, props)
+	default:
+		return c.convertV1(sessionID, eventType, props)
 	}
-	// Legacy V1 events
-	return c.convertV1(sessionID, eventType, props)
 }
 
 // --- V2 event handlers ---
@@ -77,12 +77,6 @@ func (c *Converter) convertV2(sessionID, eventType string, props json.RawMessage
 		return c.handleStepEnded(sessionID, props)
 	case ocsStepFailed:
 		return c.handleStepFailed(sessionID, props)
-	case ocsTextDelta:
-		return c.handleTextDelta(sessionID, props)
-	case ocsReasoningDelta:
-		return c.handleReasoningDelta(sessionID, props)
-	case ocsReasoningEnded:
-		return c.handleReasoningEnded(sessionID, props)
 	case ocsToolCalled:
 		return c.handleToolCalled(sessionID, props)
 	case ocsToolSuccess:
@@ -142,9 +136,13 @@ func (c *Converter) handleStepFailed(sessionID string, props json.RawMessage) []
 	}
 }
 
-func (c *Converter) handleTextDelta(sessionID string, props json.RawMessage) []*events.Envelope {
+// handlePartDelta handles message.part.delta from OCS 1.15+.
+// Routes by field: "text" → MessageDelta, "reasoning" → Reasoning.
+func (c *Converter) handlePartDelta(sessionID string, props json.RawMessage) []*events.Envelope {
 	var evt struct {
-		Delta string `json:"delta"`
+		PartID string `json:"partID"`
+		Field  string `json:"field"`
+		Delta  string `json:"delta"`
 	}
 	if err := json.Unmarshal(props, &evt); err != nil {
 		return nil
@@ -152,46 +150,19 @@ func (c *Converter) handleTextDelta(sessionID string, props json.RawMessage) []*
 	if evt.Delta == "" {
 		return nil
 	}
-	return []*events.Envelope{
-		events.NewEnvelope(aep.NewID(), sessionID, 0, events.MessageDelta, events.MessageDeltaData{Content: evt.Delta}),
-	}
-}
 
-func (c *Converter) handleReasoningDelta(sessionID string, props json.RawMessage) []*events.Envelope {
-	var evt struct {
-		ReasoningID string `json:"reasoningID"`
-		Delta       string `json:"delta"`
-	}
-	if err := json.Unmarshal(props, &evt); err != nil {
-		return nil
-	}
-	if evt.Delta == "" {
-		return nil
-	}
-	return []*events.Envelope{
-		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Reasoning, events.ReasoningData{
-			ID:      evt.ReasoningID,
-			Content: evt.Delta,
-		}),
-	}
-}
-
-func (c *Converter) handleReasoningEnded(sessionID string, props json.RawMessage) []*events.Envelope {
-	var evt struct {
-		ReasoningID string `json:"reasoningID"`
-		Text        string `json:"text"`
-	}
-	if err := json.Unmarshal(props, &evt); err != nil {
-		return nil
-	}
-	if evt.Text == "" {
-		return nil
-	}
-	return []*events.Envelope{
-		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Reasoning, events.ReasoningData{
-			ID:      evt.ReasoningID,
-			Content: evt.Text,
-		}),
+	switch evt.Field {
+	case "reasoning":
+		return []*events.Envelope{
+			events.NewEnvelope(aep.NewID(), sessionID, 0, events.Reasoning, events.ReasoningData{
+				ID:      evt.PartID,
+				Content: evt.Delta,
+			}),
+		}
+	default: // "text" or unspecified
+		return []*events.Envelope{
+			events.NewEnvelope(aep.NewID(), sessionID, 0, events.MessageDelta, events.MessageDeltaData{Content: evt.Delta}),
+		}
 	}
 }
 

--- a/internal/worker/opencodeserver/converter_test.go
+++ b/internal/worker/opencodeserver/converter_test.go
@@ -93,49 +93,67 @@ func TestConverter_StepFailed(t *testing.T) {
 	require.Equal(t, "API timeout", envs[0].Event.Data.(events.ErrorData).Message)
 }
 
-// ─── V2 Text ──────────────────────────────────────────────────────────────────
+// ─── message.part.delta (OCS 1.15+) ──────────────────────────────────────────
 
-func TestConverter_TextDelta(t *testing.T) {
+func TestConverter_PartDelta_Text(t *testing.T) {
 	c := newTestConverter()
-	props := rawProps(t, map[string]any{"delta": "Hel"})
-	envs := c.Convert("s1", ocsTextDelta, props)
+	props := rawProps(t, map[string]any{
+		"partID": "p1",
+		"field":  "text",
+		"delta":  "Hel",
+	})
+	envs := c.Convert("s1", ocsPartDelta, props)
 	require.Len(t, envs, 1)
 	require.Equal(t, events.MessageDelta, envs[0].Event.Type)
 	require.Equal(t, "Hel", envs[0].Event.Data.(events.MessageDeltaData).Content)
 }
 
-func TestConverter_TextDelta_Empty(t *testing.T) {
+func TestConverter_PartDelta_Text_Empty(t *testing.T) {
 	c := newTestConverter()
-	props := rawProps(t, map[string]any{"delta": ""})
-	envs := c.Convert("s1", ocsTextDelta, props)
+	props := rawProps(t, map[string]any{
+		"partID": "p1",
+		"field":  "text",
+		"delta":  "",
+	})
+	envs := c.Convert("s1", ocsPartDelta, props)
 	require.Empty(t, envs)
 }
 
-// ─── V2 Reasoning ─────────────────────────────────────────────────────────────
-
-func TestConverter_ReasoningDelta(t *testing.T) {
+func TestConverter_PartDelta_Reasoning(t *testing.T) {
 	c := newTestConverter()
 	props := rawProps(t, map[string]any{
-		"reasoningID": "r1",
-		"delta":       "thinking...",
+		"partID": "p1",
+		"field":  "reasoning",
+		"delta":  "thinking...",
 	})
-	envs := c.Convert("s1", ocsReasoningDelta, props)
+	envs := c.Convert("s1", ocsPartDelta, props)
 	require.Len(t, envs, 1)
 	require.Equal(t, events.Reasoning, envs[0].Event.Type)
-	require.Equal(t, "r1", envs[0].Event.Data.(events.ReasoningData).ID)
+	require.Equal(t, "p1", envs[0].Event.Data.(events.ReasoningData).ID)
 	require.Equal(t, "thinking...", envs[0].Event.Data.(events.ReasoningData).Content)
 }
 
-func TestConverter_ReasoningEnded(t *testing.T) {
+func TestConverter_PartDelta_DefaultField(t *testing.T) {
+	c := newTestConverter()
+	// Missing field → treated as text
+	props := rawProps(t, map[string]any{
+		"partID": "p1",
+		"delta":  "hello",
+	})
+	envs := c.Convert("s1", ocsPartDelta, props)
+	require.Len(t, envs, 1)
+	require.Equal(t, events.MessageDelta, envs[0].Event.Type)
+}
+
+func TestConverter_PartDelta_Reasoning_Empty(t *testing.T) {
 	c := newTestConverter()
 	props := rawProps(t, map[string]any{
-		"reasoningID": "r1",
-		"text":        "full reasoning text",
+		"partID": "p1",
+		"field":  "reasoning",
+		"delta":  "",
 	})
-	envs := c.Convert("s1", ocsReasoningEnded, props)
-	require.Len(t, envs, 1)
-	require.Equal(t, events.Reasoning, envs[0].Event.Type)
-	require.Equal(t, "full reasoning text", envs[0].Event.Data.(events.ReasoningData).Content)
+	envs := c.Convert("s1", ocsPartDelta, props)
+	require.Empty(t, envs)
 }
 
 // ─── V2 Tool Events ───────────────────────────────────────────────────────────
@@ -317,7 +335,7 @@ func TestConverter_QuestionAsked(t *testing.T) {
 
 func TestConverter_V1UnknownEvent(t *testing.T) {
 	c := newTestConverter()
-	envs := c.Convert("s1", "message.part.delta", rawProps(t, nil))
+	envs := c.Convert("s1", "some.unknown.event", rawProps(t, nil))
 	require.Empty(t, envs)
 }
 
@@ -339,7 +357,7 @@ func TestConverter_FullTurnLifecycle(t *testing.T) {
 	require.Empty(t, envs)
 
 	// Step 3: text delta
-	envs = c.Convert(sid, ocsTextDelta, rawProps(t, map[string]any{"delta": "Hello"}))
+	envs = c.Convert(sid, ocsPartDelta, rawProps(t, map[string]any{"partID": "p1", "field": "text", "delta": "Hello"}))
 	require.Len(t, envs, 1)
 	require.Equal(t, events.MessageDelta, envs[0].Event.Type)
 
@@ -364,7 +382,7 @@ func TestConverter_FullTurnLifecycle(t *testing.T) {
 	require.Empty(t, envs)
 
 	// Step 7: more text
-	envs = c.Convert(sid, ocsTextDelta, rawProps(t, map[string]any{"delta": "Done!"}))
+	envs = c.Convert(sid, ocsPartDelta, rawProps(t, map[string]any{"partID": "p1", "field": "text", "delta": "Done!"}))
 	require.Len(t, envs, 1)
 	require.Equal(t, events.MessageDelta, envs[0].Event.Type)
 
@@ -418,25 +436,13 @@ func TestConverter_ToolFailed_WithErrorMessage(t *testing.T) {
 	require.Equal(t, "permission denied", tr.Error)
 }
 
-func TestConverter_ReasoningEnded_Empty(t *testing.T) {
-	c := newTestConverter()
-	props := rawProps(t, map[string]any{
-		"reasoningID": "r1",
-		"text":        "",
-	})
-	envs := c.Convert("s1", ocsReasoningEnded, props)
-	require.Empty(t, envs)
-}
-
 func TestConverter_MalformedJSON(t *testing.T) {
 	c := newTestConverter()
 	bad := json.RawMessage(`{invalid json`)
 	for _, eventType := range []string{
 		ocsStepStarted,
 		ocsStepEnded,
-		ocsTextDelta,
-		ocsReasoningDelta,
-		ocsReasoningEnded,
+		ocsPartDelta,
 		ocsToolCalled,
 		ocsToolSuccess,
 		ocsToolFailed,
@@ -512,6 +518,6 @@ func TestConverter_Reset(t *testing.T) {
 	_, exists := c.states["s1"]
 	require.False(t, exists, "Reset should clear all state")
 
-	envs := c.Convert("s2", ocsTextDelta, rawProps(t, map[string]any{"delta": "hello"}))
+	envs := c.Convert("s2", ocsPartDelta, rawProps(t, map[string]any{"partID": "p1", "field": "text", "delta": "hello"}))
 	require.Len(t, envs, 1)
 }

--- a/internal/worker/opencodeserver/sse_test.go
+++ b/internal/worker/opencodeserver/sse_test.go
@@ -97,9 +97,11 @@ func TestReadGlobalSSE_PartUpdatedText_Skipped(t *testing.T) {
 		fmt.Fprint(rw, evt)
 		flusher.Flush()
 
-		// Followed by a V2 text delta to confirm reader is still alive.
-		deltaEvt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		// Followed by a V2 part delta to confirm reader is still alive.
+		deltaEvt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "world",
 		})
 		fmt.Fprint(rw, deltaEvt)
@@ -127,10 +129,11 @@ func TestReadGlobalSSE_PartUpdatedReasoning(t *testing.T) {
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
 
-		evt := ocsEvent(t, "session.next.reasoning.ended", map[string]any{
-			"sessionID":   "ses_1",
-			"reasoningID": "r_1",
-			"text":        "thinking...",
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
+			"sessionID": "ses_1",
+			"partID":    "r_1",
+			"field":     "reasoning",
+			"delta":     "thinking...",
 		})
 		fmt.Fprint(rw, evt)
 		flusher.Flush()
@@ -186,12 +189,16 @@ func TestReadGlobalSSE_DispatchesPartDelta(t *testing.T) {
 		flusher := rw.(http.Flusher)
 
 		// Streaming delta events — the real-time text from OCS.
-		evt1 := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt1 := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "Hel",
 		})
-		evt2 := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt2 := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "lo",
 		})
 		fmt.Fprint(rw, evt1)
@@ -321,8 +328,10 @@ func TestReadGlobalSSE_SkipsSyncEvents(t *testing.T) {
 		fmt.Fprint(rw, gdEvt)
 		flusher.Flush()
 
-		msgEvt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		msgEvt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "hi",
 		})
 		fmt.Fprint(rw, msgEvt)
@@ -353,8 +362,10 @@ func TestReadGlobalSSE_IgnoresEmptyLinesAndComments(t *testing.T) {
 		fmt.Fprint(rw, "retry: 5000\n")
 		fmt.Fprint(rw, "event: message\n")
 
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "after_noise",
 		})
 		fmt.Fprint(rw, evt)
@@ -381,8 +392,10 @@ func TestReadGlobalSSE_MultipleSessions(t *testing.T) {
 		flusher := rw.(http.Flusher)
 
 		for _, sid := range []string{"ses_A", "ses_B"} {
-			evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+			evt := ocsEvent(t, "message.part.delta", map[string]any{
 				"sessionID": sid,
+				"partID":    "p1",
+				"field":     "text",
 				"delta":     "msg_" + sid,
 			})
 			fmt.Fprint(rw, evt)
@@ -415,8 +428,10 @@ func TestReadGlobalSSE_UnsubscribeDuringDispatch(t *testing.T) {
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
 
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "first",
 		})
 		fmt.Fprint(rw, evt)
@@ -424,8 +439,10 @@ func TestReadGlobalSSE_UnsubscribeDuringDispatch(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		evt2 := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt2 := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "after_unsub",
 		})
 		fmt.Fprint(rw, evt2)
@@ -462,8 +479,10 @@ func TestReadGlobalSSE_EOF_Reconnects(t *testing.T) {
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
 
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     fmt.Sprintf("round%d", n),
 		})
 		fmt.Fprint(rw, evt)
@@ -502,8 +521,10 @@ func TestReadGlobalSSE_HTTPError_Reconnects(t *testing.T) {
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
 
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "after_503",
 		})
 		fmt.Fprint(rw, evt)
@@ -553,8 +574,10 @@ func TestReadGlobalSSE_ContextCancel_Stops(t *testing.T) {
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
 
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "hi",
 		})
 		fmt.Fprint(rw, evt)
@@ -582,8 +605,10 @@ func TestReadGlobalSSE_Backpressure_DropOnFull(t *testing.T) {
 		flusher := rw.(http.Flusher)
 
 		for i := range 10 {
-			evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+			evt := ocsEvent(t, "message.part.delta", map[string]any{
 				"sessionID": "ses_1",
+				"partID":    "p1",
+				"field":     "text",
 				"delta":     fmt.Sprintf("msg%d", i),
 			})
 			fmt.Fprint(rw, evt)
@@ -620,8 +645,10 @@ func TestReadGlobalSSE_EmptyStream_Backoff(t *testing.T) {
 		}
 		rw.Header().Set("Content-Type", "text/event-stream")
 		flusher := rw.(http.Flusher)
-		evt := ocsEvent(t, "session.next.text.delta", map[string]any{
+		evt := ocsEvent(t, "message.part.delta", map[string]any{
 			"sessionID": "ses_1",
+			"partID":    "p1",
+			"field":     "text",
 			"delta":     "after_empty",
 		})
 		fmt.Fprint(rw, evt)


### PR DESCRIPTION
## Summary

- OCS 1.15.0 将 `session.next.text.delta` 和 `session.next.reasoning.delta` 统一为 `message.part.delta`（通过 `field` 区分 "text"/"reasoning"）
- 更新 Converter 常量、路由逻辑和 handler，移除已废弃的三个 handler（handleTextDelta/handleReasoningDelta/handleReasoningEnded）
- 新增 `handlePartDelta` 统一处理，按 `field` 路由到 MessageDelta 或 Reasoning
- 同步更新 converter_test.go 和 sse_test.go 中所有旧事件类型引用

Related: #432

## Test plan

- [x] `go test ./internal/worker/opencodeserver/... -race -count=1` 全部通过
- [x] `go test ./internal/gateway/... -race -count=1` 无回归
- [x] Pre-push quality gates 全部通过 (gofmt/lint/vet/build/test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)