### PR TITLE
fix(worker): turns 表 created_at=0 和 OCS model 字段缺失

### DIFF
--- a/internal/worker/claudecode/mapper.go
+++ b/internal/worker/claudecode/mapper.go
@@ -193,45 +193,23 @@ func (m *Mapper) mapResult(p *ResultPayload) ([]*events.Envelope, error) {
 
 	if !p.Success {
 		return []*events.Envelope{
-			{
-				ID:        aep.NewID(),
-				SessionID: m.sessionID,
-				Seq:       m.seqGen(),
-				Event: events.Event{
-					Type: events.Error,
-					Data: events.ErrorData{
-						Code:    events.ErrCodeInternalError,
-						Message: p.Message,
-					},
-				},
-			},
-			{
-				ID:        aep.NewID(),
-				SessionID: m.sessionID,
-				Seq:       m.seqGen(),
-				Event: events.Event{
-					Type: events.Done,
-					Data: events.DoneData{
-						Success: false,
-						Stats:   stats,
-					},
-				},
-			},
+			events.NewEnvelope(aep.NewID(), m.sessionID, m.seqGen(), events.Error, events.ErrorData{
+				Code:    events.ErrCodeInternalError,
+				Message: p.Message,
+			}),
+			events.NewEnvelope(aep.NewID(), m.sessionID, m.seqGen(), events.Done, events.DoneData{
+				Success: false,
+				Stats:   stats,
+			}),
 		}, nil
 	}
 
-	return []*events.Envelope{{
-		ID:        aep.NewID(),
-		SessionID: m.sessionID,
-		Seq:       m.seqGen(),
-		Event: events.Event{
-			Type: events.Done,
-			Data: events.DoneData{
-				Success: true,
-				Stats:   stats,
-			},
-		},
-	}}, nil
+	return []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), m.sessionID, m.seqGen(), events.Done, events.DoneData{
+			Success: true,
+			Stats:   stats,
+		}),
+	}, nil
 }
 
 // mapSystem converts system status to state event.

