### PR TITLE
fix(test): eliminate SQLITE_BUSY flaky tests

### DIFF
--- a/.github/actions/setup-go-webchat/action.yml
+++ b/.github/actions/setup-go-webchat/action.yml
@@ -40,7 +40,7 @@ runs:
         path: internal/webchat/out
         key: webchat-v2-${{ hashFiles('webchat/app/**', 'webchat/components/**', 'webchat/context/**', 'webchat/hooks/**', 'webchat/lib/**', 'webchat/public/**', 'webchat/types/**', 'webchat/next.config.*', 'webchat/package.json', 'webchat/pnpm-lock.yaml') }}
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v4.1.0
       if: steps.webchat-cache.outputs.cache-hit != 'true'
       with:
         version: ${{ inputs.pnpm-version }}

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -107,7 +108,8 @@ func newHandlerWithRealStore(t *testing.T) (*Handler, *session.Manager, *Hub, fu
 	cleanup := func() { os.Remove(tmpPath) }
 
 	cfg.DB.Path = tmpPath
-	store, err := session.NewSQLiteStore(context.Background(), cfg, nil)
+	writeMu := sqlutil.NewWriteMu(sqlutil.DialectSQLite)
+	store, err := session.NewSQLiteStore(context.Background(), cfg, writeMu)
 	require.NoError(t, err)
 	mgr, err := session.NewManager(context.Background(), slog.Default(), cfg, nil, store)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Add `sqlutil.WriteMu` to `newHandlerWithRealStore` in gateway ctrl_test.go to serialize SQLite WAL writes across parallel tests

## Why
Parallel test execution caused intermittent `SQLITE_BUSY` errors when multiple goroutines wrote to the same temporary database simultaneously. The `WriteMu` mutex serializes writes, eliminating the race condition.

## Test plan
- [x] `go test -race -count=5 -run TestHandleInput ./internal/gateway/` passes
- [x] `go vet ./...` passes
- [x] Pre-commit hooks pass (gofmt + golangci-lint)