### PR TITLE
Batch: cron refactoring for #498 and #520

### DIFF
--- a/cmd/hotplex/gateway_cmd.go
+++ b/cmd/hotplex/gateway_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hrygo/hotplex/internal/cli/output"
+	"github.com/hrygo/hotplex/internal/cli/pidutil"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/worker/proc"
 )
@@ -204,7 +205,7 @@ func startDaemon(configPath string, devMode bool) error {
 	childPID := daemonCmd.Process.Pid
 	pidPath := gatewayPIDPath()
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err == nil {
-		state := gatewayState{PID: childPID, ConfigPath: configPath, DevMode: devMode}
+		state := pidutil.GatewayState{PID: childPID, ConfigPath: configPath, DevMode: devMode}
 		data, _ := json.Marshal(state)
 		_ = os.WriteFile(pidPath, data, 0o644)
 	}

--- a/cmd/hotplex/pid.go
+++ b/cmd/hotplex/pid.go
@@ -9,19 +9,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hrygo/hotplex/internal/cli/pidutil"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/service"
 	"github.com/hrygo/hotplex/internal/worker/proc"
 )
 
 func gatewayPIDPath() string {
-	return filepath.Join(config.HotplexHome(), ".pids", "gateway.pid")
-}
-
-type gatewayState struct {
-	PID        int    `json:"pid"`
-	ConfigPath string `json:"config,omitempty"`
-	DevMode    bool   `json:"dev,omitempty"`
+	return pidutil.PIDPath()
 }
 
 func writeGatewayState(configPath string, devMode bool) error {
@@ -29,7 +24,7 @@ func writeGatewayState(configPath string, devMode bool) error {
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
 		return err
 	}
-	state := gatewayState{
+	state := pidutil.GatewayState{
 		PID:        os.Getpid(),
 		ConfigPath: configPath,
 		DevMode:    devMode,
@@ -38,15 +33,10 @@ func writeGatewayState(configPath string, devMode bool) error {
 	return os.WriteFile(pidPath, data, 0o644)
 }
 
-func readGatewayState() (*gatewayState, error) {
-	data, err := os.ReadFile(gatewayPIDPath())
+func readGatewayState() (*pidutil.GatewayState, error) {
+	state, err := pidutil.ReadState()
 	if err != nil {
 		return nil, fmt.Errorf("gateway not running (no PID file)")
-	}
-
-	var state gatewayState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, fmt.Errorf("invalid PID file content")
 	}
 
 	if err := proc.IsProcessAlive(state.PID); err != nil {
@@ -57,7 +47,7 @@ func readGatewayState() (*gatewayState, error) {
 		return nil, fmt.Errorf("gateway not running (PID %d: %w)", state.PID, err)
 	}
 
-	return &state, nil
+	return state, nil
 }
 
 func removeGatewayState() {

--- a/cmd/hotplex/pid_test.go
+++ b/cmd/hotplex/pid_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cli/pidutil"
 )
 
 func TestGatewayStateWriteReadRemove(t *testing.T) {
@@ -30,7 +32,7 @@ func TestGatewayStateWriteReadRemove(t *testing.T) {
 	t.Setenv("HOME", origHome)
 }
 
-func requireConfigPath(t *testing.T, state *gatewayState) {
+func requireConfigPath(t *testing.T, state *pidutil.GatewayState) {
 	t.Helper()
 	require.NotNil(t, state)
 	require.Equal(t, os.Getpid(), state.PID)

--- a/internal/cli/cron/client.go
+++ b/internal/cli/cron/client.go
@@ -3,7 +3,6 @@ package croncli
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -16,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hrygo/hotplex/internal/cli/pidutil"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/cron"
 	"github.com/hrygo/hotplex/internal/dbutil"
@@ -31,13 +31,6 @@ type (
 	Store   = cron.Store
 	CronJob = cron.CronJob
 )
-
-// gatewayState mirrors cmd/hotplex/pid.go gatewayState to avoid circular imports.
-type gatewayState struct {
-	PID        int    `json:"pid"`
-	ConfigPath string `json:"config,omitempty"`
-	DevMode    bool   `json:"dev,omitempty"`
-}
 
 // OpenStore opens the config, initializes the DB, and returns cron store + eventstore + cleanup.
 func OpenStore(ctx context.Context, configPath string) (cron.Store, eventstore.TurnQuerier, func(), error) {
@@ -308,15 +301,9 @@ func QueryHistory(ctx context.Context, store cron.Store, evStore eventstore.Turn
 
 // NotifyGateway sends SIGHUP to the running gateway to reload the cron index.
 func NotifyGateway() error {
-	pidPath := filepath.Join(config.HotplexHome(), ".pids", "gateway.pid")
-	data, err := os.ReadFile(pidPath)
+	state, err := pidutil.ReadState()
 	if err != nil {
 		return nil // gateway not running, nothing to notify
-	}
-
-	var state gatewayState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return fmt.Errorf("parse gateway PID file: %w", err)
 	}
 	if state.PID <= 0 {
 		return nil
@@ -329,13 +316,8 @@ func NotifyGateway() error {
 // the running gateway is using. Returns "" if the gateway is not running or
 // the PID file doesn't exist.
 func gatewayConfigPath() string {
-	pidPath := filepath.Join(config.HotplexHome(), ".pids", "gateway.pid")
-	data, err := os.ReadFile(pidPath)
+	state, err := pidutil.ReadState()
 	if err != nil {
-		return ""
-	}
-	var state gatewayState
-	if err := json.Unmarshal(data, &state); err != nil {
 		return ""
 	}
 	if err := proc.IsProcessAlive(state.PID); err != nil {

--- a/internal/cli/pidutil/pidutil.go
+++ b/internal/cli/pidutil/pidutil.go
@@ -1,0 +1,35 @@
+package pidutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// GatewayState represents the gateway process state persisted to disk.
+type GatewayState struct {
+	PID        int    `json:"pid"`
+	ConfigPath string `json:"config,omitempty"`
+	DevMode    bool   `json:"dev,omitempty"`
+}
+
+// PIDPath returns the path to the gateway PID file.
+func PIDPath() string {
+	return filepath.Join(config.HotplexHome(), ".pids", "gateway.pid")
+}
+
+// ReadState reads and parses the gateway PID file.
+// Returns the parsed state, or an error if the file cannot be read or parsed.
+func ReadState() (*GatewayState, error) {
+	data, err := os.ReadFile(PIDPath())
+	if err != nil {
+		return nil, err
+	}
+	var s GatewayState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/cron/pg_store.go
+++ b/internal/cron/pg_store.go
@@ -286,17 +286,15 @@ func scanJobRowPG(s scanner) (*CronJob, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cron store: scan job: %w", err)
 	}
-	if err := decodeJobFields(job, b2i(enabled), b2i(deleteAfterRun), b2i(silent), schedData, payloadData, platformKeyData, stateData); err != nil {
+	if err := decodeJobFields(job, boolFromPG(enabled), boolFromPG(deleteAfterRun), boolFromPG(silent), schedData, payloadData, platformKeyData, stateData); err != nil {
 		return nil, fmt.Errorf("cron store: decode job: %w", err)
 	}
 	return job, nil
 }
 
-func b2i(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
+// boolFromPG converts a PostgreSQL BOOLEAN to int for shared decodeJobFields.
+func boolFromPG(b bool) int {
+	return boolToInt(b)
 }
 
 // compile-time interface check

--- a/internal/cron/timer.go
+++ b/internal/cron/timer.go
@@ -180,26 +180,10 @@ func (s *Scheduler) executeJob(job *CronJob) {
 
 	start := time.Now()
 	sessionKey, err := s.executor.Execute(ctx, job, timeout)
-	duration := time.Since(start)
-
-	metrics.CronDurationSeconds.WithLabelValues(job.Name).Observe(duration.Seconds())
+	metrics.CronDurationSeconds.WithLabelValues(job.Name).Observe(time.Since(start).Seconds())
 
 	job.State.LastRunID = sessionKey
-	shouldDisable := s.finishExecution(job, start.UnixMilli(), err, errorType(err))
-	s.mergeJobState(job.ID, job.State, false)
-
-	if shouldDisable {
-		s.persistAndDisable(job.ID, job.State)
-		return
-	}
-
-	if err != nil {
-		// One-shot retry logic (checked after finishExecution records the error).
-		if job.Schedule.Kind == ScheduleAt && isTemporaryError(err) && job.State.RetryCount < maxRetries(job) {
-			s.scheduleRetry(s.ctx, job)
-			return
-		}
-		s.persistState(job.ID, job.State)
+	if s.handlePostExecution(job, start.UnixMilli(), err, errorType(err)) {
 		return
 	}
 
@@ -207,7 +191,6 @@ func (s *Scheduler) executeJob(job *CronJob) {
 	if s.delivery != nil && !job.Silent && !HasCLIDelivery(job) {
 		s.delivery.Deliver(s.ctx, job, sessionKey)
 	}
-
 	s.applyLifecycle(job)
 }
 
@@ -231,25 +214,33 @@ func (s *Scheduler) executeAttached(job *CronJob) {
 
 	err := s.attachedHandler.Execute(ctx, job)
 
-	shouldDisable := s.finishExecution(job, time.Now().UnixMilli(), err, "attached")
+	if s.handlePostExecution(job, time.Now().UnixMilli(), err, "attached") {
+		return
+	}
+	s.applyLifecycle(job)
+}
+
+// handlePostExecution handles error/disable/retry logic after execution.
+// Returns true if the caller should stop (disabled, retrying, or errored).
+func (s *Scheduler) handlePostExecution(job *CronJob, startedAtMs int64, err error, errType string) bool {
+	shouldDisable := s.finishExecution(job, startedAtMs, err, errType)
 	s.mergeJobState(job.ID, job.State, false)
 
 	if shouldDisable {
 		s.persistAndDisable(job.ID, job.State)
-		return
+		return true
 	}
 
 	if err != nil {
-		// One-shot retry logic (checked after finishExecution records the error).
 		if job.Schedule.Kind == ScheduleAt && isTemporaryError(err) && job.State.RetryCount < maxRetries(job) {
 			s.scheduleRetry(s.ctx, job)
-			return
+			return true
 		}
 		s.persistState(job.ID, job.State)
-		return
+		return true
 	}
 
-	s.applyLifecycle(job)
+	return false
 }
 
 // beginExecution marks a job as running and persists state.


### PR DESCRIPTION
## Summary

Two cron module refactoring issues consolidated in one PR:

- **#498**: Extract `handlePostExecution` template method to eliminate ~80% lifecycle duplication between `executeJob` and `executeAttached`; unify `b2i`/`boolToInt` bool conversion
- **#520**: Extract `GatewayState` to shared `internal/cli/pidutil` package, removing duplicate structs from `cmd/hotplex/pid.go` and `internal/cli/cron/client.go`

## Changes

### #498 — Cron execution lifecycle dedup

- `internal/cron/timer.go`: Extract `handlePostExecution` template method
- `internal/cron/pg_store.go`: Replace `b2i()` with `boolFromPG()` delegating to shared `boolToInt()`

### #520 — PID state shared package

- `internal/cli/pidutil/pidutil.go` (NEW): `GatewayState`, `PIDPath()`, `ReadState()`
- `cmd/hotplex/pid.go`: Remove duplicate struct, delegate to pidutil
- `cmd/hotplex/gateway_cmd.go`: Use `pidutil.GatewayState` for daemon start
- `cmd/hotplex/pid_test.go`: Use `pidutil.GatewayState` type
- `internal/cli/cron/client.go`: Remove duplicate struct, use pidutil

## Testing

- [x] `make check` passes (lint + test + build)
- [x] All existing tests pass with `-race`
- [x] No breaking changes — public API unchanged

Closes #498, Closes #520