### PR TITLE
feat(worker/ocs): structured permission/question events (#435)

### DIFF
--- a/internal/messaging/feishu/interaction.go
+++ b/internal/messaging/feishu/interaction.go
@@ -134,7 +134,7 @@ func (c *FeishuConn) sendElicitationRequest(ctx context.Context, env *events.Env
 	if data.URL != "" {
 		fmt.Fprintf(&footer, "📎 [外部表单](%s)\n", data.URL)
 	}
-	footer.WriteString("💬 回复 **accept** 或 **decline** 来响应此请求")
+	footer.WriteString("💬 回复 **accept/同意** 或 **decline/拒绝** 来响应此请求")
 
 	cardJSON := buildInteractionCard(header, footer.String(), cardHeader{
 		Title:    "MCP Server 请求",
@@ -221,9 +221,14 @@ func (a *Adapter) checkPendingInteraction(ctx context.Context, text, userID stri
 		metadata = messaging.BuildQuestionResponse(matched.ID, text)
 
 	case events.ElicitationRequest:
-		action := "accept"
-		if normalized == "decline" || normalized == "拒绝" || normalized == "cancel" || normalized == "取消" {
+		action := ""
+		if isElicitationAccept(normalized) {
+			action = "accept"
+		} else if isElicitationDecline(normalized) {
 			action = "decline"
+		}
+		if action == "" {
+			return false
 		}
 		metadata = messaging.BuildElicitationResponse(matched.ID, action)
 	}
@@ -305,6 +310,26 @@ func isPermissionDeny(s string) bool {
 	}
 }
 
+// isElicitationAccept checks if the normalized text is an elicitation-accept keyword.
+func isElicitationAccept(s string) bool {
+	switch s {
+	case "accept", "同意", "确认", "ok", "yes", "是", "好", "好的", "allow":
+		return true
+	default:
+		return false
+	}
+}
+
+// isElicitationDecline checks if the normalized text is an elicitation-decline keyword.
+func isElicitationDecline(s string) bool {
+	switch s {
+	case "decline", "拒绝", "取消", "cancel", "no", "否", "不", "不要":
+		return true
+	default:
+		return false
+	}
+}
+
 // truncate shortens a string to maxLen.
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
@@ -372,6 +397,6 @@ func buildElicitationFallbackText(data *events.ElicitationRequestData) string {
 		fmt.Fprintf(&sb, "\n外部表单: %s\n", data.URL)
 	}
 
-	fmt.Fprintf(&sb, "\n回复 accept 或 decline 来响应此请求")
+	fmt.Fprintf(&sb, "\n回复 accept/同意 或 decline/拒绝 来响应此请求")
 	return sb.String()
 }

--- a/internal/messaging/feishu/interaction_coverage_test.go
+++ b/internal/messaging/feishu/interaction_coverage_test.go
@@ -243,37 +243,78 @@ func TestCheckPendingInteraction_ElicitationDecline_CN(t *testing.T) {
 	require.Equal(t, "decline", er["action"])
 }
 
-// TestCheckPendingInteraction_ElicitationDefaultAccept verifies the Feishu design
-// decision: any text that isn't a decline keyword defaults to "accept" action.
-// This is intentional — Feishu lacks interactive button callbacks for cards.
-func TestCheckPendingInteraction_ElicitationDefaultAccept(t *testing.T) {
+// TestCheckPendingInteraction_ElicitationRejectsNonKeyword verifies that
+// random text is NOT consumed as an elicitation response — consistent with
+// Slack's explicit accept/decline requirement.
+func TestCheckPendingInteraction_ElicitationRejectsNonKeyword(t *testing.T) {
 	t.Parallel()
 	a := newTestAdapter(t)
 	a.Interactions = messaging.NewInteractionManager(discardLogger)
 	a.rateLimiter = NewFeishuRateLimiter()
 	t.Cleanup(func() { a.rateLimiter.Stop() })
 
-	conn := a.GetOrCreateConn("chat_el_default", "")
+	conn := a.GetOrCreateConn("chat_el_reject", "")
 	conn.mu.Lock()
-	conn.sessionID = "sess-el-default"
+	conn.sessionID = "sess-el-reject"
 	conn.mu.Unlock()
 
-	var capturedMetadata map[string]any
 	a.Interactions.Register(&messaging.PendingInteraction{
-		ID:        "el-default",
-		SessionID: "sess-el-default",
+		ID:        "el-reject",
+		SessionID: "sess-el-reject",
 		Type:      events.ElicitationRequest,
 		Timeout:   5 * time.Minute,
 		SendResponse: func(metadata map[string]any) {
-			capturedMetadata = metadata
+			t.Fatal("should not consume random text as elicitation response")
 		},
 	})
 
-	// Random non-decline text → treated as accept
+	// Random text → NOT consumed
 	consumed := a.checkPendingInteraction(context.Background(), "some random text", "owner_123", conn)
-	require.True(t, consumed)
-	er := capturedMetadata["elicitation_response"].(map[string]any)
-	require.Equal(t, "accept", er["action"])
+	require.False(t, consumed)
+}
+
+// TestCheckPendingInteraction_ElicitationAccept_Variants verifies accept keywords.
+func TestCheckPendingInteraction_ElicitationAccept_Variants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+	}{
+		{"accept", "accept"},
+		{"同意", "同意"},
+		{"确认", "确认"},
+		{"ok", "ok"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := newTestAdapter(t)
+			a.Interactions = messaging.NewInteractionManager(discardLogger)
+			a.rateLimiter = NewFeishuRateLimiter()
+			t.Cleanup(func() { a.rateLimiter.Stop() })
+
+			conn := a.GetOrCreateConn("chat_el_acc_"+tt.name, "")
+			conn.mu.Lock()
+			conn.sessionID = "sess-el-acc-" + tt.name
+			conn.mu.Unlock()
+
+			var capturedMetadata map[string]any
+			a.Interactions.Register(&messaging.PendingInteraction{
+				ID:        "el-acc-" + tt.name,
+				SessionID: "sess-el-acc-" + tt.name,
+				Type:      events.ElicitationRequest,
+				Timeout:   5 * time.Minute,
+				SendResponse: func(metadata map[string]any) {
+					capturedMetadata = metadata
+				},
+			})
+
+			consumed := a.checkPendingInteraction(context.Background(), tt.text, "owner_123", conn)
+			require.True(t, consumed)
+			er := capturedMetadata["elicitation_response"].(map[string]any)
+			require.Equal(t, "accept", er["action"])
+		})
+	}
 }
 
 func TestCheckPendingInteraction_PermissionAllow_Variants(t *testing.T) {

--- a/internal/messaging/feishu/interaction_coverage_test.go
+++ b/internal/messaging/feishu/interaction_coverage_test.go
@@ -243,6 +243,39 @@ func TestCheckPendingInteraction_ElicitationDecline_CN(t *testing.T) {
 	require.Equal(t, "decline", er["action"])
 }
 
+// TestCheckPendingInteraction_ElicitationDefaultAccept verifies the Feishu design
+// decision: any text that isn't a decline keyword defaults to "accept" action.
+// This is intentional — Feishu lacks interactive button callbacks for cards.
+func TestCheckPendingInteraction_ElicitationDefaultAccept(t *testing.T) {
+	t.Parallel()
+	a := newTestAdapter(t)
+	a.Interactions = messaging.NewInteractionManager(discardLogger)
+	a.rateLimiter = NewFeishuRateLimiter()
+	t.Cleanup(func() { a.rateLimiter.Stop() })
+
+	conn := a.GetOrCreateConn("chat_el_default", "")
+	conn.mu.Lock()
+	conn.sessionID = "sess-el-default"
+	conn.mu.Unlock()
+
+	var capturedMetadata map[string]any
+	a.Interactions.Register(&messaging.PendingInteraction{
+		ID:        "el-default",
+		SessionID: "sess-el-default",
+		Type:      events.ElicitationRequest,
+		Timeout:   5 * time.Minute,
+		SendResponse: func(metadata map[string]any) {
+			capturedMetadata = metadata
+		},
+	})
+
+	// Random non-decline text → treated as accept
+	consumed := a.checkPendingInteraction(context.Background(), "some random text", "owner_123", conn)
+	require.True(t, consumed)
+	er := capturedMetadata["elicitation_response"].(map[string]any)
+	require.Equal(t, "accept", er["action"])
+}
+
 func TestCheckPendingInteraction_PermissionAllow_Variants(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -246,15 +246,9 @@ func (c *Converter) convertV1(sessionID, eventType string, props json.RawMessage
 	case ocsSessionError:
 		return c.handleSessionError(sessionID, props)
 	case ocsPermAsked:
-		return []*events.Envelope{
-			events.NewEnvelope(aep.NewID(), sessionID, 0, events.Raw,
-				events.RawData{Kind: "ocs:permission.asked", Raw: props}),
-		}
+		return c.handlePermAsked(sessionID, props)
 	case ocsQuestionAsked:
-		return []*events.Envelope{
-			events.NewEnvelope(aep.NewID(), sessionID, 0, events.Raw,
-				events.RawData{Kind: "ocs:question.asked", Raw: props}),
-		}
+		return c.handleQuestionAsked(sessionID, props)
 	default:
 		return nil
 	}
@@ -320,6 +314,47 @@ func (c *Converter) handleSessionError(sessionID string, props json.RawMessage) 
 	delete(c.states, sessionID)
 	return []*events.Envelope{
 		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{Message: msg}),
+	}
+}
+
+func (c *Converter) handlePermAsked(sessionID string, props json.RawMessage) []*events.Envelope {
+	var data struct {
+		ID       string         `json:"id"`
+		Metadata map[string]any `json:"metadata"`
+	}
+	if err := json.Unmarshal(props, &data); err != nil {
+		return nil
+	}
+
+	toolName, _ := data.Metadata["tool"].(string)
+	args, _ := json.Marshal(data.Metadata)
+	return []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.PermissionRequest,
+			events.PermissionRequestData{
+				ID:          data.ID,
+				ToolName:    toolName,
+				Description: toolName,
+				Args:        []string{string(args)},
+				InputRaw:    json.RawMessage(args),
+			}),
+	}
+}
+
+func (c *Converter) handleQuestionAsked(sessionID string, props json.RawMessage) []*events.Envelope {
+	var data struct {
+		ID        string            `json:"id"`
+		Questions []events.Question `json:"questions"`
+	}
+	if err := json.Unmarshal(props, &data); err != nil {
+		return nil
+	}
+
+	return []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.QuestionRequest,
+			events.QuestionRequestData{
+				ID:        data.ID,
+				Questions: data.Questions,
+			}),
 	}
 }
 

