### PR TITLE
fix(build): webchat-embed staleness + admin default scopes + build visibility

### DIFF
--- a/.agents/skills/hotplex-release/SKILL.md
+++ b/.agents/skills/hotplex-release/SKILL.md
@@ -231,7 +231,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 | 文件 | 模式 | 示例 |
 |:---|:---|:---|
 | `cmd/hotplex/main.go:16` | `version = "v1.x.x"` | `v1.2.0` |
-| `Makefile:24` | `LDFLAGS ... -X main.version=v1.x.x` | `v1.2.0` |
+| `Makefile:26` | `VERSION := v1.x.x`（LDFLAGS 引用 `$(VERSION)`） | `v1.2.0` |
 | `internal/tracing/tracing.go` | `semconv.ServiceVersion("1.x.x")` | `1.2.0` |
 
 ### 4.2 多语言 SDK

--- a/Makefile
+++ b/Makefile
@@ -319,9 +319,17 @@ webchat-rebuild:
 # ─────────────────────────────────────────────────────────────────────────────
 
 docs-build:
-	@echo "  $(CYAN)Docs$(RESET)$(DIM) building...$(RESET)"
-	@go run cmd/build-docs/main.go
-	@echo "  $(GREEN)✓$(RESET) Documentation built"
+	@if [ ! -f internal/docs/out/index.html ]; then \
+		echo "  $(CYAN)Docs$(RESET)$(DIM) building from scratch...$(RESET)"; \
+		go run cmd/build-docs/main.go; \
+	elif find docs cmd/build-docs -newer internal/docs/out \
+		\( -name "*.md" -o -name "*.go" -o -name "*.yaml" -o -name "*.png" -o -name "*.svg" \) \
+		-print 2>/dev/null | head -n 1 | grep -q .; then \
+		echo "  $(CYAN)Docs$(RESET)$(DIM) rebuilding (source changed)...$(RESET)"; \
+		go run cmd/build-docs/main.go; \
+	else \
+		echo "  $(DIM)Docs ✓ cached$(RESET)"; \
+	fi
 
 docs-clean:
 	@rm -rf internal/docs/out

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ GOOS         := $(shell go env GOOS)
 GOARCH       := $(shell go env GOARCH)
 GIT_SHA      := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME   := $(shell date '+%Y-%m-%dT%H:%M:%S%z')
+VERSION      := v1.19.0
 LDFLAGS      := -s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)
 BUILD_OPTS   := -trimpath
-VERSION      := v1.19.0
 
 GATEWAY_PID   := $(HOME)/.hotplex/.pids/gateway.pid
 GATEWAY_LOG   := $(LOG_DIR)/hotplex.log
@@ -301,6 +301,7 @@ webchat-embed:
 	elif find $(WEB_CHAT_DIR)/app $(WEB_CHAT_DIR)/lib $(WEB_CHAT_DIR)/components $(WEB_CHAT_DIR)/public \
 		$(WEB_CHAT_DIR)/next.config.mjs $(WEB_CHAT_DIR)/tsconfig.json \
 		$(WEB_CHAT_DIR)/postcss.config.mjs $(WEB_CHAT_DIR)/package.json \
+		$(WEB_CHAT_DIR)/pnpm-lock.yaml \
 		-newer $(WEB_CHAT_OUT)/_next -print 2>/dev/null | head -n 1 | grep -q .; then \
 		$(MAKE) webchat-rebuild --no-print-directory; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ GOOS         := $(shell go env GOOS)
 GOARCH       := $(shell go env GOARCH)
 GIT_SHA      := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME   := $(shell date '+%Y-%m-%dT%H:%M:%S%z')
-LDFLAGS      := -s -w -X main.version=v1.19.0 -X main.buildTime=$(BUILD_TIME)
+LDFLAGS      := -s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)
 BUILD_OPTS   := -trimpath
+VERSION      := v1.19.0
 
 GATEWAY_PID   := $(HOME)/.hotplex/.pids/gateway.pid
 GATEWAY_LOG   := $(LOG_DIR)/hotplex.log
@@ -123,9 +124,13 @@ endef
 # Build
 # ─────────────────────────────────────────────────────────────────────────────
 
-build: docs-build webchat-embed
-	@echo "$(CYAN)Building...$(RESET)"
+build:
+	@echo "$(BOLD)$(CYAN)Build$(RESET)  $(DIM)$(VERSION) · $(GIT_SHA) · $(GOOS)/$(GOARCH)$(RESET)"
+	@echo ""
+	@$(MAKE) docs-build --no-print-directory
+	@$(MAKE) webchat-embed --no-print-directory
 	@mkdir -p $(BUILD_DIR) $(LOG_DIR)
