### PR TITLE
refactor(messaging): SOLID + test coverage for issues #337, #383

### DIFF
--- a/.agents/rules/golang.md
+++ b/.agents/rules/golang.md
@@ -54,7 +54,7 @@ func init() { worker.Register(worker.TypeOpenCodeSrv, New) }
 
 ```go
 type Adapter struct {
-    *platformadapter.PlatformAdapter  // SetHub/SetSM/SetHandler/SetBridge
+    *platformadapter.PlatformAdapter  // ConfigureWith + shared state
 }
 
 // PlatformConn 接口（适配器必须实现）：
@@ -64,12 +64,10 @@ type PlatformConn interface {
 }
 ```
 
-**5 步初始化**（缺一不可）：
-1. `SetHub` — 注入 WS hub（广播路由）
-2. `SetSM` — 注入 SessionManager（状态机）
-3. `SetHandler` — 注入消息处理器（AEP dispatch）
-4. `SetBridge` — 注入 MessagingBridge（session 生命周期）
-5. `Start` — 启动连接（后台 goroutine）
+**3 步初始化**（缺一不可）：
+1. `ConfigureWith(AdapterConfig)` — 注入 Hub/Handler/Bridge/Gate/Extras
+2. `Start` — 启动连接（后台 goroutine）
+3. `Bridge.SetAdapter(adapter)` — 注册 adapter 用于 botID 解析
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,10 @@
 
 **Messaging** (`internal/messaging/`)：
 - `bridge.go` - `Bridge` StartSession → Join → Handle
-- `platform_adapter.go` - 基础适配器
+- `platform_adapter.go` - `PlatformAdapter` 基座（共享状态、ConfigureWith）
+- `platform_types.go` - `PlatformType` 常量 + `ExtractPlatformKeys`
+- `platform_interfaces.go` - `HubInterface`、`HandlerInterface`、`SessionStarter`、`PlatformAdapterInterface`
+- `platform_registry.go` - 适配器注册表（Register/New/RegisteredTypes）
 - `control_command.go` - `ParseControlCommand` 斜杠命令解析
 - `bot_registry.go` - `BotRegistry` 并发安全多 bot 注册表
 - `config.go` - `AdapterConfig` 含 `BotName` 字段

--- a/cmd/hotplex/AGENTS.md
+++ b/cmd/hotplex/AGENTS.md
@@ -57,9 +57,9 @@ type GatewayDeps struct {
 **Messaging init sequence**
 1. Iterate `config.Messaging.Slack/Feishu` → skip if `!Enabled`
 2. `messaging.New(platformType)` → adapter instance
-3. `adapter.Configure(platformConfig)` → apply credentials/policies
-4. `adapter.SetHub/SetSM/SetHandler/SetBridge` → inject dependencies
-5. `adapter.Start(ctx)` → connect to platform (Socket Mode / WS)
+3. `adapter.ConfigureWith(AdapterConfig)` → inject Hub/Handler/Bridge/Gate/Extras
+4. `adapter.Start(ctx)` → connect to platform (Socket Mode / WS)
+5. `msgBridge.SetAdapter(adapter)` → register adapter for botID resolution
 
 **Route registration (routes.go)**
 - `/ws` → Hub.HandleHTTP (WebSocket upgrade)

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -62,7 +62,6 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 	log := deps.Log
 	appCfg := deps.Config
 	hub := deps.Hub
-	sm := deps.SessionMgr
 	handler := deps.Handler
 	gwBridge := deps.Bridge
 	registry := messaging.DefaultBotRegistry()
@@ -159,11 +158,10 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 				continue
 			}
 
