### PR TITLE
fix: security/concurrency batch — XML injection bypass, data races, SSRF DNS leak

### DIFF
--- a/internal/agentconfig/prompt.go
+++ b/internal/agentconfig/prompt.go
@@ -126,13 +126,11 @@ var reservedTags = []string{
 func sanitize(s string) string {
 	res := s
 	for _, tag := range reservedTags {
-		res = strings.ReplaceAll(res, "<"+tag+">", "&lt;"+tag+"&gt;")
-		res = strings.ReplaceAll(res, "</"+tag+">", "&lt;/"+tag+"&gt;")
-		res = strings.ReplaceAll(res, "<"+tag+" ", "&lt;"+tag+" ")
-
-		tagUpper := strings.ToUpper(tag)
-		res = strings.ReplaceAll(res, "<"+tagUpper+">", "&lt;"+tagUpper+"&gt;")
-		res = strings.ReplaceAll(res, "</"+tagUpper+">", "&lt;/"+tagUpper+"&gt;")
+		for _, t := range []string{tag, strings.ToUpper(tag)} {
+			res = strings.ReplaceAll(res, "<"+t+">", "&lt;"+t+"&gt;")
+			res = strings.ReplaceAll(res, "</"+t+">", "&lt;/"+t+"&gt;")
+			res = strings.ReplaceAll(res, "<"+t+" ", "&lt;"+t+" ")
+		}
 	}
 	return res
 }

--- a/internal/agentconfig/prompt_test.go
+++ b/internal/agentconfig/prompt_test.go
@@ -1,0 +1,74 @@
+package agentconfig
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitize_LowercaseTags(t *testing.T) {
+	t.Parallel()
+
+	input := "<directives>keep</directives>"
+	got := sanitize(input)
+	require.Equal(t, "&lt;directives&gt;keep&lt;/directives&gt;", got)
+}
+
+func TestSanitize_UppercaseTags(t *testing.T) {
+	t.Parallel()
+
+	input := "<DIRECTIVES>keep</DIRECTIVES>"
+	got := sanitize(input)
+	require.Equal(t, "&lt;DIRECTIVES&gt;keep&lt;/DIRECTIVES&gt;", got)
+}
+
+func TestSanitize_AttributeEscape(t *testing.T) {
+	t.Parallel()
+
+	input := `<rules injected="1">malicious</rules>`
+	got := sanitize(input)
+	require.Equal(t, `&lt;rules injected="1">malicious&lt;/rules&gt;`, got)
+}
+
+func TestSanitize_UppercaseAttributeEscape(t *testing.T) {
+	t.Parallel()
+
+	input := `<RULES injected="1">malicious</RULES>`
+	got := sanitize(input)
+	require.Equal(t, `&lt;RULES injected="1">malicious&lt;/RULES&gt;`, got)
+}
+
+func TestSanitize_AllReservedTags(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range reservedTags {
+		for _, variant := range []struct {
+			name  string
+			input string
+		}{
+			{"lower_open", "<" + tag + ">"},
+			{"lower_close", "</" + tag + ">"},
+			{"lower_attr", "<" + tag + ` x="1">`},
+			{"upper_open", "<" + strings.ToUpper(tag) + ">"},
+			{"upper_close", "</" + strings.ToUpper(tag) + ">"},
+			{"upper_attr", "<" + strings.ToUpper(tag) + ` x="1">`},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", tag, variant.name), func(t *testing.T) {
+				t.Parallel()
+				got := sanitize(variant.input)
+				require.True(t, strings.HasPrefix(got, "&lt;"),
+					"expected escaped prefix for %q, got %q", variant.input, got)
+			})
+		}
+	}
+}
+
+func TestSanitize_NonReservedTags(t *testing.T) {
+	t.Parallel()
+
+	input := "<b>bold</b> <i>italic</i>"
+	got := sanitize(input)
+	require.Equal(t, input, got, "non-reserved tags should pass through unchanged")
+}

