### PR TITLE
docs(patrol): add PostgreSQL config and update dev-mode auth

### DIFF
--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -81,7 +81,7 @@ Browser ──init envelope──> Conn.ReadPump
 
 #### Dev 模式
 
-当未配置任何 API Key 时，所有请求以 `"anonymous"` 身份放行，无需认证。这一行为在 `AuthenticateRequest` 和 `AuthenticateKey` 中均有处理：`len(validKey) == 0` 时直接返回 `"anonymous"`。
+当未配置任何 API Key 时，所有请求以 `"anonymous"` 身份放行，无需认证。判定条件为配置源和数据库源均无 Key，且 Dev 模式未被锁定（`devModeLocked`）。一旦系统中曾存在过任何 Key（配置文件或 Admin API 创建），`devModeLocked` 即被置为 `true`，此后即使删除所有 Key 也无法重新进入 Dev 模式，防止认证绕过窗口。
 
 #### API Key 到用户身份的映射
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -142,19 +142,48 @@ Admin API 管理端点配置。
 
 ### 3.3 db — 数据持久化
 
-SQLite 数据库配置，Session 和 Event Store 共享。
+数据库配置，支持 SQLite（默认）和 PostgreSQL 两种后端。Session、Event Store、Cron 等模块共享同一数据库实例。
 
 | 字段 | 类型 | 默认值 | 环境变量 | 说明 |
 |------|------|--------|----------|------|
-| `path` | string | `~/.hotplex/data/hotplex.db` | `HOTPLEX_DB_PATH` | 主数据库文件路径。Session 和 Event 共用 |
-| `events_path` | string | `""` | — | **已废弃**：Event 表已迁移至主数据库，此字段不再使用 |
-| `wal_mode` | bool | `true` | `HOTPLEX_DB_WAL_MODE` | 启用 WAL (Write-Ahead Logging) 模式。生产环境必须开启 |
-| `busy_timeout` | duration | `5s` | — | SQLite 忙等待超时。写入冲突时的重试时间 |
-| `max_open_conns` | int | `3` | — | 最大打开连接数。1 写 + 2 读，适用于共享 Session/Event Store |
-| `vacuum_threshold` | float64 | `0.2` | — | VACUUM 触发阈值。当空闲页占比 ≥ 20% 时自动 VACUUM |
-| `cache_size_kib` | int | `8192` (8MB) | — | SQLite 页面缓存大小（KiB） |
-| `mmap_size_mib` | int | `64` (64MB) | — | SQLite mmap 大小（MiB） |
-| `wal_autocheckpoint` | int | `2000` | — | WAL 自动 checkpoint 页数阈值 |
+| `driver` | string | `"sqlite"` | `HOTPLEX_DB_DRIVER` | 数据库驱动。可选 `"sqlite"` / `"postgres"` / `"pg"` / `"postgresql"` |
+| `sqlite` | object | — | — | SQLite 子配置（见下方）。当 driver 为 sqlite 时生效 |
+| `postgres` | object | — | — | PostgreSQL 子配置（见下方）。当 driver 为 postgres 时生效 |
+
+#### SQLite 配置 (`db.sqlite.*`)
+
+当 `db.driver` 为 `sqlite`（或未设置）时使用。下方遗留字段（`db.path` 等）仍可用于向后兼容，结构化字段优先。
+
+| 字段 | 类型 | 默认值 | 环境变量 | 说明 |
+|------|------|--------|----------|------|
+| `sqlite.path` | string | `~/.hotplex/data/hotplex.db` | `HOTPLEX_DB_PATH` | 主数据库文件路径。Session 和 Event 共用 |
+| `sqlite.wal_mode` | bool | `true` | `HOTPLEX_DB_WAL_MODE` | 启用 WAL (Write-Ahead Logging) 模式。生产环境必须开启 |
+| `sqlite.busy_timeout` | duration | `5s` | — | SQLite 忙等待超时。写入冲突时的重试时间 |
+| `sqlite.max_open_conns` | int | `3` | — | 最大打开连接数。1 写 + 2 读 |
+| `sqlite.vacuum_threshold` | float64 | `0.2` | — | VACUUM 触发阈值。当空闲页占比 ≥ 20% 时自动 VACUUM |
+| `sqlite.cache_size_kib` | int | `8192` (8MB) | — | SQLite 页面缓存大小（KiB） |
+| `sqlite.mmap_size_mib` | int | `64` (64MB) | — | SQLite mmap 大小（MiB） |
+| `sqlite.wal_autocheckpoint` | int | `2000` | — | WAL 自动 checkpoint 页数阈值 |
+
+> **遗留字段**：`db.path`、`db.wal_mode`、`db.busy_timeout`、`db.max_open_conns`、`db.vacuum_threshold`、`db.cache_size_kib`、`db.mmap_size_mib`、`db.wal_autocheckpoint` 仍可使用，等价于 `db.sqlite.*`。结构化字段优先。`db.events_path` 已废弃。
+
+#### PostgreSQL 配置 (`db.postgres.*`)
+
+当 `db.driver` 设为 `"postgres"` 时使用 PostgreSQL 替代 SQLite。适用于生产环境多实例部署和高并发场景。
+
+| 字段 | 类型 | 默认值 | 环境变量 | 说明 |
+|------|------|--------|----------|------|
+| `postgres.dsn` | string | — | `HOTPLEX_DB_POSTGRES_DSN` | PostgreSQL 连接字符串。格式：`postgres://user:password@host:port/dbname?sslmode=prefer` |
+| `postgres.max_open_conns` | int | `25` | `HOTPLEX_DB_POSTGRES_MAX_OPEN_CONNS` | 最大打开连接数 |
+
+```yaml
+# PostgreSQL 配置示例
+db:
+  driver: "postgres"
+  postgres:
+    dsn: "postgres://hotplex:secret@db.example.com:5432/hotplex?sslmode=require"
+    max_open_conns: 25
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- `reference/configuration.md`: 重构 db 节，新增 `db.driver`、`db.sqlite.*`、`db.postgres.*` 子配置及 YAML 示例，反映 #490 PostgreSQL 双数据库支持
- `explanation/security-model.md`: 更新 Dev 模式描述，反映 #496 安全修复引入的 `devModeLocked` 机制

## Test plan
- [x] `make docs-build` 构建通过（55 篇文档，无断链）

🤖 Generated with [Claude Code](https://claude.com/claude-code)