### PR TITLE
fix(cron): finishExecution 后 RunningAtMs 未同步导致 job 永久跳过

### DIFF
--- a/internal/cron/timer.go
+++ b/internal/cron/timer.go
@@ -182,6 +182,7 @@ func (s *Scheduler) executeJob(job *CronJob) {
 
 	job.State.LastRunID = sessionKey
 	shouldDisable := s.finishExecution(job, start.UnixMilli(), err, errorType(err))
+	s.mergeJobState(job.ID, job.State, false)
 
 	if shouldDisable {
 		s.persistAndDisable(job.ID, job.State)
@@ -227,6 +228,7 @@ func (s *Scheduler) executeAttached(job *CronJob) {
 	err := s.attachedHandler.Execute(ctx, job)
 
 	shouldDisable := s.finishExecution(job, time.Now().UnixMilli(), err, "attached")
+	s.mergeJobState(job.ID, job.State, false)
 
 	if shouldDisable {
 		s.persistAndDisable(job.ID, job.State)

--- a/internal/cron/timer_test.go
+++ b/internal/cron/timer_test.go
@@ -238,6 +238,46 @@ func TestMaxTimerInterval(t *testing.T) {
 	require.Equal(t, 60*time.Second, maxTimerInterval)
 }
 
+func TestFinishExecution_ClearsRunningAtMs(t *testing.T) {
+	// Regression: finishExecution must sync RunningAtMs=0 back to in-memory
+	// via mergeJobState. Otherwise collectDue skips the job forever (line 411).
+	store := newTestStore(t)
+	bridge := &mockBridge{}
+	sm := &mockSessionStateChecker{
+		sessions: map[string]*session.SessionInfo{},
+		workers:  map[string]worker.Worker{},
+	}
+	s := &Scheduler{
+		log:           slog.Default(),
+		store:         store,
+		executor:      NewExecutor(slog.Default(), bridge, sm),
+		maxConcurrent: 3,
+		ctx:           context.Background(),
+		jobs:          map[string]*CronJob{},
+		tickLoop:      newTimerLoop(&Scheduler{}),
+	}
+	s.tickLoop.scheduler = s
+
+	now := time.Now()
+	job := helperJob("running-clear")
+	job.State.NextRunAtMs = now.Add(-1 * time.Second).UnixMilli()
+	require.NoError(t, store.Create(context.Background(), job))
+	s.jobs[job.ID] = job
+
+	// Fire tick → executes job in goroutine → will timeout (no worker).
+	s.tickLoop.onTick()
+	s.closed.Store(true)
+	s.tickLoop.stop()
+	s.wg.Wait()
+
+	// After execution finishes, in-memory RunningAtMs must be 0.
+	got := s.jobs[job.ID]
+	require.Equal(t, int64(0), got.State.RunningAtMs,
+		"RunningAtMs must be cleared after execution so collectDue does not skip the job")
+	require.Equal(t, StatusFailed, got.State.LastStatus)
+	require.Equal(t, 1, got.State.ConsecutiveErrs)
+}
+
 func TestGenerateJobID(t *testing.T) {
 	id := GenerateJobID()
 	require.True(t, strings.HasPrefix(id, "cron_"))


### PR DESCRIPTION
## Summary

cron job 执行超时/失败后，`finishExecution` 在 clone 上清零 `RunningAtMs` 并写 DB，但未调用 `mergeJobState` 同步 in-memory 状态。`collectDue` 检查 `RunningAtMs > 0` 时跳过该 job，导致执行失败后 job **永远无法被再次调度**。

### Changes

- **`internal/cron/timer.go`**: `executeJob` 和 `executeAttached` 的 `finishExecution` 后添加 `mergeJobState` 调用
- **`internal/cron/timer_test.go`**: 新增 `TestFinishExecution_ClearsRunningAtMs` 回归测试

**架构影响**：
- Channel: N/A
- Worker: N/A
- 平台: 跨平台

## Root Cause

```
onTick → beginExecution → mergeJobState(RunningAtMs=now)  // in-memory ✓
       → goroutine starts
       → finishExecution → RunningAtMs=0 → persistState(DB)  // DB ✓, in-memory ✗
       → collectDue skips RunningAtMs > 0  // permanent skip!
```

## Test Plan

- [x] make test（含 -race）
- [x] make lint（0 issues）
- [x] make check 全通过
- [x] `TestFinishExecution_ClearsRunningAtMs` 验证 in-memory RunningAtMs 清零

Fixes #489