### PR TITLE
fix(messaging/slack): handlerMu 添加 context timeout 防止永久阻塞

### DIFF
--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -480,12 +480,7 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 	case messaging.CmdControl:
 		conn := a.GetOrCreateConn(channelID, threadTS)
 		if conn != nil {
-			// NOTE: Lock-before-timeout is a pre-existing limitation — if another
-			// goroutine already holds handlerMu, this goroutine blocks at Lock()
-			// and the timeout does not protect this wait phase. Mitigated by the
-			// timeout on the holder side, which ensures the lock is eventually released.
-			conn.handlerMu.Lock()
-			defer conn.handlerMu.Unlock()
+			defer conn.lockHandlerMu()()
 		}
 		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerCmdTimeout)
 		defer cmdCancel()
@@ -495,9 +490,7 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 		conn := a.GetOrCreateConn(channelID, threadTS)
 		if conn != nil {
 			conn.messageTS = msgEvent.TimeStamp
-			// NOTE: Same lock-before-timeout limitation as CmdControl above.
-			conn.handlerMu.Lock()
-			defer conn.handlerMu.Unlock()
+			defer conn.lockHandlerMu()()
 		}
 		if a.isAssistantCapable.Load() && threadTS != "" {
 			_ = a.SetAssistantStatus(ctx, channelID, threadTS, "Processing "+cmd.Worker.Label+"...")
@@ -556,9 +549,7 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 		return fmt.Errorf("slack: failed to build envelope")
 	}
 
-	// NOTE: Same lock-before-timeout limitation as CmdControl/CmdWorker above.
-	conn.handlerMu.Lock()
-	defer conn.handlerMu.Unlock()
+	defer conn.lockHandlerMu()()
 	msgCtx, cancel := context.WithTimeout(ctx, handlerMsgTimeout)
 	defer cancel()
 	return a.Bridge().Handle(msgCtx, envelope, conn)
@@ -685,6 +676,11 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelI
 
 	if err := a.Bridge().Handle(ctx, ctrlEnv, conn); err != nil {
 		a.Log.Warn("slack: text control command failed", "action", result.Label, "err", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			a.sendEphemeralOrPost(ctx, channelID, threadTS, userID,
+				fmt.Sprintf("⚠️ %s timed out. Please try again.", result.Label))
+			return
+		}
 		// Provide user-friendly error message with details
 		errMsg := fmt.Sprintf("❌ Failed to execute %s: %s", result.Label, formatSecurityErrorSlack(err))
 		a.sendEphemeralOrPost(ctx, channelID, threadTS, userID, errMsg)
@@ -736,6 +732,11 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, teamID, channelID
 
 	if err := a.Bridge().Handle(ctx, cmdEnv, conn); err != nil {
 		a.Log.Warn("slack: worker command failed", "command", result.Label, "err", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			a.sendEphemeralOrPost(ctx, channelID, threadTS, userID,
+				fmt.Sprintf("⚠️ %s timed out. Please try again.", result.Label))
+			return
+		}
 		a.sendEphemeralOrPost(ctx, channelID, threadTS, userID, fmt.Sprintf("❌ Failed to execute %s.", result.Label))
 		return
 	}
@@ -768,6 +769,19 @@ type SlackConn struct {
 // NewSlackConn creates a platform connection bound to a channel/thread.
 func NewSlackConn(adapter *Adapter, channelID, threadTS, workDir string) *SlackConn {
 	return &SlackConn{adapter: adapter, channelID: channelID, threadTS: threadTS, workDir: workDir}
+}
+
+// lockHandlerMu acquires the per-thread serialization lock.
+// Returns an unlock function for use with defer.
+//
+// Known limitation: Lock() blocks without timeout if another goroutine holds
+// handlerMu. The timeout on the holder side ensures eventual release. A future
+// improvement could use TryLock + retry. Callers should use:
+//
+//	defer conn.lockHandlerMu()()
+func (c *SlackConn) lockHandlerMu() (unlock func()) {
+	c.handlerMu.Lock()
+	return c.handlerMu.Unlock
 }
 
 func (c *SlackConn) WorkDir() string {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -3,6 +3,7 @@ package slack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -33,7 +34,14 @@ const (
 	mediaTTL         = 24 * time.Hour
 	maxMessageLength = 3800            // Slack limit is ~4000
 	errPrefix        = "\u26a0\ufe0f " // ⚠️
-	handlerTimeout   = 120 * time.Second
+	// handlerMsgTimeout controls the context timeout for HandleTextMessage.
+	// Covers Bridge.Handle → session start → HTTP request (createSession, initSessionConn).
+	// Does NOT cover acquireServer's process fork (proc.Start is not context-aware).
+	// Set longer than cmd timeout because LLM agentic turns (multi-tool) can take minutes.
+	handlerMsgTimeout = 300 * time.Second
+	// handlerCmdTimeout controls the context timeout for CmdControl/CmdWorker paths.
+	// These are lightweight control-plane operations that should complete quickly.
+	handlerCmdTimeout = 60 * time.Second
 )
 
 // Subtypes that should never be processed.
@@ -472,10 +480,14 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 	case messaging.CmdControl:
 		conn := a.GetOrCreateConn(channelID, threadTS)
 		if conn != nil {
+			// NOTE: Lock-before-timeout is a pre-existing limitation — if another
+			// goroutine already holds handlerMu, this goroutine blocks at Lock()
+			// and the timeout does not protect this wait phase. Mitigated by the
+			// timeout on the holder side, which ensures the lock is eventually released.
 			conn.handlerMu.Lock()
 			defer conn.handlerMu.Unlock()
 		}
-		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerTimeout)
+		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerCmdTimeout)
 		defer cmdCancel()
 		a.handleTextControlCommand(cmdCtx, teamID, channelID, threadTS, userID, cmd.Control)
 		return
@@ -483,13 +495,14 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 		conn := a.GetOrCreateConn(channelID, threadTS)
 		if conn != nil {
 			conn.messageTS = msgEvent.TimeStamp
+			// NOTE: Same lock-before-timeout limitation as CmdControl above.
 			conn.handlerMu.Lock()
 			defer conn.handlerMu.Unlock()
 		}
 		if a.isAssistantCapable.Load() && threadTS != "" {
 			_ = a.SetAssistantStatus(ctx, channelID, threadTS, "Processing "+cmd.Worker.Label+"...")
 		}
-		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerTimeout)
+		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerCmdTimeout)
 		defer cmdCancel()
 		a.handleTextWorkerCommand(cmdCtx, teamID, channelID, threadTS, userID, cmd.Worker)
 		return