--- a/internal/worker/opencodeserver/converter_test.go
+++ b/internal/worker/opencodeserver/converter_test.go
@@ -318,19 +318,25 @@ func TestConverter_PermissionAsked(t *testing.T) {
 	props := rawProps(t, map[string]any{"id": "p1", "metadata": map[string]any{"tool": "bash"}})
 	envs := c.Convert("s1", ocsPermAsked, props)
 	require.Len(t, envs, 1)
-	require.Equal(t, events.Raw, envs[0].Event.Type)
-	data := envs[0].Event.Data.(events.RawData)
-	require.Equal(t, "ocs:permission.asked", data.Kind)
+	require.Equal(t, events.PermissionRequest, envs[0].Event.Type)
+	data := envs[0].Event.Data.(events.PermissionRequestData)
+	require.Equal(t, "p1", data.ID)
+	require.Equal(t, "bash", data.ToolName)
 }
 
 func TestConverter_QuestionAsked(t *testing.T) {
 	c := newTestConverter()
-	props := rawProps(t, map[string]any{"id": "q1"})
+	props := rawProps(t, map[string]any{
+		"id":        "q1",
+		"questions": []map[string]any{{"question": "Continue?", "header": "Confirm", "options": []map[string]any{{"label": "Yes"}}}},
+	})
 	envs := c.Convert("s1", ocsQuestionAsked, props)
 	require.Len(t, envs, 1)
-	require.Equal(t, events.Raw, envs[0].Event.Type)
-	data := envs[0].Event.Data.(events.RawData)
-	require.Equal(t, "ocs:question.asked", data.Kind)
+	require.Equal(t, events.QuestionRequest, envs[0].Event.Type)
+	data := envs[0].Event.Data.(events.QuestionRequestData)
+	require.Equal(t, "q1", data.ID)
+	require.Len(t, data.Questions, 1)
+	require.Equal(t, "Continue?", data.Questions[0].Question)
 }
 
 func TestConverter_V1UnknownEvent(t *testing.T) {

--- a/internal/worker/opencodeserver/converter_test.go
+++ b/internal/worker/opencodeserver/converter_test.go
@@ -315,20 +315,27 @@ func TestConverter_SessionError_NameOnly(t *testing.T) {
 
 func TestConverter_PermissionAsked(t *testing.T) {
 	c := newTestConverter()
-	props := rawProps(t, map[string]any{"id": "p1", "metadata": map[string]any{"tool": "bash"}})
+	props := rawProps(t, map[string]any{"id": "p1", "metadata": map[string]any{"tool": "bash", "cmd": "ls -la"}})
 	envs := c.Convert("s1", ocsPermAsked, props)
 	require.Len(t, envs, 1)
 	require.Equal(t, events.PermissionRequest, envs[0].Event.Type)
 	data := envs[0].Event.Data.(events.PermissionRequestData)
 	require.Equal(t, "p1", data.ID)
 	require.Equal(t, "bash", data.ToolName)
+	require.Equal(t, "bash", data.Description)
+	require.NotEmpty(t, data.Args, "Args should contain serialized metadata")
+	require.NotEmpty(t, data.InputRaw, "InputRaw should contain serialized metadata")
+	// InputRaw must be valid JSON
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data.InputRaw, &parsed))
+	require.Equal(t, "bash", parsed["tool"])
 }
 
 func TestConverter_QuestionAsked(t *testing.T) {
 	c := newTestConverter()
 	props := rawProps(t, map[string]any{
 		"id":        "q1",
-		"questions": []map[string]any{{"question": "Continue?", "header": "Confirm", "options": []map[string]any{{"label": "Yes"}}}},
+		"questions": []map[string]any{{"question": "Continue?", "header": "Confirm", "options": []map[string]any{{"label": "Yes"}, {"label": "No"}}}},
 	})
 	envs := c.Convert("s1", ocsQuestionAsked, props)
 	require.Len(t, envs, 1)
@@ -337,6 +344,22 @@ func TestConverter_QuestionAsked(t *testing.T) {
 	require.Equal(t, "q1", data.ID)
 	require.Len(t, data.Questions, 1)
 	require.Equal(t, "Continue?", data.Questions[0].Question)
+	require.Equal(t, "Confirm", data.Questions[0].Header)
+	require.Len(t, data.Questions[0].Options, 2)
+	require.Equal(t, "Yes", data.Questions[0].Options[0].Label)
+	require.Equal(t, "No", data.Questions[0].Options[1].Label)
+}
+
+func TestConverter_PermissionAsked_MalformedJSON(t *testing.T) {
+	c := newTestConverter()
+	envs := c.Convert("s1", ocsPermAsked, json.RawMessage(`{invalid`))
+	require.Empty(t, envs, "malformed JSON should produce nil for permission.asked")
+}
+
+func TestConverter_QuestionAsked_MalformedJSON(t *testing.T) {
+	c := newTestConverter()
+	envs := c.Convert("s1", ocsQuestionAsked, json.RawMessage(`{invalid`))
+	require.Empty(t, envs, "malformed JSON should produce nil for question.asked")
 }
 
 func TestConverter_V1UnknownEvent(t *testing.T) {

--- a/internal/worker/opencodeserver/sse_test.go
+++ b/internal/worker/opencodeserver/sse_test.go
@@ -299,9 +299,10 @@ func TestReadGlobalSSE_DispatchesPermissionAsked(t *testing.T) {
 	go s.readGlobalSSE(ctx)
 
 	got := collectN(t, ch, 1)
-	require.Equal(t, events.Raw, got[0].Event.Type)
-	data := got[0].Event.Data.(events.RawData)
-	require.Equal(t, "ocs:permission.asked", data.Kind)
+	require.Equal(t, events.PermissionRequest, got[0].Event.Type)
+	data := got[0].Event.Data.(events.PermissionRequestData)
+	require.Equal(t, "perm_1", data.ID)
+	require.Equal(t, "bash", data.ToolName)
 	s.Unsubscribe("ses_1")
 }
 
@@ -700,7 +701,7 @@ func TestForwardBusEvents_MessageDelta(t *testing.T) {
 	require.Equal(t, events.MessageDelta, got[0].Event.Type)
 }
 
-func TestForwardBusEvents_PermissionAsked(t *testing.T) {
+func TestForwardBusEvents_PermissionRequest(t *testing.T) {
 	t.Parallel()
 
 	w, busCh := newWorkerWithBusCh(t)
@@ -709,20 +710,18 @@ func TestForwardBusEvents_PermissionAsked(t *testing.T) {
 	defer cancel()
 	go w.forwardBusEvents(ctx, "ses_test", busCh)
 
-	props, _ := json.Marshal(map[string]any{
-		"id":       "perm_1",
-		"metadata": map[string]any{"tool": "bash"},
-	})
-	// Use json.RawMessage so the Raw field is the correct type after round-trip.
-	rawEnv := events.NewEnvelope("id1", "ses_test", 0, events.Raw,
-		events.RawData{Kind: "ocs:permission.asked", Raw: json.RawMessage(props)})
-	busCh <- rawEnv
+	env := events.NewEnvelope("id1", "ses_test", 0, events.PermissionRequest,
+		events.PermissionRequestData{ID: "perm_1", ToolName: "bash"})
+	busCh <- env
 
 	got := collectN(t, w.httpConn.recvCh, 1)
 	require.Equal(t, events.PermissionRequest, got[0].Event.Type)
+	data := got[0].Event.Data.(events.PermissionRequestData)
+	require.Equal(t, "perm_1", data.ID)
+	require.Equal(t, "bash", data.ToolName)
 }
 
-func TestForwardBusEvents_QuestionAsked(t *testing.T) {
+func TestForwardBusEvents_QuestionRequest(t *testing.T) {
 	t.Parallel()
 
 	w, busCh := newWorkerWithBusCh(t)
@@ -731,16 +730,17 @@ func TestForwardBusEvents_QuestionAsked(t *testing.T) {
 	defer cancel()
 	go w.forwardBusEvents(ctx, "ses_test", busCh)
 
-	props, _ := json.Marshal(map[string]any{
-		"id":        "q_1",
-		"questions": []map[string]any{{"id": "q1", "title": "Confirm?"}},
-	})
-	rawEnv := events.NewEnvelope("id1", "ses_test", 0, events.Raw,
-		events.RawData{Kind: "ocs:question.asked", Raw: json.RawMessage(props)})
-	busCh <- rawEnv
+	env := events.NewEnvelope("id1", "ses_test", 0, events.QuestionRequest,
+		events.QuestionRequestData{
+			ID:        "q_1",
+			Questions: []events.Question{{Question: "Continue?", Header: "Confirm"}},
+		})
+	busCh <- env
 
 	got := collectN(t, w.httpConn.recvCh, 1)
 	require.Equal(t, events.QuestionRequest, got[0].Event.Type)
+	data := got[0].Event.Data.(events.QuestionRequestData)
+	require.Equal(t, "q_1", data.ID)
 }
 
 func TestForwardBusEvents_ChannelClosed_Stops(t *testing.T) {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -634,20 +634,6 @@ func (w *Worker) forwardBusEvents(ctx context.Context, sessionID string, busCh c
 				return
 			}
 
-			// Handle OCS-specific Raw events (permission/question asks).
-			if env.Event.Type == events.Raw {
-				data, _ := env.Event.Data.(events.RawData)
-				raw := toRawMessage(data.Raw)
-				switch data.Kind {
-				case "ocs:permission.asked":
-					w.handlePermissionAsked(sessionID, raw)
-					continue
-				case "ocs:question.asked":
-					w.handleQuestionAsked(sessionID, raw)
-					continue
-				}
-			}
-
 			w.SetLastIO(time.Now())
 
 			w.Mu.Lock()
@@ -703,74 +689,6 @@ func (w *Worker) release() {
 
 	if conn != nil {
 		_ = conn.Close()
-	}
-}
-
-// ─── OpenCode Bus Event Handlers ──────────────────────────────────────────────
-
-func (w *Worker) handlePermissionAsked(sessionID string, props json.RawMessage) {
-	var data struct {
-		ID       string         `json:"id"`
-		Metadata map[string]any `json:"metadata"`
-	}
-	if err := json.Unmarshal(props, &data); err != nil {
-		w.Log.Warn("opencodeserver: parse permission.asked", "session_id", sessionID, "err", err)
-		return
-	}
-
-	toolName, _ := data.Metadata["tool"].(string)
-	args, _ := json.Marshal(data.Metadata)
-	env := events.NewEnvelope(
-		aep.NewID(), sessionID, 0,
-		events.PermissionRequest,
-		events.PermissionRequestData{
-			ID:          data.ID,
-			ToolName:    toolName,
-			Description: toolName,
-			Args:        []string{string(args)},
-			InputRaw:    json.RawMessage(args),
-		},
-	)
-	w.trySend(env)
-}
-
-func (w *Worker) handleQuestionAsked(sessionID string, props json.RawMessage) {
-	var data struct {
-		ID        string            `json:"id"`
-		Questions []events.Question `json:"questions"`
-	}
-	if err := json.Unmarshal(props, &data); err != nil {
-		w.Log.Warn("opencodeserver: parse question.asked", "session_id", sessionID, "err", err)
-		return
-	}
-
-	env := events.NewEnvelope(
-		aep.NewID(), sessionID, 0,
-		events.QuestionRequest,
-		events.QuestionRequestData{
-			ID:        data.ID,
-			Questions: data.Questions,
-		},
-	)
-	w.trySend(env)
-}
-
-func (w *Worker) trySend(env *events.Envelope) {
-	w.Mu.Lock()
-	c := w.httpConn
-	closed := c == nil
-	w.Mu.Unlock()
-
-	if closed {
-		return
-	}
-
-	w.SetLastIO(time.Now())
-	select {
-	case c.recvCh <- env:
-	default:
-		w.Log.Warn("opencodeserver: recv channel full, dropping bus event",
-			"event_type", env.Event.Type)
 	}
 }
 
@@ -962,24 +880,6 @@ func isServerDownError(err error) bool {
 }
 
 // ─── Init ────────────────────────────────────────────────────────────────────
-
-// toRawMessage safely converts any to json.RawMessage.
-func toRawMessage(v any) json.RawMessage {
-	if v == nil {
-		return nil
-	}
-	switch raw := v.(type) {
-	case json.RawMessage:
-		return raw
-	case []byte:
-		return json.RawMessage(raw)
-	case string:
-		return json.RawMessage(raw)
-	default:
-		b, _ := json.Marshal(v)
-		return json.RawMessage(b)
-	}
-}
 
 func init() {
 	worker.Register(worker.TypeOpenCodeSrv, func() (worker.Worker, error) {


### PR DESCRIPTION
## Summary

- OCS Converter 直接产出 `PermissionRequest`/`QuestionRequest` 结构化事件，移除 worker.go 中的 Raw passthrough 中间层（净减 ~70 行）
- Feishu elicitation 统一为显式 accept/decline 关键词匹配，与 Slack 行为一致
- 新增 malformed JSON 测试、完整字段断言（Description/Args/InputRaw/Header/Options）、Feishu elicitation 关键词覆盖测试
- 新增 E2E 交互事件测试脚本 `scripts/test_interaction_events.py`

Closes #435

## Test plan

- [x] `make check` 全绿（quality + build）
- [x] `go test ./internal/worker/opencodeserver/... -count=1 -race` 通过
- [x] `go test ./internal/messaging/feishu/... -count=1 -race` 通过
- [x] `scripts/test_interaction_events.py --worker claude_code` 全通过
- [x] `scripts/test_interaction_events.py --worker opencode_server` 全通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)