### PR TITLE
fix(gateway): 全局 WriteMu 消除 SQLITE_BUSY + PID 崩溃清理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@
 - `service/` - 跨平台系统服务管理（systemd/launchd/SCM）
 - `eventstore/` - 会话事件持久化 + delta 聚合
 - `updater/` - 自更新（GitHub API、sha256 校验、原子替换）
-- `sqlutil/` - SQLite 驱动（modernc.org/sqlite，纯 Go）
+- `sqlutil/` - SQLite 驱动（modernc.org/sqlite，纯 Go）+ `WriteMu` 跨 store 全局写序列化（消除 SQLITE_BUSY）
 - `webchat/` - 嵌入式 Next.js SPA (go:embed)
 - `docs/` - 自托管中文文档门户（Markdown → 静态 HTML → go:embed → `/docs` 路由）
 

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/skills"
+	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/tracing"
 	"github.com/hrygo/hotplex/internal/webchat"
 	"github.com/hrygo/hotplex/internal/worker/claudecode"
@@ -294,9 +295,10 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 
 	// Cron scheduler: init after Bridge, before messaging adapters.
 	if cfg.Cron.Enabled {
-		cronStore := cron.NewSQLiteStore(stores.session.DB(), log)
+		cronStore := cron.NewSQLiteStore(stores.session.DB(), log, stores.writeMu)
 		cronDelivery = cron.NewDelivery(log,
 			func(ctx context.Context, sessionID string) (string, error) {
+				stores.collector.Flush()
 				turns, err := stores.event.QueryTurns(ctx, sessionID, 1, 0)
 				if err != nil || len(turns) == 0 {
 					return "", err
@@ -354,7 +356,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		Bridge:          bridge,
 		ConfigWatcher:   configWatcher,
 		CronScheduler:   cronScheduler,
-		ChatAccessStore: messaging.NewChatAccessStore(stores.session.DB(), log),
+		ChatAccessStore: messaging.NewChatAccessStore(stores.session.DB(), log, stores.writeMu),
 		DB:              stores.session.DB(),
 		DBResolver:      dbResolver,
 		ConfigPath:      configPath,
@@ -565,21 +567,24 @@ type gatewayStores struct {
 	session   *session.SQLiteStore
 	event     *eventstore.SQLiteStore
 	collector *eventstore.Collector
+	writeMu   *sqlutil.WriteMu
 }
 
 func initStores(ctx context.Context, cfg *config.Config, log *slog.Logger) (*gatewayStores, error) {
-	sessionStore, err := session.NewSQLiteStore(ctx, cfg)
+	writeMu := sqlutil.NewWriteMu()
+	sessionStore, err := session.NewSQLiteStore(ctx, cfg, writeMu)
 	if err != nil {
 		return nil, err
 	}
 
 	// EventStore shares the session store's *sql.DB (schema managed by goose migration 002).
-	eventStore := eventstore.NewSQLiteStore(sessionStore.DB())
+	eventStore := eventstore.NewSQLiteStore(sessionStore.DB(), writeMu)
 
 	return &gatewayStores{
 		session:   sessionStore,
 		event:     eventStore,
 		collector: eventstore.NewCollector(eventStore, log),
+		writeMu:   writeMu,
 	}, nil
 }
 

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -44,13 +44,13 @@ func OpenStore(ctx context.Context, configPath string) (cron.Store, *eventstore.
 		return nil, nil, nil, err
 	}
 
-	ss, err := session.NewSQLiteStore(ctx, cfg)
+	ss, err := session.NewSQLiteStore(ctx, cfg, nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("open session store: %w", err)
 	}
 
-	cronStore := cron.NewSQLiteStore(ss.DB(), slog.Default())
-	evStore := eventstore.NewSQLiteStore(ss.DB())
+	cronStore := cron.NewSQLiteStore(ss.DB(), slog.Default(), nil)
+	evStore := eventstore.NewSQLiteStore(ss.DB(), nil)
 	cleanup := func() { _ = ss.Close() }
 
 	return cronStore, evStore, cleanup, nil

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -163,6 +163,9 @@ func resolvePlatform(cliPlatform string, cliPlatformKey map[string]string) (stri
 		if chatID := os.Getenv("GATEWAY_CHANNEL_ID"); chatID != "" {
 			key["chat_id"] = chatID
 		}
+		if msgID := os.Getenv("GATEWAY_THREAD_ID"); msgID != "" {
+			key["message_id"] = msgID
+		}
 		return "feishu", key
 	}
 

--- a/internal/cli/cron/client_test.go
+++ b/internal/cli/cron/client_test.go
@@ -61,6 +61,7 @@ func TestPrepareJobForCreate(t *testing.T) {
 	job, err := PrepareJobForCreate(
 		"test-job", "every:5m", "say hello", "a test",
 		"/tmp/work", "bot-1", "owner-1", 300, nil, JobCreateOptions{
+			Platform:  "cron",
 			MaxRuns:   50,
 			ExpiresAt: "2099-01-01T00:00:00Z",
 		},
@@ -81,7 +82,7 @@ func TestPrepareJobForCreate_DefaultLifecycle(t *testing.T) {
 	// Recurring job without lifecycle opts gets safe defaults.
 	job, err := PrepareJobForCreate(
 		"default-lifecycle", "every:30m", "test", "", "",
-		"bot-1", "owner-1", 0, nil, JobCreateOptions{},
+		"bot-1", "owner-1", 0, nil, JobCreateOptions{Platform: "cron"},
 	)
 	require.NoError(t, err)
 	require.Equal(t, 10, job.MaxRuns)
@@ -95,7 +96,7 @@ func TestPrepareJobForCreate_OneShotNoLifecycle(t *testing.T) {
 	// One-shot jobs don't need lifecycle constraints.
 	job, err := PrepareJobForCreate(
 		"one-shot", "at:2099-01-01T00:00:00Z", "test", "", "",
-		"bot-1", "owner-1", 0, nil, JobCreateOptions{},
+		"bot-1", "owner-1", 0, nil, JobCreateOptions{Platform: "cron"},
 	)
 	require.NoError(t, err)
 	require.Equal(t, 0, job.MaxRuns)
@@ -189,6 +190,7 @@ func TestPrepareJobForCreate_Callback(t *testing.T) {
 	job, err := PrepareJobForCreate(
 		"callback-test", "at:+5m", "check result", "", "",
 		"bot-1", "owner-1", 0, nil, JobCreateOptions{
+			Platform:        "cron",
 			Attach:          true,
 			TargetSessionID: "sess_abc",
 			DeleteAfterRun:  true,

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -137,14 +137,11 @@ func (e *Executor) waitForCompletion(ctx context.Context, sessionID string, time
 // HasCLIDelivery returns true if the job has sufficient platform info
 // for CLI-based result delivery.
 func HasCLIDelivery(job *CronJob) bool {
-	switch job.Platform {
-	case "slack":
-		return job.PlatformKey["channel_id"] != ""
-	case "feishu":
-		return job.PlatformKey["chat_id"] != ""
-	default:
+	key, ok := RequiredPlatformKey[job.Platform]
+	if !ok {
 		return false
 	}
+	return job.PlatformKey[key] != ""
 }
 
 // buildDeliverySuffix appends CLI delivery instructions to the cron prompt.
@@ -166,7 +163,7 @@ func buildDeliverySuffix(job *CronJob) string {
 }
 
 func buildSlackDelivery(job *CronJob) string {
-	ch := job.PlatformKey["channel_id"]
+	ch := job.PlatformKey[RequiredPlatformKey["slack"]]
 	if ch == "" {
 		return ""
 	}
@@ -178,9 +175,14 @@ func buildSlackDelivery(job *CronJob) string {
 }
 
 func buildFeishuDelivery(job *CronJob) string {
-	chatID := job.PlatformKey["chat_id"]
+	chatID := job.PlatformKey[RequiredPlatformKey["feishu"]]
 	if chatID == "" {
 		return ""
+	}
+	msgID := job.PlatformKey["message_id"]
+	if msgID != "" {
+		cmd := fmt.Sprintf("lark-cli im +messages-reply --as bot --message-id %s --markdown \"结果内容\"", msgID)
+		return fmt.Sprintf(deliveryBlockFmt, job.Name, cmd)
 	}
 	cmd := fmt.Sprintf("lark-cli im +messages-send --as bot --chat-id %s --markdown \"结果内容\"", chatID)
 	return fmt.Sprintf(deliveryBlockFmt, job.Name, cmd)

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/session"
@@ -49,9 +50,7 @@ func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Durat
 	// Merge platform context so the bridge can inject environment variables (like channel_id).
 	platformKey := make(map[string]string)
 	if job.PlatformKey != nil {
-		for k, v := range job.PlatformKey {
-			platformKey[k] = v
-		}
+		maps.Copy(platformKey, job.PlatformKey)
 	}
 	platformKey["cron_job_id"] = job.ID
 	title := fmt.Sprintf("cron:%s", job.Name)
@@ -179,12 +178,12 @@ func buildFeishuDelivery(job *CronJob) string {
 	if chatID == "" {
 		return ""
 	}
-	msgID := job.PlatformKey["message_id"]
-	if msgID != "" {
-		cmd := fmt.Sprintf("lark-cli im +messages-reply --as bot --message-id %s --markdown \"结果内容\"", msgID)
-		return fmt.Sprintf(deliveryBlockFmt, job.Name, cmd)
+	var cmd string
+	if msgID := job.PlatformKey["message_id"]; msgID != "" {
+		cmd = fmt.Sprintf("lark-cli im +messages-reply --as bot --message-id %s --markdown \"结果内容\"", msgID)
+	} else {
+		cmd = fmt.Sprintf("lark-cli im +messages-send --as bot --chat-id %s --markdown \"结果内容\"", chatID)
 	}
-	cmd := fmt.Sprintf("lark-cli im +messages-send --as bot --chat-id %s --markdown \"结果内容\"", chatID)
 	return fmt.Sprintf(deliveryBlockFmt, job.Name, cmd)
 }
 

--- a/internal/cron/loader_test.go
+++ b/internal/cron/loader_test.go
@@ -89,7 +89,7 @@ func TestYAMLDefToJob(t *testing.T) {
 		WorkDir:       "/tmp",
 		BotID:         "bot1",
 		OwnerID:       "user1",
-		Platform:      "feishu",
+		Platform:      "cron",
 		TimeoutSec:    120,
 		MaxRetries:    3,
 		Silent:        true,
@@ -112,7 +112,7 @@ func TestYAMLDefToJob(t *testing.T) {
 	require.Equal(t, "/tmp", job.WorkDir)
 	require.Equal(t, "bot1", job.BotID)
 	require.Equal(t, "user1", job.OwnerID)
-	require.Equal(t, "feishu", job.Platform)
+	require.Equal(t, "cron", job.Platform)
 	require.Equal(t, 120, job.TimeoutSec)
 	require.Equal(t, 3, job.MaxRetries)
 	require.True(t, job.Silent)

--- a/internal/cron/normalize.go
+++ b/internal/cron/normalize.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+// RequiredPlatformKey maps each platform to the PlatformKey field required
+// for CLI-based result delivery. Used by ValidateJob, HasCLIDelivery, and
+// buildDeliverySuffix to avoid duplicating platform→key mappings.
+var RequiredPlatformKey = map[string]string{
+	"feishu": "chat_id",
+	"slack":  "channel_id",
+}
+
 var threatPatterns = []string{
 	"ignore previous instructions",
 	"system prompt override",
@@ -59,15 +67,10 @@ func ValidateJob(job *CronJob) error {
 			return errors.New("cron: attached_session does not support cron expression schedules")
 		}
 	}
-	// Platform delivery validation: feishu requires chat_id, slack requires channel_id.
-	switch job.Platform {
-	case "feishu":
-		if job.PlatformKey["chat_id"] == "" {
-			return errors.New("cron: feishu platform requires chat_id in platform_key")
-		}
-	case "slack":
-		if job.PlatformKey["channel_id"] == "" {
-			return errors.New("cron: slack platform requires channel_id in platform_key")
+	// Platform delivery validation: each platform requires a specific key in platform_key.
+	if key, ok := RequiredPlatformKey[job.Platform]; ok {
+		if job.PlatformKey[key] == "" {
+			return fmt.Errorf("cron: %s platform requires %s in platform_key", job.Platform, key)
 		}
 	}
 	// Recurring jobs must have lifecycle constraints to prevent infinite execution.

--- a/internal/cron/normalize.go
+++ b/internal/cron/normalize.go
@@ -59,6 +59,17 @@ func ValidateJob(job *CronJob) error {
 			return errors.New("cron: attached_session does not support cron expression schedules")
 		}
 	}
+	// Platform delivery validation: feishu requires chat_id, slack requires channel_id.
+	switch job.Platform {
+	case "feishu":
+		if job.PlatformKey["chat_id"] == "" {
+			return errors.New("cron: feishu platform requires chat_id in platform_key")
+		}
+	case "slack":
+		if job.PlatformKey["channel_id"] == "" {
+			return errors.New("cron: slack platform requires channel_id in platform_key")
+		}
+	}
 	// Recurring jobs must have lifecycle constraints to prevent infinite execution.
 	if job.Schedule.Kind != ScheduleAt {
 		if job.MaxRuns <= 0 {

--- a/internal/cron/normalize_test.go
+++ b/internal/cron/normalize_test.go
@@ -203,6 +203,54 @@ func TestValidateJob(t *testing.T) {
 			wantErr: true,
 			errPart: "max_runs is required",
 		},
+		{
+			name: "feishu without chat_id rejected",
+			job: func() *CronJob {
+				j := validJob()
+				j.Platform = "feishu"
+				j.PlatformKey = map[string]string{}
+				return j
+			}(),
+			wantErr: true,
+			errPart: "feishu platform requires chat_id",
+		},
+		{
+			name: "feishu with chat_id passes",
+			job: func() *CronJob {
+				j := validJob()
+				j.Platform = "feishu"
+				j.PlatformKey = map[string]string{"chat_id": "oc_123"}
+				return j
+			}(),
+		},
+		{
+			name: "slack without channel_id rejected",
+			job: func() *CronJob {
+				j := validJob()
+				j.Platform = "slack"
+				j.PlatformKey = map[string]string{}
+				return j
+			}(),
+			wantErr: true,
+			errPart: "slack platform requires channel_id",
+		},
+		{
+			name: "slack with channel_id passes",
+			job: func() *CronJob {
+				j := validJob()
+				j.Platform = "slack"
+				j.PlatformKey = map[string]string{"channel_id": "C123"}
+				return j
+			}(),
+		},
+		{
+			name: "cron platform needs no key",
+			job: func() *CronJob {
+				j := validJob()
+				j.Platform = "cron"
+				return j
+			}(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -50,10 +50,10 @@ func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 }
 
 const jobColumns = `id, name, description, enabled,
-	schedule_kind, schedule_data, payload_kind, payload_data,
-	work_dir, bot_id, owner_id, platform, platform_key,
-	timeout_sec, delete_after_run, silent, max_retries, max_runs, expires_at,
-	state, created_at, updated_at`
+		schedule_kind, schedule_data, payload_kind, payload_data,
+		work_dir, bot_id, owner_id, platform, platform_key,
+		timeout_sec, delete_after_run, silent, max_retries, max_runs, expires_at,
+		state, created_at, updated_at`
 
 func (s *SQLiteStore) Create(ctx context.Context, job *CronJob) error {
 	if job.ID == "" {
@@ -68,23 +68,21 @@ func (s *SQLiteStore) Create(ctx context.Context, job *CronJob) error {
 		return err
 	}
 
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO cron_jobs (`+jobColumns+`)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		job.ID, job.Name, job.Description, boolToInt(job.Enabled),
-		job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
-		job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
-		job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries, job.MaxRuns, job.ExpiresAt,
-		stateData, job.CreatedAtMs, job.UpdatedAtMs,
-	)
-	if err != nil {
-		return fmt.Errorf("cron store: create job: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err = s.db.ExecContext(ctx, `
+			INSERT INTO cron_jobs (`+jobColumns+`)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			job.ID, job.Name, job.Description, boolToInt(job.Enabled),
+			job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
+			job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
+			job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries, job.MaxRuns, job.ExpiresAt,
+			stateData, job.CreatedAtMs, job.UpdatedAtMs,
+		)
+		if err != nil {
+			return fmt.Errorf("cron store: create job: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) Update(ctx context.Context, job *CronJob) error {
@@ -96,54 +94,50 @@ func (s *SQLiteStore) Update(ctx context.Context, job *CronJob) error {
 		return err
 	}
 
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE cron_jobs SET
-			name = ?, description = ?, enabled = ?,
-			schedule_kind = ?, schedule_data = ?, payload_kind = ?, payload_data = ?,
-			work_dir = ?, bot_id = ?, owner_id = ?, platform = ?, platform_key = ?,
-			timeout_sec = ?, delete_after_run = ?, silent = ?, max_retries = ?,
-			max_runs = ?, expires_at = ?,
-			state = ?, updated_at = ?
-		WHERE id = ?`,
-		job.Name, job.Description, boolToInt(job.Enabled),
-		job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
-		job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
-		job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries,
-		job.MaxRuns, job.ExpiresAt,
-		stateData, job.UpdatedAtMs,
-		job.ID,
-	)
-	if err != nil {
-		return fmt.Errorf("cron store: update job: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("%w: %s", ErrJobNotFound, job.ID)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx, `
+			UPDATE cron_jobs SET
+				name = ?, description = ?, enabled = ?,
+				schedule_kind = ?, schedule_data = ?, payload_kind = ?, payload_data = ?,
+				work_dir = ?, bot_id = ?, owner_id = ?, platform = ?, platform_key = ?,
+				timeout_sec = ?, delete_after_run = ?, silent = ?, max_retries = ?,
+				max_runs = ?, expires_at = ?,
+				state = ?, updated_at = ?
+			WHERE id = ?`,
+			job.Name, job.Description, boolToInt(job.Enabled),
+			job.Schedule.Kind, schedData, job.Payload.Kind, payloadData,
+			job.WorkDir, job.BotID, job.OwnerID, job.Platform, platformKeyData,
+			job.TimeoutSec, boolToInt(job.DeleteAfterRun), boolToInt(job.Silent), job.MaxRetries,
+			job.MaxRuns, job.ExpiresAt,
+			stateData, job.UpdatedAtMs,
+			job.ID,
+		)
+		if err != nil {
+			return fmt.Errorf("cron store: update job: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("%w: %s", ErrJobNotFound, job.ID)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 	ctx, cancel := withTimeout(ctx)
 	defer cancel()
 
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx, `DELETE FROM cron_jobs WHERE id = ?`, id)
-	if err != nil {
-		return fmt.Errorf("cron store: delete job: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("%w: %s", ErrJobNotFound, id)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx, `DELETE FROM cron_jobs WHERE id = ?`, id)
+		if err != nil {
+			return fmt.Errorf("cron store: delete job: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("%w: %s", ErrJobNotFound, id)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) Get(ctx context.Context, id string) (*CronJob, error) {
@@ -199,22 +193,20 @@ func (s *SQLiteStore) UpdateState(ctx context.Context, id string, state CronJobS
 	}
 
 	now := time.Now().UnixMilli()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE cron_jobs SET state = ?, updated_at = ? WHERE id = ?`,
-		string(data), now, id,
-	)
-	if err != nil {
-		return fmt.Errorf("cron store: update state: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("%w: %s", ErrJobNotFound, id)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx,
+			`UPDATE cron_jobs SET state = ?, updated_at = ? WHERE id = ?`,
+			string(data), now, id,
+		)
+		if err != nil {
+			return fmt.Errorf("cron store: update state: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("%w: %s", ErrJobNotFound, id)
+		}
+		return nil
+	})
 }
 
 // SetEnabled updates the enabled flag for a job without touching other fields.
@@ -223,22 +215,20 @@ func (s *SQLiteStore) SetEnabled(ctx context.Context, id string, enabled bool) e
 	defer cancel()
 
 	now := time.Now().UnixMilli()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE cron_jobs SET enabled = ?, updated_at = ? WHERE id = ?`,
-		boolToInt(enabled), now, id,
-	)
-	if err != nil {
-		return fmt.Errorf("cron store: set enabled: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("%w: %s", ErrJobNotFound, id)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx,
+			`UPDATE cron_jobs SET enabled = ?, updated_at = ? WHERE id = ?`,
+			boolToInt(enabled), now, id,
+		)
+		if err != nil {
+			return fmt.Errorf("cron store: set enabled: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("%w: %s", ErrJobNotFound, id)
+		}
+		return nil
+	})
 }
 
 // UpsertByName inserts or updates a job by name (idempotent for YAML import).

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/hrygo/hotplex/internal/sqlutil"
 )
 
 // ErrJobNotFound is returned when a job is not found in the store.
@@ -28,13 +30,14 @@ type Store interface {
 
 // SQLiteStore implements Store using SQLite.
 type SQLiteStore struct {
-	db  *sql.DB
-	log *slog.Logger
+	db      *sql.DB
+	log     *slog.Logger
+	writeMu *sqlutil.WriteMu
 }
 
 // NewSQLiteStore creates a new cron store backed by the given database.
-func NewSQLiteStore(db *sql.DB, log *slog.Logger) *SQLiteStore {
-	return &SQLiteStore{db: db, log: log.With("component", "cron_store")}
+func NewSQLiteStore(db *sql.DB, log *slog.Logger, writeMu *sqlutil.WriteMu) *SQLiteStore {
+	return &SQLiteStore{db: db, log: log.With("component", "cron_store"), writeMu: writeMu}
 }
 
 const defaultTimeout = 5 * time.Second
@@ -65,6 +68,10 @@ func (s *SQLiteStore) Create(ctx context.Context, job *CronJob) error {
 		return err
 	}
 
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO cron_jobs (`+jobColumns+`)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -89,6 +96,10 @@ func (s *SQLiteStore) Update(ctx context.Context, job *CronJob) error {
 		return err
 	}
 
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE cron_jobs SET
 			name = ?, description = ?, enabled = ?,
@@ -120,6 +131,10 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
 	ctx, cancel := withTimeout(ctx)
 	defer cancel()
 
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx, `DELETE FROM cron_jobs WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("cron store: delete job: %w", err)
@@ -184,6 +199,10 @@ func (s *SQLiteStore) UpdateState(ctx context.Context, id string, state CronJobS
 	}
 
 	now := time.Now().UnixMilli()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE cron_jobs SET state = ?, updated_at = ? WHERE id = ?`,
 		string(data), now, id,
@@ -204,6 +223,10 @@ func (s *SQLiteStore) SetEnabled(ctx context.Context, id string, enabled bool) e
 	defer cancel()
 
 	now := time.Now().UnixMilli()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE cron_jobs SET enabled = ?, updated_at = ? WHERE id = ?`,
 		boolToInt(enabled), now, id,

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -58,7 +58,7 @@ func newTestStore(t *testing.T) *SQLiteStore {
 		)`)
 	require.NoError(t, err)
 
-	return NewSQLiteStore(db, slog.Default())
+	return NewSQLiteStore(db, slog.Default(), nil)
 }
 
 func helperJob(name string) *CronJob {

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -49,22 +49,29 @@ func IsStorable(eventType events.Kind) bool {
 }
 
 // captureRequest is a pending write for the background batch writer.
-// event and turn are mutually exclusive: one is set, the other is nil.
+// event, turn, and flush are mutually exclusive: exactly one is set.
 type captureRequest struct {
 	event *StoredEvent
 	turn  *TurnWriteRequest
+	flush chan struct{} // non-nil: flush marker; closed by runWriter after batch commit
 }
 
 func (r *captureRequest) sessionID() string {
 	if r.event != nil {
 		return r.event.SessionID
 	}
-	return r.turn.SessionID
+	if r.turn != nil {
+		return r.turn.SessionID
+	}
+	return ""
 }
 
 func kindOf(req *captureRequest) string {
 	if req.turn != nil {
 		return "turn"
+	}
+	if req.flush != nil {
+		return "flush"
 	}
 	return "event"
 }
@@ -260,6 +267,34 @@ func (c *Collector) CaptureTurn(turn *TurnWriteRequest) {
 	c.send(&captureRequest{turn: turn})
 }
 
+// Flush blocks until all pending writes in the capture channel have been
+// committed to the underlying store. Safe for concurrent use.
+// Returns immediately if the collector is closed.
+func (c *Collector) Flush() {
+	// Fast path: return immediately if already closed.
+	select {
+	case <-c.closeC:
+		return
+	default:
+	}
+
+	done := make(chan struct{})
+	select {
+	case c.captureC <- &captureRequest{flush: done}:
+	case <-c.closeC:
+		return
+	case <-time.After(5 * time.Second):
+		c.log.Warn("eventstore: flush send timeout")
+		return
+	}
+	select {
+	case <-done:
+	case <-c.closeC:
+	case <-time.After(5 * time.Second):
+		c.log.Warn("eventstore: flush wait timeout")
+	}
+}
+
 // Close drains the capture channel and flushes remaining events.
 func (c *Collector) Close() error {
 	// Swap accumulator maps under lock, flush outside to avoid deadlock.
@@ -312,6 +347,11 @@ func (c *Collector) runWriter() {
 			for {
 				select {
 				case req := <-c.captureC:
+					if req.flush != nil {
+						flush()
+						close(req.flush)
+						continue
+					}
 					batch = append(batch, req)
 				default:
 					flush()
@@ -319,6 +359,11 @@ func (c *Collector) runWriter() {
 				}
 			}
 		case req := <-c.captureC:
+			if req.flush != nil {
+				flush()
+				close(req.flush)
+				continue
+			}
 			batch = append(batch, req)
 			if len(batch) >= collectorBatchMax {
 				flush()
@@ -365,6 +410,13 @@ func (c *Collector) flushBatch(batch []*captureRequest) {
 		return
 	}
 
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
 	for _, req := range batch {
 		var err error
 		switch {
@@ -386,6 +438,7 @@ func (c *Collector) flushBatch(batch []*captureRequest) {
 	if err := tx.Commit(); err != nil {
 		c.log.Error("eventstore: batch commit", "err", err)
 	}
+	committed = true
 }
 
 // CaptureDeltaString accumulates a message.delta content string directly,

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -355,6 +355,9 @@ func (c *Collector) runWriter() {
 					batch = append(batch, req)
 				default:
 					flush()
+					if d := c.dropped.Load(); d > 0 {
+						c.log.Warn("eventstore: events dropped during lifetime", "count", d)
+					}
 					return
 				}
 			}

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -413,9 +413,9 @@ func (c *Collector) flushBatch(batch []*captureRequest) {
 		return
 	}
 
-	committed := false
+	done := false
 	defer func() {
-		if !committed {
+		if !done {
 			_ = tx.Rollback()
 		}
 	}()
@@ -441,7 +441,7 @@ func (c *Collector) flushBatch(batch []*captureRequest) {
 	if err := tx.Commit(); err != nil {
 		c.log.Error("eventstore: batch commit", "err", err)
 	}
-	committed = true
+	done = true
 }
 
 // CaptureDeltaString accumulates a message.delta content string directly,

--- a/internal/eventstore/collector_test.go
+++ b/internal/eventstore/collector_test.go
@@ -434,3 +434,80 @@ func TestCollector_CaptureReasoningStringEmptyContent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(page.Events[0].Data, &data))
 	require.Equal(t, "", data["content"])
 }
+
+func TestCollector_Flush(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+	defer func() { _ = c.Close() }()
+
+	// Send events without waiting for timer flush.
+	c.Capture("s1", 1, events.Input, json.RawMessage(`{"content":"hello"}`), "inbound", SourceNormal)
+	c.Capture("s1", 2, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+
+	// Flush must make events queryable immediately (no 1s timer wait).
+	c.Flush()
+
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, 2)
+	require.Equal(t, string(events.Input), page.Events[0].Type)
+	require.Equal(t, string(events.Done), page.Events[1].Type)
+}
+
+func TestCollector_FlushAfterClose(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+
+	require.NoError(t, c.Close())
+
+	// Flush on a closed collector must return immediately without panic.
+	c.Flush()
+}
+
+func TestCollector_FlushConcurrent(t *testing.T) {
+	store := newTestStore(t)
+	c := NewCollector(store, slog.Default())
+	defer func() { _ = c.Close() }()
+
+	const flushers = 5
+	done := make(chan struct{})
+	for i := range flushers {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			c.Capture("s1", int64(i+1), events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+			c.Flush()
+		}()
+	}
+	for range flushers {
+		<-done
+	}
+
+	// All events must be persisted.
+	page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+	require.NoError(t, err)
+	require.Len(t, page.Events, flushers)
+}
+
+func TestCollector_FlushTurn(t *testing.T) {
+	store := newTestStoreWithTurnsTable(t)
+	c := NewCollector(store, slog.Default())
+	defer func() { _ = c.Close() }()
+
+	// Capture a turn (the exact pattern used by cron delivery).
+	c.CaptureTurn(&TurnWriteRequest{
+		SessionID:  "s1",
+		Generation: 1,
+		TurnNum:    1,
+		Role:       "assistant",
+		Content:    "cron result",
+		Source:     SourceNormal,
+		CreatedAt:  time.Now().UnixMilli(),
+	})
+
+	c.Flush()
+
+	turns, err := store.QueryTurns(context.Background(), "s1", 1, 0)
+	require.NoError(t, err)
+	require.Len(t, turns, 1)
+	require.Equal(t, "cron result", turns[0].Content)
+}

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -198,6 +198,7 @@ type EventTx interface {
 	Append(ctx context.Context, event *StoredEvent) error
 	AppendTurn(ctx context.Context, turn *TurnWriteRequest) error
 	Commit() error
+	Rollback() error
 }
 
 // TurnQuerier provides read-only access to conversation turn records.
@@ -211,16 +212,17 @@ type TurnQuerier interface {
 
 // SQLiteStore implements EventStore using a shared SQLite database connection.
 type SQLiteStore struct {
-	db     *sql.DB
-	ownsDB bool // true only when opened independently (tests); false when sharing session store DB.
+	db      *sql.DB
+	ownsDB  bool // true only when opened independently (tests); false when sharing session store DB.
+	writeMu *sqlutil.WriteMu
 }
 
 var _ EventStore = (*SQLiteStore)(nil)
 
 // NewSQLiteStore creates an event store using a shared *sql.DB.
 // The schema is managed by the session store goose migrations (002_events_table.sql).
-func NewSQLiteStore(db *sql.DB) *SQLiteStore {
-	return &SQLiteStore{db: db, ownsDB: false}
+func NewSQLiteStore(db *sql.DB, writeMu *sqlutil.WriteMu) *SQLiteStore {
+	return &SQLiteStore{db: db, ownsDB: false, writeMu: writeMu}
 }
 
 // NewIndependentStore opens its own DB for testing.
@@ -238,6 +240,10 @@ func NewIndependentStore(dbPath string) (*SQLiteStore, error) {
 func (s *SQLiteStore) Append(ctx context.Context, event *StoredEvent) error {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err := s.db.ExecContext(ctx, queries["insert"],
 		event.SessionID, event.Seq, event.Type, event.Data, event.Direction, event.Source, event.CreatedAt)
 	if err != nil {
@@ -247,17 +253,35 @@ func (s *SQLiteStore) Append(ctx context.Context, event *StoredEvent) error {
 }
 
 func (s *SQLiteStore) BeginTx(ctx context.Context) (EventTx, error) {
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+	}
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		if s.writeMu != nil {
+			s.writeMu.Unlock()
+		}
 		return nil, fmt.Errorf("eventstore: begin tx: %w", err)
 	}
-	return &sqliteTx{tx: tx}, nil
+	return &sqliteTx{tx: tx, writeMu: s.writeMu}, nil
 }
 
 type sqliteTx struct {
-	tx *sql.Tx
+	tx       *sql.Tx
+	writeMu  *sqlutil.WriteMu
+	released bool
+}
+
+func (t *sqliteTx) release() {
+	if t.released {
+		return
+	}
+	t.released = true
+	if t.writeMu != nil {
+		t.writeMu.Unlock()
+	}
 }
 
 func (t *sqliteTx) Append(ctx context.Context, event *StoredEvent) error {
@@ -290,7 +314,15 @@ func (t *sqliteTx) AppendTurn(ctx context.Context, turn *TurnWriteRequest) error
 }
 
 func (t *sqliteTx) Commit() error {
-	return t.tx.Commit()
+	err := t.tx.Commit()
+	t.release()
+	return err
+}
+
+func (t *sqliteTx) Rollback() error {
+	err := t.tx.Rollback()
+	t.release()
+	return err
 }
 
 func (s *SQLiteStore) QueryBySession(ctx context.Context, sessionID string, cursor int64, dir CursorDirection, limit int) (*EventPage, error) {
@@ -363,6 +395,10 @@ func (s *SQLiteStore) QueryBySession(ctx context.Context, sessionID string, curs
 func (s *SQLiteStore) DeleteBySession(ctx context.Context, sessionID string) error {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err := s.db.ExecContext(ctx, queries["delete_by_session"], sessionID)
 	if err != nil {
 		return fmt.Errorf("eventstore: delete by session: %w", err)
@@ -373,6 +409,10 @@ func (s *SQLiteStore) DeleteBySession(ctx context.Context, sessionID string) err
 func (s *SQLiteStore) DeleteExpired(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx, queries["delete_expired"], cutoff.UnixMilli())
 	if err != nil {
 		return 0, fmt.Errorf("eventstore: delete expired: %w", err)
@@ -500,6 +540,10 @@ func (s *SQLiteStore) LatestGeneration(ctx context.Context, sessionID string) (i
 func (s *SQLiteStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	res, err := s.db.ExecContext(ctx, queries["turns.delete_expired"], cutoff.UnixMilli())
 	if err != nil {
 		return 0, fmt.Errorf("eventstore: delete expired turns: %w", err)

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -240,16 +240,14 @@ func NewIndependentStore(dbPath string) (*SQLiteStore, error) {
 func (s *SQLiteStore) Append(ctx context.Context, event *StoredEvent) error {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err := s.db.ExecContext(ctx, queries["insert"],
-		event.SessionID, event.Seq, event.Type, event.Data, event.Direction, event.Source, event.CreatedAt)
-	if err != nil {
-		return fmt.Errorf("eventstore: append: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["insert"],
+			event.SessionID, event.Seq, event.Type, event.Data, event.Direction, event.Source, event.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("eventstore: append: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) BeginTx(ctx context.Context) (EventTx, error) {
@@ -395,29 +393,28 @@ func (s *SQLiteStore) QueryBySession(ctx context.Context, sessionID string, curs
 func (s *SQLiteStore) DeleteBySession(ctx context.Context, sessionID string) error {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err := s.db.ExecContext(ctx, queries["delete_by_session"], sessionID)
-	if err != nil {
-		return fmt.Errorf("eventstore: delete by session: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["delete_by_session"], sessionID)
+		if err != nil {
+			return fmt.Errorf("eventstore: delete by session: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) DeleteExpired(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx, queries["delete_expired"], cutoff.UnixMilli())
-	if err != nil {
-		return 0, fmt.Errorf("eventstore: delete expired: %w", err)
-	}
-	return res.RowsAffected()
+	var rowsAffected int64
+	err := s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx, queries["delete_expired"], cutoff.UnixMilli())
+		if err != nil {
+			return fmt.Errorf("eventstore: delete expired: %w", err)
+		}
+		rowsAffected, _ = res.RowsAffected()
+		return nil
+	})
+	return rowsAffected, err
 }
 
 func (s *SQLiteStore) Close() error {
@@ -540,15 +537,16 @@ func (s *SQLiteStore) LatestGeneration(ctx context.Context, sessionID string) (i
 func (s *SQLiteStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	res, err := s.db.ExecContext(ctx, queries["turns.delete_expired"], cutoff.UnixMilli())
-	if err != nil {
-		return 0, fmt.Errorf("eventstore: delete expired turns: %w", err)
-	}
-	return res.RowsAffected()
+	var rowsAffected int64
+	err := s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx, queries["turns.delete_expired"], cutoff.UnixMilli())
+		if err != nil {
+			return fmt.Errorf("eventstore: delete expired turns: %w", err)
+		}
+		rowsAffected, _ = res.RowsAffected()
+		return nil
+	})
+	return rowsAffected, err
 }
 
 func scanEvents(rows *sql.Rows) ([]*StoredEvent, error) {

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -194,6 +194,8 @@ type EventStore interface {
 }
 
 // EventTx is a transaction handle for batch event and turn writes.
+// Callers MUST call either Commit or Rollback to release the underlying
+// write lock — failure to do so will deadlock all subsequent writes.
 type EventTx interface {
 	Append(ctx context.Context, event *StoredEvent) error
 	AppendTurn(ctx context.Context, turn *TurnWriteRequest) error

--- a/internal/eventstore/store_test.go
+++ b/internal/eventstore/store_test.go
@@ -260,3 +260,54 @@ func TestCollector_DropNonStorable(t *testing.T) {
 	_, err := store.QueryBySession(context.Background(), "sess1", 0, CursorLatest, 10)
 	require.ErrorIs(t, err, ErrNotFound)
 }
+
+func TestSqliteTx_DoubleRelease(t *testing.T) {
+	store := newTestStoreWithWriteMu(t)
+	ctx := context.Background()
+
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+
+	_ = tx.Commit()
+	_ = tx.Rollback()
+
+	// Core assertion: writeMu is NOT deadlocked after Commit+Rollback.
+	require.NoError(t, store.writeMu.WithLock(func() error { return nil }))
+}
+
+func TestSqliteTx_RollbackThenCommit(t *testing.T) {
+	store := newTestStoreWithWriteMu(t)
+	ctx := context.Background()
+
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+
+	_ = tx.Rollback()
+	_ = tx.Commit()
+
+	require.NoError(t, store.writeMu.WithLock(func() error { return nil }))
+}
+
+func newTestStoreWithWriteMu(t *testing.T) *SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := NewIndependentStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	store.writeMu = sqlutil.NewWriteMu()
+
+	_, err = store.db.Exec(`CREATE TABLE IF NOT EXISTS events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		seq INTEGER NOT NULL,
+		type TEXT NOT NULL,
+		data TEXT NOT NULL,
+		direction TEXT NOT NULL DEFAULT 'outbound',
+		source TEXT NOT NULL DEFAULT 'normal'
+			CHECK(source IN ('normal', 'crash', 'timeout', 'fresh_start')),
+		created_at INTEGER NOT NULL DEFAULT 0
+	)`)
+	require.NoError(t, err)
+	return store
+}

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -107,7 +107,7 @@ func newHandlerWithRealStore(t *testing.T) (*Handler, *session.Manager, *Hub, fu
 	cleanup := func() { os.Remove(tmpPath) }
 
 	cfg.DB.Path = tmpPath
-	store, err := session.NewSQLiteStore(context.Background(), cfg)
+	store, err := session.NewSQLiteStore(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	mgr, err := session.NewManager(context.Background(), slog.Default(), cfg, nil, store)
 	require.NoError(t, err)

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1051,7 +1051,7 @@ func newBridgeWithCollector(t *testing.T) (*Bridge, *eventstore.SQLiteStore) {
 	)`)
 	require.NoError(t, err)
 
-	store := eventstore.NewSQLiteStore(db)
+	store := eventstore.NewSQLiteStore(db, nil)
 	collector := eventstore.NewCollector(store, slog.Default())
 
 	return &Bridge{log: slog.Default(), collector: collector, accum: make(map[string]*sessionAccumulator), turnsQuerier: store}, store

--- a/internal/messaging/chat_access_store.go
+++ b/internal/messaging/chat_access_store.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+
+	"github.com/hrygo/hotplex/internal/sqlutil"
 )
 
 // ChatAccessType classifies why the chat-entered event fired.
@@ -32,13 +34,14 @@ type ChatAccessRecord struct {
 
 // ChatAccessStore provides dedup + cooldown + persistence for chat-entered events.
 type ChatAccessStore struct {
-	db  *sql.DB
-	log *slog.Logger
+	db      *sql.DB
+	log     *slog.Logger
+	writeMu *sqlutil.WriteMu
 }
 
 // NewChatAccessStore creates a store backed by the shared SQLite connection.
-func NewChatAccessStore(db *sql.DB, log *slog.Logger) *ChatAccessStore {
-	return &ChatAccessStore{db: db, log: log}
+func NewChatAccessStore(db *sql.DB, log *slog.Logger, writeMu *sqlutil.WriteMu) *ChatAccessStore {
+	return &ChatAccessStore{db: db, log: log, writeMu: writeMu}
 }
 
 // Record inserts the event. Returns false (with nil error) when event_id
@@ -46,6 +49,10 @@ func NewChatAccessStore(db *sql.DB, log *slog.Logger) *ChatAccessStore {
 func (s *ChatAccessStore) Record(ctx context.Context, r ChatAccessRecord) (inserted bool, err error) {
 	now := time.Now().Unix()
 	r.CreatedAt = now
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO chat_access_events (event_id, platform, chat_id, user_id, bot_id, last_message_at, welcome_sent, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/internal/messaging/chat_access_store.go
+++ b/internal/messaging/chat_access_store.go
@@ -46,26 +46,27 @@ func NewChatAccessStore(db *sql.DB, log *slog.Logger, writeMu *sqlutil.WriteMu) 
 
 // Record inserts the event. Returns false (with nil error) when event_id
 // already exists (duplicate event from the platform).
-func (s *ChatAccessStore) Record(ctx context.Context, r ChatAccessRecord) (inserted bool, err error) {
+func (s *ChatAccessStore) Record(ctx context.Context, r ChatAccessRecord) (bool, error) {
 	now := time.Now().Unix()
 	r.CreatedAt = now
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO chat_access_events (event_id, platform, chat_id, user_id, bot_id, last_message_at, welcome_sent, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.EventID, r.Platform, r.ChatID, r.UserID, r.BotID, r.LastMessageAt, boolToInt(r.WelcomeSent), r.CreatedAt,
-	)
-	if err != nil {
-		// UNIQUE constraint violation → duplicate event.
-		if isSQLiteUnique(err) {
-			return false, nil
+	var inserted bool
+	err := s.writeMu.WithLock(func() error {
+		res, err := s.db.ExecContext(ctx,
+			`INSERT INTO chat_access_events (event_id, platform, chat_id, user_id, bot_id, last_message_at, welcome_sent, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			r.EventID, r.Platform, r.ChatID, r.UserID, r.BotID, r.LastMessageAt, boolToInt(r.WelcomeSent), r.CreatedAt,
+		)
+		if err != nil {
+			if isSQLiteUnique(err) {
+				return nil
+			}
+			return fmt.Errorf("chat_access insert: %w", err)
 		}
-		return false, fmt.Errorf("chat_access insert: %w", err)
-	}
-	return true, nil
+		n, _ := res.RowsAffected()
+		inserted = n > 0
+		return nil
+	})
+	return inserted, err
 }
 
 // Classify determines whether a welcome should be sent.

--- a/internal/messaging/chat_access_store_test.go
+++ b/internal/messaging/chat_access_store_test.go
@@ -1,0 +1,155 @@
+package messaging
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/sqlutil"
+)
+
+func init() {
+	_ = sqlutil.DriverName
+}
+
+type testChatStore struct {
+	*ChatAccessStore
+	db *sql.DB
+}
+
+func newTestChatAccessStore(t *testing.T) *testChatStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open(sqlutil.DriverName, dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS chat_access_events (
+		id              INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_id        TEXT NOT NULL UNIQUE,
+		platform        TEXT NOT NULL CHECK(platform IN ('feishu', 'slack')),
+		chat_id         TEXT NOT NULL,
+		user_id         TEXT NOT NULL,
+		bot_id          TEXT NOT NULL DEFAULT '',
+		last_message_at INTEGER NOT NULL DEFAULT 0,
+		welcome_sent    INTEGER NOT NULL DEFAULT 0 CHECK(welcome_sent IN (0, 1)),
+		created_at      INTEGER NOT NULL
+	)`)
+	require.NoError(t, err)
+
+	return &testChatStore{
+		ChatAccessStore: NewChatAccessStore(db, nil, sqlutil.NewWriteMu()),
+		db:              db,
+	}
+}
+
+func TestChatAccessStore_Record(t *testing.T) {
+	s := newTestChatAccessStore(t)
+	ctx := context.Background()
+
+	t.Run("insert new record", func(t *testing.T) {
+		inserted, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_1",
+			Platform: "feishu",
+			ChatID:   "oc_abc",
+			UserID:   "ou_123",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+		require.True(t, inserted)
+	})
+
+	t.Run("duplicate event_id returns false", func(t *testing.T) {
+		inserted, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_1",
+			Platform: "feishu",
+			ChatID:   "oc_abc",
+			UserID:   "ou_123",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+		require.False(t, inserted)
+	})
+
+	t.Run("different event_id inserts", func(t *testing.T) {
+		inserted, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_2",
+			Platform: "slack",
+			ChatID:   "C123",
+			UserID:   "U456",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+		require.True(t, inserted)
+	})
+}
+
+func TestChatAccessStore_Classify(t *testing.T) {
+	s := newTestChatAccessStore(t)
+	ctx := context.Background()
+
+	t.Run("no prior record returns new", func(t *testing.T) {
+		got := s.Classify(ctx, "feishu", "oc_new", "bot_1", "ou_1", 0)
+		require.Equal(t, ChatAccessNew, got)
+	})
+
+	t.Run("recent record returns active", func(t *testing.T) {
+		_, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_recent",
+			Platform: "feishu",
+			ChatID:   "oc_active",
+			UserID:   "ou_1",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+
+		got := s.Classify(ctx, "feishu", "oc_active", "bot_1", "ou_1", time.Now().UnixMilli())
+		require.Equal(t, ChatAccessActive, got)
+	})
+
+	t.Run("old record + stale payload returns returning", func(t *testing.T) {
+		_, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_old",
+			Platform: "feishu",
+			ChatID:   "oc_return",
+			UserID:   "ou_2",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+
+		// Backdate created_at to 2 hours ago.
+		_, err = s.db.Exec(
+			`UPDATE chat_access_events SET created_at = ? WHERE event_id = ?`,
+			time.Now().Unix()-7200, "evt_old")
+		require.NoError(t, err)
+
+		// Feishu fast-path: payload lastMessageAtMs > 2h ago.
+		oldMs := time.Now().Add(-2 * time.Hour).UnixMilli()
+		got := s.Classify(ctx, "feishu", "oc_return", "bot_1", "ou_2", oldMs)
+		require.Equal(t, ChatAccessReturning, got)
+	})
+
+	t.Run("slack path checks user activity", func(t *testing.T) {
+		_, err := s.Record(ctx, ChatAccessRecord{
+			EventID:  "evt_slack_old",
+			Platform: "slack",
+			ChatID:   "C_slack",
+			UserID:   "U_slack",
+			BotID:    "bot_1",
+		})
+		require.NoError(t, err)
+
+		_, err = s.db.Exec(
+			`UPDATE chat_access_events SET created_at = ? WHERE event_id = ?`,
+			time.Now().Unix()-7200, "evt_slack_old")
+		require.NoError(t, err)
+
+		// lastMessageAtMs=0 triggers Slack DB fallback path.
+		got := s.Classify(ctx, "slack", "C_slack", "bot_1", "U_slack", 0)
+		require.Equal(t, ChatAccessReturning, got)
+	})
+}

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -235,11 +235,7 @@ func (a *Adapter) SendCronResult(ctx context.Context, text string, platformKey m
 	if chatID == "" {
 		return fmt.Errorf("feishu: missing chat_id in platform_key")
 	}
-	text = messaging.SanitizeText(text)
-	if msgID := platformKey["message_id"]; msgID != "" {
-		return a.replyMessage(ctx, msgID, text, false)
-	}
-	return a.sendTextMessage(ctx, chatID, text)
+	return a.replyOrSend(ctx, platformKey["message_id"], chatID, messaging.SanitizeText(text))
 }
 
 func (a *Adapter) sendTextMessage(ctx context.Context, chatID, text string) error {

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -229,12 +229,16 @@ func (a *Adapter) replyOrSend(ctx context.Context, msgID, chatID, text string) e
 }
 
 // SendCronResult delivers a cron job result to a Feishu chat.
+// When message_id is present in platformKey, replies to that message (thread delivery).
 func (a *Adapter) SendCronResult(ctx context.Context, text string, platformKey map[string]string) error {
 	chatID := platformKey["chat_id"]
 	if chatID == "" {
 		return fmt.Errorf("feishu: missing chat_id in platform_key")
 	}
 	text = messaging.SanitizeText(text)
+	if msgID := platformKey["message_id"]; msgID != "" {
+		return a.replyMessage(ctx, msgID, text, false)
+	}
 	return a.sendTextMessage(ctx, chatID, text)
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -85,20 +85,18 @@ func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		}
 	}
 
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err := s.db.ExecContext(ctx, queries["sessions.upsert_session"],
-		info.ID, info.UserID, info.OwnerID, info.BotID, info.WorkerSessionID, info.WorkerType, string(info.State),
-		info.Platform, string(platformKeyJSON), info.WorkDir, info.Title,
-		info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
-		string(ctxJSON), info.Source,
-	)
-	if err != nil {
-		return fmt.Errorf("session store: upsert: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["sessions.upsert_session"],
+			info.ID, info.UserID, info.OwnerID, info.BotID, info.WorkerSessionID, info.WorkerType, string(info.State),
+			info.Platform, string(platformKeyJSON), info.WorkDir, info.Title,
+			info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
+			string(ctxJSON), info.Source,
+		)
+		if err != nil {
+			return fmt.Errorf("session store: upsert: %w", err)
+		}
+		return nil
+	})
 }
 
 type rowScanner interface{ Scan(dest ...any) error }
@@ -204,27 +202,23 @@ func (s *SQLiteStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]stri
 
 // Events lifecycle is managed independently — session deletion does not cascade to events.
 func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err := s.db.ExecContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
-	if err != nil {
-		return fmt.Errorf("session store: delete terminated: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
+		if err != nil {
+			return fmt.Errorf("session store: delete terminated: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) DeletePhysical(ctx context.Context, id string) error {
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	_, err := s.db.ExecContext(ctx, queries["store.delete_physical"], id)
-	if err != nil {
-		return fmt.Errorf("session store: delete physical: %w", err)
-	}
-	return nil
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["store.delete_physical"], id)
+		if err != nil {
+			return fmt.Errorf("session store: delete physical: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteStore) Close() error {
@@ -232,28 +226,28 @@ func (s *SQLiteStore) Close() error {
 }
 
 func (s *SQLiteStore) Compact(ctx context.Context, threshold float64) error {
-	if s.writeMu != nil {
-		s.writeMu.Lock()
-		defer s.writeMu.Unlock()
-	}
-	var pageCount, freeCount int
-	if err := s.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
-		return fmt.Errorf("session store: compact page_count: %w", err)
-	}
-	if err := s.db.QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&freeCount); err != nil {
-		return fmt.Errorf("session store: compact freelist_count: %w", err)
-	}
-	if pageCount == 0 || float64(freeCount)/float64(pageCount) < threshold {
-		return nil
-	}
-	s.log.Info("session store: VACUUM starting",
-		"page_count", pageCount, "free_count", freeCount,
-		"ratio", fmt.Sprintf("%.1f%%", float64(freeCount)/float64(pageCount)*100))
-	if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		return fmt.Errorf("session store: compact checkpoint: %w", err)
-	}
-	_, err := s.db.ExecContext(ctx, "VACUUM")
-	return err
+	return s.writeMu.WithLock(func() error {
+		var pageCount, freeCount int
+		if err := s.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+			return fmt.Errorf("session store: compact page_count: %w", err)
+		}
+		if err := s.db.QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&freeCount); err != nil {
+			return fmt.Errorf("session store: compact freelist_count: %w", err)
+		}
+		if pageCount == 0 || float64(freeCount)/float64(pageCount) < threshold {
+			return nil
+		}
+		start := time.Now()
+		s.log.Info("session store: VACUUM starting",
+			"page_count", pageCount, "free_count", freeCount,
+			"ratio", fmt.Sprintf("%.1f%%", float64(freeCount)/float64(pageCount)*100))
+		if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+			return fmt.Errorf("session store: compact checkpoint: %w", err)
+		}
+		_, err := s.db.ExecContext(ctx, "VACUUM")
+		s.log.Info("session store: VACUUM completed", "duration", time.Since(start))
+		return err
+	})
 }
 
 func (s *SQLiteStore) GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error) {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -29,15 +30,17 @@ type Store interface {
 
 // SQLiteStore implements Store using SQLite.
 type SQLiteStore struct {
-	db  *sql.DB
-	log *slog.Logger
+	db      *sql.DB
+	log     *slog.Logger
+	writeMu *sqlutil.WriteMu
 }
 
 // DB returns the underlying *sql.DB for sharing with other stores (e.g., eventstore).
 func (s *SQLiteStore) DB() *sql.DB { return s.db }
 
 // NewSQLiteStore creates and initializes a new SQLiteStore.
-func NewSQLiteStore(ctx context.Context, cfg *config.Config) (*SQLiteStore, error) {
+// If writeMu is non-nil, all write operations are serialized through it.
+func NewSQLiteStore(ctx context.Context, cfg *config.Config, writeMu *sqlutil.WriteMu) (*SQLiteStore, error) {
 	db, err := openSQLiteDB(cfg, dbOpenOpts{
 		Label:       "session",
 		MaxOpen:     cfg.DB.MaxOpenConns,
@@ -54,7 +57,7 @@ func NewSQLiteStore(ctx context.Context, cfg *config.Config) (*SQLiteStore, erro
 		return nil, err
 	}
 
-	return &SQLiteStore{db: db, log: slog.Default().With("component", "session_store")}, nil
+	return &SQLiteStore{db: db, log: slog.Default().With("component", "session_store"), writeMu: writeMu}, nil
 }
 
 func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
@@ -82,6 +85,10 @@ func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		}
 	}
 
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err := s.db.ExecContext(ctx, queries["sessions.upsert_session"],
 		info.ID, info.UserID, info.OwnerID, info.BotID, info.WorkerSessionID, info.WorkerType, string(info.State),
 		info.Platform, string(platformKeyJSON), info.WorkDir, info.Title,
@@ -197,6 +204,10 @@ func (s *SQLiteStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]stri
 
 // Events lifecycle is managed independently — session deletion does not cascade to events.
 func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err := s.db.ExecContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
 	if err != nil {
 		return fmt.Errorf("session store: delete terminated: %w", err)
@@ -205,6 +216,10 @@ func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultC
 }
 
 func (s *SQLiteStore) DeletePhysical(ctx context.Context, id string) error {
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	_, err := s.db.ExecContext(ctx, queries["store.delete_physical"], id)
 	if err != nil {
 		return fmt.Errorf("session store: delete physical: %w", err)
@@ -217,6 +232,10 @@ func (s *SQLiteStore) Close() error {
 }
 
 func (s *SQLiteStore) Compact(ctx context.Context, threshold float64) error {
+	if s.writeMu != nil {
+		s.writeMu.Lock()
+		defer s.writeMu.Unlock()
+	}
 	var pageCount, freeCount int
 	if err := s.db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
 		return fmt.Errorf("session store: compact page_count: %w", err)

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -19,7 +19,7 @@ func helperDB(t *testing.T) (*SQLiteStore, *config.Config) {
 	cfg.DB.Path = filepath.Join(t.TempDir(), "test.db")
 	cfg.DB.WALMode = true
 
-	store, err := NewSQLiteStore(context.Background(), cfg)
+	store, err := NewSQLiteStore(context.Background(), cfg, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store, cfg

--- a/internal/sqlutil/writemu.go
+++ b/internal/sqlutil/writemu.go
@@ -1,0 +1,19 @@
+package sqlutil
+
+import "sync"
+
+// WriteMu serializes SQLite write operations across all stores sharing
+// the same database file. In WAL mode, reads proceed concurrently;
+// only writes are serialized to prevent SQLITE_BUSY errors.
+type WriteMu struct {
+	mu sync.Mutex
+}
+
+// NewWriteMu creates a new write serializer.
+func NewWriteMu() *WriteMu { return &WriteMu{} }
+
+// Lock acquires the write mutex.
+func (m *WriteMu) Lock() { m.mu.Lock() }
+
+// Unlock releases the write mutex.
+func (m *WriteMu) Unlock() { m.mu.Unlock() }

--- a/internal/sqlutil/writemu.go
+++ b/internal/sqlutil/writemu.go
@@ -17,3 +17,13 @@ func (m *WriteMu) Lock() { m.mu.Lock() }
 
 // Unlock releases the write mutex.
 func (m *WriteMu) Unlock() { m.mu.Unlock() }
+
+// WithLock acquires the write mutex, calls fn, and releases it.
+// If m is nil, fn is called without locking (e.g. CLI standalone mode).
+func (m *WriteMu) WithLock(fn func() error) error {
+	if m != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+	}
+	return fn()
+}

--- a/internal/sqlutil/writemu_test.go
+++ b/internal/sqlutil/writemu_test.go
@@ -1,0 +1,76 @@
+package sqlutil
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteMu_WithLock_Nil(t *testing.T) {
+	var mu *WriteMu
+	err := mu.WithLock(func() error {
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestWriteMu_WithLock_ReturnsError(t *testing.T) {
+	mu := NewWriteMu()
+	expected := errors.New("test error")
+	err := mu.WithLock(func() error {
+		return expected
+	})
+	require.ErrorIs(t, err, expected)
+}
+
+func TestWriteMu_WithLock_SerializesAccess(t *testing.T) {
+	mu := NewWriteMu()
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := mu.WithLock(func() error {
+				cur := concurrent.Add(1)
+				for {
+					old := maxConcurrent.Load()
+					if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				concurrent.Add(-1)
+				return nil
+			})
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), maxConcurrent.Load(), "WithLock should serialize all writes")
+}
+
+func TestWriteMu_WithLock_Nil_Concurrent(t *testing.T) {
+	var mu *WriteMu
+	var count atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mu.WithLock(func() error {
+				count.Add(1)
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(50), count.Load(), "nil WriteMu should still execute all closures")
+}

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -257,6 +257,8 @@ func (m *Manager) Wait() (int, error) {
 
 	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
 	m.captureExitCodeLocked()
+	pidKey := m.pidKey
+	m.untrackPID(pidKey)
 	if closeErr := m.closeLocked(); closeErr != nil {
 		m.log.Warn("proc: pipe close after wait", "err", closeErr)
 	}


### PR DESCRIPTION
## Summary

修复三个运行时问题：SQLite 并发写入 SQLITE_BUSY、Worker 崩溃后 PID 文件累积、Cron Job 飞书投递失败。

### Changes

- 新增 `internal/sqlutil/writemu.go` 全局写序列化器，跨所有 SQLite store 共享写锁消除 SQLITE_BUSY
- `session/cron/eventstore/chat_access` store 写操作加 writeMu 保护
- eventstore 事务级 writeMu + `released` 防双重释放
- collector `Flush()` + close-drain 顺序修复 + tx safety net（修复 "eventstore: no events found" 投递失败）
- `proc/manager.Wait()` 增加 `untrackPID()` 清理崩溃路径（修复 PID 文件累积 171 个僵尸文件）
- `ValidateJob` 增加 platform→PlatformKey 校验：feishu 必须 chat_id，slack 必须 channel_id（修复 "feishu: missing chat_id" 投递失败）

**架构影响**：
- Channel: Feishu（投递校验）
- Worker: CC / OCS / Pi（PID 清理影响所有 Worker 进程）
- 平台: 跨平台

## Test Plan

- [x] make test（含 -race）
- [x] make lint（0 issues）
- [x] pre-commit hooks passed
- [x] pre-push validation passed
- [x] 高强度代码审查（3 角度 × 6 候选 → 1-vote verify → 0 发现）

Fixes #480