### PR TITLE
feat(messaging/feishu): configurable welcome card via phrases

### DIFF
--- a/internal/messaging/chat_access_store.go
+++ b/internal/messaging/chat_access_store.go
@@ -77,36 +77,30 @@ func (s *ChatAccessStore) Classify(ctx context.Context, platform, chatID, botID,
 		platform, chatID, botID,
 	).Scan(&lastCreatedAt)
 
-	if err == nil {
-		now := time.Now().Unix()
-		// Within 1 h cooldown — suppress even if we'd otherwise send.
-		if now-lastCreatedAt < cooldown {
-			return ChatAccessActive
-		}
+	if err != nil {
+		// No prior record — first contact, always welcome.
+		return ChatAccessNew
 	}
+
+	// Existing record — check cooldown.
+	now := time.Now().Unix()
+	if now-lastCreatedAt < cooldown {
+		return ChatAccessActive
+	}
+
+	// Outside cooldown — check activity level.
 
 	// Feishu fast-path: use event payload timestamp directly.
 	if lastMessageAtMs > 0 {
 		lastSec := lastMessageAtMs / 1000
-		since := time.Now().Unix() - lastSec
-		if since > 24*3600 {
-			return ChatAccessNew // no prior messages in 24 h
+		since := now - lastSec
+		if since > 3600 {
+			return ChatAccessReturning
 		}
 		return ChatAccessActive
 	}
 
-	// Slack path: check if we've ever seen this user.
-	var cnt int
-	err = s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM chat_access_events
-		 WHERE platform = ? AND user_id = ? AND bot_id = ?`,
-		platform, userID, botID,
-	).Scan(&cnt)
-	if err != nil || cnt == 0 {
-		return ChatAccessNew
-	}
-
-	// Existing user — check last activity.
+	// Slack path: check user's last recorded activity.
 	var lastAct int64
 	err = s.db.QueryRowContext(ctx,
 		`SELECT COALESCE(MAX(created_at), 0) FROM chat_access_events
@@ -114,10 +108,10 @@ func (s *ChatAccessStore) Classify(ctx context.Context, platform, chatID, botID,
 		platform, userID, botID,
 	).Scan(&lastAct)
 	if err != nil {
-		return ChatAccessNew
+		return ChatAccessReturning
 	}
-	since := time.Now().Unix() - lastAct
-	if since > 24*3600 {
+	since := now - lastAct
+	if since > 3600 {
 		return ChatAccessReturning
 	}
 	return ChatAccessActive

--- a/internal/messaging/feishu/chat_access.go
+++ b/internal/messaging/feishu/chat_access.go
@@ -2,36 +2,36 @@ package feishu
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 
 	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/internal/messaging/phrases"
 )
 
 // handleChatEntered processes the bot_p2p_chat_entered_v1 event.
 // It sends a welcome card to new/returning users and records analytics.
-func (a *Adapter) handleChatEntered(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) error {
+func (a *Adapter) handleChatEntered(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) {
 	if event.Event == nil {
-		return nil
+		return
 	}
 
 	chatID := ptrStr(event.Event.ChatId)
 	if chatID == "" {
-		return nil
+		return
 	}
 	openID := ptrStr(event.Event.OperatorId.OpenId)
 	if openID == "" {
-		return nil
+		return
 	}
 	eventID := ""
 	if event.EventV2Base != nil && event.EventV2Base.Header != nil {
 		eventID = event.EventV2Base.Header.EventID
 	}
 	if eventID == "" {
-		return nil
+		return
 	}
 
 	var lastMsgMs int64
@@ -43,7 +43,7 @@ func (a *Adapter) handleChatEntered(ctx context.Context, event *larkim.P2ChatAcc
 
 	store := a.chatAccessStore()
 	if store == nil {
-		return nil
+		return
 	}
 
 	accessType := store.Classify(ctx, string(messaging.PlatformFeishu), chatID, a.botOpenID, openID, lastMsgMs)
@@ -67,12 +67,11 @@ func (a *Adapter) handleChatEntered(ctx context.Context, event *larkim.P2ChatAcc
 		WelcomeSent:   welcomeSent,
 	})
 	if err != nil {
-		return fmt.Errorf("feishu: chat access record: %w", err)
+		a.Log.Warn("feishu: chat access record failed", "err", err)
 	}
 	if !inserted {
 		a.Log.Debug("feishu: duplicate chat_entered event", "event_id", eventID)
 	}
-	return nil
 }
 
 // sendWelcomeCard builds and sends a welcome card to the chat.
@@ -87,8 +86,7 @@ func (a *Adapter) sendWelcomeCard(ctx context.Context, chatID string, accessType
 		text = "Hi，我是 {bot_name}，你的 AI 编程助手！"
 	}
 	text = strings.ReplaceAll(text, "{bot_name}", a.resolveBotName())
-
-	body := fmt.Sprintf("%s\n\n我可以帮你：\n• 💻 编写、审查、调试代码\n• 📁 管理项目文件和目录\n• 🔍 搜索代码库和分析架构\n\n快捷命令：/help /reset /cd\n直接发消息即可开始 ✨", text)
+	body := buildWelcomeBody(text, a.phrases)
 
 	cardJSON := buildCard(
 		cardHeader{Title: a.resolveBotName(), Template: headerBlue},
@@ -98,6 +96,30 @@ func (a *Adapter) sendWelcomeCard(ctx context.Context, chatID string, accessType
 
 	_, err := larkCreateMessage(ctx, a.larkClient, chatID, cardJSON)
 	return err
+}
+
+// buildWelcomeBody assembles the welcome card body from phrases.
+func buildWelcomeBody(greeting string, p *phrases.Phrases) string {
+	body := greeting
+	if caps := p.All("capabilities"); len(caps) > 0 {
+		body += "\n\n我可以帮你："
+		for _, c := range caps {
+			body += "\n• " + c
+		}
+	}
+	if cmds := p.All("quick_commands"); len(cmds) > 0 {
+		body += "\n\n快捷命令："
+		for i, c := range cmds {
+			if i > 0 {
+				body += " "
+			}
+			body += c
+		}
+	}
+	if cl := p.Random("closing_line"); cl != "" {
+		body += "\n" + cl
+	}
+	return body
 }
 
 // chatAccessStore extracts the ChatAccessStore from the adapter extras.

--- a/internal/messaging/feishu/chat_access_test.go
+++ b/internal/messaging/feishu/chat_access_test.go
@@ -1,0 +1,64 @@
+package feishu
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging/phrases"
+)
+
+func TestBuildWelcomeBody_AllDefaults(t *testing.T) {
+	t.Parallel()
+	p := phrases.Defaults()
+	got := buildWelcomeBody("Hi，我是 TestBot，你的 AI 编程助手！", p)
+
+	// Greeting present
+	require.True(t, strings.HasPrefix(got, "Hi，我是 TestBot"), got)
+	// Capabilities section
+	require.Contains(t, got, "我可以帮你：")
+	require.Contains(t, got, "• 💻 编写、审查、调试代码")
+	// Quick commands section
+	require.Contains(t, got, "快捷命令：")
+	require.Contains(t, got, "/help")
+	// Closing line
+	require.Contains(t, got, "直接发消息即可开始")
+}
+
+func TestBuildWelcomeBody_EmptyCategories(t *testing.T) {
+	t.Parallel()
+	p := &phrases.Phrases{}
+	got := buildWelcomeBody("Hello!", p)
+	require.Equal(t, "Hello!", got)
+}
+
+func TestBuildWelcomeBody_CapabilitiesOnly(t *testing.T) {
+	t.Parallel()
+	// Empty phrases → no sections appended
+	empty := &phrases.Phrases{}
+	got := buildWelcomeBody("Hi!", empty)
+	require.Equal(t, "Hi!", got)
+}
+
+func TestBuildWelcomeBody_NilPhrases(t *testing.T) {
+	t.Parallel()
+	got := buildWelcomeBody("Hello!", nil)
+	require.Equal(t, "Hello!", got)
+}
+
+func TestBuildWelcomeBody_AllSections(t *testing.T) {
+	t.Parallel()
+	def := phrases.Defaults()
+	got := buildWelcomeBody("Hi!", def)
+
+	// With defaults all 3 sections are present
+	parts := strings.Split(got, "\n\n")
+	require.Len(t, parts, 3, "expected greeting, capabilities, quick_commands sections")
+
+	require.True(t, strings.HasPrefix(parts[0], "Hi!"))
+	require.Contains(t, parts[1], "我可以帮你：")
+	require.Contains(t, parts[2], "快捷命令：")
+	// Closing line is appended after last \n (not \n\n)
+	require.True(t, strings.Contains(parts[2], "直接发消息即可开始"), parts[2])
+}

--- a/internal/messaging/feishu/ws.go
+++ b/internal/messaging/feishu/ws.go
@@ -40,7 +40,8 @@ func (a *Adapter) newEventHandler() *dispatcher.EventDispatcher {
 					err = fmt.Errorf("feishu chat entered panic: %v", r)
 				}
 			}()
-			return a.handleChatEntered(ctx, event)
+			a.handleChatEntered(ctx, event)
+			return nil
 		})
 }
 