@@ -513,6 +526,10 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 
 	if err := a.HandleTextMessage(ctx, platformMsgID, channelID, teamID, threadTS, userID, text); err != nil {
 		a.Log.Warn("slack: handle message failed", "err", err, "channel", channelID, "thread", threadTS, "user", userID)
+		if errors.Is(err, context.DeadlineExceeded) {
+			a.sendEphemeralOrPost(ctx, channelID, threadTS, userID,
+				"⚠️ Request timed out. The operation took too long and was cancelled. Please try again.")
+		}
 	}
 }
 
@@ -539,9 +556,10 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 		return fmt.Errorf("slack: failed to build envelope")
 	}
 
+	// NOTE: Same lock-before-timeout limitation as CmdControl/CmdWorker above.
 	conn.handlerMu.Lock()
 	defer conn.handlerMu.Unlock()
-	msgCtx, cancel := context.WithTimeout(ctx, handlerTimeout)
+	msgCtx, cancel := context.WithTimeout(ctx, handlerMsgTimeout)
 	defer cancel()
 	return a.Bridge().Handle(msgCtx, envelope, conn)
 }

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -33,6 +33,7 @@ const (
 	mediaTTL         = 24 * time.Hour
 	maxMessageLength = 3800            // Slack limit is ~4000
 	errPrefix        = "\u26a0\ufe0f " // ⚠️
+	handlerTimeout   = 120 * time.Second
 )
 
 // Subtypes that should never be processed.
@@ -474,7 +475,9 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 			conn.handlerMu.Lock()
 			defer conn.handlerMu.Unlock()
 		}
-		a.handleTextControlCommand(ctx, teamID, channelID, threadTS, userID, cmd.Control)
+		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerTimeout)
+		defer cmdCancel()
+		a.handleTextControlCommand(cmdCtx, teamID, channelID, threadTS, userID, cmd.Control)
 		return
 	case messaging.CmdWorker:
 		conn := a.GetOrCreateConn(channelID, threadTS)
@@ -486,7 +489,9 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 		if a.isAssistantCapable.Load() && threadTS != "" {
 			_ = a.SetAssistantStatus(ctx, channelID, threadTS, "Processing "+cmd.Worker.Label+"...")
 		}