+	@echo "  $(CYAN)Compiling$(RESET)$(DIM) Go binary...$(RESET)"
 	@CGO_ENABLED=0 go build $(BUILD_OPTS) -ldflags="$(LDFLAGS)" \
 		-o $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH) $(MAIN_PATH)
 	@echo "  $(GREEN)✓$(RESET) $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH)"
@@ -288,10 +293,18 @@ webchat-stop:
 
 webchat-embed:
 	@if [ ! -d $(WEB_CHAT_OUT)/_next ]; then \
-		echo "$(CYAN)Building webchat for embedding...$(RESET)"; \
+		echo "  $(CYAN)Webchat$(RESET)$(DIM) building from scratch...$(RESET)"; \
 		cd $(WEB_CHAT_DIR) && pnpm install --frozen-lockfile && pnpm build && \
 		rm -rf ../$(WEB_CHAT_OUT).tmp && cp -r out ../$(WEB_CHAT_OUT).tmp && \
 		rm -rf ../$(WEB_CHAT_OUT) && mv ../$(WEB_CHAT_OUT).tmp ../$(WEB_CHAT_OUT); \
+		echo "  $(GREEN)✓$(RESET) Webchat built"; \
+	elif find $(WEB_CHAT_DIR)/app $(WEB_CHAT_DIR)/lib $(WEB_CHAT_DIR)/components $(WEB_CHAT_DIR)/public \
+		$(WEB_CHAT_DIR)/next.config.mjs $(WEB_CHAT_DIR)/tsconfig.json \
+		$(WEB_CHAT_DIR)/postcss.config.mjs $(WEB_CHAT_DIR)/package.json \
+		-newer $(WEB_CHAT_OUT)/_next -print 2>/dev/null | head -n 1 | grep -q .; then \
+		$(MAKE) webchat-rebuild --no-print-directory; \
+	else \
+		echo "  $(DIM)Webchat ✓ cached$(RESET)"; \
 	fi
 
 webchat-rebuild:
@@ -306,7 +319,7 @@ webchat-rebuild:
 # ─────────────────────────────────────────────────────────────────────────────
 
 docs-build:
-	@echo "$(CYAN)Building documentation...$(RESET)"
+	@echo "  $(CYAN)Docs$(RESET)$(DIM) building...$(RESET)"
 	@go run cmd/build-docs/main.go
 	@echo "  $(GREEN)✓$(RESET) Documentation built"
 

