### PR TITLE
fix(codexcli): harden dispatch routing, approval mapping, and appConn safety

### DIFF
--- a/internal/worker/codexcli/commands.go
+++ b/internal/worker/codexcli/commands.go
@@ -17,7 +17,7 @@ func NewServerCommander(manager *CodexAppServerManager, threadID string) *Server
 func (sc *ServerCommander) SendControlRequest(ctx context.Context, subtype string, body map[string]any) (map[string]any, error) {
 	switch subtype {
 	case "set_model":
-		return nil, nil
+		return nil, fmt.Errorf("codexcli: set_model not supported")
 	case "get_context_usage":
 		resp, err := sc.manager.Call("thread/read", map[string]string{
 			"threadId": sc.threadID,

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -434,6 +434,12 @@ func (m *CodexAppServerManager) readNotifications(ctx context.Context) {
 }
 
 // dispatchFrame parses a single JSON-RPC frame once and routes to response or notification.
+//
+// Routing logic (in order):
+//  1. ID != 0 → this is a response (request IDs start at 1, monotonically increasing)
+//  2. ID == 0 && Error != nil → error notification or response to ID 0 (which never
+//     exists in pending — dropped silently, logged as debug)
+//  3. ID == 0 && Error == nil → try to parse as notification by method presence
 func (m *CodexAppServerManager) dispatchFrame(data []byte) {
 	var resp JSONRPCResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
@@ -446,7 +452,11 @@ func (m *CodexAppServerManager) dispatchFrame(data []byte) {
 		return
 	}
 
+	// ID == 0: either a notification or a response to an unknown request.
 	if resp.Error != nil {
+		// Error with no ID — treat as notification-like (e.g. server-side error).
+		// Since no pending request has ID 0, dispatchResponse will drop it silently.
+		m.log.Debug("codex-app-server: response with ID=0, dropping", "error", resp.Error.Message)
 		m.dispatchResponse(&resp)
 		return
 	}
@@ -458,6 +468,8 @@ func (m *CodexAppServerManager) dispatchFrame(data []byte) {
 	}
 	if notif.Method != "" {
 		m.dispatchNotification(&notif)
+	} else {
+		m.log.Debug("codex-app-server: frame with ID=0, no method, no error — dropped")
 	}
 }
 

--- a/internal/worker/codexcli/mapper.go
+++ b/internal/worker/codexcli/mapper.go
@@ -264,17 +264,34 @@ func (m *Mapper) mapNotifTurnCompleted(params json.RawMessage) []*events.Envelop
 
 func (m *Mapper) mapNotifApproval(params json.RawMessage) []*events.Envelope {
 	var p struct {
-		RequestID string `json:"requestId"`
-		ToolName  string `json:"toolName"`
+		RequestID string          `json:"requestId"`
+		ToolName  string          `json:"toolName"`
+		Arguments json.RawMessage `json:"arguments,omitempty"`
+		Reason    string          `json:"reason,omitempty"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil
 	}
+	desc := p.ToolName
+	if p.Reason != "" {
+		desc = p.Reason
+	}
+
+	input := map[string]any{"tool": p.ToolName}
+	if p.Arguments != nil {
+		var args map[string]any
+		if err := json.Unmarshal(p.Arguments, &args); err == nil {
+			for k, v := range args {
+				input[k] = v
+			}
+		}
+	}
+
 	return []*events.Envelope{
 		newEnvelope(events.PermissionRequest, events.PermissionRequestData{
 			ID:          p.RequestID,
 			ToolName:    p.ToolName,
-			Description: p.ToolName,
+			Description: desc,
 		}, m.sessionID, m.nextSeq()),
 	}
 }

--- a/internal/worker/codexcli/mapper.go
+++ b/internal/worker/codexcli/mapper.go
@@ -264,10 +264,9 @@ func (m *Mapper) mapNotifTurnCompleted(params json.RawMessage) []*events.Envelop
 
 func (m *Mapper) mapNotifApproval(params json.RawMessage) []*events.Envelope {
 	var p struct {
-		RequestID string          `json:"requestId"`
-		ToolName  string          `json:"toolName"`
-		Arguments json.RawMessage `json:"arguments,omitempty"`
-		Reason    string          `json:"reason,omitempty"`
+		RequestID string `json:"requestId"`
+		ToolName  string `json:"toolName"`
+		Reason    string `json:"reason,omitempty"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil
@@ -275,16 +274,6 @@ func (m *Mapper) mapNotifApproval(params json.RawMessage) []*events.Envelope {
 	desc := p.ToolName
 	if p.Reason != "" {
 		desc = p.Reason
-	}
-
-	input := map[string]any{"tool": p.ToolName}
-	if p.Arguments != nil {
-		var args map[string]any
-		if err := json.Unmarshal(p.Arguments, &args); err == nil {
-			for k, v := range args {
-				input[k] = v
-			}
-		}
 	}
 
 	return []*events.Envelope{

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -387,20 +387,11 @@ type appConn struct {
 	manager   *CodexAppServerManager
 }
 
+// Send returns ErrNotImplemented because in app-server mode the manager
+// handles all communication via JSON-RPC. Writing AEP envelopes directly
+// to stdin would bypass the JSON-RPC protocol and break the codex process.
 func (c *appConn) Send(ctx context.Context, msg *events.Envelope) error {
-	data, err := json.Marshal(msg)
-	if err != nil {
-		return fmt.Errorf("app-conn: marshal envelope: %w", err)
-	}
-
-	c.manager.writeMu.Lock()
-	_, err = c.manager.stdin.Write(append(data, '\n'))
-	c.manager.writeMu.Unlock()
-
-	if err != nil {
-		return fmt.Errorf("app-conn: write to stdin: %w", err)
-	}
-	return nil
+	return worker.ErrNotImplemented
 }
 func (c *appConn) Recv() <-chan *events.Envelope { return c.recvCh }
 func (c *appConn) TrySend(env *events.Envelope) bool {


### PR DESCRIPTION
## Summary

- Return explicit error for unsupported `set_model` instead of silent `nil` (commands.go)
- Add routing logic docs and debug logging for ID=0 edge cases in `dispatchFrame` (manager.go)
- Use `Reason` field for richer permission request descriptions, remove dead `input` map code (mapper.go)
- Replace dangerous stdin write in `appConn.Send` with `ErrNotImplemented` — app-server mode uses JSON-RPC, not raw stdin (worker.go)

## Test plan

- [x] `go build ./internal/worker/codexcli/` compiles cleanly
- [x] Mapper tests pass (`TestMapperMapItem*` — all green)
- [x] Pre-commit hooks pass (gofmt + golangci-lint)
- [ ] Manual verification: codex app-server mode permission request shows Reason instead of bare ToolName