-		a.handleTextWorkerCommand(ctx, teamID, channelID, threadTS, userID, cmd.Worker)
+		cmdCtx, cmdCancel := context.WithTimeout(ctx, handlerTimeout)
+		defer cmdCancel()
+		a.handleTextWorkerCommand(cmdCtx, teamID, channelID, threadTS, userID, cmd.Worker)
 		return
 	}
 
@@ -536,7 +541,9 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 
 	conn.handlerMu.Lock()
 	defer conn.handlerMu.Unlock()
-	return a.Bridge().Handle(ctx, envelope, conn)
+	msgCtx, cancel := context.WithTimeout(ctx, handlerTimeout)
+	defer cancel()
+	return a.Bridge().Handle(msgCtx, envelope, conn)
 }
 
 // NewStreamingWriter creates a streaming writer for the given channel/thread.

--- a/internal/messaging/slack/adapter_test.go
+++ b/internal/messaging/slack/adapter_test.go
@@ -1991,24 +1991,25 @@ func TestWriteCtx_InteractionEvents_ClosesStream(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandlerMu_TimeoutReleasesLock(t *testing.T) {
+	t.Parallel()
 	// Verify that handlerMu is correctly released after a context timeout.
 	// This tests the lock-before-timeout pattern used in HandleTextMessage/CmdControl/CmdWorker.
 	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}
 
-	// Goroutine 1: acquire handlerMu, then wait for a short context timeout.
+	// Goroutine 1: acquire handlerMu, signal via barrier, then wait for context timeout.
+	locked := make(chan struct{})
 	goroutineDone := make(chan struct{})
 	go func() {
 		defer close(goroutineDone)
 		conn.handlerMu.Lock()
 		defer conn.handlerMu.Unlock()
+		close(locked) // barrier: lock acquired
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 		<-ctx.Done() // blocks until timeout
 	}()
-
-	// Wait for goroutine 1 to acquire the lock.
-	time.Sleep(20 * time.Millisecond)
+	<-locked // wait until goroutine 1 holds the lock
 
 	// Goroutine 2: try to acquire handlerMu — should block until goroutine 1 finishes.
 	acquired := make(chan struct{})
@@ -2030,6 +2031,7 @@ func TestHandlerMu_TimeoutReleasesLock(t *testing.T) {
 }
 
 func TestHandlerMu_MultipleAcquireRelease(t *testing.T) {
+	t.Parallel()
 	// Verify that handlerMu can be acquired multiple times in sequence
 	// (simulating sequential message processing in the same thread).
 	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}
@@ -2047,6 +2049,7 @@ func TestHandlerMu_MultipleAcquireRelease(t *testing.T) {
 }
 
 func TestHandlerMu_TimeoutDoesNotBlockSubsequentCalls(t *testing.T) {
+	t.Parallel()
 	// Verify that after a simulated timeout path, the next goroutine
 	// can immediately acquire the lock (no permanent hold).
 	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}

--- a/internal/messaging/slack/adapter_test.go
+++ b/internal/messaging/slack/adapter_test.go
@@ -1985,3 +1985,97 @@ func TestWriteCtx_InteractionEvents_ClosesStream(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// HandlerMu timeout boundary tests
+// ---------------------------------------------------------------------------
+
+func TestHandlerMu_TimeoutReleasesLock(t *testing.T) {
+	// Verify that handlerMu is correctly released after a context timeout.
+	// This tests the lock-before-timeout pattern used in HandleTextMessage/CmdControl/CmdWorker.
+	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}
+
+	// Goroutine 1: acquire handlerMu, then wait for a short context timeout.
+	goroutineDone := make(chan struct{})
+	go func() {
+		defer close(goroutineDone)
+		conn.handlerMu.Lock()
+		defer conn.handlerMu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		<-ctx.Done() // blocks until timeout
+	}()
+
+	// Wait for goroutine 1 to acquire the lock.
+	time.Sleep(20 * time.Millisecond)
+
+	// Goroutine 2: try to acquire handlerMu — should block until goroutine 1 finishes.
+	acquired := make(chan struct{})
+	go func() {
+		conn.handlerMu.Lock()
+		defer conn.handlerMu.Unlock()
+		close(acquired)
+	}()
+
+	// After goroutine 1's timeout (50ms) + margin, goroutine 2 should acquire the lock.
+	select {
+	case <-acquired:
+		// Success: mu was released after timeout.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handlerMu was not released after context timeout — defer Unlock failed")
+	}
+
+	<-goroutineDone
+}
+
+func TestHandlerMu_MultipleAcquireRelease(t *testing.T) {
+	// Verify that handlerMu can be acquired multiple times in sequence
+	// (simulating sequential message processing in the same thread).
+	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}
+
+	for i := 0; i < 5; i++ {
+		conn.handlerMu.Lock()
+		// Simulate a short-lived context timeout as in the production code.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		<-ctx.Done()
+		cancel()
+		conn.handlerMu.Unlock()
+	}
+
+	// If we reach here, the lock was properly acquired and released 5 times.
+}
+
+func TestHandlerMu_TimeoutDoesNotBlockSubsequentCalls(t *testing.T) {
+	// Verify that after a simulated timeout path, the next goroutine
+	// can immediately acquire the lock (no permanent hold).
+	conn := &SlackConn{channelID: "C_test", threadTS: "123.000"}
+
+	// Simulate one complete timeout cycle: Lock → context timeout → Unlock (via defer).
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn.handlerMu.Lock()
+		defer conn.handlerMu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+		<-ctx.Done()
+	}()
+	<-done
+
+	// Now verify immediate acquisition.
+	acquired := make(chan struct{})
+	go func() {
+		conn.handlerMu.Lock()
+		defer conn.handlerMu.Unlock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		// Lock acquired immediately after previous timeout cycle.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("handlerMu still held after timeout cycle completed")
+	}
+}

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -203,19 +203,24 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	}
 
 	// Acquire ref from singleton (starts process if first session)
