### PR TITLE
perf(eventstore): buffer and aggregate reasoning events before persistence

### DIFF
--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -93,21 +93,18 @@ func NewCollector(store EventStore, log *slog.Logger) *Collector {
 // on flush trigger (MessageEnd, next storable event, size/timer threshold).
 func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, data json.RawMessage, direction, source string) {
 	if eventType == events.MessageDelta {
-		c.flushReasoning(sessionID)
-		c.accumulateDelta(sessionID, seq, data)
+		c.flushAndAccumulate(sessionID, seq, false, data)
 		return
 	}
 
 	if eventType == events.Reasoning {
-		c.flushDelta(sessionID)
-		c.accumulateReasoning(sessionID, seq, data)
+		c.flushAndAccumulate(sessionID, seq, true, data)
 		return
 	}
 
 	// MessageEnd triggers flush of both accumulators but is not stored itself.
 	if eventType == events.MessageEnd {
-		c.flushDelta(sessionID)
-		c.flushReasoning(sessionID)
+		c.flushBoth(sessionID)
 		return
 	}
 
@@ -115,8 +112,7 @@ func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, 
 		return
 	}
 
-	c.flushDelta(sessionID)
-	c.flushReasoning(sessionID)
+	c.flushBoth(sessionID)
 
 	req := &captureRequest{event: &StoredEvent{
 		SessionID: sessionID,
@@ -128,6 +124,55 @@ func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, 
 		CreatedAt: time.Now().UnixMilli(),
 	}}
 	c.send(req)
+}
+
+// flushAndAccumulate holds accumMu once to cross-flush the other accumulator and
+// accumulate the incoming event. isReasoning selects which map to use.
+func (c *Collector) flushAndAccumulate(sessionID string, seq int64, isReasoning bool, data json.RawMessage) {
+	c.accumMu.Lock()
+
+	// Cross-flush the other accumulator under the same lock.
+	var flushed *deltaAccumulator
+	if isReasoning {
+		flushed = c.accum[sessionID]
+		delete(c.accum, sessionID)
+	} else {
+		flushed = c.reasoningAccum[sessionID]
+		delete(c.reasoningAccum, sessionID)
+	}
+
+	// Accumulate into target map.
+	var acc *deltaAccumulator
+	if isReasoning {
+		acc = c.getOrCreateReasoningAccum(sessionID)
+	} else {
+		acc = c.getOrCreateAccum(sessionID)
+	}
+	if acc != nil {
+		acc.append(seq, data)
+	}
+	c.accumMu.Unlock()
+
+	if flushed != nil && flushed.count > 0 {
+		c.send(flushed.toRequest(sessionID))
+	}
+}
+
+// flushBoth flushes both delta and reasoning accumulators under a single lock.
+func (c *Collector) flushBoth(sessionID string) {
+	c.accumMu.Lock()
+	dAcc := c.accum[sessionID]
+	delete(c.accum, sessionID)
+	rAcc := c.reasoningAccum[sessionID]
+	delete(c.reasoningAccum, sessionID)
+	c.accumMu.Unlock()
+
+	if dAcc != nil && dAcc.count > 0 {
+		c.send(dAcc.toRequest(sessionID))
+	}
+	if rAcc != nil && rAcc.count > 0 {
+		c.send(rAcc.toRequest(sessionID))
+	}
 }
 
 // getOrCreateAccum returns the delta accumulator for sessionID, creating one if needed.
@@ -144,28 +189,6 @@ func (c *Collector) getOrCreateAccum(sessionID string) *deltaAccumulator {
 	return acc
 }
 
-// accumulateDelta appends a message.delta event to the per-session accumulator.
-func (c *Collector) accumulateDelta(sessionID string, seq int64, data json.RawMessage) {
-	c.accumMu.Lock()
-	acc := c.getOrCreateAccum(sessionID)
-	if acc != nil {
-		acc.append(seq, data)
-	}
-	c.accumMu.Unlock()
-}
-
-func (c *Collector) flushDelta(sessionID string) {
-	c.accumMu.Lock()
-	acc := c.accum[sessionID]
-	delete(c.accum, sessionID)
-	c.accumMu.Unlock()
-
-	if acc == nil || acc.count == 0 {
-		return
-	}
-	c.send(acc.toRequest(sessionID))
-}
-
 // getOrCreateReasoningAccum returns the reasoning accumulator for sessionID.
 // Caller must hold c.accumMu. Returns nil if the collector is closed.
 func (c *Collector) getOrCreateReasoningAccum(sessionID string) *deltaAccumulator {
@@ -178,28 +201,6 @@ func (c *Collector) getOrCreateReasoningAccum(sessionID string) *deltaAccumulato
 		c.reasoningAccum[sessionID] = acc
 	}
 	return acc
