### PR TITLE
feat(messaging/feishu): persona phrases for placeholder and closing sign-off

### DIFF
--- a/internal/messaging/feishu/placeholder.go
+++ b/internal/messaging/feishu/placeholder.go
@@ -6,3 +6,26 @@ import "github.com/hrygo/hotplex/internal/messaging/phrases"
 func buildPlaceholderText(p *phrases.Phrases) string {
 	return ":Get: " + p.Random("greetings") + "\n:StatusFlashOfInspiration: " + p.Random("tips")
 }
+
+// buildPersonaText returns two distinct persona lines for the tool_activity area
+// during the placeholder phase, giving the bot a lively "preparing" presence.
+func buildPersonaText(p *phrases.Phrases) string {
+	line1 := p.Random("persona")
+	if line1 == "" {
+		return ""
+	}
+	line2 := p.Random("persona")
+	for attempts := 0; line2 == line1 && attempts < 3; attempts++ {
+		line2 = p.Random("persona")
+	}
+	if line2 == "" || line2 == line1 {
+		return line1
+	}
+	return line1 + "\n" + line2
+}
+
+// buildClosingText returns a single closing phrase for the tool_activity area
+// when a turn completes, replacing the transient tool status with a personified sign-off.
+func buildClosingText(p *phrases.Phrases) string {
+	return p.Random("closings")
+}

--- a/internal/messaging/feishu/placeholder_test.go
+++ b/internal/messaging/feishu/placeholder_test.go
@@ -1,0 +1,79 @@
+package feishu
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging/phrases"
+)
+
+func TestBuildPersonaText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns two distinct lines from defaults", func(t *testing.T) {
+		t.Parallel()
+		p := phrases.Defaults()
+		text := buildPersonaText(p)
+		require.NotEmpty(t, text)
+		lines := strings.Split(text, "\n")
+		require.Len(t, lines, 2)
+		require.NotEqual(t, lines[0], lines[1])
+	})
+
+	t.Run("nil phrases returns empty", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, buildPersonaText(nil))
+	})
+
+	t.Run("empty category returns empty", func(t *testing.T) {
+		t.Parallel()
+		p := &phrases.Phrases{}
+		require.Empty(t, buildPersonaText(p))
+	})
+}
+
+func TestBuildClosingText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns non-empty from defaults", func(t *testing.T) {
+		t.Parallel()
+		p := phrases.Defaults()
+		require.NotEmpty(t, buildClosingText(p))
+	})
+
+	t.Run("nil phrases returns empty", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, buildClosingText(nil))
+	})
+
+	t.Run("returns varied values from pool", func(t *testing.T) {
+		t.Parallel()
+		p := phrases.Defaults()
+		seen := make(map[string]bool)
+		for range 100 {
+			seen[buildClosingText(p)] = true
+		}
+		require.GreaterOrEqual(t, len(seen), 2)
+	})
+}
+
+func TestBuildPlaceholderText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns two lines from defaults", func(t *testing.T) {
+		t.Parallel()
+		p := phrases.Defaults()
+		text := buildPlaceholderText(p)
+		require.Contains(t, text, "\n")
+		require.Contains(t, text, ":Get:")
+		require.Contains(t, text, ":StatusFlashOfInspiration:")
+	})
+
+	t.Run("nil phrases returns stickers only", func(t *testing.T) {
+		t.Parallel()
+		text := buildPlaceholderText(nil)
+		require.Contains(t, text, ":Get: \n:StatusFlashOfInspiration: ")
+	})
+}

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -310,12 +310,12 @@ func (c *StreamingCardController) SendPlaceholder(ctx context.Context, chatID, c
 	c.placeholder = placeholder
 	c.mu.Unlock()
 
-	// Step 1: Send card message with placeholder content.
+	personaActivity := buildPersonaText(c.phrases)
 	contentJSON := buildStreamingCard(
 		cardHeader{Title: c.agentName, Template: headerWathet, Tags: turnTags(c.turnNum, c.model, c.branch, c.workDir)},
 		truncateForSummary(placeholder),
 		placeholder,
-		"",
+		personaActivity,
 	)
 	msgID, err := c.sendCardMessageRaw(ctx, chatID, chatType, contentJSON)
 	if err != nil {
@@ -698,7 +698,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		Title:    c.agentName,
 		Template: headerBlue,
 		Tags:     c.closeTags(),
-	}, content)
+	}, content, true)
 
 	return nil
 }
@@ -729,20 +729,30 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 		Title:    c.agentName,
 		Template: headerGrey,
 		Tags:     turnTags(c.turnNum, c.model, c.branch, c.workDir),
-	}, "")
+	}, "", false)
 
 	return nil
 }
 
 // buildFinalElements builds the elements list for the final card (Close/Abort).