--- a/cmd/hotplex/pid.go
+++ b/cmd/hotplex/pid.go
@@ -115,7 +115,10 @@ func findRunningGateway() (*gatewayInstance, error) {
 func stopGateway(inst *gatewayInstance) error {
 	switch inst.Source {
 	case sourcePID:
-		if err := proc.GracefulTerminate(inst.PID); err != nil {
+		// Use Terminate (direct PID signal) instead of GracefulTerminate (process
+		// group signal). The gateway may not be a process group leader when started
+		// in foreground mode (PGID inherited from parent shell).
+		if err := proc.Terminate(inst.PID); err != nil {
 			return fmt.Errorf("stop PID %d: %w", inst.PID, err)
 		}
 		removeGatewayState()

--- a/configs/README.md
+++ b/configs/README.md
@@ -88,7 +88,7 @@ log:
 | `addr` | string | `:9999` | — | Admin API 监听地址。生产环境应绑定到内网 IP（如 `10.0.0.1:9999`）或通过 `allowed_cidrs` 限制访问 |
 | `tokens` | []string | `[]` | ✅ | 授权令牌列表。通过 `HOTPLEX_ADMIN_TOKEN_1..N` 编号式环境变量设置。每个请求需携带 `Authorization: Bearer <token>` 头。支持多令牌用于无损轮转 |
 | `token_scopes` | map | `{}` | — | 令牌到权限的 RBAC 映射。key 为令牌值，value 为权限列表（如 `["session:read", "session:write"]`）。未映射的令牌使用 `default_scopes` |
-| `default_scopes` | []string | `["session:read", "stats:read", "health:read"]` | — | 未在 `token_scopes` 中显式映射的令牌的默认权限集 |
+| `default_scopes` | []string | `["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]` | — | 未在 `token_scopes` 中显式映射的令牌的默认权限集。`admin:write` 隐含 `admin:read` → `config:read` |
 | `ip_whitelist_enabled` | bool | `false` | — | 启用 CIDR 白名单。开启后仅 `allowed_cidrs` 中的网段可访问 Admin API。Docker/Kubernetes 环境建议使用网络策略替代 |
 | `allowed_cidrs` | []string | `127.0.0.0/8, 10.0.0.0/8` | — | 信任的 CIDR 网段列表。仅当 `ip_whitelist_enabled: true` 时生效 |
 | `rate_limit_enabled` | bool | `true` | ✅ | 启用基于令牌桶的速率限制。按客户端 IP 独立计数，防止单个客户端滥用管理接口 |

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -40,7 +40,7 @@ admin:
   addr: "localhost:9999"
   # Tokens must be provided via HOTPLEX_ADMIN_TOKEN_1..N env vars
   tokens: []
-  default_scopes: ["session:read", "stats:read", "health:read", "admin:write"]
+  default_scopes: ["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]
   ip_whitelist_enabled: false
   allowed_cidrs: ["127.0.0.0/8", "10.0.0.0/8"]
   rate_limit_enabled: true

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -32,8 +32,8 @@ admin:
     - "my-admin-token"
   token_scopes:                    # 细粒度 scope token
     "ops-token": ["session:read", "stats:read", "health:read"]
-    "admin-token": ["session:read", "session:write", "session:delete", "stats:read", "health:read", "config:read", "config:write", "admin:read", "admin:write"]
-  default_scopes: ["session:read", "stats:read", "health:read"]  # 简单 token 的默认 scope
+    "admin-token": ["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]
+  default_scopes: ["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]
 ```
 
 ### Scope 权限矩阵

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -131,7 +131,7 @@ Admin API 管理端点配置。
 | `addr` | string | `localhost:9999` | `HOTPLEX_ADMIN_ADDR` | Admin API 监听地址。默认仅绑定 localhost |
 | `tokens` | []string | `[]` | `HOTPLEX_ADMIN_TOKEN_1..N` | 认证 token 列表。**只能通过环境变量设置**，支持编号后缀用于轮换 |
 | `token_scopes` | map[string][]string | `nil` | — | 每 token 的权限范围映射 |
-| `default_scopes` | []string | `["session:read", "stats:read", "health:read"]` | — | 未配置 scopes 的 token 的默认权限范围 |
+| `default_scopes` | []string | `["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]` | — | 未配置 scopes 的 token 的默认权限范围。`admin:write` 隐含 `admin:read` → `config:read` |
 | `ip_whitelist_enabled` | bool | `false` | — | 是否启用 IP 白名单 |
 | `allowed_cidrs` | []string | `["127.0.0.0/8", "10.0.0.0/8"]` | — | 允许访问的 CIDR 列表 |
 | `rate_limit_enabled` | bool | `true` | — | 是否启用速率限制 |

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -96,7 +96,7 @@ func (m *mockConfig) Get() *config.Config {
 	return &config.Config{
 		Admin: config.AdminConfig{
 			Tokens:        []string{"test-token"},
-			DefaultScopes: []string{ScopeSessionRead, ScopeSessionWrite, ScopeSessionKill, ScopeStatsRead, ScopeHealthRead, ScopeAdminRead, ScopeConfigRead},
+			DefaultScopes: []string{ScopeSessionRead, ScopeSessionWrite, ScopeSessionKill, ScopeStatsRead, ScopeHealthRead, ScopeAdminWrite},
 		},
 	}
 }

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -28,10 +28,23 @@ func hasScope(r *http.Request, required string) bool {
 	if slices.Contains(granted, required) {
 		return true
 	}
-	// Check implied scopes: if the user holds a higher scope, it grants the required one.
-	for _, s := range granted {
-		if implied, ok := scopeImplies[s]; ok && slices.Contains(implied, required) {
-			return true
+	// Check implied scopes with transitive closure:
+	// admin:write → admin:read → config:read
+	visited := map[string]bool{}
+	queue := make([]string, len(granted))
+	copy(queue, granted)
+	for len(queue) > 0 {
+		s := queue[0]
+		queue = queue[1:]
+		if visited[s] {
+			continue
+		}
+		visited[s] = true
+		if implied, ok := scopeImplies[s]; ok {
+			if slices.Contains(implied, required) {
+				return true
+			}
+			queue = append(queue, implied...)
 		}
 	}
 	return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -768,7 +768,7 @@ func Default() *Config {
 			Addr:               "localhost:9999",
 			Tokens:             nil,
 			TokenScopes:        nil,
-			DefaultScopes:      []string{"session:read", "stats:read", "health:read"},
+			DefaultScopes:      []string{"session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"},
 			IPWhitelistEnabled: false,
 			AllowedCIDRs:       []string{"127.0.0.0/8", "10.0.0.0/8"},
 			RateLimitEnabled:   true,

--- a/internal/webchat/server.go
+++ b/internal/webchat/server.go
@@ -21,7 +21,7 @@ func securityHeaders(next http.Handler) http.Handler {
 			"default-src 'self'; "+
 				"script-src 'self' 'unsafe-inline' 'unsafe-eval'; "+
 				"style-src 'self' 'unsafe-inline'; "+
-				"connect-src 'self' ws://localhost:* wss://*; "+
+				"connect-src 'self' http://localhost:* ws://localhost:* wss://*; "+
 				"img-src 'self' data: blob:; "+
 				"font-src 'self' data:")
 		next.ServeHTTP(w, r)

--- a/internal/worker/proc/signal_unix.go
+++ b/internal/worker/proc/signal_unix.go
@@ -19,6 +19,12 @@ func GracefulTerminate(pgid int) error {
 	return syscall.Kill(-pgid, syscall.SIGTERM)
 }
 
+// Terminate sends SIGTERM to a single process (not its group).
+// Use this when the target may not be a process group leader.
+func Terminate(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}
+
 // ForceKill sends SIGKILL to the entire process group.
 func ForceKill(pgid int) error {
 	return syscall.Kill(-pgid, syscall.SIGKILL)

--- a/internal/worker/proc/signal_windows.go
+++ b/internal/worker/proc/signal_windows.go
@@ -27,6 +27,13 @@ func GracefulTerminate(pgid int) error {
 	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pgid))
 }
 
+// Terminate gracefully stops a single process by PID.
+// On Windows this uses the same mechanism as GracefulTerminate since
+// GenerateConsoleCtrlEvent targets a process group ID.
+func Terminate(pid int) error {
+	return GracefulTerminate(pid)
+}
+
 // ForceKill terminates the process via TerminateProcess.
 // NOTE: Only kills the target process, not its children. The Manager creates a
 // Job Object (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) at process start to handle

--- a/webchat/app/admin/login/page.tsx
+++ b/webchat/app/admin/login/page.tsx
@@ -82,7 +82,7 @@ export default function LoginPage() {
                 type="url"
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
-                placeholder="http://127.0.0.1:9999"
+                placeholder="http://localhost:9999"
                 className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-faint)] outline-none transition-colors focus:border-[var(--accent-gold)]/40 focus:ring-1 focus:ring-[var(--accent-gold)]/20"
               />
             </div>

--- a/webchat/app/admin/settings/page.tsx
+++ b/webchat/app/admin/settings/page.tsx
@@ -147,7 +147,7 @@ export default function SettingsPage() {
                   type="url"
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
-                  placeholder="http://localhost:9090"
+                  placeholder="http://localhost:9999"
                   className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-faint)] outline-none transition-colors focus:border-[var(--accent-gold)]/40 focus:ring-1 focus:ring-[var(--accent-gold)]/20 font-mono"
                 />
               </div>


### PR DESCRIPTION
## Summary

Closes #548

- **webchat-embed 缓存失效检测**：基于 `find -newer` 检测源码/配置文件变更，自动触发重建；使用 POSIX 兼容的 `find | head -n 1` 替代非标准的 `find -quit`
- **Admin 默认 scopes 不足**：Go 默认 `default_scopes` 从 3 个扩充为 6 个，利用 `admin:write → admin:read → config:read` 继承链保持精简
- **构建过程可视化**：`make build` 增加版本/SHA 头部 + 三阶段状态输出（Docs/Webchat/Binary + cached 标识）
- **版本号去硬编码**：提取 `VERSION` 变量，LDFLAGS 和 build 头部统一引用
- **前端 placeholder 修正**：login 页 127.0.0.1→localhost，settings 页 9090→9999
- **文档同步**：admin-api.md、configuration.md、configs/README.md、release skill

## Test plan

- [x] `make build` 缓存命中时显示 `Webchat ✓ cached`
- [x] `touch webchat/lib/config.ts && make build` 自动检测变更并重建 webchat
- [x] 删除 `internal/webchat/out/_next` 后 `make build` 完整构建 webchat
- [x] `/admin/bots/config` 和 `/admin/cron/jobs` 返回 200（不再 403）
- [x] Pre-push 质量门通过（fmt + lint + vet + mod verify + build + test）