-}
-
-// accumulateReasoning appends a reasoning event to the per-session accumulator.
-func (c *Collector) accumulateReasoning(sessionID string, seq int64, data json.RawMessage) {
-	c.accumMu.Lock()
-	acc := c.getOrCreateReasoningAccum(sessionID)
-	if acc != nil {
-		acc.append(seq, data)
-	}
-	c.accumMu.Unlock()
-}
-
-func (c *Collector) flushReasoning(sessionID string) {
-	c.accumMu.Lock()
-	acc := c.reasoningAccum[sessionID]
-	delete(c.reasoningAccum, sessionID)
-	c.accumMu.Unlock()
-
-	if acc == nil || acc.count == 0 {
-		return
-	}
-	c.send(acc.toRequest(sessionID))
 }
 
 // CaptureReasoningString accumulates a reasoning content string directly,
@@ -424,7 +425,7 @@ func (a *deltaAccumulator) appendRaw(seq int64, content string) {
 func (a *deltaAccumulator) toRequest(sessionID string) *captureRequest {
 	mergedData, _ := json.Marshal(map[string]any{
 		"content":      a.content.String(),
-		"merged_count": a.lastSeq - a.firstSeq + 1,
+		"merged_count": a.count,
 		"seq_range":    []int64{a.firstSeq, a.lastSeq},
 	})
 	return &captureRequest{event: &StoredEvent{

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -67,19 +67,21 @@ type Collector struct {
 	closeWg  sync.WaitGroup
 	log      *slog.Logger
 
-	accumMu sync.Mutex
-	accum   map[string]*deltaAccumulator // sessionID → active delta accumulator
-	dropped atomic.Int64
+	accumMu        sync.Mutex
+	accum          map[string]*deltaAccumulator // sessionID → active delta accumulator
+	reasoningAccum map[string]*deltaAccumulator // sessionID → active reasoning accumulator
+	dropped        atomic.Int64
 }
 
 // NewCollector creates a Collector that writes events to store.
 func NewCollector(store EventStore, log *slog.Logger) *Collector {
 	c := &Collector{
-		store:    store,
-		captureC: make(chan *captureRequest, collectorChanCap),
-		closeC:   make(chan struct{}),
-		log:      log.With("component", "eventstore-collector"),
-		accum:    make(map[string]*deltaAccumulator),
+		store:          store,
+		captureC:       make(chan *captureRequest, collectorChanCap),
+		closeC:         make(chan struct{}),
+		log:            log.With("component", "eventstore-collector"),
+		accum:          make(map[string]*deltaAccumulator),
+		reasoningAccum: make(map[string]*deltaAccumulator),
 	}
 	c.closeWg.Add(1)
 	go c.runWriter()
@@ -87,17 +89,25 @@ func NewCollector(store EventStore, log *slog.Logger) *Collector {
 }
 
 // Capture sends an event to the collector for async persistence.
-// If the event is a message.delta, it is accumulated in-memory and merged
-// on message.end or next non-delta event.
+// MessageDelta and Reasoning events are accumulated in-memory and merged
+// on flush trigger (MessageEnd, next storable event, size/timer threshold).
 func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, data json.RawMessage, direction, source string) {
 	if eventType == events.MessageDelta {
+		c.flushReasoning(sessionID)
 		c.accumulateDelta(sessionID, seq, data)
 		return
 	}
 
-	// MessageEnd triggers flush but is not stored itself.
+	if eventType == events.Reasoning {
+		c.flushDelta(sessionID)
+		c.accumulateReasoning(sessionID, seq, data)
+		return
+	}
+
+	// MessageEnd triggers flush of both accumulators but is not stored itself.
 	if eventType == events.MessageEnd {
 		c.flushDelta(sessionID)
+		c.flushReasoning(sessionID)
 		return
 	}
 
@@ -106,6 +116,7 @@ func (c *Collector) Capture(sessionID string, seq int64, eventType events.Kind, 
 	}
 
 	c.flushDelta(sessionID)
+	c.flushReasoning(sessionID)
 
 	req := &captureRequest{event: &StoredEvent{
 		SessionID: sessionID,
@@ -127,7 +138,7 @@ func (c *Collector) getOrCreateAccum(sessionID string) *deltaAccumulator {
 	}
 	acc := c.accum[sessionID]
 	if acc == nil {
-		acc = newDeltaAccumulator()
+		acc = newDeltaAccumulator(events.Message)
 		c.accum[sessionID] = acc
 	}
 	return acc
@@ -155,6 +166,63 @@ func (c *Collector) flushDelta(sessionID string) {
 	c.send(acc.toRequest(sessionID))
 }
 
+// getOrCreateReasoningAccum returns the reasoning accumulator for sessionID.
+// Caller must hold c.accumMu. Returns nil if the collector is closed.
+func (c *Collector) getOrCreateReasoningAccum(sessionID string) *deltaAccumulator {
+	if c.reasoningAccum == nil {
+		return nil
+	}
+	acc := c.reasoningAccum[sessionID]
+	if acc == nil {
+		acc = newDeltaAccumulator(events.Reasoning)
+		c.reasoningAccum[sessionID] = acc
+	}
+	return acc
+}
+
+// accumulateReasoning appends a reasoning event to the per-session accumulator.
+func (c *Collector) accumulateReasoning(sessionID string, seq int64, data json.RawMessage) {
+	c.accumMu.Lock()
+	acc := c.getOrCreateReasoningAccum(sessionID)
+	if acc != nil {
+		acc.append(seq, data)
+	}
+	c.accumMu.Unlock()
+}
+
+func (c *Collector) flushReasoning(sessionID string) {
+	c.accumMu.Lock()
+	acc := c.reasoningAccum[sessionID]
+	delete(c.reasoningAccum, sessionID)
+	c.accumMu.Unlock()
+
+	if acc == nil || acc.count == 0 {
+		return
+	}
+	c.send(acc.toRequest(sessionID))
+}
+
+// CaptureReasoningString accumulates a reasoning content string directly,
+// skipping the json.Marshal/Unmarshal round-trip of Capture.
+// Flushes immediately when accumulated content exceeds deltaFlushSize.
+func (c *Collector) CaptureReasoningString(sessionID string, seq int64, content string) {
+	c.accumMu.Lock()
+	acc := c.getOrCreateReasoningAccum(sessionID)
+	if acc == nil {
+		c.accumMu.Unlock()
+		return
+	}
+	acc.appendRaw(seq, content)
+
+	if acc.content.Len() >= deltaFlushSize {
+		delete(c.reasoningAccum, sessionID)
+		c.accumMu.Unlock()
+		c.send(acc.toRequest(sessionID))
+		return
+	}
+	c.accumMu.Unlock()
+}
+
 func (c *Collector) send(req *captureRequest) {
 	select {
 	case c.captureC <- req:
@@ -170,13 +238,20 @@ func (c *Collector) send(req *captureRequest) {
 
 // Close drains the capture channel and flushes remaining events.
 func (c *Collector) Close() error {
-	// Swap accumulator map under lock, flush outside to avoid deadlock.
+	// Swap accumulator maps under lock, flush outside to avoid deadlock.
 	c.accumMu.Lock()
 	pending := c.accum
+	pendingReasoning := c.reasoningAccum
 	c.accum = nil
+	c.reasoningAccum = nil
 	c.accumMu.Unlock()
 
 	for sid, acc := range pending {
+		if acc.count > 0 {
+			c.send(acc.toRequest(sid))
+		}
+	}
+	for sid, acc := range pendingReasoning {
 		if acc.count > 0 {
 			c.send(acc.toRequest(sid))
 		}
@@ -243,6 +318,12 @@ func (c *Collector) flushTimedOutAccumulators(batch *[]*captureRequest) {
 			*batch = append(*batch, acc.toRequest(sid))
 		}
 	}
+	for sid, acc := range c.reasoningAccum {
+		if now.Sub(acc.firstSeenAt) >= deltaFlushInterval {
+			delete(c.reasoningAccum, sid)
+			*batch = append(*batch, acc.toRequest(sid))
+		}
+	}
 	c.accumMu.Unlock()
 }
 
@@ -297,15 +378,17 @@ func (c *Collector) CaptureDeltaString(sessionID string, seq int64, content stri
 	c.accumMu.Unlock()
 }
 
-// ResetSession discards any accumulated delta content for the given session.
+// ResetSession discards any accumulated delta and reasoning content for the given session.
 func (c *Collector) ResetSession(sessionID string) {
 	c.accumMu.Lock()
 	delete(c.accum, sessionID)
+	delete(c.reasoningAccum, sessionID)
 	c.accumMu.Unlock()
 }
 
-// deltaAccumulator merges message.delta content in-memory.
+// deltaAccumulator merges streaming content (message.delta or reasoning) in-memory.
 type deltaAccumulator struct {
+	eventType   events.Kind
 	content     strings.Builder
 	seq         int64
 	firstSeq    int64
@@ -314,8 +397,8 @@ type deltaAccumulator struct {
 	firstSeenAt time.Time
 }
 
-func newDeltaAccumulator() *deltaAccumulator {
-	return &deltaAccumulator{}
+func newDeltaAccumulator(eventType events.Kind) *deltaAccumulator {
+	return &deltaAccumulator{eventType: eventType}
 }
 
 func (a *deltaAccumulator) append(seq int64, data json.RawMessage) {
@@ -347,7 +430,7 @@ func (a *deltaAccumulator) toRequest(sessionID string) *captureRequest {
 	return &captureRequest{event: &StoredEvent{
 		SessionID: sessionID,
 		Seq:       a.seq,
-		Type:      string(events.Message),
+		Type:      string(a.eventType),
 		Data:      mergedData,
 		Direction: "outbound",
 		Source:    SourceNormal,

--- a/internal/eventstore/collector_test.go
+++ b/internal/eventstore/collector_test.go
@@ -390,3 +390,47 @@ func TestCollector_ReasoningTimerFlush(t *testing.T) {
 	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
 	require.Equal(t, "think1think2", data["content"])
 }
+
+func TestCollector_CaptureReasoningViaCapture(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	c.Capture("s1", 1, events.Reasoning, json.RawMessage(`{"content":"think"}`), "outbound", SourceNormal)
+	c.Capture("s1", 2, events.Reasoning, json.RawMessage(`{"content":" more"}`), "outbound", SourceNormal)
+	c.Capture("s1", 3, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+
+	require.NoError(t, c.Close())
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 2) // Reasoning + Done
+
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+	require.Equal(t, int64(1), page.Events[0].Seq)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
+	require.Equal(t, "think more", data["content"])
+	require.Equal(t, float64(2), data["merged_count"])
+}
+
+func TestCollector_CaptureReasoningStringEmptyContent(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	c.CaptureReasoningString("s1", 1, "")
+	c.Capture("s1", 2, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+
+	require.NoError(t, c.Close())
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	// Only Done — empty content accumulator flushed but has count=1 with empty string
+	require.Len(t, page.Events, 2)
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+	require.Equal(t, string(events.Done), page.Events[1].Type)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
+	require.Equal(t, "", data["content"])
+}

--- a/internal/eventstore/collector_test.go
+++ b/internal/eventstore/collector_test.go
@@ -297,3 +297,96 @@ func (s *stallingEventStore) BeginTx(ctx context.Context) (EventTx, error) {
 	}
 	return s.EventStore.BeginTx(ctx)
 }
+
+func TestCollector_CaptureReasoningString(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	c.CaptureReasoningString("s1", 1, "Let me think")
+	c.CaptureReasoningString("s1", 2, " about this")
+	c.Capture("s1", 3, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+
+	require.NoError(t, c.Close())
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 2) // Reasoning + Done
+
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+	require.Equal(t, int64(1), page.Events[0].Seq)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
+	require.Equal(t, "Let me think about this", data["content"])
+	require.Equal(t, float64(2), data["merged_count"])
+}
+
+func TestCollector_ReasoningSizeFlush(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	c.CaptureReasoningString("s1", 1, strings.Repeat("x", 3000))
+	c.CaptureReasoningString("s1", 2, strings.Repeat("y", 1100))
+
+	c.Capture("s1", 3, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+	require.NoError(t, c.Close())
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 2)
+
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
+	require.Equal(t, float64(2), data["merged_count"])
+	content, _ := data["content"].(string)
+	require.Len(t, content, 4100)
+}
+
+func TestCollector_ReasoningDeltaInterleave(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	// Reasoning first, then delta — both should flush at boundaries
+	c.CaptureReasoningString("s1", 1, "thinking...")
+	c.CaptureDeltaString("s1", 2, "Hello")                               // flushes reasoning
+	c.Capture("s1", 3, events.MessageEnd, nil, "outbound", SourceNormal) // flushes delta
+
+	require.NoError(t, c.Close())
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 2) // Reasoning + Message
+
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+	require.Equal(t, string(events.Message), page.Events[1].Type)
+
+	var rData map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &rData))
+	require.Equal(t, "thinking...", rData["content"])
+}
+
+func TestCollector_ReasoningTimerFlush(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timer test in short mode")
+	}
+
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+	defer func() { _ = c.Close() }()
+
+	c.CaptureReasoningString("s1", 1, "think1")
+	c.CaptureReasoningString("s1", 2, "think2")
+
+	time.Sleep(deltaFlushInterval + 200*time.Millisecond)
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 1)
+	require.Equal(t, string(events.Reasoning), page.Events[0].Type)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
+	require.Equal(t, "think1think2", data["content"])
+}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -110,6 +110,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		env.OwnerID = sessOwner
 
 		var capturedDeltaContent string
+		var capturedReasoningContent string
 		if env.Event.Type == events.MessageDelta || env.Event.Type == events.Message {
 			if content := extractMessageContent(env); content != "" {
 				turnText.WriteString(content)
@@ -117,6 +118,8 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 					capturedDeltaContent = content
 				}
 			}
+		} else if env.Event.Type == events.Reasoning {
+			capturedReasoningContent = extractReasoningContent(env)
 		}
 
 		// Stats accumulation: track tool calls and merge per-turn stats on done.
@@ -187,7 +190,9 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 
 		if capturedDeltaContent != "" && b.collector != nil {
 			b.collector.CaptureDeltaString(sessionID, env.Seq, capturedDeltaContent)
-		} else if env.Event.Type != events.MessageDelta {
+		} else if capturedReasoningContent != "" && b.collector != nil {
+			b.collector.CaptureReasoningString(sessionID, env.Seq, capturedReasoningContent)
+		} else if env.Event.Type != events.MessageDelta && env.Event.Type != events.Reasoning {
 			b.captureEvent(sessionID, env.Seq, env.Event.Type, env.Event.Data)
 		}
 
@@ -463,6 +468,22 @@ func extractMessageContent(env *events.Envelope) string {
 			if content, ok := m["content"].(string); ok {
 				return content
 			}
+		}
+	}
+	return ""
+}
+
+// extractReasoningContent extracts text content from a reasoning event.
+func extractReasoningContent(env *events.Envelope) string {
+	if env.Event.Type != events.Reasoning {
+		return ""
+	}
+	if d, ok := env.Event.Data.(events.ReasoningData); ok {
+		return d.Content
+	}
+	if m, ok := env.Event.Data.(map[string]any); ok {
+		if content, ok := m["content"].(string); ok {
+			return content
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary

- Extend existing `deltaAccumulator` pattern to buffer `reasoning` events before persistence
- Add `reasoningAccum` map with same flush triggers: size (4096B), timer (3s), event boundary
- Route reasoning through `CaptureReasoningString()` in bridge_forward.go, skipping per-event SQLite writes
- Merged result stored as single `reasoning` event with `merged_count`/`seq_range` metadata

## Metrics

- **Before**: N reasoning events per reasoning block → N SQLite `Append` calls
- **After**: 1 merged reasoning event per block → 1 `Append` call

## Test plan

- [x] `TestCollector_CaptureReasoningString` — accumulate + flush on Done
- [x] `TestCollector_ReasoningSizeFlush` — 4096B size threshold
- [x] `TestCollector_ReasoningDeltaInterleave` — reasoning → delta boundary flush
- [x] `TestCollector_ReasoningTimerFlush` — 3s timer trigger
- [x] `make check` — CI full green (fmt + lint + test + build)
- [x] All existing delta accumulator tests still pass

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)