### PR TITLE
perf(test): parameterize time constants to reduce CI wait times

### DIFF
--- a/e2e/session_test.go
+++ b/e2e/session_test.go
@@ -167,7 +167,7 @@ func TestE2E_ResumeSession(t *testing.T) {
 
 			err = c1.SendInput(context.Background(), "first message")
 			require.NoError(t, err)
-			_ = collectEvents(t, c1.Events(), 5*time.Second)
+			_ = collectEvents(t, c1.Events(), 500*time.Millisecond)
 
 			// Close first connection — session goes to IDLE.
 			require.NoError(t, c1.Close())
@@ -212,7 +212,7 @@ func TestE2E_CloseGracefully(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(time.Second):
 		t.Fatal("Close() blocked for too long")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -563,6 +563,7 @@ type CodexCLIConfig struct {
 	Ephemeral       bool          `mapstructure:"ephemeral"`         // ephemeral sessions, default true
 	Personality     string        `mapstructure:"personality"`       // agent personality for app-server mode, default "friendly"
 	StartupTimeout  time.Duration `mapstructure:"startup_timeout"`   // process startup timeout, default 30s
+	CallTimeout     time.Duration `mapstructure:"call_timeout"`      // JSON-RPC call timeout, default 30s
 	UseAppServer    bool          `mapstructure:"use_app_server"`    // use persistent app-server mode instead of one-shot exec
 	IdleDrainPeriod time.Duration `mapstructure:"idle_drain_period"` // idle drain timeout for app-server mode, default 30m
 }
@@ -738,6 +739,7 @@ func Default() *Config {
 				Ephemeral:       true,
 				Personality:     "friendly",
 				StartupTimeout:  30 * time.Second,
+				CallTimeout:     30 * time.Second,
 				UseAppServer:    true,
 				IdleDrainPeriod: 30 * time.Minute,
 			},

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -91,6 +91,9 @@ type Collector struct {
 	closeWg  sync.WaitGroup
 	log      *slog.Logger
 
+	flushInterval time.Duration // ticker interval for batch flush (default: collectorFlushInterval)
+	deltaFlush    time.Duration // max age before flushing accumulated deltas (default: deltaFlushInterval)
+
 	accumMu        sync.Mutex
 	accum          map[string]*deltaAccumulator // sessionID → active delta accumulator
 	reasoningAccum map[string]*deltaAccumulator // sessionID → active reasoning accumulator
@@ -99,11 +102,22 @@ type Collector struct {
 
 // NewCollector creates a Collector that writes events to store.
 func NewCollector(store EventStore, log *slog.Logger) *Collector {
+	return newCollector(store, log, collectorFlushInterval, deltaFlushInterval)
+}
+
+// NewCollectorWithIntervals creates a Collector with custom flush intervals (for tests).
+func NewCollectorWithIntervals(store EventStore, log *slog.Logger, flush, deltaFlush time.Duration) *Collector {
+	return newCollector(store, log, flush, deltaFlush)
+}
+
+func newCollector(store EventStore, log *slog.Logger, flush, deltaFlush time.Duration) *Collector {
 	c := &Collector{
 		store:          store,
 		captureC:       make(chan *captureRequest, collectorChanCap),
 		closeC:         make(chan struct{}),
 		log:            log.With("component", "eventstore-collector"),
+		flushInterval:  flush,
+		deltaFlush:     deltaFlush,
 		accum:          make(map[string]*deltaAccumulator),
 		reasoningAccum: make(map[string]*deltaAccumulator),
 	}
@@ -343,7 +357,7 @@ func (c *Collector) DroppedEvents() int64 {
 func (c *Collector) runWriter() {
 	defer c.closeWg.Done()
 
-	ticker := time.NewTicker(collectorFlushInterval)
+	ticker := time.NewTicker(c.flushInterval)
 	defer ticker.Stop()
 
 	var batch []*captureRequest
@@ -399,13 +413,13 @@ func (c *Collector) flushTimedOutAccumulators(batch *[]*captureRequest) {
 	now := time.Now()
 	c.accumMu.Lock()
 	for sid, acc := range c.accum {
-		if now.Sub(acc.firstSeenAt) >= deltaFlushInterval {
+		if now.Sub(acc.firstSeenAt) >= c.deltaFlush {
 			delete(c.accum, sid)
 			*batch = append(*batch, acc.toRequest(sid))
 		}
 	}
 	for sid, acc := range c.reasoningAccum {
-		if now.Sub(acc.firstSeenAt) >= deltaFlushInterval {
+		if now.Sub(acc.firstSeenAt) >= c.deltaFlush {
 			delete(c.reasoningAccum, sid)
 			*batch = append(*batch, acc.toRequest(sid))
 		}

--- a/internal/eventstore/collector_test.go
+++ b/internal/eventstore/collector_test.go
@@ -221,14 +221,14 @@ func TestCollector_TimerFlush(t *testing.T) {
 	}
 
 	store := newTestStore(t)
-	c := NewCollector(store, slog.Default())
+	c := NewCollectorWithIntervals(store, slog.Default(), 50*time.Millisecond, 100*time.Millisecond)
 	defer func() { _ = c.Close() }()
 
 	// Accumulate small content (< 4096) so size trigger won't fire
 	c.CaptureDeltaString("s1", 1, "chunk1")
 	c.CaptureDeltaString("s1", 2, "chunk2")
 
-	// Wait for timer trigger (deltaFlushInterval + ticker margin)
+	// Wait for timer trigger (deltaFlush + ticker margin)
 	require.Eventually(t, func() bool {
 		page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
 		if err != nil || len(page.Events) != 1 {
@@ -242,7 +242,7 @@ func TestCollector_TimerFlush(t *testing.T) {
 			return false
 		}
 		return data["content"] == "chunk1chunk2"
-	}, deltaFlushInterval+collectorFlushInterval+2*time.Second, 200*time.Millisecond, "expected flushed message event")
+	}, 500*time.Millisecond, 50*time.Millisecond, "expected flushed message event")
 }
 
 func TestCollector_ResetSessionEmptyFlush(t *testing.T) {
@@ -376,7 +376,7 @@ func TestCollector_ReasoningTimerFlush(t *testing.T) {
 	}
 
 	store := newTestStore(t)
-	c := NewCollector(store, slog.Default())
+	c := NewCollectorWithIntervals(store, slog.Default(), 50*time.Millisecond, 100*time.Millisecond)
 	defer func() { _ = c.Close() }()
 
 	c.CaptureReasoningString("s1", 1, "think1")
@@ -395,7 +395,7 @@ func TestCollector_ReasoningTimerFlush(t *testing.T) {
 			return false
 		}
 		return data["content"] == "think1think2"
-	}, deltaFlushInterval+collectorFlushInterval+2*time.Second, 200*time.Millisecond, "expected flushed reasoning event")
+	}, 500*time.Millisecond, 50*time.Millisecond, "expected flushed reasoning event")
 }
 
 func TestCollector_CaptureReasoningViaCapture(t *testing.T) {

--- a/internal/gateway/llm_retry_test.go
+++ b/internal/gateway/llm_retry_test.go
@@ -312,7 +312,7 @@ func TestLLMRetryController_UpdateConfig_InvalidPattern(t *testing.T) {
 
 func TestLLMRetryController_ConcurrentShouldRetryAndUpdateConfig(t *testing.T) {
 	ctrl := NewLLMRetryController(config.AutoRetryConfig{Enabled: true, MaxRetries: 10}, slog.Default())
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	var wg sync.WaitGroup

--- a/internal/messaging/feishu/rate_limiter.go
+++ b/internal/messaging/feishu/rate_limiter.go
@@ -29,9 +29,14 @@ type FeishuRateLimiter struct {
 
 // NewFeishuRateLimiter creates a rate limiter with standard intervals.
 func NewFeishuRateLimiter() *FeishuRateLimiter {
+	return NewFeishuRateLimiterWithLimits(100*time.Millisecond, 1500*time.Millisecond)
+}
+
+// NewFeishuRateLimiterWithLimits creates a rate limiter with custom intervals (for tests).
+func NewFeishuRateLimiterWithLimits(cardKit, patch time.Duration) *FeishuRateLimiter {
 	return &FeishuRateLimiter{
-		cardKitLimit: 100 * time.Millisecond,
-		patchLimit:   1500 * time.Millisecond,
+		cardKitLimit: cardKit,
+		patchLimit:   patch,
 		lastCardKit:  make(map[string]time.Time),
 		lastPatch:    make(map[string]time.Time),
 		done:         make(chan struct{}),

--- a/internal/messaging/feishu/rate_limiter_test.go
+++ b/internal/messaging/feishu/rate_limiter_test.go
@@ -120,7 +120,7 @@ func TestFeishuRateLimiter_AllowCardKit(t *testing.T) {
 func TestFeishuRateLimiter_AllowPatch(t *testing.T) {
 	t.Parallel()
 
-	rl := NewFeishuRateLimiter()
+	rl := NewFeishuRateLimiterWithLimits(10*time.Millisecond, 50*time.Millisecond)
 
 	msgID := "msg123"
 
@@ -128,8 +128,8 @@ func TestFeishuRateLimiter_AllowPatch(t *testing.T) {
 	require.True(t, rl.AllowPatch(msgID), "first request should be allowed")
 
 	// Immediate second request should be rate limited
-	require.False(t, rl.AllowPatch(msgID), "second request within 1500ms should be rate limited")
+	require.False(t, rl.AllowPatch(msgID), "second request within cooldown should be rate limited")
 
 	// After waiting, request should be allowed
-	require.Eventually(t, func() bool { return rl.AllowPatch(msgID) }, 3*time.Second, 100*time.Millisecond, "request after cooldown should be allowed")
+	require.Eventually(t, func() bool { return rl.AllowPatch(msgID) }, 300*time.Millisecond, 10*time.Millisecond, "request after cooldown should be allowed")
 }

--- a/internal/messaging/slack/slash_command.go
+++ b/internal/messaging/slack/slash_command.go
@@ -23,13 +23,20 @@ const (
 
 // SlashRateLimiter provides per-user cooldown for slash commands.
 type SlashRateLimiter struct {
-	cache *TTLCache[string, time.Time]
+	cache    *TTLCache[string, time.Time]
+	cooldown time.Duration
 }
 
 // NewSlashRateLimiter creates a new slash command rate limiter.
 func NewSlashRateLimiter() *SlashRateLimiter {
+	return NewSlashRateLimiterWithCooldown(slashCooldown)
+}
+
+// NewSlashRateLimiterWithCooldown creates a slash command rate limiter with a custom cooldown.
+func NewSlashRateLimiterWithCooldown(cooldown time.Duration) *SlashRateLimiter {
 	return &SlashRateLimiter{
-		cache: NewTTLCache[string, time.Time](slashEntryTTL, slashSweepInterval),
+		cache:    NewTTLCache[string, time.Time](slashEntryTTL, slashSweepInterval),
+		cooldown: cooldown,
 	}
 }
 
@@ -40,7 +47,7 @@ func (r *SlashRateLimiter) Allow(userID string) bool {
 	r.cache.Do(func(items map[string]ttlEntry[time.Time]) {
 		now := time.Now()
 		e, ok := items[userID]
-		if ok && now.Sub(e.Value) < slashCooldown {
+		if ok && now.Sub(e.Value) < r.cooldown {
 			return
 		}
 		items[userID] = ttlEntry[time.Time]{

--- a/internal/messaging/slack/slash_command_test.go
+++ b/internal/messaging/slack/slash_command_test.go
@@ -10,7 +10,8 @@ import (
 func TestSlashRateLimiter_Allow(t *testing.T) {
 	t.Parallel()
 
-	rl := NewSlashRateLimiter()
+	cooldown := 100 * time.Millisecond
+	rl := NewSlashRateLimiterWithCooldown(cooldown)
 	defer rl.Stop()
 
 	userID := "U123"
@@ -18,7 +19,7 @@ func TestSlashRateLimiter_Allow(t *testing.T) {
 	require.True(t, rl.Allow(userID), "first request should be allowed")
 	require.False(t, rl.Allow(userID), "second request within cooldown should be rate limited")
 
-	require.Eventually(t, func() bool { return rl.Allow(userID) }, slashCooldown+2*time.Second, 100*time.Millisecond, "request after cooldown should be allowed")
+	require.Eventually(t, func() bool { return rl.Allow(userID) }, cooldown+200*time.Millisecond, 20*time.Millisecond, "request after cooldown should be allowed")
 }
 
 func TestSlashRateLimiter_DifferentUsers(t *testing.T) {

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -209,7 +209,11 @@ func (m *CodexAppServerManager) Call(method string, params any) (json.RawMessage
 		return nil, fmt.Errorf("codex-app-server: write request: %w", err)
 	}
 
-	timer := time.NewTimer(defaultCallTimeout)
+	callTimeout := m.cfg.CallTimeout
+	if callTimeout <= 0 {
+		callTimeout = defaultCallTimeout
+	}
+	timer := time.NewTimer(callTimeout)
 	defer timer.Stop()
 
 	select {
@@ -221,7 +225,7 @@ func (m *CodexAppServerManager) Call(method string, params any) (json.RawMessage
 		return resp.Result, nil
 	case <-timer.C:
 		return nil, fmt.Errorf("codex-app-server: %s: timeout after %v",
-			method, defaultCallTimeout)
+			method, callTimeout)
 	}
 }
 

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -843,7 +843,7 @@ func TestExecWorkerBuildArgsWithModel(t *testing.T) {
 
 func newTestAppServerWorker(t *testing.T) *AppServerWorker {
 	t.Helper()
-	cfg := config.CodexCLIConfig{IdleDrainPeriod: time.Minute}
+	cfg := config.CodexCLIConfig{IdleDrainPeriod: time.Minute, StartupTimeout: time.Second, CallTimeout: time.Second}
 	mgr := NewCodexAppServerManager(slog.Default(), cfg)
 	return &AppServerWorker{
 		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
@@ -1203,7 +1203,7 @@ func TestManagerAcquireStartsProcess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping: requires codex binary")
 	}
-	cfg := config.CodexCLIConfig{IdleDrainPeriod: time.Minute}
+	cfg := config.CodexCLIConfig{IdleDrainPeriod: time.Minute, StartupTimeout: time.Second, CallTimeout: time.Second}
 	mgr := NewCodexAppServerManager(slog.Default(), cfg)
 
 	// Acquire will try to start the process, which requires codex binary.


### PR DESCRIPTION
## Summary

- Parameterize hardcoded time constants (flush intervals, cooldowns, timeouts) into configurable fields with `With*` test constructors
- Tests use short intervals (10-100ms) instead of production defaults (1.5-5s), eliminating meaningless waits
- Add `CallTimeout` config field to `CodexCLIConfig` for JSON-RPC timeout customization

Closes #505

## Test plan

- [x] `make check` 通过（quality + build）
- [x] `go test -short -race ./...` 全绿
- [ ] CI 三平台验证