### PR TITLE
fix(worker/ocs,messaging): HTTP timeout false unreachable, CardKit flush, event drop (#448)

### DIFF
--- a/configs/config-dev.yaml
+++ b/configs/config-dev.yaml
@@ -29,6 +29,8 @@ pool:
 worker:
   idle_timeout: 30m
   execution_timeout: 30m
+  opencode_server:
+    password: "${OPENCODE_SERVER_PASSWORD}"
 
 log:
   level: "debug"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -481,6 +481,7 @@ type ClaudeCodeConfig struct {
 // OpenCodeServerConfig holds OpenCode Server singleton process settings.
 type OpenCodeServerConfig struct {
 	Command           string        `mapstructure:"command"` // binary + optional subcommand, e.g. "opencode" or "opencode serve"
+	Password          string        `mapstructure:"password"`
 	IdleDrainPeriod   time.Duration `mapstructure:"idle_drain_period"`
 	ReadyTimeout      time.Duration `mapstructure:"ready_timeout"`
 	ReadyPollInterval time.Duration `mapstructure:"ready_poll_interval"`
@@ -856,6 +857,7 @@ func Load(filePath string, opts LoadOptions) (*Config, error) {
 	_ = v.BindEnv("worker.opencode_server.ready_timeout")
 	_ = v.BindEnv("worker.opencode_server.ready_poll_interval")
 	_ = v.BindEnv("worker.opencode_server.http_timeout")
+	_ = v.BindEnv("worker.opencode_server.password")
 	_ = v.BindEnv("security.jwt_audience")
 	_ = v.BindEnv("security.api_key_header")
 	_ = v.BindEnv("agent_config.enabled")
@@ -1022,6 +1024,7 @@ func (c *Config) normalizePaths() {
 		&c.Admin.Addr,
 		&c.Worker.ClaudeCode.Command,
 		&c.Worker.OpenCodeServer.Command,
+		&c.Worker.OpenCodeServer.Password,
 		&c.Messaging.Slack.LocalCmd,
 		&c.Messaging.Feishu.LocalCmd,
 		&c.Messaging.Feishu.MossModelDir,

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -22,10 +22,16 @@ func (h *Handler) sendErrorf(ctx context.Context, env *events.Envelope, code eve
 // classifyWorkerError converts worker errors into AEP error codes.
 // Worker process death (ErrKindUnavailable) maps to ErrCodeSessionTerminated
 // so clients can reconnect rather than treating them as transient internal errors.
+// Timeout errors (ErrKindTimeout) are not treated as fatal — the worker is still alive.
 func classifyWorkerError(err error) events.ErrorCode {
-	var we *worker.WorkerError
-	if errors.As(err, &we) && we.Kind == worker.ErrKindUnavailable {
-		return events.ErrCodeSessionTerminated
+	we, ok := errors.AsType[*worker.WorkerError](err)
+	if ok {
+		switch we.Kind {
+		case worker.ErrKindUnavailable:
+			return events.ErrCodeSessionTerminated
+		case worker.ErrKindTimeout:
+			return events.ErrCodeInternalError
+		}
 	}
 	return events.ErrCodeInternalError
 }

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -221,6 +221,12 @@ func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {
 			h.log.Debug("gateway: delivering input to worker", "session_id", env.SessionID, "content_len", len(content), "preview", preview)
 		}
 		if err := w.Input(ctx, content, nil); err != nil {
+			// Timeout errors mean the worker is still processing — don't send error card.
+			var we *worker.WorkerError
+			if errors.As(err, &we) && we.Kind == worker.ErrKindTimeout {
+				h.log.Info("gateway: worker input delivery timed out (worker still processing)", "session_id", env.SessionID)
+				return nil
+			}
 			h.log.Warn("gateway: worker input", "err", err, "session_id", env.SessionID)
 			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker input failed: %v", err)
 		}

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -76,6 +76,12 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 		return fmt.Errorf("messaging bridge: OwnerID not set for platform message")
 	}
 
+	// Register platform conn BEFORE starting the session so that early events
+	// (e.g. state transitions) are routed to the platform instead of being dropped.
+	if pc != nil && b.hub != nil {
+		b.hub.JoinPlatformSession(env.SessionID, pc)
+	}
+
 	// Auto-create session if starter is available.
 	if b.starter != nil {
 		// Extract platform key from envelope metadata for persistence.
@@ -87,11 +93,6 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, platform, platformKey, botID); err != nil {
 			return fmt.Errorf("messaging bridge: session start failed: %w", err)
 		}
-	}
-
-	// Register platform conn so worker output is routed back to the platform.
-	if pc != nil && b.hub != nil {
-		b.hub.JoinPlatformSession(env.SessionID, pc)
 	}
 
 	// Assign monotonically increasing seq (messaging path lacks conn.go's NextSeq call).

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -635,7 +635,14 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		"last_flushed_len", len(c.lastFlushed))
 
 	finalFlushOK := false
-	if c.cardKitOK && c.cardID != "" {
+	// Skip final flush when content is empty — CardKit rejects empty content
+	// with code 99992402. If lastFlushed has content, the streaming card already
+	// displays it from the periodic flush loop.
+	if content == "" && c.lastFlushed != "" {
+		c.log.Debug("feishu: skipping final flush, content empty (already flushed)",
+			"last_flushed_len", len(c.lastFlushed))
+		finalFlushOK = true
+	} else if c.cardKitOK && c.cardID != "" {
 		seq := int(c.sequence.Add(1))
 		if err := c.flushCardKitElement(ctx, c.elementID, content, seq); err != nil {
 			c.log.Warn("feishu: final cardkit flush failed, attempting IM patch fallback",

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -9,6 +9,9 @@ const (
 	// ErrKindSessionInUse indicates session files are locked by another process
 	// (e.g. leftover from a crashed session).
 	ErrKindSessionInUse
+	// ErrKindTimeout indicates the worker operation timed out (not unreachable).
+	// The worker is alive but the response took too long.
+	ErrKindTimeout
 )
 
 // WorkerError is a typed error carrying a classification kind.

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -436,6 +436,9 @@ func (s *SingletonProcessManager) startIdleDrainLocked() {
 func (s *SingletonProcessManager) buildEnv() []string {
 	env := base.BuildEnv(worker.SessionInfo{}, openCodeSrvEnvBlocklist, "opencode-server")
 	env = append(env, "OPENCODE_EXPERIMENTAL_EVENT_SYSTEM=true")
+	if s.cfg.Password != "" {
+		env = append(env, "OPENCODE_SERVER_PASSWORD="+s.cfg.Password)
+	}
 	return env
 }
 

--- a/internal/worker/opencodeserver/sse_test.go
+++ b/internal/worker/opencodeserver/sse_test.go
@@ -1088,9 +1088,9 @@ func TestConn_ImplementsInputRecoverer(t *testing.T) {
 	var _ worker.InputRecoverer = (*conn)(nil)
 }
 
-// ─── isServerDownError Tests ──────────────────────────────────────────────────
+// ─── Error Classification Tests ─────────────────────────────────────────────
 
-func TestIsServerDownError(t *testing.T) {
+func TestIsTimeoutError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1106,7 +1106,28 @@ func TestIsServerDownError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.want, isServerDownError(tt.err))
+			require.Equal(t, tt.want, isTimeoutError(tt.err))
+		})
+	}
+}
+
+func TestIsUnreachableError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context deadline is not unreachable", context.DeadlineExceeded, false},
+		{"nil error", nil, false},
+		{"generic error", io.ErrUnexpectedEOF, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isUnreachableError(tt.err))
 		})
 	}
 }

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -78,8 +78,13 @@ const (
 	// recvChannelSize is the buffer size for SSE event channel.
 	recvChannelSize = 256
 
-	// httpClientTimeout is the timeout for HTTP client operations.
+	// httpClientTimeout is the timeout for general HTTP client operations.
 	httpClientTimeout = 30 * time.Second
+
+	// sendTimeout is the timeout for sending user input to the OCS server.
+	// The OCS POST /session/{id}/message blocks until the turn completes,
+	// so this must be long enough for the longest expected turn.
+	sendTimeout = 5 * time.Minute
 )
 
 // Worker implements the OpenCode Server worker adapter.
@@ -155,6 +160,20 @@ func New() *Worker {
 func newHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: httpClientTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+}
+
+// newSendClient creates an HTTP client with a longer timeout for sending
+// user input. The OCS POST /session/{id}/message blocks until the turn
+// completes, so the default 30s timeout causes false "server unreachable" errors.
+func newSendClient() *http.Client {
+	return &http.Client{
+		Timeout: sendTimeout,
 		Transport: &http.Transport{
 			MaxIdleConns:        100,
 			MaxIdleConnsPerHost: 100,
@@ -520,6 +539,7 @@ func (w *Worker) initHTTPConn(userID, sessionID, systemPrompt string, session wo
 		sessionID:    sessionID,
 		httpAddr:     w.httpAddr,
 		client:       w.client,
+		sendClient:   newSendClient(),
 		recvCh:       make(chan *events.Envelope, recvChannelSize),
 		log:          w.Log,
 		systemPrompt: systemPrompt,
@@ -744,6 +764,7 @@ type conn struct {
 	sessionID    string
 	httpAddr     string
 	client       *http.Client
+	sendClient   *http.Client // longer timeout for input delivery (OCS blocks until turn completes)
 	recvCh       chan *events.Envelope
 	log          *slog.Logger
 	systemPrompt string
@@ -833,9 +854,18 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req)
+	// Use sendClient (long timeout) for input delivery; fall back to client for tests.
+	sendCl := c.sendClient
+	if sendCl == nil {
+		sendCl = c.client
+	}
+	resp, err := sendCl.Do(req)
 	if err != nil {
-		if isServerDownError(err) {
+		if isTimeoutError(err) {
+			// Server is alive but response took too long — do not treat as unreachable.
+			return &worker.WorkerError{Kind: worker.ErrKindTimeout, Message: "opencodeserver: input delivery timed out", Cause: err}
+		}
+		if isUnreachableError(err) {
 			return &worker.WorkerError{Kind: worker.ErrKindUnavailable, Message: "opencodeserver: server unreachable", Cause: err}
 		}
 		return fmt.Errorf("opencodeserver: send input: %w", err)
@@ -873,15 +903,24 @@ func (c *conn) Close() error {
 func (c *conn) UserID() string    { return c.userID }
 func (c *conn) SessionID() string { return c.sessionID }
 
-// isServerDownError classifies network/timeout errors as "server unavailable".
-func isServerDownError(err error) bool {
+// isTimeoutError reports whether the error is a timeout (deadline exceeded or
+// net.Error with Timeout()=true). The server may still be alive and processing.
+func isTimeoutError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	if _, ok := errors.AsType[net.Error](err); ok {
-		return true
+	ne, ok := errors.AsType[net.Error](err)
+	return ok && ne.Timeout()
+}
+
+// isUnreachableError reports whether the error indicates the server is actually
+// unreachable (connection refused, DNS failure, etc.) — not a timeout.
+func isUnreachableError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false // timeout is not unreachable
 	}
-	return false
+	ne, ok := errors.AsType[net.Error](err)
+	return ok && !ne.Timeout()
 }
 
 // ─── Init ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #448 — 4 个运行时诊断问题的合并修复：

- **P1**: OCS HTTP POST 30s 超时误报 "server unreachable" — 拆分超时/不可达错误分类，使用独立 5min 长超时 client 投递输入，handler 不再为超时发送错误卡片
- **P2**: CardKit final flush 空内容触发 99992402 — 跳过空内容 flush（flush loop 已投递内容）
- **P2**: Messaging bridge state event dropped — 调换 JoinPlatformSession/StartPlatformSession 顺序
- **P3**: OCS server 密码配置 — 添加 `password` 字段，通过环境变量注入

## 根因

1. `opencode serve` POST `/session/{id}/message` 阻塞直到 turn 完成（>30s），触发 `http.Client.Timeout`，被 `isServerDownError` 误判为"不可达"
2. `Close()` 在 flush loop 停止后读取空 buffer，空内容被 CardKit API 拒绝
3. `Handle()` 先调用 `StartPlatformSession`（触发 state 事件），后注册 platform conn → Hub 无订阅者丢弃事件

## 修改清单

| 文件 | 变更 |
|------|------|
| `internal/worker/errors.go` | 添加 `ErrKindTimeout` |
| `internal/worker/opencodeserver/worker.go` | `sendClient`(5min) + `isTimeoutError`/`isUnreachableError` 拆分 |
| `internal/gateway/handler.go` | 超时错误不发送错误卡片 |
| `internal/gateway/errors.go` | `classifyWorkerError` 处理 `ErrKindTimeout` |
| `internal/messaging/bridge.go` | `JoinPlatformSession` 移到 `StartPlatformSession` 之前 |
| `internal/messaging/feishu/streaming.go` | 空内容跳过 cardkit flush |
| `internal/worker/opencodeserver/singleton.go` | 注入 `OPENCODE_SERVER_PASSWORD` |
| `internal/config/config.go` | 添加 `password` 字段和 BindEnv |
| `configs/config-dev.yaml` | 添加 `opencode_server.password` 配置 |
| `internal/worker/opencodeserver/sse_test.go` | 更新错误分类测试 |

## Test plan

- [x] `go test ./internal/...` 全部通过
- [x] `golangci-lint` 0 issues
- [x] 全平台编译通过
- [ ] 部署验证：OCS 处理 >30s 任务时不再误报 "server unreachable"
- [ ] 飞书流式卡片关闭时不再出现 99992402 错误
- [ ] 消息桥 state(running) 事件正常投递到平台