-			msgBridge := messaging.NewBridge(log, pt, hub, sm, handler, gwBridge, botWorkerType, botWorkDir)
+			msgBridge := messaging.NewBridge(log, pt, hub, handler, gwBridge, botWorkerType, botWorkDir)
 
 			acfg := messaging.AdapterConfig{
 				Hub:     hub,
-				SM:      sm,
 				Handler: handler,
 				Bridge:  msgBridge,
 				BotName: entry.Name,

--- a/docs/architecture/Platform-Messaging-Architecture-Diagrams.md
+++ b/docs/architecture/Platform-Messaging-Architecture-Diagrams.md
@@ -54,8 +54,7 @@
 │   │  ├─ ResumeSession()                 │  │    └─→ Handler.Handle()          │     │
 │   │  ├─ forwardEvents(w, sessionID)    │  ├─ JoinSession(pc)                │     │
 │   │  │    goroutine 事件转发           │  │    └─→ Hub.JoinPlatformSession() │     │
-│   │  └─ worker lifecycle               │  ├─ MakeSlackEnvelope()            │     │
-│   │                                      │  ├─ MakeFeishuEnvelope()            │     │
+│   │  └─ worker lifecycle               │  ├─ MakeEnvelope()                  │     │
 │   │                                      │  └─ platform 身份验证                │     │
 │   └────────────────────────────────────┬──────────────────────────────────────┘     │
 │                                        │                                           │

--- a/docs/architecture/Platform-Messaging-Extension.md
+++ b/docs/architecture/Platform-Messaging-Extension.md
@@ -210,10 +210,6 @@ type HandlerInterface interface {
 	Handle(ctx context.Context, env *events.Envelope) error
 }
 
-// SessionManager is an opaque interface for session management.
-// Platform adapters don't call session creation directly; the bridge handles it.
-type SessionManager any
-
 // SessionStarter creates a new gateway session for a platform message.
 // Implemented by gateway.Bridge and injected during wiring.
 type SessionStarter interface {
@@ -338,7 +334,7 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope) error {
 // [实现说明] 两个 MakeXxxEnvelope 方法共享 makeEnvelope helper（DRY 优化），
 // 仅 session ID 格式和 metadata 内容不同。
 
-func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text string) *events.Envelope {
+func (b *Bridge) MakeEnvelope(teamID, channelID, threadTS, userID, text string) *events.Envelope {
 	sessionID := fmt.Sprintf("slack:%s:%s:%s:%s", teamID, channelID, threadTS, userID)
 	return b.makeEnvelope(sessionID, userID, text, map[string]any{
 		"platform":   "slack",
@@ -347,7 +343,7 @@ func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text str
 	})
 }
 
-func (b *Bridge) MakeFeishuEnvelope(chatID, threadTS, userID, text string) *events.Envelope {
+func (b *Bridge) MakeEnvelope(chatID, threadTS, userID, text string) *events.Envelope {
 	sessionID := fmt.Sprintf("feishu:%s:%s:%s", chatID, threadTS, userID)
 	return b.makeEnvelope(sessionID, userID, text, map[string]any{
 		"platform": "feishu",
@@ -420,7 +416,7 @@ func pcToConnWrapper(pc PlatformConn) *Conn { /* inline wrapper, ~10 lines */ }
    └─▶ 建立 WebSocket 长连接到 Slack 云
 2. Slack → message event
    └─▶ Adapter.HandleTextMessage(ctx, event.Team, event.Channel, event.User, event.Text)
-       ├─▶ Bridge.MakeSlackEnvelope() → AEP Envelope
+       ├─▶ Bridge.MakeEnvelope() → AEP Envelope
        ├─▶ Bridge.JoinSession(sessionID, platformConn)
        │   └─▶ Hub.JoinPlatformSession() — 注册连接用于接收响应
        └─▶ Bridge.Handle(ctx, env)
@@ -455,7 +451,7 @@ func init() {
 }
 
 type Adapter struct {
-	messaging.PlatformAdapter // embedding for SetHub/SetSM/SetHandler
+	messaging.PlatformAdapter // embedding for ConfigureWith
 
 	app    *slack.App
 	client *slack.Client
@@ -531,7 +527,7 @@ func (a *Adapter) handleMessage(ctx context.Context, ev slackevents.EventsAPIEve
 
 func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelID, userID, text string) error {
 	// Map Slack message to AEP Envelope
-	env := a.Bridge.MakeSlackEnvelope("", channelID, userID, text)
+	env := a.Bridge.MakeEnvelope("", channelID, userID, text)
 	if env == nil {
 		return nil
 	}
@@ -846,7 +842,7 @@ func (r *ChannelRateLimiter) Allow(channelID string) bool {
 1. wsClient.Connect() — 建立飞书 WebSocket 长连接
 2. 飞书 → larkim event (receive message)
    └─▶ Adapter.HandleTextMessage(ctx, chatID, userID, text)
-       ├─▶ Bridge.MakeFeishuEnvelope() → AEP Envelope
+       ├─▶ Bridge.MakeEnvelope() → AEP Envelope
        ├─▶ Bridge.JoinSession(sessionID, platformConn)
        └─▶ Bridge.Handle(ctx, env)
 3. Worker → AEP events → Hub.SendToSession()
@@ -960,7 +956,7 @@ func (a *Adapter) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV
 }
 
 func (a *Adapter) HandleTextMessage(ctx context.Context, chatID, userID, text string) error {
-	env := a.Bridge.MakeFeishuEnvelope(chatID, userID, text)
+	env := a.Bridge.MakeEnvelope(chatID, userID, text)
 	if env == nil {
 		return nil
 	}
@@ -1398,8 +1394,8 @@ func (h *Hub) JoinPlatformSession(sessionID string, pc PlatformConn) {
 | ID | 验收标准 | 验证方式 | 状态 |
 |----|---------|---------|------|
 | AC-3.1 | `Bridge.Handle()` 验证 `OwnerID` 非空后调用 `handler.Handle()` | 单元测试: OwnerID 空返回错误 | ✅ |
-| AC-3.2 | `MakeSlackEnvelope` 生成 session ID: `slack:{team}:{channel}:{thread_ts}:{user_id}` | 单元测试: 验证格式 | ✅ |
-| AC-3.3 | `MakeFeishuEnvelope` 生成 session ID: `feishu:{chat_id}:{thread_ts}:{user_id}` | 单元测试: 验证格式 | ✅ |
+| AC-3.2 | `MakeEnvelope` 生成 session ID: `slack:{team}:{channel}:{thread_ts}:{user_id}` | 单元测试: 验证格式 | ✅ |
+| AC-3.3 | `MakeEnvelope` 生成 session ID: `feishu:{chat_id}:{thread_ts}:{user_id}` | 单元测试: 验证格式 | ✅ |
 | AC-3.4 | Envelope `Data.content` 去首尾空白，`Data.metadata` 含 platform 标识 | 单元测试 | ✅ |
 
 #### AC-4: Hub.JoinPlatformSession

--- a/docs/architecture/Platform-Messaging-Extension.md
+++ b/docs/architecture/Platform-Messaging-Extension.md
@@ -216,17 +216,13 @@ type SessionStarter interface {
 	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir string) error
 }
 
-// SetHub injects the gateway Hub. Called by main.go during wiring.
-func (a *PlatformAdapter) SetHub(hub HubInterface) { a.hub = hub }
-
-// SetSessionManager injects the session manager. Called by main.go during wiring.
-func (a *PlatformAdapter) SetSessionManager(sm SessionManager) { a.sm = sm }
-
-// SetHandler injects the gateway Handler. Called by main.go during wiring.
-func (a *PlatformAdapter) SetHandler(h HandlerInterface) { a.handler = h }
-
-// SetBridge injects the messaging Bridge. Called by main.go during wiring.
-func (a *PlatformAdapter) SetBridge(b *Bridge) { a.bridge = b }
+// ConfigureWith injects all dependencies via AdapterConfig. Called by messaging_init.go during wiring.
+func (a *PlatformAdapter) ConfigureWith(config AdapterConfig) error {
+    a.hub = config.Hub
+    a.handler = config.Handler
+    a.bridge = config.Bridge
+    // ... Gate, BotName, Extras
+}
 
 // PlatformType identifies the messaging platform.
 type PlatformType string

--- a/docs/architecture/Platform-Messaging-Extension.md
+++ b/docs/architecture/Platform-Messaging-Extension.md
@@ -189,13 +189,12 @@ import (
 // PlatformAdapter is the base type for all messaging platform adapters.
 // Each adapter embeds this struct and implements Start, HandleTextMessage, and Close.
 //
-// [实现说明] hub/sm/handler 使用接口类型（HubInterface, HandlerInterface）而非具体类型，
-// 消除对 internal/gateway 包的直接依赖。SessionManager 为空接口（any）占位。
+// [实现说明] hub/handler 使用接口类型（HubInterface, HandlerInterface）而非具体类型，
+// 消除对 internal/gateway 包的直接依赖。依赖通过 ConfigureWith(AdapterConfig) 一次性注入。
 type PlatformAdapter struct {
 	Log *slog.Logger
 
 	hub     HubInterface
-	sm      SessionManager
 	handler HandlerInterface
 	bridge  *Bridge
 }
@@ -290,7 +289,6 @@ type Bridge struct {
 	log         *slog.Logger
 	platform    PlatformType
 	hub         HubInterface
-	sm          SessionManager
 	handler     HandlerInterface
 	starter     SessionStarter       // gateway.Bridge.StartPlatformSession
 	workerType  string
@@ -1383,7 +1381,7 @@ func (h *Hub) JoinPlatformSession(sessionID string, pc PlatformConn) {
 | AC-2.1 | `PlatformAdapterInterface` 定义 `Platform()` / `Start()` / `HandleTextMessage()` / `Close()` | 编译通过 | ✅ |
 | AC-2.2 | `init()` 自注册: `Register(PlatformSlack, ...)` 和 `Register(PlatformFeishu, ...)` | 单元测试: `New()` 返回正确类型 | ✅ |
 | AC-2.3 | 未知 platform 类型返回错误 `messaging: unknown platform %q` | 单元测试 | ✅ |
-| AC-2.4 | `SetHub` / `SetSessionManager` / `SetHandler` / `SetBridge` 注入依赖 | 集成测试 | ✅ |
+| AC-2.4 | `ConfigureWith(AdapterConfig)` 注入 Hub/Handler/Bridge/Gate/Extras | 集成测试 | ✅ |
 
 #### AC-3: PlatformBridge 编排
 

--- a/docs/architecture/Platform-Messaging-Extension.md
+++ b/docs/architecture/Platform-Messaging-Extension.md
@@ -283,67 +283,35 @@ func New(pt PlatformType, log *slog.Logger) (PlatformAdapterInterface, error) {
 ```go
 // internal/messaging/bridge.go（实际实现）
 
-type ConnFactory func(sessionID string) PlatformConn
-
 type Bridge struct {
-	log         *slog.Logger
-	platform    PlatformType
-	hub         HubInterface
-	handler     HandlerInterface
-	starter     SessionStarter       // gateway.Bridge.StartPlatformSession
-	workerType  string
-	workDir     string
-	connFactory ConnFactory          // per-platform conn 工厂
-
-	mu     sync.Mutex
-	joined map[string]bool           // sessionID → already joined (去重)
+	log        *slog.Logger
+	platform   PlatformType
+	hub        HubInterface
+	handler    HandlerInterface
+	starter    SessionStarter
+	workerType string
+	workDir    string
+	adapter    atomic.Value // PlatformAdapterInterface; set via SetAdapter after Start()
 }
 
-func (b *Bridge) Handle(ctx context.Context, env *events.Envelope) error {
-	if env.OwnerID == "" {
-		return fmt.Errorf("messaging bridge: OwnerID not set for platform message")
+// Handle routes a platform message through the gateway.
+// pc is the PlatformConn provided by the adapter (caller manages lifecycle).
+func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformConn) error {
+	// 1. Register platform conn with hub so worker output routes back.
+	if pc != nil && b.hub != nil {
+		b.hub.JoinPlatformSession(env.SessionID, pc)
 	}
-	// 1. Auto-create session if starter is available.
+	// 2. Auto-create session if starter is available.
 	if b.starter != nil {
 		_ = b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir)
-	}
-	// 2. Join platform conn (once per session) so worker output routes back.
-	if b.connFactory != nil && b.hub != nil {
-		b.mu.Lock()
-		if !b.joined[env.SessionID] {
-			pc := b.connFactory(env.SessionID)
-			if pc != nil {
-				b.hub.JoinPlatformSession(env.SessionID, pc)
-				b.joined[env.SessionID] = true
-			}
-		}
-		b.mu.Unlock()
 	}
 	// 3. Route through gateway handler.
 	return b.handler.Handle(ctx, env)
 }
 
-// ─── Slack-specific bridge helpers ─────────────────────────────────────────
-
-// [实现说明] 两个 MakeXxxEnvelope 方法共享 makeEnvelope helper（DRY 优化），
-// 仅 session ID 格式和 metadata 内容不同。
-
-func (b *Bridge) MakeEnvelope(teamID, channelID, threadTS, userID, text string) *events.Envelope {
-	sessionID := fmt.Sprintf("slack:%s:%s:%s:%s", teamID, channelID, threadTS, userID)
-	return b.makeEnvelope(sessionID, userID, text, map[string]any{
-		"platform":   "slack",
-		"team_id":    teamID,
-		"channel_id": channelID,
-	})
-}
-
-func (b *Bridge) MakeEnvelope(chatID, threadTS, userID, text string) *events.Envelope {
-	sessionID := fmt.Sprintf("feishu:%s:%s:%s", chatID, threadTS, userID)
-	return b.makeEnvelope(sessionID, userID, text, map[string]any{
-		"platform": "feishu",
-		"chat_id":  chatID,
-	})
-}
+// MakeEnvelope creates an AEP input envelope with UUIDv5 session ID.
+// Called by per-adapter makeEnvelope helpers (Slack/Feishu).
+func (b *Bridge) MakeEnvelope(userID, text string, platformCtx session.PlatformContext) *events.Envelope { ... }
 ```
 
 ### 4.4 Hub.JoinPlatformSession（唯一核心改动）

--- a/docs/guides/contributor/adding-messaging-adapter.md
+++ b/docs/guides/contributor/adding-messaging-adapter.md
@@ -69,7 +69,6 @@ type PlatformConn interface {
 ```go
 type AdapterConfig struct {
     Hub     HubInterface       // WebSocket Hub（广播路由）
-    SM      SessionManager     // Session 状态机
     Handler HandlerInterface   // AEP Handler（事件分发）
     Bridge  *Bridge            // MessagingBridge（Session 生命周期）
     Gate    *Gate              // 访问控制

--- a/docs/specs/Feishu-Adapter-Improvement-Spec.md
+++ b/docs/specs/Feishu-Adapter-Improvement-Spec.md
@@ -64,7 +64,7 @@ last_updated: 2026-05-08
 
 #### 2.1.1 问题
 
-`adapter.go:157` 的 `MakeFeishuEnvelope` 始终传入空 `threadTS`；出站消息不支持回复引用。
+`adapter.go:157` 的 `makeEnvelope` 始终传入空 `threadTS`；出站消息不支持回复引用。
 
 #### 2.1.2 入站：提取线程信息
 
@@ -102,7 +102,7 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
         threadKey = ptrStr(msg.ThreadId)
     }
 
-    envelope := a.bridge.MakeFeishuEnvelope(chatID, threadKey, userID, text)
+    envelope := a.makeEnvelope(chatID, threadKey, userID, text)
     // 将 chatType、rootID、parentID、messageID 注入 envelope metadata
 }
 ```
@@ -184,7 +184,7 @@ func (a *Adapter) replyMessage(ctx context.Context, messageID, content string, r
 | 2.1-1 | DM 消息（chat_type=p2p）正确路由，session ID 格式 `feishu:{chat_id}::{user_id}` | 单元测试 |
 | 2.1-2 | 群消息中的话题消息提取 root_id 作为 threadKey | 单元测试 |
 | 2.1-3 | 回复消息提取 parent_id，出站使用 Reply API | 单元测试 |
-| 2.1-4 | bridge.MakeFeishuEnvelope 正确传递 threadKey | 单元测试 |
+| 2.1-4 | makeEnvelope 正确传递 threadKey | 单元测试 |
 | 2.1-5 | FeishuConn 在有 replyToMsgID 时使用 Reply API 而非 Create | 集成测试 |
 
 ---
@@ -1213,7 +1213,7 @@ P2MessageReceiveV1 Event
     └─ 9. Chat 队列入队 (ChatQueue.Enqueue → HandleTextMessage)
             │
             ├─ Typing indicator ON
-            ├─ MakeFeishuEnvelope (chatID, threadKey, userID, text)
+            ├─ makeEnvelope (chatID, threadKey, userID, text)
             ├─ Bridge.Handle → Session → Worker
             ├─ FeishuConn.WriteCtx
             │   ├─ Phase 1: sendTextMessage (静态)

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -418,7 +418,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 | `internal/messaging/platform_adapter.go` | `PlatformAdapterInterface` +`GetBotID()`, `SessionStarter` +botID, `ExtractPlatformKeys` +`bot_id` extraction |
 | `internal/messaging/slack/adapter.go` | 实现 `GetBotID()`, 更新 `makeEnvelope` 调用 +botID 参数 |
 | `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()`, 更新 `makeEnvelope` 调用 +botID 参数 |
-| `internal/messaging/bridge.go` | `Bridge` +adapter field +`SetAdapter()`, `makeEnvelope`/`makeEnvelope` +botID, `MakeEnvelope` metadata +bot_id, `Handle()` 提取 botID |
+| `internal/messaging/bridge.go` | `Bridge` +adapter field +`SetAdapter()`, `MakeEnvelope` (public) +botID, `Handle()` 提取 botID; adapters use private `makeEnvelope` helpers |
 | `internal/gateway/bridge.go` | `injectAgentConfig` +botID, `startOrResumeOnInUse` 使用 botID, `workerLaunchParams` +botID, 3个 `createAndLaunchWorker` 调用点 +botID |
 | `cmd/hotplex/messaging_init.go` | `adapter.Start()` 后调用 `msgBridge.SetAdapter(adapter)` |
 | `cmd/hotplex/gateway_run.go` | 启动时扫描旧 suffix 文件, 日志 deprecation warning |

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -231,14 +231,14 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform string)
 func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string)
 ```
 
-### 3.11 messaging.Bridge.makeEnvelope / makeEnvelope
+### 3.11 Slack adapter.makeEnvelope / Feishu adapter.makeEnvelope
 
 ```go
-// Before
-func (b *Bridge) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope
+// Slack adapter — platform-specific helper (moved from Bridge)
+func (a *Adapter) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope
 
-// After — botID parameter added
-func (b *Bridge) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope
+// Feishu adapter — platform-specific helper (moved from Bridge)
+func (a *Adapter) makeEnvelope(chatID, threadTS, userID, text, workDir string) *events.Envelope
 ```
 
 `PlatformContext` in both methods now includes `BotID` field, which flows into `DerivePlatformSessionKey` and envelope metadata.
@@ -347,8 +347,8 @@ Three `createAndLaunchWorker` call sites must pass botID:
 - Add `BotID` field to `session.PlatformContext`
 - Update `FromMap()`: parse `m["bot_id"]`
 - Update `DerivePlatformSessionKey()`: include botID in hash input
-- Update `makeEnvelope` / `makeEnvelope`: +botID parameter
-- Update all callers of `makeEnvelope` / `makeEnvelope` in adapter files
+- Update Slack and Feishu adapter.makeEnvelope: +botID parameter
+- Update all callers of adapter.makeEnvelope in Slack and Feishu adapter files
 - Update `MakeEnvelope()`: include botID in metadata as `"bot_id"`
 - Update `ExtractPlatformKeys`: extract `bot_id` from metadata for both Slack and Feishu cases
 

--- a/docs/specs/Per-Bot-Agent-Config-Spec.md
+++ b/docs/specs/Per-Bot-Agent-Config-Spec.md
@@ -231,14 +231,14 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform string)
 func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string)
 ```
 
-### 3.11 messaging.Bridge.MakeSlackEnvelope / MakeFeishuEnvelope
+### 3.11 messaging.Bridge.makeEnvelope / makeEnvelope
 
 ```go
 // Before
-func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope
+func (b *Bridge) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope
 
 // After — botID parameter added
-func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope
+func (b *Bridge) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope
 ```
 
 `PlatformContext` in both methods now includes `BotID` field, which flows into `DerivePlatformSessionKey` and envelope metadata.
@@ -275,7 +275,7 @@ Adapter.Start()
   └─> auth.test / Bot API → adapter.botID / adapter.botOpenID
 
 Adapter.HandleTextMessage()
-  └─> a.Bridge().MakeSlackEnvelope(teamID, ch, threadTS, userID, text, workDir, a.botID)
+  └─> a.Bridge().makeEnvelope(teamID, ch, threadTS, userID, text, workDir, a.botID)
         └─> MakeEnvelope(userID, text, PlatformContext{..., BotID: botID})
               └─> DerivePlatformSessionKey(userID, wt, pctx)  ← botID in hash
               └─> metadata["bot_id"] = botID
@@ -347,8 +347,8 @@ Three `createAndLaunchWorker` call sites must pass botID:
 - Add `BotID` field to `session.PlatformContext`
 - Update `FromMap()`: parse `m["bot_id"]`
 - Update `DerivePlatformSessionKey()`: include botID in hash input
-- Update `MakeSlackEnvelope` / `MakeFeishuEnvelope`: +botID parameter
-- Update all callers of `MakeSlackEnvelope` / `MakeFeishuEnvelope` in adapter files
+- Update `makeEnvelope` / `makeEnvelope`: +botID parameter
+- Update all callers of `makeEnvelope` / `makeEnvelope` in adapter files
 - Update `MakeEnvelope()`: include botID in metadata as `"bot_id"`
 - Update `ExtractPlatformKeys`: extract `bot_id` from metadata for both Slack and Feishu cases
 
@@ -388,7 +388,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 | PBAC-008 | Empty file (frontmatter only) falls through to next level | Unit test |
 | PBAC-009 | Slack adapter exposes botID via `GetBotID()` | Unit test |
 | PBAC-010 | Feishu adapter exposes botID via `GetBotID()` | Unit test |
-| PBAC-011 | `MakeSlackEnvelope` includes botID in PlatformContext | Unit test |
+| PBAC-011 | `makeEnvelope` includes botID in PlatformContext | Unit test |
 | PBAC-012 | `DerivePlatformSessionKey` with different botIDs produces different session IDs | Unit test |
 | PBAC-013 | `StartPlatformSession` receives botID from adapter | Integration test |
 | PBAC-014 | `injectAgentConfig` passes botID directly to `agentconfig.Load` | Unit test |
@@ -399,7 +399,7 @@ Three `createAndLaunchWorker` call sites must pass botID:
 | PBAC-019 | `hotplex doctor` detects old suffix files and suggests migration | Unit test |
 | PBAC-020 | `make check` passes (lint + test + build) | CI |
 | PBAC-021 | Cross-platform build passes (linux/macOS/windows) | CI |
-| PBAC-022 | `MakeFeishuEnvelope` includes botID in PlatformContext and metadata | Unit test |
+| PBAC-022 | `makeEnvelope` includes botID in PlatformContext and metadata | Unit test |
 | PBAC-023 | `MakeEnvelope` includes `bot_id` in metadata map | Unit test |
 | PBAC-024 | `ExtractPlatformKeys` extracts `bot_id` from metadata for both Slack and Feishu | Unit test |
 | PBAC-025 | `messaging.Bridge.Handle()` extracts botID from adapter via `GetBotID()`, passes to `StartPlatformSession` | Unit test |
@@ -416,9 +416,9 @@ Three `createAndLaunchWorker` call sites must pass botID:
 | `internal/agentconfig/loader_test.go` | 替换 suffix-append 测试为 3级 fallback 测试, +path traversal +empty file tests |
 | `internal/session/key.go` | `PlatformContext` +BotID, `FromMap` +bot_id, `DerivePlatformSessionKey` hash input +botID |
 | `internal/messaging/platform_adapter.go` | `PlatformAdapterInterface` +`GetBotID()`, `SessionStarter` +botID, `ExtractPlatformKeys` +`bot_id` extraction |
-| `internal/messaging/slack/adapter.go` | 实现 `GetBotID()`, 更新 `MakeSlackEnvelope` 调用 +botID 参数 |
-| `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()`, 更新 `MakeFeishuEnvelope` 调用 +botID 参数 |
-| `internal/messaging/bridge.go` | `Bridge` +adapter field +`SetAdapter()`, `MakeSlackEnvelope`/`MakeFeishuEnvelope` +botID, `MakeEnvelope` metadata +bot_id, `Handle()` 提取 botID |
+| `internal/messaging/slack/adapter.go` | 实现 `GetBotID()`, 更新 `makeEnvelope` 调用 +botID 参数 |
+| `internal/messaging/feishu/adapter.go` | 实现 `GetBotID()`, 更新 `makeEnvelope` 调用 +botID 参数 |
+| `internal/messaging/bridge.go` | `Bridge` +adapter field +`SetAdapter()`, `makeEnvelope`/`makeEnvelope` +botID, `MakeEnvelope` metadata +bot_id, `Handle()` 提取 botID |
 | `internal/gateway/bridge.go` | `injectAgentConfig` +botID, `startOrResumeOnInUse` 使用 botID, `workerLaunchParams` +botID, 3个 `createAndLaunchWorker` 调用点 +botID |
 | `cmd/hotplex/messaging_init.go` | `adapter.Start()` 后调用 `msgBridge.SetAdapter(adapter)` |
 | `cmd/hotplex/gateway_run.go` | 启动时扫描旧 suffix 文件, 日志 deprecation warning |

--- a/internal/messaging/AGENTS.md
+++ b/internal/messaging/AGENTS.md
@@ -22,7 +22,7 @@ messaging/
 | Task | Location | Notes |
 |------|----------|-------|
 | Add new platform adapter | `internal/messaging/<name>/` | Embed `PlatformAdapter`, implement `PlatformAdapterInterface`: `Platform()`/`Start()`/`HandleTextMessage()`/`Close()` |
-| Wire adapter in main | `cmd/hotplex/main.go` | `startMessagingAdapters()`: config → New → Configure → SetHub/SetSM/SetHandler/SetBridge → Start |
+| Wire adapter in main | `cmd/hotplex/messaging_init.go` | `startMessagingAdapters()`: New → ConfigureWith(AdapterConfig) → Start → SetAdapter |
 | Bridge lifecycle | `bridge.go` | 3-step: `StartPlatformSession` → `JoinPlatformSession` → `Handle` |
 | PlatformConn interface | `platform_conn.go:11` | `WriteCtx(ctx, env)` + `Close()` — the contract gateway uses to send to platforms |
 | Adapter registration | `platform_adapter.go:47` | `Register(PlatformType, Builder)` — called in each adapter's `init()` |
@@ -62,7 +62,7 @@ _ "hotplex/internal/messaging/feishu"
 - Response delivered back to worker via gateway → auto-deny after 5min if no response
 
 ## ANTI-PATTERNS
-- ❌ Skip `SetHub`/`SetSM`/`SetHandler`/`SetBridge` — all 4 must be called before `Start()`
+- ❌ Skip `ConfigureWith` — must be called before `Start()`
 - ❌ Create platform connections without dedup — always use `GetOrCreateConn`
 - ❌ Send messages directly — use `Bridge.Handle()` to ensure session lifecycle
 - ❌ Skip `SanitizeText()` on user-facing output

--- a/internal/messaging/AGENTS.md
+++ b/internal/messaging/AGENTS.md
@@ -7,7 +7,10 @@ Bidirectional messaging bridge connecting Slack/Feishu platforms to the gateway 
 ```
 messaging/
   platform_conn.go       # PlatformConn interface: WriteCtx + Close
-  platform_adapter.go    # PlatformAdapter base + registry (Register/New/RegisteredTypes)
+  platform_adapter.go    # PlatformAdapter base (shared state, ConfigureWith)
+  platform_types.go      # PlatformType + constants + ExtractPlatformKeys
+  platform_interfaces.go # HubInterface, HandlerInterface, SessionStarter, PlatformAdapterInterface
+  platform_registry.go   # Adapter registry (Register/New/RegisteredTypes)
   bridge.go              # Bridge: 3-step join (StartSession → Join → Handle)
   interaction.go         # InteractionManager: user permission/Q&A/elicitation with timeout + auto-deny
   control_command.go     # Slash commands (/gc, /reset, /park, /new) + $prefix natural language
@@ -25,7 +28,7 @@ messaging/
 | Wire adapter in main | `cmd/hotplex/messaging_init.go` | `startMessagingAdapters()`: New → ConfigureWith(AdapterConfig) → Start → SetAdapter |
 | Bridge lifecycle | `bridge.go` | 3-step: `StartPlatformSession` → `JoinPlatformSession` → `Handle` |
 | PlatformConn interface | `platform_conn.go:11` | `WriteCtx(ctx, env)` + `Close()` — the contract gateway uses to send to platforms |
-| Adapter registration | `platform_adapter.go:47` | `Register(PlatformType, Builder)` — called in each adapter's `init()` |
+| Adapter registration | `platform_registry.go:18` | `Register(PlatformType, Builder)` — called in each adapter's `init()` |
 | Interaction management | `interaction.go` | InteractionManager: timeout (5min) + auto-deny for permission/Q&A/elicitation |
 | Control commands | `control_command.go` | Slash + $prefix parsing, natural language triggers |
 | Text sanitization | `sanitize.go` | `SanitizeText()` — all user-facing output must pass through |

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -149,39 +149,6 @@ func (b *Bridge) MakeEnvelope(userID, text string, pctx session.PlatformContext)
 	return b.makeEnvelope(sessionID, userID, text, md)
 }
 
-// MakeSlackEnvelope converts a Slack message to an AEP input envelope.
-// workDir overrides the bridge's default workDir for session key derivation; empty falls back to b.workDir.
-func (b *Bridge) MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, workDir, botID string) *events.Envelope {
-	if workDir == "" {
-		workDir = b.workDir
-	}
-	return b.MakeEnvelope(userID, text, session.PlatformContext{
-		Platform:  string(PlatformSlack),
-		BotID:     botID,
-		TeamID:    teamID,
-		ChannelID: channelID,
-		ThreadTS:  threadTS,
-		UserID:    userID,
-		WorkDir:   workDir,
-	})
-}
-
-// MakeFeishuEnvelope converts a Feishu message to an AEP input envelope.
-// workDir overrides the bridge's default workDir for session key derivation; empty falls back to b.workDir.
-func (b *Bridge) MakeFeishuEnvelope(chatID, threadTS, userID, text, workDir, botID string) *events.Envelope {
-	if workDir == "" {
-		workDir = b.workDir
-	}
-	return b.MakeEnvelope(userID, text, session.PlatformContext{
-		Platform: string(PlatformFeishu),
-		BotID:    botID,
-		ChatID:   chatID,
-		ThreadTS: threadTS,
-		UserID:   userID,
-		WorkDir:  workDir,
-	})
-}
-
 // extractPlatformKey extracts the consistency-mapping inputs from the envelope metadata.
 // Returns (platform, platformKey) suitable for session persistence.
 func (b *Bridge) extractPlatformKey(env *events.Envelope) (string, map[string]string) {

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -19,7 +19,6 @@ type Bridge struct {
 	log        *slog.Logger
 	platform   PlatformType
 	hub        HubInterface
-	sm         SessionManager
 	handler    HandlerInterface
 	starter    SessionStarter
 	workerType string
@@ -29,13 +28,12 @@ type Bridge struct {
 
 // NewBridge creates a new platform bridge.
 func NewBridge(log *slog.Logger, platform PlatformType, hub HubInterface,
-	sm SessionManager, handler HandlerInterface, starter SessionStarter, workerType, workDir string,
+	handler HandlerInterface, starter SessionStarter, workerType, workDir string,
 ) *Bridge {
 	return &Bridge{
 		log:        log.With("component", "messaging_bridge", "platform", string(platform)),
 		platform:   platform,
 		hub:        hub,
-		sm:         sm,
 		handler:    handler,
 		starter:    starter,
 		workerType: workerType,

--- a/internal/messaging/bridge_test.go
+++ b/internal/messaging/bridge_test.go
@@ -55,12 +55,19 @@ func TestBridge_MakeEnvelope_BotIDInMetadata(t *testing.T) {
 	})
 }
 
-// PBAC-011: MakeSlackEnvelope includes botID in PlatformContext.
-func TestBridge_MakeSlackEnvelope_BotID(t *testing.T) {
+// PBAC-011: MakeEnvelope includes botID in PlatformContext for Slack.
+func TestBridge_MakeEnvelope_SlackBotID(t *testing.T) {
 	t.Parallel()
 
 	b := newTestBridge()
-	env := b.MakeSlackEnvelope("T001", "C100", "123.456", "U001", "hello", "", "U_BOT_X")
+	env := b.MakeEnvelope("U001", "hello", session.PlatformContext{
+		Platform:  "slack",
+		BotID:     "U_BOT_X",
+		TeamID:    "T001",
+		ChannelID: "C100",
+		ThreadTS:  "123.456",
+		UserID:    "U001",
+	})
 
 	md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
 	require.Equal(t, "U_BOT_X", md["bot_id"])
@@ -68,12 +75,18 @@ func TestBridge_MakeSlackEnvelope_BotID(t *testing.T) {
 	require.Equal(t, "C100", md["channel_id"])
 }
 
-// PBAC-022: MakeFeishuEnvelope includes botID in PlatformContext and metadata.
-func TestBridge_MakeFeishuEnvelope_BotID(t *testing.T) {
+// PBAC-022: MakeEnvelope includes botID in PlatformContext for Feishu.
+func TestBridge_MakeEnvelope_FeishuBotID(t *testing.T) {
 	t.Parallel()
 
 	b := newTestBridge()
-	env := b.MakeFeishuEnvelope("oc_chat1", "msg_001", "ou_user1", "hello", "", "ou_bot_Y")
+	env := b.MakeEnvelope("ou_user1", "hello", session.PlatformContext{
+		Platform: "feishu",
+		BotID:    "ou_bot_Y",
+		ChatID:   "oc_chat1",
+		ThreadTS: "msg_001",
+		UserID:   "ou_user1",
+	})
 
 	md := env.Event.Data.(map[string]any)["metadata"].(map[string]any)
 	require.Equal(t, "ou_bot_Y", md["bot_id"])

--- a/internal/messaging/command_map_test.go
+++ b/internal/messaging/command_map_test.go
@@ -1,0 +1,177 @@
+package messaging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestCommandMap_Lookup(t *testing.T) {
+	t.Parallel()
+
+	cm := NewCommandMap(
+		map[string]string{
+			"/gc":    "gc",
+			"/reset": "reset",
+		},
+		map[string]string{
+			"$gc":    "gc",
+			"$休眠":    "gc",
+			"$reset": "reset",
+		},
+	)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{"slash exact match", "/gc", "gc", true},
+		{"slash exact match reset", "/reset", "reset", true},
+		{"natural exact match", "$gc", "gc", true},
+		{"natural cjk match", "$休眠", "gc", true},
+		{"natural reset", "$reset", "reset", true},
+		{"not found", "hello", "", false},
+		{"empty string", "", "", false},
+		{"slash not in natural", "/gc", "gc", true}, // slash takes priority
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := cm.Lookup(tt.input)
+			require.Equal(t, tt.ok, ok)
+			if tt.ok {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCommandMap_LookupSlash(t *testing.T) {
+	t.Parallel()
+
+	cm := NewCommandMap(
+		map[string]string{"/gc": "gc"},
+		map[string]string{"$gc": "gc"},
+	)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{"found", "/gc", "gc", true},
+		{"not in slash map", "$gc", "", false},
+		{"not found", "/reset", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := cm.LookupSlash(tt.input)
+			require.Equal(t, tt.ok, ok)
+			if tt.ok {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCommandMap_LookupNatural(t *testing.T) {
+	t.Parallel()
+
+	cm := NewCommandMap(
+		map[string]string{"/gc": "gc"},
+		map[string]string{"$gc": "gc", "$休眠": "gc"},
+	)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{"found", "$gc", "gc", true},
+		{"cjk found", "$休眠", "gc", true},
+		{"not in natural map", "/gc", "", false},
+		{"not found", "$reset", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := cm.LookupNatural(tt.input)
+			require.Equal(t, tt.ok, ok)
+			if tt.ok {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCommandMap_Empty(t *testing.T) {
+	t.Parallel()
+
+	cm := NewCommandMap[string](nil, nil)
+
+	_, ok := cm.Lookup("anything")
+	require.False(t, ok)
+
+	_, ok = cm.LookupSlash("anything")
+	require.False(t, ok)
+
+	_, ok = cm.LookupNatural("anything")
+	require.False(t, ok)
+}
+
+func TestCommandMap_SlashPriority(t *testing.T) {
+	t.Parallel()
+
+	// When same key exists in both maps, Lookup returns slash first.
+	cm := NewCommandMap(
+		map[string]string{"/x": "slash"},
+		map[string]string{"/x": "natural"},
+	)
+
+	got, ok := cm.Lookup("/x")
+	require.True(t, ok)
+	require.Equal(t, "slash", got)
+
+	got, ok = cm.LookupNatural("/x")
+	require.True(t, ok)
+	require.Equal(t, "natural", got)
+}
+
+func TestControlCommands_Integration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  events.ControlAction
+		ok    bool
+	}{
+		{"/gc", events.ControlActionGC, true},
+		{"/reset", events.ControlActionReset, true},
+		{"/park", events.ControlActionGC, true},
+		{"/new", events.ControlActionReset, true},
+		{"hello", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := ParseControlCommand(tt.input)
+			if !tt.ok {
+				require.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			require.Equal(t, tt.want, result.Action)
+		})
+	}
+}

--- a/internal/messaging/config.go
+++ b/internal/messaging/config.go
@@ -11,7 +11,6 @@ import (
 type AdapterConfig struct {
 	// Core dependencies (from PlatformAdapter setters)
 	Hub     HubInterface
-	SM      SessionManager
 	Handler HandlerInterface
 	Bridge  *Bridge
 

--- a/internal/messaging/control_command.go
+++ b/internal/messaging/control_command.go
@@ -31,11 +31,19 @@ func (m *CommandMap[T]) Lookup(normalized string) (T, bool) {
 	if v, ok := m.slash[normalized]; ok {
 		return v, true
 	}
-	if v, ok := m.natural[normalized]; ok {
-		return v, true
-	}
-	var zero T
-	return zero, false
+	return m.LookupNatural(normalized)
+}
+
+// LookupSlash finds a command in the slash entries only.
+func (m *CommandMap[T]) LookupSlash(normalized string) (T, bool) {
+	v, ok := m.slash[normalized]
+	return v, ok
+}
+
+// LookupNatural finds a command in the natural language entries only.
+func (m *CommandMap[T]) LookupNatural(normalized string) (T, bool) {
+	v, ok := m.natural[normalized]
+	return v, ok
 }
 
 // controlCommands maps slash and natural language triggers to control actions.
@@ -171,7 +179,7 @@ func ParseWorkerCommand(text string) *WorkerCommandResult {
 	t = trimTrailingPunct(t)
 
 	base, args := parseWorkerSlashCommands(t)
-	if cmd, ok := workerCommands.slash[base]; ok {
+	if cmd, ok := workerCommands.LookupSlash(base); ok {
 		label := base
 		if !workerSlashCommandsWithArgs[base] {
 			args = ""
@@ -183,7 +191,7 @@ func ParseWorkerCommand(text string) *WorkerCommandResult {
 		}
 	}
 
-	if cmd, ok := workerCommands.natural[t]; ok {
+	if cmd, ok := workerCommands.LookupNatural(t); ok {
 		return &WorkerCommandResult{
 			Command: cmd,
 			Label:   t,

--- a/internal/messaging/control_command.go
+++ b/internal/messaging/control_command.go
@@ -15,28 +15,46 @@ type ControlCommandResult struct {
 	Arg    string // optional argument, e.g. path for cd
 }
 
-// slashCommandMap maps slash-form strings to control actions.
-var slashCommandMap = map[string]ControlCommandResult{
-	// GC: reclaim process and resources, session preserved for resume.
-	"/gc":   {Action: events.ControlActionGC, Label: "gc"},
-	"/park": {Action: events.ControlActionGC, Label: "gc"},
-	// Reset: reuse session ID, everything else starts from scratch.
-	"/reset": {Action: events.ControlActionReset, Label: "reset"},
-	"/new":   {Action: events.ControlActionReset, Label: "reset"},
-	"/cd":    {Action: events.ControlActionCD, Label: "cd"},
+// CommandMap is a generic slash + natural language command lookup table.
+type CommandMap[T any] struct {
+	slash   map[string]T
+	natural map[string]T
 }
 
-// naturalLanguageMap maps normalized natural language triggers to control actions.
-// All keys require $ prefix to avoid accidental matches in normal conversation.
-var naturalLanguageMap = map[string]ControlCommandResult{
-	// GC: sleep, suspend — worker stopped but session alive for resume.
-	"$gc": {Action: events.ControlActionGC, Label: "gc"},
-	"$休眠": {Action: events.ControlActionGC, Label: "gc"},
-	"$挂起": {Action: events.ControlActionGC, Label: "gc"},
-	// Reset: start over — same session ID, fresh context.
-	"$重置":    {Action: events.ControlActionReset, Label: "reset"},
-	"$reset": {Action: events.ControlActionReset, Label: "reset"},
+// NewCommandMap creates a command map from slash and natural language entries.
+func NewCommandMap[T any](slash, natural map[string]T) *CommandMap[T] {
+	return &CommandMap[T]{slash: slash, natural: natural}
 }
+
+// Lookup finds a command by normalized text, checking slash entries first.
+func (m *CommandMap[T]) Lookup(normalized string) (T, bool) {
+	if v, ok := m.slash[normalized]; ok {
+		return v, true
+	}
+	if v, ok := m.natural[normalized]; ok {
+		return v, true
+	}
+	var zero T
+	return zero, false
+}
+
+// controlCommands maps slash and natural language triggers to control actions.
+var controlCommands = NewCommandMap(
+	map[string]ControlCommandResult{
+		"/gc":    {Action: events.ControlActionGC, Label: "gc"},
+		"/park":  {Action: events.ControlActionGC, Label: "gc"},
+		"/reset": {Action: events.ControlActionReset, Label: "reset"},
+		"/new":   {Action: events.ControlActionReset, Label: "reset"},
+		"/cd":    {Action: events.ControlActionCD, Label: "cd"},
+	},
+	map[string]ControlCommandResult{
+		"$gc":    {Action: events.ControlActionGC, Label: "gc"},
+		"$休眠":    {Action: events.ControlActionGC, Label: "gc"},
+		"$挂起":    {Action: events.ControlActionGC, Label: "gc"},
+		"$重置":    {Action: events.ControlActionReset, Label: "reset"},
+		"$reset": {Action: events.ControlActionReset, Label: "reset"},
+	},
+)
 
 // ParseControlCommand checks whether text is a control command.
 // Returns nil if the text is not a control command.
@@ -51,10 +69,7 @@ func ParseControlCommand(text string) *ControlCommandResult {
 		return &arg
 	}
 
-	if result, ok := slashCommandMap[tl]; ok {
-		return &result
-	}
-	if result, ok := naturalLanguageMap[tl]; ok {
+	if result, ok := controlCommands.Lookup(tl); ok {
 		return &result
 	}
 	return nil
@@ -101,42 +116,41 @@ var workerSlashCommandsWithArgs = map[string]bool{
 	"/effort": true,
 }
 
-// workerSlashMap maps slash-form strings to worker stdio commands.
-var workerSlashMap = map[string]events.WorkerStdioCommand{
-	"/context": events.StdioContextUsage,
-	"/skills":  events.StdioSkills,
-	"/mcp":     events.StdioMCPStatus,
-	"/model":   events.StdioSetModel,
-	"/perm":    events.StdioSetPermMode,
-	"/compact": events.StdioCompact,
-	"/clear":   events.StdioClear,
-	"/effort":  events.StdioEffort,
-	"/rewind":  events.StdioRewind,
-	"/commit":  events.StdioCommit,
-}
-
-// workerNLMap maps natural language triggers to worker stdio commands.
-// All keys require $ prefix to avoid accidental matches in normal conversation.
-var workerNLMap = map[string]events.WorkerStdioCommand{
-	"$context": events.StdioContextUsage,
-	"$上下文":     events.StdioContextUsage,
-	"$skills":  events.StdioSkills,
-	"$技能":      events.StdioSkills,
-	"$mcp":     events.StdioMCPStatus,
-	"$model":   events.StdioSetModel,
-	"$切换模型":    events.StdioSetModel,
-	"$perm":    events.StdioSetPermMode,
-	"$权限模式":    events.StdioSetPermMode,
-	"$compact": events.StdioCompact,
-	"$压缩":      events.StdioCompact,
-	"$clear":   events.StdioClear,
-	"$清空":      events.StdioClear,
-	"$effort":  events.StdioEffort,
-	"$rewind":  events.StdioRewind,
-	"$回退":      events.StdioRewind,
-	"$commit":  events.StdioCommit,
-	"$提交":      events.StdioCommit,
-}
+// workerCommands maps slash and natural language triggers to worker stdio commands.
+var workerCommands = NewCommandMap(
+	map[string]events.WorkerStdioCommand{
+		"/context": events.StdioContextUsage,
+		"/skills":  events.StdioSkills,
+		"/mcp":     events.StdioMCPStatus,
+		"/model":   events.StdioSetModel,
+		"/perm":    events.StdioSetPermMode,
+		"/compact": events.StdioCompact,
+		"/clear":   events.StdioClear,
+		"/effort":  events.StdioEffort,
+		"/rewind":  events.StdioRewind,
+		"/commit":  events.StdioCommit,
+	},
+	map[string]events.WorkerStdioCommand{
+		"$context": events.StdioContextUsage,
+		"$上下文":     events.StdioContextUsage,
+		"$skills":  events.StdioSkills,
+		"$技能":      events.StdioSkills,
+		"$mcp":     events.StdioMCPStatus,
+		"$model":   events.StdioSetModel,
+		"$切换模型":    events.StdioSetModel,
+		"$perm":    events.StdioSetPermMode,
+		"$权限模式":    events.StdioSetPermMode,
+		"$compact": events.StdioCompact,
+		"$压缩":      events.StdioCompact,
+		"$clear":   events.StdioClear,
+		"$清空":      events.StdioClear,
+		"$effort":  events.StdioEffort,
+		"$rewind":  events.StdioRewind,
+		"$回退":      events.StdioRewind,
+		"$commit":  events.StdioCommit,
+		"$提交":      events.StdioCommit,
+	},
+)
 
 // WorkerCommandResult holds the parsed worker stdio command and its arguments.
 type WorkerCommandResult struct {
@@ -157,7 +171,7 @@ func ParseWorkerCommand(text string) *WorkerCommandResult {
 	t = trimTrailingPunct(t)
 
 	base, args := parseWorkerSlashCommands(t)
-	if cmd, ok := workerSlashMap[base]; ok {
+	if cmd, ok := workerCommands.slash[base]; ok {
 		label := base
 		if !workerSlashCommandsWithArgs[base] {
 			args = ""
@@ -169,7 +183,7 @@ func ParseWorkerCommand(text string) *WorkerCommandResult {
 		}
 	}
 
-	if cmd, ok := workerNLMap[t]; ok {
+	if cmd, ok := workerCommands.natural[t]; ok {
 		return &WorkerCommandResult{
 			Command: cmd,
 			Label:   t,

--- a/internal/messaging/feishu/adapter_test.go
+++ b/internal/messaging/feishu/adapter_test.go
@@ -365,3 +365,48 @@ func TestMediaExtByType(t *testing.T) {
 		})
 	}
 }
+
+func TestAdapter_MakeEnvelope(t *testing.T) {
+	t.Parallel()
+
+	br := messaging.NewBridge(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		messaging.PlatformFeishu,
+		nil, nil, nil,
+		"claude_code", "/tmp/hotplex/workspace",
+	)
+
+	a := &Adapter{botOpenID: "ou_bot123"}
+	err := a.ConfigureWith(messaging.AdapterConfig{Bridge: br})
+	require.NoError(t, err)
+
+	env := a.makeEnvelope("oc_chat1", "msg_001", "ou_user1", "飞书消息", "")
+
+	require.NotNil(t, env)
+	require.Equal(t, "ou_user1", env.OwnerID)
+	require.NotEmpty(t, env.SessionID)
+
+	data, ok := env.Event.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "飞书消息", data["content"])
+}
+
+func TestAdapter_MakeEnvelope_CustomWorkDir(t *testing.T) {
+	t.Parallel()
+
+	br := messaging.NewBridge(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		messaging.PlatformFeishu,
+		nil, nil, nil,
+		"claude_code", "/default",
+	)
+
+	a := &Adapter{botOpenID: "ou_bot123"}
+	err := a.ConfigureWith(messaging.AdapterConfig{Bridge: br})
+	require.NoError(t, err)
+
+	env1 := a.makeEnvelope("oc_chat1", "", "ou_user1", "hi", "/custom")
+	env2 := a.makeEnvelope("oc_chat1", "", "ou_user1", "hi", "")
+
+	require.NotEqual(t, env1.SessionID, env2.SessionID)
+}

--- a/internal/messaging/feishu/events.go
+++ b/internal/messaging/feishu/events.go
@@ -18,7 +18,7 @@ func ExtractChatID(env *events.Envelope) string {
 	if id, ok := md["chat_id"].(string); ok && id != "" {
 		return id
 	}
-	// Nested: used by Bridge.MakeFeishuEnvelope.
+	// Nested: used by Adapter.makeEnvelope.
 	if meta, ok := md["metadata"].(map[string]any); ok {
 		if id, ok := meta["chat_id"].(string); ok && id != "" {
 			return id

--- a/internal/messaging/feishu/handler.go
+++ b/internal/messaging/feishu/handler.go
@@ -9,8 +9,24 @@ import (
 
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+// makeEnvelope builds an AEP input envelope for a Feishu message.
+func (a *Adapter) makeEnvelope(chatID, threadTS, userID, text, workDir string) *events.Envelope {
+	if workDir == "" {
+		workDir = a.Bridge().WorkDir()
+	}
+	return a.Bridge().MakeEnvelope(userID, text, session.PlatformContext{
+		Platform: string(messaging.PlatformFeishu),
+		BotID:    a.botOpenID,
+		ChatID:   chatID,
+		ThreadTS: threadTS,
+		UserID:   userID,
+		WorkDir:  workDir,
+	})
+}
 
 func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
 	if event.Event == nil || event.Event.Message == nil {
@@ -155,7 +171,7 @@ func (a *Adapter) handleTextMessage(ctx context.Context, platformMsgID, channelI
 		conn.voiceTriggered.Store(true)
 	}
 
-	envelope := a.Bridge().MakeFeishuEnvelope(channelID, threadKey, userID, text, conn.WorkDir(), a.botOpenID)
+	envelope := a.makeEnvelope(channelID, threadKey, userID, text, conn.WorkDir())
 	if envelope == nil {
 		return fmt.Errorf("feishu: failed to build envelope")
 	}
@@ -235,7 +251,7 @@ func (a *Adapter) GetOrCreateConn(chatID, threadKey string) *FeishuConn {
 
 func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, threadKey, platformMsgID string, result *messaging.ControlCommandResult) {
 	conn := a.GetOrCreateConn(chatID, threadKey)
-	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir(), a.botOpenID)
+	envelope := a.makeEnvelope(chatID, threadKey, userID, "", conn.WorkDir())
 	if envelope == nil {
 		a.Log.Warn("feishu: text control command failed to derive session", "action", result.Label)
 		return
@@ -298,7 +314,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, 
 
 func (a *Adapter) handleTextWorkerCommand(ctx context.Context, chatID, chatType, userID, threadKey, platformMsgID, replyToMsgID string, result *messaging.WorkerCommandResult) {
 	conn := a.GetOrCreateConn(chatID, threadKey)
-	envelope := a.Bridge().MakeFeishuEnvelope(chatID, threadKey, userID, "", conn.WorkDir(), a.botOpenID)
+	envelope := a.makeEnvelope(chatID, threadKey, userID, "", conn.WorkDir())
 	if envelope == nil {
 		a.Log.Warn("feishu: worker command failed to derive session", "command", result.Label)
 		return

--- a/internal/messaging/feishu/tool_status_test.go
+++ b/internal/messaging/feishu/tool_status_test.go
@@ -1,0 +1,542 @@
+package feishu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// ---------------------------------------------------------------------------
+// renderToolActivity
+// ---------------------------------------------------------------------------
+
+func TestRenderToolActivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entries  []toolEntry
+		expected string
+	}{
+		{
+			name:     "empty entries returns empty string",
+			entries:  nil,
+			expected: "",
+		},
+		{
+			name:     "zero-length slice returns empty string",
+			entries:  []toolEntry{},
+			expected: "",
+		},
+		{
+			name: "single pending entry",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "Read file.go", done: false, result: ""},
+			},
+			expected: "Read file.go",
+		},
+		{
+			name: "single done entry without result",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "Read file.go", done: true, result: ""},
+			},
+			expected: "Read file.go",
+		},
+		{
+			name: "single done entry with result",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "Read file.go", done: true, result: "42 lines"},
+			},
+			expected: "Read file.go · 42 lines",
+		},
+		{
+			name: "multiple entries joined by newline",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "Read a.go", done: true, result: "ok"},
+				{id: "2", name: "Write", text: "Write b.go", done: false, result: ""},
+				{id: "3", name: "Bash", text: "Bash make test", done: true, result: "passed"},
+			},
+			expected: "Read a.go · ok\nWrite b.go\nBash make test · passed",
+		},
+		{
+			name: "long text is visually truncated",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", done: false, result: ""},
+			},
+			expected: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…",
+		},
+		{
+			name: "text at exactly maxCols limit is not truncated",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", done: false, result: ""},
+			},
+			expected: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name: "CJK text is visually truncated",
+			entries: []toolEntry{
+				{id: "1", name: "Read", text: "这是一段很长很长很长很长很长很长很长很长很长很长的中文文本用来测试截断", done: false, result: ""},
+			},
+			expected: "这是一段很长很长很长很长很长很长很长很长很长很长的…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := renderToolActivity(tt.entries)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractToolCallData
+// ---------------------------------------------------------------------------
+
+func TestExtractToolCallData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		env       *events.Envelope
+		wantID    string
+		wantName  string
+		wantInput map[string]any
+	}{
+		{
+			name: "nil envelope data",
+			env: &events.Envelope{
+				Event: events.Event{Type: events.ToolCall, Data: nil},
+			},
+			wantID:    "",
+			wantName:  "",
+			wantInput: nil,
+		},
+		{
+			name: "wrong data type",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolCall,
+					Data: "not a map",
+				},
+			},
+			wantID:    "",
+			wantName:  "",
+			wantInput: nil,
+		},
+		{
+			name: "empty map data",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolCall,
+					Data: map[string]any{},
+				},
+			},
+			wantID:    "",
+			wantName:  "",
+			wantInput: nil,
+		},
+		{
+			name: "valid tool call data via map",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolCall,
+					Data: map[string]any{
+						"id":    "call-123",
+						"name":  "Read",
+						"input": map[string]any{"path": "/tmp/test.go"},
+					},
+				},
+			},
+			wantID:   "call-123",
+			wantName: "Read",
+			wantInput: map[string]any{
+				"path": "/tmp/test.go",
+			},
+		},
+		{
+			name: "valid tool call data as concrete type",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolCall,
+					Data: events.ToolCallData{
+						ID:   "call-456",
+						Name: "Bash",
+						Input: map[string]any{
+							"command": "go test ./...",
+						},
+					},
+				},
+			},
+			wantID:   "call-456",
+			wantName: "Bash",
+			wantInput: map[string]any{
+				"command": "go test ./...",
+			},
+		},
+		{
+			name: "nil input field",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolCall,
+					Data: map[string]any{
+						"id":   "call-789",
+						"name": "Glob",
+					},
+				},
+			},
+			wantID:    "call-789",
+			wantName:  "Glob",
+			wantInput: nil,
+		},
+		{
+			name: "wrong event kind still decodes data",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.State,
+					Data: events.ToolCallData{
+						ID:    "call-miscat",
+						Name:  "Edit",
+						Input: map[string]any{"file": "main.go"},
+					},
+				},
+			},
+			wantID:    "call-miscat",
+			wantName:  "Edit",
+			wantInput: map[string]any{"file": "main.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id, name, input := extractToolCallData(tt.env)
+			require.Equal(t, tt.wantID, id)
+			require.Equal(t, tt.wantName, name)
+			require.Equal(t, tt.wantInput, input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractToolResultData
+// ---------------------------------------------------------------------------
+
+func TestExtractToolResultData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		env       *events.Envelope
+		wantID    string
+		wantOut   any
+		wantError string
+	}{
+		{
+			name: "nil envelope data",
+			env: &events.Envelope{
+				Event: events.Event{Type: events.ToolResult, Data: nil},
+			},
+			wantID:    "",
+			wantOut:   nil,
+			wantError: "",
+		},
+		{
+			name: "wrong data type",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: 42,
+				},
+			},
+			wantID:    "",
+			wantOut:   nil,
+			wantError: "",
+		},
+		{
+			name: "empty map data",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: map[string]any{},
+				},
+			},
+			wantID:    "",
+			wantOut:   nil,
+			wantError: "",
+		},
+		{
+			name: "valid tool result via map with output",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: map[string]any{
+						"id":     "result-1",
+						"output": "file contents here",
+					},
+				},
+			},
+			wantID:    "result-1",
+			wantOut:   "file contents here",
+			wantError: "",
+		},
+		{
+			name: "valid tool result via map with error",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: map[string]any{
+						"id":    "result-2",
+						"error": "permission denied",
+					},
+				},
+			},
+			wantID:    "result-2",
+			wantOut:   nil,
+			wantError: "permission denied",
+		},
+		{
+			name: "valid tool result as concrete type",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: events.ToolResultData{
+						ID:     "result-3",
+						Output: map[string]any{"lines": 100},
+						Error:  "",
+					},
+				},
+			},
+			wantID:  "result-3",
+			wantOut: map[string]any{"lines": 100},
+		},
+		{
+			name: "valid tool result with both output and error",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: events.ToolResultData{
+						ID:     "result-4",
+						Output: "partial output",
+						Error:  "timeout after 30s",
+					},
+				},
+			},
+			wantID:    "result-4",
+			wantOut:   "partial output",
+			wantError: "timeout after 30s",
+		},
+		{
+			name: "nil output in concrete type",
+			env: &events.Envelope{
+				Event: events.Event{
+					Type: events.ToolResult,
+					Data: events.ToolResultData{
+						ID:     "result-5",
+						Output: nil,
+					},
+				},
+			},
+			wantID:    "result-5",
+			wantOut:   nil,
+			wantError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id, output, errMsg := extractToolResultData(tt.env)
+			require.Equal(t, tt.wantID, id)
+			require.Equal(t, tt.wantOut, output)
+			require.Equal(t, tt.wantError, errMsg)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runeWidth
+// ---------------------------------------------------------------------------
+
+func TestRuneWidth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		r    rune
+		want int
+	}{
+		{name: "null byte", r: 0, want: 1},
+		{name: "space", r: ' ', want: 1},
+		{name: "ASCII digit", r: '7', want: 1},
+		{name: "ASCII letter", r: 'A', want: 1},
+		{name: "ASCII lowercase", r: 'z', want: 1},
+		{name: "Latin-1 extended", r: 0xE9, want: 1}, // e-acute
+		{name: "Latin-1 max", r: 0xFF, want: 1},      // y-umlaut
+		{name: "CJK Han character", r: '中', want: 2},
+		{name: "CJK Han another", r: '国', want: 2},
+		{name: "Hangul syllable", r: '한', want: 2},
+		{name: "Hiragana", r: 'あ', want: 2},
+		{name: "Katakana", r: 'ア', want: 2},
+		{name: "fullwidth A", r: 'Ａ', want: 2},
+		{name: "fullwidth 0", r: '０', want: 2},
+		{name: "fullwidth range middle", r: 'Ｐ', want: 2},
+		{name: "emoji grinning face", r: '😀', want: 2},
+		{name: "emoji rocket", r: '🚀', want: 2},
+		{name: "emoji cyclone", r: '🌀', want: 2}, // U+1F300, start of emoji range
+		{name: "general punctuation em dash", r: '—', want: 2},
+		{name: "general punctuation ellipsis", r: '…', want: 2},
+		{name: "Cyrillic A", r: 'А', want: 1},
+		{name: "Thai character", r: 'ก', want: 1},
+		{name: "Devanagari", r: 'अ', want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := runeWidth(tt.r)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// truncateVisual
+// ---------------------------------------------------------------------------
+
+func TestTruncateVisual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		s       string
+		maxCols int
+		want    string
+	}{
+		{
+			name:    "zero maxCols returns empty",
+			s:       "hello",
+			maxCols: 0,
+			want:    "",
+		},
+		{
+			name:    "negative maxCols returns empty",
+			s:       "hello",
+			maxCols: -5,
+			want:    "",
+		},
+		{
+			name:    "empty string within budget",
+			s:       "",
+			maxCols: 10,
+			want:    "",
+		},
+		{
+			name:    "ASCII fits exactly",
+			s:       "abc",
+			maxCols: 3,
+			want:    "abc",
+		},
+		{
+			name:    "ASCII within budget",
+			s:       "abc",
+			maxCols: 10,
+			want:    "abc",
+		},
+		{
+			name:    "ASCII truncated at boundary",
+			s:       "abcdefgh",
+			maxCols: 5,
+			want:    "abcde…",
+		},
+		{
+			name:    "single ASCII char budget",
+			s:       "abcdef",
+			maxCols: 1,
+			want:    "a…",
+		},
+		{
+			name:    "CJK fits exactly even number cols",
+			s:       "你好",
+			maxCols: 4,
+			want:    "你好",
+		},
+		{
+			name:    "CJK truncated mid-character",
+			s:       "你好世界",
+			maxCols: 5,
+			want:    "你好…",
+		},
+		{
+			name:    "CJK with ASCII mix truncated at boundary",
+			s:       "Hi你好",
+			maxCols: 5,
+			want:    "Hi你…",
+		},
+		{
+			name:    "CJK with ASCII mix fits",
+			s:       "Hi你好",
+			maxCols: 6,
+			want:    "Hi你好",
+		},
+		{
+			name:    "CJK with ASCII mix truncated",
+			s:       "Hi你好世界",
+			maxCols: 5,
+			want:    "Hi你…",
+		},
+		{
+			name:    "emoji fits",
+			s:       "🚀",
+			maxCols: 2,
+			want:    "🚀",
+		},
+		{
+			name:    "emoji truncated",
+			s:       "🚀abc",
+			maxCols: 3,
+			want:    "🚀a…",
+		},
+		{
+			name:    "fullwidth form truncated",
+			s:       "ＡＢＣ",
+			maxCols: 3,
+			want:    "Ａ…",
+		},
+		{
+			name:    "maxCols 1 with wide char returns empty truncation",
+			s:       "你好",
+			maxCols: 1,
+			want:    "…",
+		},
+		{
+			name:    "ellipsis char itself is wide",
+			s:       "aaa…bbb",
+			maxCols: 4,
+			want:    "aaa…",
+		},
+		{
+			name:    "byte length fast path short ASCII",
+			s:       "hi",
+			maxCols: 50,
+			want:    "hi",
+		},
+		{
+			name:    "long CJK string truncated to 50 cols",
+			s:       "这是一段很长很长很长很长很长很长很长很长很长很长的中文文本用来测试截断效果",
+			maxCols: 50,
+			want:    "这是一段很长很长很长很长很长很长很长很长很长很长的…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := truncateVisual(tt.s, tt.maxCols)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/messaging/integration_test.go
+++ b/internal/messaging/integration_test.go
@@ -118,6 +118,7 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 	threadTS := "1234567890.123456"
 	userID := "U789"
 	text := "hello"
+	workDir := config.Default().Worker.DefaultWorkDir
 
 	br := NewBridge(
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -126,17 +127,19 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 		nil,
 		nil,
 		"claude_code",
-		config.Default().Worker.DefaultWorkDir,
+		workDir,
 	)
 
-	env := br.MakeEnvelope(userID, text, session.PlatformContext{
+	slackCtx := session.PlatformContext{
 		Platform:  "slack",
 		TeamID:    teamID,
 		ChannelID: channelID,
 		ThreadTS:  threadTS,
 		UserID:    userID,
-		WorkDir:   config.Default().Worker.DefaultWorkDir,
-	})
+		WorkDir:   workDir,
+	}
+
+	env := br.MakeEnvelope(userID, text, slackCtx)
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
@@ -144,25 +147,11 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 	require.Equal(t, userID, env.OwnerID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeEnvelope(userID, text, session.PlatformContext{
-		Platform:  "slack",
-		TeamID:    teamID,
-		ChannelID: channelID,
-		ThreadTS:  threadTS,
-		UserID:    userID,
-		WorkDir:   config.Default().Worker.DefaultWorkDir,
-	})
+	env2 := br.MakeEnvelope(userID, text, slackCtx)
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.
-	expected := session.DerivePlatformSessionKey(userID, "claude_code", session.PlatformContext{
-		Platform:  "slack",
-		TeamID:    teamID,
-		ChannelID: channelID,
-		ThreadTS:  threadTS,
-		UserID:    userID,
-		WorkDir:   config.Default().Worker.DefaultWorkDir,
-	})
+	expected := session.DerivePlatformSessionKey(userID, "claude_code", slackCtx)
 	require.Equal(t, expected, env.SessionID)
 
 	// Event.Data is a map with content and metadata
@@ -178,6 +167,7 @@ func TestBridge_MakeFeishuEnvelope(t *testing.T) {
 	threadTS := "msg_456"
 	userID := "ou_789"
 	text := "飞书消息"
+	workDir := config.Default().Worker.DefaultWorkDir
 
 	br := NewBridge(
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -186,39 +176,29 @@ func TestBridge_MakeFeishuEnvelope(t *testing.T) {
 		nil,
 		nil,
 		"claude_code",
-		config.Default().Worker.DefaultWorkDir,
+		workDir,
 	)
 
-	env := br.MakeEnvelope(userID, text, session.PlatformContext{
+	feishuCtx := session.PlatformContext{
 		Platform: "feishu",
 		ChatID:   chatID,
 		ThreadTS: threadTS,
 		UserID:   userID,
-		WorkDir:  config.Default().Worker.DefaultWorkDir,
-	})
+		WorkDir:  workDir,
+	}
+
+	env := br.MakeEnvelope(userID, text, feishuCtx)
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
 	require.Regexp(t, uuidV5Regex, env.SessionID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeEnvelope(userID, text, session.PlatformContext{
-		Platform: "feishu",
-		ChatID:   chatID,
-		ThreadTS: threadTS,
-		UserID:   userID,
-		WorkDir:  config.Default().Worker.DefaultWorkDir,
-	})
+	env2 := br.MakeEnvelope(userID, text, feishuCtx)
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.
-	expected := session.DerivePlatformSessionKey(userID, "claude_code", session.PlatformContext{
-		Platform: "feishu",
-		ChatID:   chatID,
-		ThreadTS: threadTS,
-		UserID:   userID,
-		WorkDir:  config.Default().Worker.DefaultWorkDir,
-	})
+	expected := session.DerivePlatformSessionKey(userID, "claude_code", feishuCtx)
 	require.Equal(t, expected, env.SessionID)
 
 	data, ok := env.Event.Data.(map[string]any)

--- a/internal/messaging/integration_test.go
+++ b/internal/messaging/integration_test.go
@@ -110,7 +110,7 @@ func (m *mockHub) NextSeq(sessionID string) int64 { return 1 }
 
 var uuidV5Regex = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`)
 
-func TestBridge_MakeSlackEnvelope(t *testing.T) {
+func TestBridge_MakeEnvelope_Slack(t *testing.T) {
 	t.Parallel()
 
 	teamID := "T123"
@@ -160,7 +160,7 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 	require.Equal(t, text, data["content"])
 }
 
-func TestBridge_MakeFeishuEnvelope(t *testing.T) {
+func TestBridge_MakeEnvelope_Feishu(t *testing.T) {
 	t.Parallel()
 
 	chatID := "oc_abc123"

--- a/internal/messaging/integration_test.go
+++ b/internal/messaging/integration_test.go
@@ -129,7 +129,14 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 		config.Default().Worker.DefaultWorkDir,
 	)
 
-	env := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "", "")
+	env := br.MakeEnvelope(userID, text, session.PlatformContext{
+		Platform:  "slack",
+		TeamID:    teamID,
+		ChannelID: channelID,
+		ThreadTS:  threadTS,
+		UserID:    userID,
+		WorkDir:   config.Default().Worker.DefaultWorkDir,
+	})
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
@@ -137,7 +144,14 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 	require.Equal(t, userID, env.OwnerID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, "", "")
+	env2 := br.MakeEnvelope(userID, text, session.PlatformContext{
+		Platform:  "slack",
+		TeamID:    teamID,
+		ChannelID: channelID,
+		ThreadTS:  threadTS,
+		UserID:    userID,
+		WorkDir:   config.Default().Worker.DefaultWorkDir,
+	})
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.
@@ -175,14 +189,26 @@ func TestBridge_MakeFeishuEnvelope(t *testing.T) {
 		config.Default().Worker.DefaultWorkDir,
 	)
 
-	env := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "", "")
+	env := br.MakeEnvelope(userID, text, session.PlatformContext{
+		Platform: "feishu",
+		ChatID:   chatID,
+		ThreadTS: threadTS,
+		UserID:   userID,
+		WorkDir:  config.Default().Worker.DefaultWorkDir,
+	})
 	require.NotNil(t, env)
 
 	// Session ID is now a UUIDv5 derived from platform context.
 	require.Regexp(t, uuidV5Regex, env.SessionID)
 
 	// Deterministic: same inputs produce the same UUIDv5.
-	env2 := br.MakeFeishuEnvelope(chatID, threadTS, userID, text, "", "")
+	env2 := br.MakeEnvelope(userID, text, session.PlatformContext{
+		Platform: "feishu",
+		ChatID:   chatID,
+		ThreadTS: threadTS,
+		UserID:   userID,
+		WorkDir:  config.Default().Worker.DefaultWorkDir,
+	})
 	require.Equal(t, env.SessionID, env2.SessionID)
 
 	// Matches the underlying derivation function.

--- a/internal/messaging/integration_test.go
+++ b/internal/messaging/integration_test.go
@@ -125,7 +125,6 @@ func TestBridge_MakeSlackEnvelope(t *testing.T) {
 		&mockHub{},
 		nil,
 		nil,
-		nil,
 		"claude_code",
 		config.Default().Worker.DefaultWorkDir,
 	)
@@ -170,7 +169,6 @@ func TestBridge_MakeFeishuEnvelope(t *testing.T) {
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		PlatformFeishu,
 		&mockHub{},
-		nil,
 		nil,
 		nil,
 		"claude_code",

--- a/internal/messaging/platform_adapter.go
+++ b/internal/messaging/platform_adapter.go
@@ -132,7 +132,6 @@ type PlatformAdapter struct {
 	Log *slog.Logger
 
 	hub     HubInterface
-	sm      SessionManager
 	handler HandlerInterface
 	bridge  *Bridge
 
@@ -157,10 +156,6 @@ type HandlerInterface interface {
 	Handle(ctx context.Context, env *events.Envelope) error
 }
 
-// SessionManager is an opaque interface for session management.
-// Platform adapters don't call session creation directly; the bridge handles it.
-type SessionManager any
-
 // SessionStarter creates a new gateway session for a platform message.
 // Implemented by gateway.Bridge and injected during wiring.
 type SessionStarter interface {
@@ -173,7 +168,6 @@ func (a *PlatformAdapter) Bridge() *Bridge { return a.bridge }
 // ConfigureWith sets the common adapter dependencies from config.
 func (a *PlatformAdapter) ConfigureWith(config AdapterConfig) error {
 	a.hub = config.Hub
-	a.sm = config.SM
 	a.handler = config.Handler
 	a.bridge = config.Bridge
 	return nil

--- a/internal/messaging/platform_adapter.go
+++ b/internal/messaging/platform_adapter.go
@@ -1,130 +1,10 @@
 package messaging
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
-	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/hrygo/hotplex/pkg/events"
 )
-
-// PlatformType identifies the messaging platform.
-type PlatformType string
-
-const (
-	PlatformSlack  PlatformType = "slack"
-	PlatformFeishu PlatformType = "feishu"
-)
-
-// ExtractPlatformKeys pulls platform-specific fields from generic metadata.
-func (p PlatformType) ExtractPlatformKeys(md map[string]any) map[string]string {
-	pk := make(map[string]string)
-	switch p {
-	case PlatformFeishu:
-		if v, ok := md["chat_id"].(string); ok && v != "" {
-			pk["chat_id"] = v
-		}
-		if v, ok := md["thread_ts"].(string); ok {
-			pk["thread_ts"] = v
-		}
-		if v, ok := md["user_id"].(string); ok && v != "" {
-			pk["user_id"] = v
-		}
-	case PlatformSlack:
-		if v, ok := md["team_id"].(string); ok && v != "" {
-			pk["team_id"] = v
-		}
-		if v, ok := md["channel_id"].(string); ok && v != "" {
-			pk["channel_id"] = v
-		}
-		if v, ok := md["thread_ts"].(string); ok {
-			pk["thread_ts"] = v
-		}
-		if v, ok := md["user_id"].(string); ok && v != "" {
-			pk["user_id"] = v
-		}
-	}
-	// bot_id is platform-agnostic — extracted for all platform types.
-	if v, ok := md["bot_id"].(string); ok && v != "" {
-		pk["bot_id"] = v
-	}
-	return pk
-}
-
-// PlatformAdapterInterface is the minimal interface that all platform adapters must implement.
-type PlatformAdapterInterface interface {
-	// Platform returns the platform type identifier.
-	Platform() PlatformType
-
-	// Start initiates the platform connection.
-	// It must be non-blocking: long-running setup runs in background goroutines.
-	Start(ctx context.Context) error
-
-	// HandleTextMessage processes an incoming text message from the platform.
-	// The adapter maps the platform message to an AEP Envelope and delegates to PlatformBridge.Handle.
-	// teamID and threadTS are optional; adapters that don't use them should ignore them.
-	HandleTextMessage(ctx context.Context, platformMsgID, channelID, teamID, threadTS, userID, text string) error
-
-	// Close gracefully terminates the platform connection.
-	Close(ctx context.Context) error
-
-	// ConfigureWith applies a unified configuration to the adapter.
-	ConfigureWith(config AdapterConfig) error
-
-	// GetBotID returns the platform bot identity (Slack UserID, Feishu OpenID, etc.).
-	GetBotID() string
-}
-
-// CronResultSender sends a cron job execution result to a platform target.
-type CronResultSender interface {
-	SendCronResult(ctx context.Context, text string, platformKey map[string]string) error
-}
-
-// AdapterBuilder creates a new adapter instance.
-type AdapterBuilder func(log *slog.Logger) PlatformAdapterInterface
-
-var (
-	registryMu sync.RWMutex
-	registry   = make(map[PlatformType]AdapterBuilder)
-)
-
-// Register records an adapter builder under its platform type.
-func Register(pt PlatformType, builder AdapterBuilder) {
-	registryMu.Lock()
-	defer registryMu.Unlock()
-	if builder == nil {
-		panic(fmt.Sprintf("messaging: nil builder for platform %q", pt))
-	}
-	if _, exists := registry[pt]; exists {
-		panic(fmt.Sprintf("messaging: duplicate registration for platform %q", pt))
-	}
-	registry[pt] = builder
-}
-
-// New creates an adapter by type.
-func New(pt PlatformType, log *slog.Logger) (PlatformAdapterInterface, error) {
-	registryMu.RLock()
-	b, ok := registry[pt]
-	registryMu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("messaging: unknown platform %q", pt)
-	}
-	return b(log.With("platform", string(pt))), nil
-}
-
-// RegisteredTypes returns all registered platform types.
-func RegisteredTypes() []PlatformType {
-	registryMu.RLock()
-	defer registryMu.RUnlock()
-	types := make([]PlatformType, 0, len(registry))
-	for pt := range registry {
-		types = append(types, pt)
-	}
-	return types
-}
 
 // PlatformAdapter is the base type for all messaging platform adapters.
 // Each adapter embeds this struct and implements Start, HandleTextMessage, and Close.
@@ -143,23 +23,6 @@ type PlatformAdapter struct {
 	Interactions     *InteractionManager
 	BackoffBaseDelay time.Duration
 	BackoffMaxDelay  time.Duration
-}
-
-// HubInterface is the subset of gateway.Hub methods needed by platform adapters.
-type HubInterface interface {
-	JoinPlatformSession(sessionID string, pc PlatformConn)
-	NextSeq(sessionID string) int64
-}
-
-// HandlerInterface is the subset of gateway.Handler methods needed by platform adapters.
-type HandlerInterface interface {
-	Handle(ctx context.Context, env *events.Envelope) error
-}
-
-// SessionStarter creates a new gateway session for a platform message.
-// Implemented by gateway.Bridge and injected during wiring.
-type SessionStarter interface {
-	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
 }
 
 // Bridge returns the messaging bridge.

--- a/internal/messaging/platform_interfaces.go
+++ b/internal/messaging/platform_interfaces.go
@@ -1,0 +1,53 @@
+package messaging
+
+import (
+	"context"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// PlatformAdapterInterface is the minimal interface that all platform adapters must implement.
+type PlatformAdapterInterface interface {
+	// Platform returns the platform type identifier.
+	Platform() PlatformType
+
+	// Start initiates the platform connection.
+	// It must be non-blocking: long-running setup runs in background goroutines.
+	Start(ctx context.Context) error
+
+	// HandleTextMessage processes an incoming text message from the platform.
+	// The adapter maps the platform message to an AEP Envelope and delegates to PlatformBridge.Handle.
+	// teamID and threadTS are optional; adapters that don't use them should ignore them.
+	HandleTextMessage(ctx context.Context, platformMsgID, channelID, teamID, threadTS, userID, text string) error
+
+	// Close gracefully terminates the platform connection.
+	Close(ctx context.Context) error
+
+	// ConfigureWith applies a unified configuration to the adapter.
+	ConfigureWith(config AdapterConfig) error
+
+	// GetBotID returns the platform bot identity (Slack UserID, Feishu OpenID, etc.).
+	GetBotID() string
+}
+
+// CronResultSender sends a cron job execution result to a platform target.
+type CronResultSender interface {
+	SendCronResult(ctx context.Context, text string, platformKey map[string]string) error
+}
+
+// HubInterface is the subset of gateway.Hub methods needed by platform adapters.
+type HubInterface interface {
+	JoinPlatformSession(sessionID string, pc PlatformConn)
+	NextSeq(sessionID string) int64
+}
+
+// HandlerInterface is the subset of gateway.Handler methods needed by platform adapters.
+type HandlerInterface interface {
+	Handle(ctx context.Context, env *events.Envelope) error
+}
+
+// SessionStarter creates a new gateway session for a platform message.
+// Implemented by gateway.Bridge and injected during wiring.
+type SessionStarter interface {
+	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, platform string, platformKey map[string]string, botID string) error
+}

--- a/internal/messaging/platform_registry.go
+++ b/internal/messaging/platform_registry.go
@@ -1,0 +1,50 @@
+package messaging
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// AdapterBuilder creates a new adapter instance.
+type AdapterBuilder func(log *slog.Logger) PlatformAdapterInterface
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[PlatformType]AdapterBuilder)
+)
+
+// Register records an adapter builder under its platform type.
+func Register(pt PlatformType, builder AdapterBuilder) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if builder == nil {
+		panic(fmt.Sprintf("messaging: nil builder for platform %q", pt))
+	}
+	if _, exists := registry[pt]; exists {
+		panic(fmt.Sprintf("messaging: duplicate registration for platform %q", pt))
+	}
+	registry[pt] = builder
+}
+
+// New creates an adapter by type.
+func New(pt PlatformType, log *slog.Logger) (PlatformAdapterInterface, error) {
+	registryMu.RLock()
+	b, ok := registry[pt]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("messaging: unknown platform %q", pt)
+	}
+	return b(log.With("platform", string(pt))), nil
+}
+
+// RegisteredTypes returns all registered platform types.
+func RegisteredTypes() []PlatformType {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	types := make([]PlatformType, 0, len(registry))
+	for pt := range registry {
+		types = append(types, pt)
+	}
+	return types
+}

--- a/internal/messaging/platform_types.go
+++ b/internal/messaging/platform_types.go
@@ -1,0 +1,44 @@
+package messaging
+
+// PlatformType identifies the messaging platform.
+type PlatformType string
+
+const (
+	PlatformSlack  PlatformType = "slack"
+	PlatformFeishu PlatformType = "feishu"
+)
+
+// ExtractPlatformKeys pulls platform-specific fields from generic metadata.
+func (p PlatformType) ExtractPlatformKeys(md map[string]any) map[string]string {
+	pk := make(map[string]string)
+	switch p {
+	case PlatformFeishu:
+		if v, ok := md["chat_id"].(string); ok && v != "" {
+			pk["chat_id"] = v
+		}
+		if v, ok := md["thread_ts"].(string); ok {
+			pk["thread_ts"] = v
+		}
+		if v, ok := md["user_id"].(string); ok && v != "" {
+			pk["user_id"] = v
+		}
+	case PlatformSlack:
+		if v, ok := md["team_id"].(string); ok && v != "" {
+			pk["team_id"] = v
+		}
+		if v, ok := md["channel_id"].(string); ok && v != "" {
+			pk["channel_id"] = v
+		}
+		if v, ok := md["thread_ts"].(string); ok {
+			pk["thread_ts"] = v
+		}
+		if v, ok := md["user_id"].(string); ok && v != "" {
+			pk["user_id"] = v
+		}
+	}
+	// bot_id is platform-agnostic — extracted for all platform types.
+	if v, ok := md["bot_id"].(string); ok && v != "" {
+		pk["bot_id"] = v
+	}
+	return pk
+}

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/phrases"
 	"github.com/hrygo/hotplex/internal/messaging/stt"
+	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/pkg/events"
 
 	"runtime/debug"
@@ -544,7 +545,7 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 		return fmt.Errorf("slack: adapter closed, dropping message for channel %s", channelID)
 	}
 
-	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, text, conn.WorkDir(), a.botID)
+	envelope := a.makeEnvelope(teamID, channelID, threadTS, userID, text, conn.WorkDir())
 	if envelope == nil {
 		return fmt.Errorf("slack: failed to build envelope")
 	}
@@ -553,6 +554,22 @@ func (a *Adapter) HandleTextMessage(ctx context.Context, platformMsgID, channelI
 	msgCtx, cancel := context.WithTimeout(ctx, handlerMsgTimeout)
 	defer cancel()
 	return a.Bridge().Handle(msgCtx, envelope, conn)
+}
+
+// makeEnvelope builds an AEP input envelope for a Slack message.
+func (a *Adapter) makeEnvelope(teamID, channelID, threadTS, userID, text, workDir string) *events.Envelope {
+	if workDir == "" {
+		workDir = a.Bridge().WorkDir()
+	}
+	return a.Bridge().MakeEnvelope(userID, text, session.PlatformContext{
+		Platform:  string(messaging.PlatformSlack),
+		BotID:     a.botID,
+		TeamID:    teamID,
+		ChannelID: channelID,
+		ThreadTS:  threadTS,
+		UserID:    userID,
+		WorkDir:   workDir,
+	})
 }
 
 // NewStreamingWriter creates a streaming writer for the given channel/thread.
@@ -661,7 +678,7 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelI
 		return
 	}
 
-	env := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir(), a.botID)
+	env := a.makeEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir())
 	if env == nil {
 		a.Log.Warn("slack: text control command failed to derive session", "action", result.Label)
 		return
@@ -722,7 +739,7 @@ func (a *Adapter) handleTextWorkerCommand(ctx context.Context, teamID, channelID
 		return
 	}
 
-	envelope := a.Bridge().MakeSlackEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir(), a.botID)
+	envelope := a.makeEnvelope(teamID, channelID, threadTS, userID, "", conn.WorkDir())
 	if envelope == nil {
 		a.Log.Warn("slack: worker command failed to derive session", "command", result.Label)
 		return

--- a/internal/messaging/slack/adapter_test.go
+++ b/internal/messaging/slack/adapter_test.go
@@ -1914,6 +1914,52 @@ func TestAdapter_Platform(t *testing.T) {
 	require.Equal(t, messaging.PlatformSlack, a.Platform())
 }
 
+func TestAdapter_MakeEnvelope(t *testing.T) {
+	t.Parallel()
+
+	br := messaging.NewBridge(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		messaging.PlatformSlack,
+		nil, nil, nil,
+		"claude_code", "/tmp/hotplex/workspace",
+	)
+
+	a := &Adapter{botID: "B123"}
+	err := a.ConfigureWith(messaging.AdapterConfig{Bridge: br})
+	require.NoError(t, err)
+
+	env := a.makeEnvelope("T1", "C1", "1234.56", "U1", "hello", "")
+
+	require.NotNil(t, env)
+	require.Equal(t, "U1", env.OwnerID)
+	require.NotEmpty(t, env.SessionID)
+
+	data, ok := env.Event.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "hello", data["content"])
+}
+
+func TestAdapter_MakeEnvelope_CustomWorkDir(t *testing.T) {
+	t.Parallel()
+
+	br := messaging.NewBridge(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		messaging.PlatformSlack,
+		nil, nil, nil,
+		"claude_code", "/default",
+	)
+
+	a := &Adapter{botID: "B123"}
+	err := a.ConfigureWith(messaging.AdapterConfig{Bridge: br})
+	require.NoError(t, err)
+
+	env1 := a.makeEnvelope("T1", "C1", "", "U1", "hi", "/custom")
+	env2 := a.makeEnvelope("T1", "C1", "", "U1", "hi", "")
+
+	// Different workDir → different session ID.
+	require.NotEqual(t, env1.SessionID, env2.SessionID)
+}
+
 // ---------------------------------------------------------------------------
 // WriteCtx interaction events close stream writer
 // ---------------------------------------------------------------------------

--- a/internal/messaging/slack/adapter_test.go
+++ b/internal/messaging/slack/adapter_test.go
@@ -1891,7 +1891,7 @@ func TestAdapter_ConfigureWith_BridgeSetsWorkDir(t *testing.T) {
 	testBridge := messaging.NewBridge(
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		messaging.PlatformSlack,
-		nil, nil, nil, nil, "claude_code", "/tmp/hotplex/workspace",
+		nil, nil, nil, "claude_code", "/tmp/hotplex/workspace",
 	)
 
 	a := &Adapter{}

--- a/internal/messaging/slack/e2e_semi_test.go
+++ b/internal/messaging/slack/e2e_semi_test.go
@@ -247,7 +247,7 @@ func TestSemi_AssistantProbeResult(t *testing.T) {
 // TestSemi_SessionIDFormat verifies that session IDs produced from real
 // Slack events have the correct 4-segment slack:{team}:{channel}:{thread}:{user} format.
 //
-// AC: 2.1-2 — MakeSlackEnvelope receives correct teamID/threadTS
+// AC: 2.1-2 — adapter.makeEnvelope receives correct teamID/threadTS
 // AC: 2.1-3 — session ID four segments complete
 // AC: 2.1-4 — threadTS empty when no thread (DM)
 func TestSemi_SessionIDFormat(t *testing.T) {

--- a/internal/messaging/slack/e2e_semi_test.go
+++ b/internal/messaging/slack/e2e_semi_test.go
@@ -113,7 +113,6 @@ func startRealAdapter(t *testing.T, cfg semiConfig) (*Adapter, *[]capturedCall, 
 		logger,
 		messaging.PlatformSlack,
 		nil, // hub
-		nil, // sm
 		handler,
 		nil,    // starter
 		"noop", // use noop worker to avoid launching real AI

--- a/internal/messaging/slack/e2e_test.go
+++ b/internal/messaging/slack/e2e_test.go
@@ -93,8 +93,7 @@ func newAdapterWithCapture(t *testing.T) (*Adapter, *[]capturedCall) {
 	bridge := messaging.NewBridge(
 		slog.Default(),
 		messaging.PlatformSlack,
-		nil, // hub (nil → JoinPlatformSession is no-op)
-		nil, // sm
+		nil, // hub (nil JoinPlatformSession is no-op)
 		handler,
 		nil, // starter
 		"test_worker",

--- a/internal/messaging/slack/slash_command.go
+++ b/internal/messaging/slack/slash_command.go
@@ -152,7 +152,7 @@ func (a *Adapter) deriveSessionIDFromCommand(cmd slack.SlashCommand) string {
 	if conn != nil {
 		workDir = conn.WorkDir()
 	}
-	envelope := a.Bridge().MakeSlackEnvelope(cmd.TeamID, cmd.ChannelID, "", cmd.UserID, "", workDir, a.botID)
+	envelope := a.makeEnvelope(cmd.TeamID, cmd.ChannelID, "", cmd.UserID, "", workDir)
 	if envelope == nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

Batch PR addressing messaging layer SOLID refactor (#337) and test coverage (#383). 5 atomic commits, `make check` passes.

## Changes

### #337 — SOLID + coupling findings (4 commits)

| Commit | Finding | Change |
|--------|---------|--------|
| c1a5215 | ISP: `SessionManager` empty interface | Removed `type SessionManager any`, `PlatformAdapter.sm`, `AdapterConfig.SM`, `Bridge.sm` — dead dependency eliminated |
| 9751f5c | DRY: 4 parallel command maps | Introduced `CommandMap[T]` generic type with `Lookup()`, unified `controlCommands` and `workerCommands` |
| d35fcf5 | OCP: Bridge platform-specific methods | Removed `MakeSlackEnvelope`/`MakeFeishuEnvelope` from Bridge; adapters now own `makeEnvelope` helpers, Bridge is platform-agnostic |
| bd26fb0 | SRP: platform_adapter.go mixed responsibilities | Split into 4 files: `platform_types.go`, `platform_interfaces.go`, `platform_registry.go`, `platform_adapter.go` |

### #383 — Test coverage (1 commit)

| Commit | Finding | Change |
|--------|---------|--------|
| a05ca38 | tool_status.go 116 lines untested | Added 67 table-driven subtests covering `renderToolActivity`, `extractToolCallData`, `extractToolResultData`, `runeWidth`, `truncateVisual` |

## Files Changed

- `internal/messaging/platform_adapter.go` — PlatformAdapter struct only (SRP split)
- `internal/messaging/platform_types.go` — PlatformType + constants + ExtractPlatformKeys (new)
- `internal/messaging/platform_interfaces.go` — All interfaces (new)
- `internal/messaging/platform_registry.go` — Register/New/RegisteredTypes (new)
- `internal/messaging/config.go` — Removed SM field
- `internal/messaging/bridge.go` — Removed sm field, MakeSlackEnvelope, MakeFeishuEnvelope
- `internal/messaging/control_command.go` — CommandMap[T] generic type
- `internal/messaging/slack/adapter.go` — Added makeEnvelope helper
- `internal/messaging/slack/slash_command.go` — Uses adapter.makeEnvelope
- `internal/messaging/feishu/handler.go` — Added makeEnvelope helper
- `internal/messaging/feishu/tool_status_test.go` — 67 subtests (new)
- `cmd/hotplex/messaging_init.go` — Removed SM parameter

## Testing

- [x] `make check` passes (lint + test + build)
- [x] All existing messaging tests pass with `-race`
- [x] 67 new table-driven tests for tool_status.go
- [x] Bridge tests updated for MakeEnvelope migration
- [x] Zero regressions in integration tests

Closes #337, Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)