### PR TITLE
fix(gateway): add timeout protection for Worker.Resume to prevent handler mutex deadlock

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -80,8 +80,9 @@ type crashHistory struct {
 }
 
 const (
-	crashLoopMax    = 3               // max consecutive crashes before abort
-	crashLoopWindow = 5 * time.Minute // window for counting consecutive crashes
+	crashLoopMax    = 3                // max consecutive crashes before abort
+	crashLoopWindow = 5 * time.Minute  // window for counting consecutive crashes
+	resumeTimeout   = 60 * time.Second // max time for Worker.Resume(); prevents indefinite blocking
 )
 
 // NewBridge creates a new bridge.
@@ -249,7 +250,10 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 				opts.resumed = false
 				return nil
 			}
-			if err := w.Resume(ctx, info); err != nil {
+			resumeCtx, resumeCancel := context.WithTimeout(ctx, resumeTimeout)
+			err := w.Resume(resumeCtx, info)
+			resumeCancel()
+			if err != nil {
 				return fmt.Errorf("bridge: resume start: %w", err)
 			}
 			return nil

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -268,26 +268,30 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 		return err
 	}
 
+	w.Log.Debug("opencodeserver: resume step 1 - acquiring server")
 	if err := w.acquireServer(ctx); err != nil {
 		return err
 	}
+	w.Log.Debug("opencodeserver: resume step 2 - server acquired", "addr", w.httpAddr)
 
 	// Try to reuse the OCS-internal session if we have one from a previous Start.
 	ocsSessionID := session.WorkerSessionID
 	if ocsSessionID != "" {
-		// Verify the OCS session still exists.
+		w.Log.Debug("opencodeserver: resume step 3 - checking session existence", "ocs_session_id", ocsSessionID)
 		if w.ocsSessionExists(ctx, ocsSessionID) {
 			w.Log.Info("opencodeserver: resuming existing OCS session",
 				"ocs_session_id", ocsSessionID, "hotplex_session_id", session.SessionID)
 			w.initSessionConn(ctx, ocsSessionID, session)
 			w.startSSE(ocsSessionID)
+			w.Log.Debug("opencodeserver: resume completed (reused session)")
 			return nil
 		}
 		w.Log.Info("opencodeserver: OCS session not found, creating fresh",
 			"stale_ocs_session_id", ocsSessionID, "hotplex_session_id", session.SessionID)
 	}
 
-	// No valid OCS session — create a new one (conversation context is lost).
+	// No valid OCS session - create a new one (conversation context is lost).
+	w.Log.Debug("opencodeserver: resume step 3 - creating fresh session", "dir", session.ProjectDir)
 	newSessionID, err := w.createSession(ctx, session.ProjectDir)
 	if err != nil {
 		w.releaseOnce.Do(func() { w.singleton.Release() })
@@ -296,6 +300,7 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 
 	w.initSessionConn(ctx, newSessionID, session)
 	w.startSSE(newSessionID)
+	w.Log.Debug("opencodeserver: resume completed (fresh session)")
 	return nil
 }
 


### PR DESCRIPTION
Fixes #447

## Summary

- Worker.Resume() 可能无限阻塞（实测 40+ 分钟），持有 Slack adapter 的 `handlerMu` 锁，导致同线程所有后续消息排队等待
- 为 `resumeWithOpts` startFn 中的 `w.Resume()` 添加 60s `context.WithTimeout`，超时后触发 `attemptResumeFallback`（fresh start）
- 为 OCS `Resume()` 添加分步 DEBUG 日志，便于下次复现时定位精确阻塞步骤

## Root Cause

OCS Worker `Resume()` 在 resume 流程中某步骤卡死（无超时、无日志），导致：
1. `createAndLaunchWorker` 的 `startFn` 阻塞
2. `forwardEvents` goroutine 无法启动
3. Slack `HandleTextMessage` 持有 `conn.handlerMu` 等待 `Bridge().Handle()` 返回
4. 同一线程所有后续消息被阻塞

## Test plan

- [x] `make build` 编译通过
- [x] `go test ./internal/gateway/ ./internal/worker/opencodeserver/` 全部通过
- [x] pre-commit hooks (gofmt + golangci-lint + go vet) 通过
- [ ] 手动验证：Resume 超时后是否正确触发 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)