--- a/internal/worker/claudecode/mapper_test.go
+++ b/internal/worker/claudecode/mapper_test.go
@@ -223,10 +223,29 @@ func TestMapper_Map_Result(t *testing.T) {
 		require.Len(t, envs, 1)
 		env := envs[0]
 		require.Equal(t, events.Done, env.Event.Type)
+		require.Greater(t, env.Timestamp, int64(0), "NewEnvelope must set timestamp")
 
 		data, ok := env.Event.Data.(events.DoneData)
 		require.True(t, ok)
 		require.True(t, data.Success)
+	})
+
+	t.Run("failure includes error and done with timestamp", func(t *testing.T) {
+		event := &WorkerEvent{
+			Type: EventResult,
+			Payload: &ResultPayload{
+				Success: false,
+				Message: "something broke",
+			},
+		}
+
+		envs, err := mapper.Map(event)
+		require.NoError(t, err)
+		require.Len(t, envs, 2)
+		require.Equal(t, events.Error, envs[0].Event.Type)
+		require.Equal(t, events.Done, envs[1].Event.Type)
+		require.Greater(t, envs[0].Timestamp, int64(0))
+		require.Greater(t, envs[1].Timestamp, int64(0))
 	})
 
 	t.Run("success merges usage and model_usage into stats", func(t *testing.T) {

--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -43,7 +43,8 @@ type Converter struct {
 type turnState struct {
 	cost            float64
 	tokens          tokenAccum
-	reasoningActive bool // true between reasoning.started and reasoning.ended
+	reasoningActive bool   // true between reasoning.started and reasoning.ended
+	model           string // "providerID/modelID" from step.started
 }
 
 type tokenAccum struct {
@@ -101,7 +102,22 @@ func (c *Converter) convertV2(sessionID, eventType string, props json.RawMessage
 	}
 }
 
-func (c *Converter) handleStepStarted(_ string, _ json.RawMessage) []*events.Envelope {
+func (c *Converter) handleStepStarted(sessionID string, props json.RawMessage) []*events.Envelope {
+	var evt struct {
+		Model struct {
+			ProviderID string `json:"providerID"`
+			ModelID    string `json:"modelID"`
+		} `json:"model"`
+	}
+	if err := json.Unmarshal(props, &evt); err != nil {
+		return nil
+	}
+	if evt.Model.ModelID != "" {
+		st := c.getOrCreateState(sessionID)
+		if st.model == "" {
+			st.model = evt.Model.ProviderID + "/" + evt.Model.ModelID
+		}
+	}
 	return nil
 }
 
@@ -387,7 +403,7 @@ func (c *Converter) takeStats(sessionID string) map[string]any {
 	if st.cost == 0 && st.tokens == (tokenAccum{}) {
 		return nil
 	}
-	return map[string]any{
+	stats := map[string]any{
 		"tokens": map[string]any{
 			"input":       st.tokens.input,
 			"output":      st.tokens.output,
@@ -397,4 +413,13 @@ func (c *Converter) takeStats(sessionID string) map[string]any {
 		},
 		"cost": st.cost,
 	}
+	if st.model != "" {
+		stats["model_usage"] = map[string]any{
+			st.model: map[string]any{
+				"input_tokens":  st.tokens.input,
+				"output_tokens": st.tokens.output,
+			},
+		}
+	}
+	return stats
 }

--- a/internal/worker/opencodeserver/converter_test.go
+++ b/internal/worker/opencodeserver/converter_test.go
@@ -22,7 +22,7 @@ func rawProps(t *testing.T, v map[string]any) json.RawMessage {
 
 // ─── V2 Step Events ───────────────────────────────────────────────────────────
 
-func TestConverter_StepStarted_NoOutput(t *testing.T) {
+func TestConverter_StepStarted_TracksModel(t *testing.T) {
 	c := newTestConverter()
 	props := rawProps(t, map[string]any{
 		"model": map[string]any{
@@ -32,6 +32,17 @@ func TestConverter_StepStarted_NoOutput(t *testing.T) {
 	})
 	envs := c.Convert("s1", ocsStepStarted, props)
 	require.Empty(t, envs)
+
+	st := c.states["s1"]
+	require.Equal(t, "anthropic/claude-sonnet-4-6", st.model)
+}
+
+func TestConverter_StepStarted_NoModelField(t *testing.T) {
+	c := newTestConverter()
+	envs := c.Convert("s1", ocsStepStarted, rawProps(t, map[string]any{}))
+	require.Empty(t, envs)
+	_, exists := c.states["s1"]
+	require.False(t, exists)
 }
 
 func TestConverter_StepEnded_Accumulates(t *testing.T) {
@@ -80,6 +91,43 @@ func TestConverter_StepEnded_MultipleAccumulates(t *testing.T) {
 	require.InDelta(t, 0.003, st.cost, 0.0001)
 	require.Equal(t, int64(1300), st.tokens.input)
 	require.Equal(t, int64(150), st.tokens.output)
+}
+
+func TestConverter_TakeStats_ModelUsage(t *testing.T) {
+	c := newTestConverter()
+	// step.started sets model
+	c.Convert("s1", ocsStepStarted, rawProps(t, map[string]any{
+		"model": map[string]any{"providerID": "anthropic", "modelID": "claude-sonnet-4-6"},
+	}))
+	// step.ended accumulates tokens
+	c.Convert("s1", ocsStepEnded, rawProps(t, map[string]any{
+		"cost":   0.005,
+		"tokens": map[string]any{"input": 1000, "output": 200, "reasoning": 0, "cache": map[string]any{"read": 0, "write": 0}},
+	}))
+
+	stats := c.takeStats("s1")
+	require.NotNil(t, stats)
+	require.Equal(t, 0.005, stats["cost"])
+
+	mu, ok := stats["model_usage"].(map[string]any)
+	require.True(t, ok, "model_usage should be present")
+	inner, ok := mu["anthropic/claude-sonnet-4-6"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, int64(1000), inner["input_tokens"])
+	require.Equal(t, int64(200), inner["output_tokens"])
+}
+
+func TestConverter_TakeStats_NoModel(t *testing.T) {
+	c := newTestConverter()
+	c.Convert("s1", ocsStepEnded, rawProps(t, map[string]any{
+		"cost":   0.001,
+		"tokens": map[string]any{"input": 100, "output": 10, "reasoning": 0, "cache": map[string]any{"read": 0, "write": 0}},
+	}))
+
+	stats := c.takeStats("s1")
+	require.NotNil(t, stats)
+	_, hasModelUsage := stats["model_usage"]
+	require.False(t, hasModelUsage, "model_usage should be absent when no model tracked")
 }
 
 func TestConverter_StepFailed(t *testing.T) {

--- a/internal/worker/opencodeserver/converter_test.go
+++ b/internal/worker/opencodeserver/converter_test.go
@@ -480,6 +480,14 @@ func TestConverter_FullTurnLifecycle(t *testing.T) {
 	require.Equal(t, int64(500), tokens["cache_write"])
 	require.InDelta(t, 0.02, dd.Stats["cost"], 0.0001)
 
+	// model_usage from step.started
+	mu, ok := dd.Stats["model_usage"].(map[string]any)
+	require.True(t, ok, "model_usage should be present in lifecycle done stats")
+	inner, ok := mu["anthropic/claude-sonnet-4-6"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, int64(5000), inner["input_tokens"])
+	require.Equal(t, int64(600), inner["output_tokens"])
+
 	// State cleared
 	_, exists := c.states[sid]
 	require.False(t, exists)


### PR DESCRIPTION
## Summary

修复 turns 表数据分析发现的两个数据质量问题：CC worker done envelope 缺少 Timestamp 导致 `created_at=0`；OCS converter 未追踪 model 导致 23 条 assistant turns 的 model 字段为空。

### Changes

- **`internal/worker/claudecode/mapper.go`**: `mapResult` 的 error/done envelope 从结构体字面量改为 `events.NewEnvelope()`，自动填充 Timestamp 和 Version
- **`internal/worker/opencodeserver/converter.go`**: `handleStepStarted` 解析 model 字段存入 `turnState.model`；`takeStats()` 输出 `model_usage` 与 CC 格式对齐
- **`internal/worker/opencodeserver/converter_test.go`**: 新增 4 个测试覆盖 model 追踪和 model_usage 输出

**架构影响**：
- Channel: N/A
- Worker: CC + OCS
- 平台: 跨平台

## Test Plan

- [x] make test（含 -race）
- [x] make lint（0 issues）
- [x] make check 全通过

## Root Cause

| 问题 | 根因 | 影响 |
|------|------|------|
| `created_at=0` | mapper.go done envelope 用 struct literal 缺少 Timestamp | 13 条 turns 时间戳为零 |
| 空 model | OCS takeStats() 不输出 model_usage，mergePerTurnStats 路径 A 断裂 | 23 条 turns model 为空 |
| 05-21/22 缺 assistant turns | eventstore 无 WriteMu + 事务泄漏 | 已在 #479 修复 |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Fixes #486