--- a/internal/messaging/phrases/phrases.go
+++ b/internal/messaging/phrases/phrases.go
@@ -149,5 +149,18 @@ func Defaults() *Phrases {
 			{"😌 收工～", WeightDefault},
 			{"🎯 完美收尾！", WeightDefault},
 		},
+		"capabilities": {
+			{"💻 编写、审查、调试代码", WeightDefault},
+			{"📁 管理项目文件和目录", WeightDefault},
+			{"🔍 搜索代码库和分析架构", WeightDefault},
+		},
+		"quick_commands": {
+			{"/help — 查看帮助", WeightDefault},
+			{"/reset — 重置上下文", WeightDefault},
+			{"/cd — 切换工作目录", WeightDefault},
+		},
+		"closing_line": {
+			{"直接发消息即可开始 ✨", WeightDefault},
+		},
 	}}
 }

--- a/internal/messaging/phrases/phrases.md
+++ b/internal/messaging/phrases/phrases.md
@@ -54,6 +54,9 @@ Markdown，`## 分类名` + `- 条目文本`：
 | `status` | 助手状态文本 | Slack assistant status |
 | `welcome` | 首次进入聊天欢迎语 | 飞书 welcome card（支持 `{bot_name}` 占位符） |
 | `welcome_back` | 回访用户欢迎语 | 飞书 welcome card |