--- a/internal/brain/guard.go
+++ b/internal/brain/guard.go
@@ -265,7 +265,19 @@ func (g *SafetyGuard) CheckInput(ctx context.Context, input string) *GuardResult
 func (g *SafetyGuard) CheckInputWithUser(ctx context.Context, input, userID string) *GuardResult {
 	g.totalChecks.Add(1)
 
-	if !g.config.Enabled || !g.config.InputGuardEnabled {
+	// Snapshot shared state under RLock to avoid data races with
+	// concurrent UpdateBanPatterns / AddBanPattern / SetEnabled calls.
+	g.mu.RLock()
+	patterns := g.banPatterns
+	enabled := g.config.Enabled && g.config.InputGuardEnabled
+	maxLen := g.config.MaxInputLength
+	sensitivity := g.config.Sensitivity
+	brain := g.brain
+	responseTimeout := g.config.ResponseTimeout
+	failClosed := g.config.FailClosedOnBrainError
+	g.mu.RUnlock()
+
+	if !enabled {
 		return &GuardResult{
 			Safe:        true,
 			ThreatLevel: ThreatLevelNone,
@@ -290,18 +302,18 @@ func (g *SafetyGuard) CheckInputWithUser(ctx context.Context, input, userID stri
 	}
 
 	// Length check
-	if len(input) > g.config.MaxInputLength {
+	if len(input) > maxLen {
 		return &GuardResult{
 			Safe:        false,
 			ThreatLevel: ThreatLevelLow,
 			ThreatType:  "input_too_long",
-			Reason:      fmt.Sprintf("Input exceeds maximum length of %d characters", g.config.MaxInputLength),
+			Reason:      fmt.Sprintf("Input exceeds maximum length of %d characters", maxLen),
 			Action:      GuardActionBlock,
 		}
 	}
 
 	// Pattern-based detection
-	for _, pattern := range g.banPatterns {
+	for _, pattern := range patterns {
 		if pattern.MatchString(input) {
 			g.blockedInputs.Add(1)
 			g.logger.Warn("Input blocked by pattern match",
@@ -319,8 +331,8 @@ func (g *SafetyGuard) CheckInputWithUser(ctx context.Context, input, userID stri
 	}
 
 	// Use Brain for deeper analysis if available
-	if g.brain != nil && g.config.Sensitivity != "low" {
-		return g.deepInputAnalysis(ctx, input)
+	if brain != nil && sensitivity != "low" {
+		return g.deepInputAnalysis(ctx, input, brain, responseTimeout, failClosed)
 	}
 
 	return &GuardResult{
@@ -371,7 +383,7 @@ func (g *SafetyGuard) evictStaleLimiters() {
 }
 
 // deepInputAnalysis uses Brain for deeper threat analysis.
-func (g *SafetyGuard) deepInputAnalysis(ctx context.Context, input string) *GuardResult {
+func (g *SafetyGuard) deepInputAnalysis(ctx context.Context, input string, brain Brain, responseTimeout time.Duration, failClosed bool) *GuardResult {
 	var analysis struct {
 		Safe        bool        `json:"safe"`
 		ThreatLevel ThreatLevel `json:"threat_level"`
@@ -397,12 +409,12 @@ Return JSON:
   "reason": "explanation"
 }`, truncate(input))
 
-	ctx, cancel := context.WithTimeout(ctx, g.config.ResponseTimeout)
+	ctx, cancel := context.WithTimeout(ctx, responseTimeout)
 	defer cancel()
 
-	if err := g.brain.Analyze(ctx, prompt, &analysis); err != nil {
+	if err := brain.Analyze(ctx, prompt, &analysis); err != nil {
 		g.logger.Warn("Deep input analysis failed", "error", err)
-		if g.config.FailClosedOnBrainError {
+		if failClosed {
 			return &GuardResult{
 				Safe:        false,
 				ThreatLevel: ThreatLevelMedium,
@@ -455,7 +467,12 @@ Return JSON:
 //
 // Returns GuardResult with SanitizedInput containing the redacted version.
 func (g *SafetyGuard) CheckOutput(output string) *GuardResult {
-	if !g.config.Enabled || !g.config.OutputGuardEnabled {
+	g.mu.RLock()
+	enabled := g.config.Enabled && g.config.OutputGuardEnabled
+	sensitivePatterns := g.sensitivePatterns
+	g.mu.RUnlock()
+
+	if !enabled {
 		return &GuardResult{
 			Safe:        true,
 			ThreatLevel: ThreatLevelNone,
@@ -466,7 +483,7 @@ func (g *SafetyGuard) CheckOutput(output string) *GuardResult {
 	sanitized := output
 	sensitiveFound := false
 
-	for _, pattern := range g.sensitivePatterns {
+	for _, pattern := range sensitivePatterns {
 		if pattern.MatchString(sanitized) {
 			sensitiveFound = true
 			// Replace with redacted version

--- a/internal/security/apikey_resolver.go
+++ b/internal/security/apikey_resolver.go
@@ -3,6 +3,8 @@ package security
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -97,6 +99,9 @@ func (r *DBResolver) Resolve(ctx context.Context, key string) (string, bool) {
 		key,
 	).Scan(&userID)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("security: DBResolver query failed", "error", err)
+		}
 		return "", false
 	}
 	// Cache for 60 seconds — balances freshness with DB load.

--- a/internal/security/model.go
+++ b/internal/security/model.go
@@ -3,19 +3,21 @@ package security
 import (
 	"fmt"
 	"strings"
+	"sync"
 )
 
-// AllowedModels contains the set of permitted AI model identifiers.
-// New models must be explicitly added here before use.
-var AllowedModels = map[string]bool{
-	// Claude models.
-	"claude-sonnet-4-6":          true,
-	"claude-opus-4-6":            true,
-	"claude-3-5-sonnet-20241022": true,
-	"claude-3-5-haiku-20241022":  true,
-	"claude-3-opus-20240229":     true,
-	"claude-3-sonnet-20240229":   true,
-}
+var (
+	modelsMu      sync.RWMutex
+	allowedModels = map[string]bool{
+		// Claude models.
+		"claude-sonnet-4-6":          true,
+		"claude-opus-4-6":            true,
+		"claude-3-5-sonnet-20241022": true,
+		"claude-3-5-haiku-20241022":  true,
+		"claude-3-opus-20240229":     true,
+		"claude-3-sonnet-20240229":   true,
+	}
+)
 
 // ValidateModel checks that the model identifier is in the allowed list.
 func ValidateModel(model string) error {
@@ -23,7 +25,10 @@ func ValidateModel(model string) error {
 		return fmt.Errorf("security: empty model name")
 	}
 	lower := strings.ToLower(model)
-	if !AllowedModels[lower] {
+	modelsMu.RLock()
+	ok := allowedModels[lower]
+	modelsMu.RUnlock()
+	if !ok {
 		return fmt.Errorf("security: model %q not in allowed list", model)
 	}
 	return nil
@@ -31,5 +36,15 @@ func ValidateModel(model string) error {
 
 // IsModelAllowed returns true if the model is permitted.
 func IsModelAllowed(model string) bool {
-	return AllowedModels[strings.ToLower(model)]
+	modelsMu.RLock()
+	ok := allowedModels[strings.ToLower(model)]
+	modelsMu.RUnlock()
+	return ok
+}
+
+// RegisterModel adds a model to the allowed list.
+func RegisterModel(model string) {
+	modelsMu.Lock()
+	allowedModels[strings.ToLower(model)] = true
+	modelsMu.Unlock()
 }

--- a/internal/security/ssrf.go
+++ b/internal/security/ssrf.go
@@ -114,7 +114,7 @@ func ValidateURL(targetURL string) error {
 	// Layer 3: DNS resolution.
 	ips, err := LookupHost(host)
 	if err != nil {
-		return &SSRFProtectionError{URL: targetURL, Reason: "DNS lookup failed: " + err.Error()}
+		return &SSRFProtectionError{URL: targetURL, Reason: "DNS lookup failed"}
 	}
 
 	// Layer 4: check all resolved IPs against BlockedCIDRs.
@@ -161,7 +161,7 @@ func ValidateURLDoubleResolve(targetURL string) error {
 
 	ips, err := LookupHost(u.Hostname())
 	if err != nil {
-		return &SSRFProtectionError{URL: targetURL, Reason: "DNS re-lookup failed: " + err.Error()}
+		return &SSRFProtectionError{URL: targetURL, Reason: "DNS re-lookup failed"}
 	}
 
 	for _, ipStr := range ips {

--- a/internal/security/tool.go
+++ b/internal/security/tool.go
@@ -2,21 +2,24 @@ package security
 
 import (
 	"fmt"
+	"sync"
 )
 
-// AllowedTools contains the set of permitted Claude Code tools.
-var AllowedTools = map[string]bool{
-	"Read":         true,
-	"Edit":         true,
-	"Write":        true,
-	"Bash":         true,
-	"Grep":         true,
-	"Glob":         true,
-	"Agent":        true,
-	"WebFetch":     true,
-	"NotebookEdit": true,
-	"TodoWrite":    true,
-}
+var (
+	toolsMu      sync.RWMutex
+	allowedTools = map[string]bool{
+		"Read":         true,
+		"Edit":         true,
+		"Write":        true,
+		"Bash":         true,
+		"Grep":         true,
+		"Glob":         true,
+		"Agent":        true,
+		"WebFetch":     true,
+		"NotebookEdit": true,
+		"TodoWrite":    true,
+	}
+)
 
 // ProductionAllowedTools is the set of tools enabled in production (no Bash/WebFetch).
 var ProductionAllowedTools = map[string]bool{
@@ -29,7 +32,10 @@ var ProductionAllowedTools = map[string]bool{
 // Returns nil if all tools are valid, or an error listing the first invalid tool.
 func ValidateTools(tools []string) error {
 	for _, tool := range tools {
-		if !AllowedTools[tool] {
+		toolsMu.RLock()
+		ok := allowedTools[tool]
+		toolsMu.RUnlock()
+		if !ok {
 			return fmt.Errorf("security: tool %q not in allowed list", tool)
 		}
 	}
@@ -47,5 +53,15 @@ func BuildAllowedToolsArgs(tools []string) []string {
 
 // IsToolAllowed returns true if the tool is in the allowed set.
 func IsToolAllowed(tool string) bool {
-	return AllowedTools[tool]
+	toolsMu.RLock()
+	ok := allowedTools[tool]
+	toolsMu.RUnlock()
+	return ok
+}
+
+// RegisterTool adds a tool to the allowed list.
+func RegisterTool(tool string) {
+	toolsMu.Lock()
+	allowedTools[tool] = true
+	toolsMu.Unlock()
 }


### PR DESCRIPTION
## Summary

Batch fix of 3 high-priority security and concurrency issues:

| Issue | Module | Fix |
|-------|--------|-----|
| **#517** | agentconfig | `sanitize()` missed uppercase attribute tags (`<RULES x="1">`) — 10 XML injection bypass vectors |
| **#531** | brain | `CheckInputWithUser`/`CheckOutput` read `banPatterns` and `config` fields without lock — data race on every user message |
| **#537** | security | `AllowedModels`/`AllowedTools` exported mutable maps + DBResolver swallows DB errors + SSRF leaks DNS topology |

## Changes

### #517 — sanitize XML injection bypass
- Refactor `sanitize()` loop to handle both cases (lowercase + uppercase) for all 3 variants (open/close/attr)
- Add `prompt_test.go` with 6 test functions covering all reserved tags

### #531 — SafetyGuard data race
- Add `RLock` snapshot at `CheckInputWithUser` and `CheckOutput` entry points
- `deepInputAnalysis` receives parameters instead of reading shared state
- Eliminates race on `g.banPatterns`, `g.config.*`, `g.sensitivePatterns`

### #537 — Security module fixes
- `allowedModels`/`allowedTools`: unexport + `sync.RWMutex`, add `RegisterModel`/`RegisterTool`
- `DBResolver.Resolve`: log non-`ErrNoRows` DB errors
- `SSRFProtectionError.Reason`: generic message instead of raw DNS error string

## Test plan

- [x] `make check` 通过（quality + build）
- [x] `go test -race ./internal/agentconfig/...` — 新 sanitize 测试全绿
- [x] `go test -race ./internal/brain/...` — race detector 无报告
- [x] `go test -race ./internal/security/...` — race detector 无报告
- [ ] CI 三平台验证

Closes #517, Closes #531, Closes #537