+	w.Log.Debug("opencodeserver: start step 1 - acquiring server")
 	if err := w.acquireServer(ctx); err != nil {
 		return err
 	}
+	w.Log.Debug("opencodeserver: start step 2 - server acquired", "addr", w.httpAddr)
 
 	// Create new session via HTTP API
+	w.Log.Debug("opencodeserver: start step 3 - creating session", "dir", session.ProjectDir)
 	sessionID, err := w.createSession(ctx, session.ProjectDir)
 	if err != nil {
 		w.releaseOnce.Do(func() { w.singleton.Release() })
 		return fmt.Errorf("opencodeserver: create session: %w", err)
 	}
+	w.Log.Debug("opencodeserver: start step 4 - session created", "ocs_session_id", sessionID)
 
 	w.initSessionConn(ctx, sessionID, session)
 	w.startSSE(sessionID)
+	w.Log.Debug("opencodeserver: start completed")
 	return nil
 }
 


### PR DESCRIPTION
Resolves #482

## Summary

Slack adapter 的 `handlerMu`（裸 `sync.Mutex`）在 OCS Worker.Start() 的 HTTP 调用无响应时可能永久持有，导致同一 Slack thread 所有后续消息处理中断。添加 context timeout 作为纵深防御，同时为 OCS Worker.Start() 添加分步日志以便未来根因定位。

### Changes

- `internal/messaging/slack/adapter.go`:
  - 拆分 timeout 常量：`handlerMsgTimeout=300s`（HandleTextMessage，覆盖 LLM agentic turn）+ `handlerCmdTimeout=60s`（CmdControl/CmdWorker 轻量操作）
  - 3 处 `handlerMu.Lock()` 替换为 `conn.lockHandlerMu()` 辅助方法，收拢 lock-before-timeout 已知局限注释
  - HandleTextMessage/CmdControl/CmdWorker 超时后检测 `errors.Is(err, context.DeadlineExceeded)` 并通过 `sendEphemeralOrPost` 发送友好提示
  - 常量注释说明 timeout 覆盖范围（HTTP 请求路径，不含 acquireServer 进程 fork）
- `internal/messaging/slack/adapter_test.go`:
  - 新增 3 个 handlerMu 边界行为测试（`t.Parallel()` + channel barrier 同步），验证 defer Unlock 正确性、多次 acquire/release、超时后不阻塞后续调用
- `internal/worker/opencodeserver/worker.go`:
  - `Start()` 添加分步 Debug 日志（step 1-4: acquireServer → createSession → initSessionConn → startSSE）

**架构影响**：
- Channel: Slack
- Worker: OCS
- 平台: 跨平台（纯 Go 标准库，无平台特定代码）

## Test Plan

- [x] `go test -race` — affected packages 全部通过（messaging/slack, worker/ocs, gateway, session, messaging）
- [x] `make lint` — 0 issues
- [x] pre-commit hooks 通过（gofmt + golangci-lint + go vet）

## Related Issues

- Resolves #482