+| `capabilities` | 能力描述列表 | 飞书 welcome card（每条前加 `• `） |
+| `quick_commands` | 快捷命令列表 | 飞书 welcome card（空格分隔） |
+| `closing_line` | 欢迎卡片结尾语 | 飞书 welcome card |
 
 ## 配置操作
 

--- a/internal/messaging/slack/conn_events.go
+++ b/internal/messaging/slack/conn_events.go
@@ -16,6 +16,8 @@ type envelopeSendFunc func(ctx context.Context, env *events.Envelope) error
 // notifyStatusFromEvent maps AEP events to processing status indicators.
 func (c *SlackConn) notifyStatusFromEvent(ctx context.Context, env *events.Envelope) {
 	switch env.Event.Type {
+	case events.Reasoning:
+		_ = c.adapter.statusMgr.Notify(ctx, c.channelID, c.threadTS, StatusThinking, "Thinking...")
 	case events.ToolCall:
 		name, input := extractCallNameInput(env)
 		text := toolfmt.FormatCall(name, input)


### PR DESCRIPTION
## Summary

- Fix Slack reasoning status gap (events.Reasoning → StatusThinking mapping)
- Make chat_access feature non-blocking (errors logged, not propagated)
- Rewrite ChatAccessStore.Classify logic (no-record → New, 1h cooldown/threshold)
- Make welcome card capabilities configurable via phrases system (Closes #440)

## Changes

**fix(messaging)**: Reasoning status, chat_access non-blocking, Classify logic
- Add `events.Reasoning → StatusThinking` in Slack `notifyStatusFromEvent`
- `handleChatEntered` no longer returns error — Record failures logged as Warn
- `Classify`: no DB record → `ChatAccessNew`; 1h cooldown; 1h activity threshold

**feat(messaging/feishu)**: Configurable welcome card via phrases (#440)
- Add 3 built-in phrase categories: `capabilities`, `quick_commands`, `closing_line`
- Extract `buildWelcomeBody()` for testability + 5 test cases
- Update phrases skill manual

## Test plan

- [x] `go test ./internal/messaging/... -count=1` 全部通过
- [x] `make build` 构建成功
- [x] pre-commit hooks (gofmt + golangci-lint) 通过
- [ ] 清空 chat_access_events 表 → 进入聊天窗口 → 验证欢迎卡片
- [ ] 配置自定义 capabilities/quick_commands → 验证覆盖生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)