-// Tool activity is transient and excluded from the final card.
-func (c *StreamingCardController) buildFinalElements(body string) []map[string]any {
-	return []map[string]any{
+// On normal Close (showClosing=true), the tool_activity strip shows a closing phrase;
+// on Abort (showClosing=false) or when no closing is available, the strip is omitted.
+func (c *StreamingCardController) buildFinalElements(body string, showClosing bool) []map[string]any {
+	elements := []map[string]any{
 		{"tag": "markdown", "element_id": streamingElementID, "content": body},
 	}
+	if showClosing {
+		if closing := buildClosingText(c.phrases); closing != "" {
+			elements = append(elements,
+				map[string]any{"tag": "hr"},
+				map[string]any{"tag": "markdown", "element_id": toolActivityElementID, "content": closing},
+			)
+		}
+	}
+	return elements
 }
 
-func (c *StreamingCardController) updateHeader(ctx context.Context, cardID string, header cardHeader, body string) {
+func (c *StreamingCardController) updateHeader(ctx context.Context, cardID string, header cardHeader, body string, showClosing bool) {
 	if cardID == "" {
 		return
 	}
@@ -752,7 +762,7 @@ func (c *StreamingCardController) updateHeader(ctx context.Context, cardID strin
 			"streaming_mode": false,
 			"summary":        map[string]any{"content": truncateForSummary(body)},
 		},
-		c.buildFinalElements(body),
+		c.buildFinalElements(body, showClosing),
 	)
 
 	reqBody := larkcardkit.NewUpdateCardReqBodyBuilder().
@@ -962,7 +972,7 @@ func (c *StreamingCardController) flushIMPatchWithConfig(ctx context.Context, co
 }
 
 func (c *StreamingCardController) doFlushIMPatch(ctx context.Context, header cardHeader, config map[string]any, content string, final bool) error {
-	elements := c.buildFinalElements(content)
+	elements := c.buildFinalElements(content, final)
 	contentJSON := buildCard(header, config, elements)
 
 	body := larkim.NewPatchMessageReqBodyBuilder().

--- a/internal/messaging/phrases/phrases.go
+++ b/internal/messaging/phrases/phrases.go
@@ -129,5 +129,25 @@ func Defaults() *Phrases {
 			{"好久不见！有什么我可以帮你的？", WeightDefault},
 			{"欢迎回来～随时继续。", WeightDefault},
 		},
+		"persona": {
+			{"🧠 正在回忆上次对话...", WeightDefault},
+			{"📋 加载技能库...", WeightDefault},
+			{"🔍 检查工作目录...", WeightDefault},
+			{"🎯 分析需求中...", WeightDefault},
+			{"🛠️ 准备开发工具...", WeightDefault},
+			{"📂 浏览项目结构...", WeightDefault},
+			{"💡 思考最佳方案...", WeightDefault},
+			{"🚀 引擎预热中...", WeightDefault},
+		},
+		"closings": {
+			{"搞定了！有事随时找我～", WeightDefault},
+			{"✅ 完成！还需要什么？", WeightDefault},
+			{"搞定～", WeightDefault},
+			{"🎉 大功告成！", WeightDefault},
+			{"☕ 任务完成，随时待命", WeightDefault},
+			{"✨ 处理好了，有事吱声", WeightDefault},
+			{"😌 收工～", WeightDefault},
+			{"🎯 完美收尾！", WeightDefault},
+		},
 	}}
 }

--- a/internal/messaging/phrases/phrases_test.go
+++ b/internal/messaging/phrases/phrases_test.go
@@ -20,6 +20,8 @@ func TestDefaults(t *testing.T) {
 	require.Contains(t, cats, "greetings")
 	require.Contains(t, cats, "tips")
 	require.Contains(t, cats, "status")
+	require.Contains(t, cats, "persona")
+	require.Contains(t, cats, "closings")
 }
 
 func TestRandomReturnsFromPool(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `persona` and `closings` phrase categories for livelier bot presence
- Placeholder card tool_activity area now shows 2 distinct persona status lines
- Turn completion shows a random closing phrase instead of removing the area
- Abort correctly omits closing phrase (fixes review finding: misleading upbeat on failure)

## Changes
| File | Change |
|------|--------|
| `phrases/phrases.go` | New `persona` (8) + `closings` (8) default categories |
| `feishu/placeholder.go` | New `buildPersonaText` + `buildClosingText` helpers |
| `feishu/streaming.go` | `SendPlaceholder` fills persona into tool_activity; `buildFinalElements` shows closing on Close only |
| `feishu/placeholder_test.go` | New tests for persona/closing/placeholder builders |
| `phrases/phrases_test.go` | Assert new categories in Defaults |

## Card lifecycle narrative arc
`Preparing (persona 2-line)` → `Working (real tool calls)` → `Done (closing 1-line)`

## Test plan
- [x] `go test ./internal/messaging/...` all pass
- [x] `make lint` clean
- [x] Code review: 1 bug found and fixed (Abort showing closing)

🤖 Generated with [Claude Code](https://claude.ai/code)