### PR TITLE
Batch: reliability & security quick wins for #547, #529, #524, #530

### DIFF
--- a/.agents/skills/hotplex-release/SKILL.md
+++ b/.agents/skills/hotplex-release/SKILL.md
@@ -269,7 +269,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 git diff
 
 # 或者使用 grep 确认新版本号已写入所有关键文件（如 1.2.0）
-grep -rn "1\.2\.0" cmd/hotplex/main.go Makefile internal/tracing/tracing.go \
+grep -rn "1\.2\.0" cmd/hotplex/main.go Makefile \
   examples/typescript-client/package.json examples/python-client/pyproject.toml \
   examples/python-client/hotplex_client/__init__.py examples/java-client/pom.xml \
   Dockerfile README.md README_zh.md AGENTS.md
@@ -315,7 +315,6 @@ git diff --stat
 git add \
   cmd/hotplex/main.go \
   Makefile \
-  internal/tracing/tracing.go \
   examples/typescript-client/package.json \
   examples/python-client/pyproject.toml \
   examples/python-client/hotplex_client/__init__.py \
@@ -527,7 +526,7 @@ gh release view vX.X.X
 
 > [!IMPORTANT]
 > **同步检查**：以下位置的版本号必须全部匹配，共 12 处：
-> - **Go 核心**：`cmd/hotplex/main.go`、`Makefile`、`internal/tracing/tracing.go`
+> - **Go 核心**：`cmd/hotplex/main.go`、`Makefile`（版本通过 `gateway_run.go` → `tracing.Init` 传入）
 > - **SDK**：`examples/{typescript,python,java}-client/` 各自的版本文件
 > - **文档**：`README.md` badge、`README_zh.md` badge、`AGENTS.md` 头部
 > - **基础设施**：`Dockerfile`

--- a/.agents/skills/hotplex-release/SKILL.md
+++ b/.agents/skills/hotplex-release/SKILL.md
@@ -232,7 +232,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 |:---|:---|:---|
 | `cmd/hotplex/main.go:16` | `version = "v1.x.x"` | `v1.2.0` |
 | `Makefile:26` | `VERSION := v1.x.x`（LDFLAGS 引用 `$(VERSION)`） | `v1.2.0` |
-| `internal/tracing/tracing.go` | `semconv.ServiceVersion("1.x.x")` | `1.2.0` |
+| `cmd/hotplex/gateway_run.go` | `tracing.Init(ctx, log, "hotplex-gateway", versionString())` | version from LDFLAGS |
 
 ### 4.2 多语言 SDK
 

--- a/cmd/hotplex/bot_config_adapter.go
+++ b/cmd/hotplex/bot_config_adapter.go
@@ -232,7 +232,7 @@ func (a *botConfigAdapter) DeleteBot(ctx context.Context, name string) error {
 	registry := messaging.DefaultBotRegistry()
 	entry, found := registry.GetByName(name)
 	if found && entry.Status == messaging.BotStatusRunning {
-		return fmt.Errorf("bot %q is running (status=%s); stop it before deleting", name, entry.Status)
+		return fmt.Errorf("bot %q is running (status=%s); stop it before deleting: %w", name, entry.Status, admin.ErrBotRunning)
 	}
 
 	cfg := a.cfgStore.Load()

--- a/cmd/hotplex/dev.go
+++ b/cmd/hotplex/dev.go
@@ -18,6 +18,9 @@ func newDevCmd() *cobra.Command {
 		Example: `  hotplex dev                        # Start in dev mode
   hotplex dev -c /path/to/config.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureNotRunning(); err != nil {
+				return err
+			}
 			if err := writeGatewayState(configPath, true); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write PID file: %s\n", err)
 			}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -111,7 +111,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	log, cfgStore, levelVar := initLogging(cfg)
 	pidTracker, cleanupWG := initOrphanCleanup(ctx, cfg, log)
 
-	tracing.Init(ctx, log, "hotplex-gateway")
+	tracing.Init(ctx, log, "hotplex-gateway", versionString())
 	log.Info("gateway: starting",
 		"go", runtime.Version(),
 		"addr", cfg.Gateway.Addr,

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -150,7 +150,7 @@ func (w *simulatedWorker) Input(_ context.Context, content string, _ map[string]
 	if conn == nil {
 		return fmt.Errorf("worker not started")
 	}
-	go conn.emitEvents(content)
+	conn.emitEvents(content)
 	return nil
 }
 

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -283,8 +283,7 @@ func (a *AdminAPI) HandleAPIKeyUserUpdate(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := a.akStore.update(r.Context(), id, &u); err != nil {
-		a.log.Error("admin: update api key user", "error", err)
-		http.Error(w, "not found", http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: update api key user", err)
 		return
 	}
 	if inv := a.akStore.Invalidator(); inv != nil {
@@ -313,8 +312,7 @@ func (a *AdminAPI) HandleAPIKeyUserDelete(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := a.akStore.delete(r.Context(), id); err != nil {
-		a.log.Error("admin: delete api key user", "error", err)
-		http.Error(w, "not found", http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: delete api key user", err)
 		return
 	}
 	if inv := a.akStore.Invalidator(); inv != nil {

--- a/internal/admin/bot_config_handlers.go
+++ b/internal/admin/bot_config_handlers.go
@@ -20,8 +20,7 @@ func (a *AdminAPI) HandleListBotConfigs(w http.ResponseWriter, r *http.Request) 
 	}
 	result, err := a.botConfig.ListBotConfigs(r.Context())
 	if err != nil {
-		a.log.Error("admin: list bot configs", "err", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		respondStoreError(w, a.log, "admin: list bot configs", err)
 		return
 	}
 	respondJSON(w, result)
@@ -44,8 +43,7 @@ func (a *AdminAPI) HandleGetBotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := a.botConfig.GetBotConfig(r.Context(), name)
 	if err != nil {
-		a.log.Error("admin: get bot config", "err", err)
-		http.Error(w, "not found", http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: get bot config", err)
 		return
 	}
 	respondJSON(w, result)
@@ -74,8 +72,7 @@ func (a *AdminAPI) HandleGetAgentConfigFile(w http.ResponseWriter, r *http.Reque
 	}
 	result, err := a.botConfig.GetAgentConfigFile(r.Context(), name, fileName)
 	if err != nil {
-		a.log.Error("admin: get agent config file", "err", err)
-		http.Error(w, "not found", http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: get agent config file", err)
 		return
 	}
 	respondJSON(w, result)
@@ -98,8 +95,7 @@ func (a *AdminAPI) HandleSystemPromptPreview(w http.ResponseWriter, r *http.Requ
 	}
 	result, err := a.botConfig.GetSystemPromptPreview(r.Context(), name)
 	if err != nil {
-		a.log.Error("admin: system prompt preview", "err", err)
-		http.Error(w, "not found", http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: get system prompt preview", err)
 		return
 	}
 	respondJSON(w, map[string]string{"preview": result})
@@ -181,12 +177,12 @@ func (a *AdminAPI) HandleDeleteBot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.botConfig.DeleteBot(r.Context(), name); err != nil {
-		status := http.StatusNotFound
 		if isConflictError(err) {
-			status = http.StatusConflict
+			a.log.Error("admin: delete bot conflict", "bot", name, "error", err)
+			http.Error(w, "bot is currently running", http.StatusConflict)
+		} else {
+			respondStoreError(w, a.log, "admin: delete bot", err)
 		}
-		a.log.Error("admin: delete bot", "err", err)
-		http.Error(w, http.StatusText(status), status)
 		return
 	}
 	a.log.Info("admin: bot deleted", "bot", name, "admin", adminKeyPrefix(r))

--- a/internal/admin/bot_config_handlers.go
+++ b/internal/admin/bot_config_handlers.go
@@ -2,10 +2,10 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 )
 
 // HandleListBotConfigs returns all registered bot configurations.
@@ -177,7 +177,7 @@ func (a *AdminAPI) HandleDeleteBot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.botConfig.DeleteBot(r.Context(), name); err != nil {
-		if isConflictError(err) {
+		if errors.Is(err, ErrBotRunning) {
 			a.log.Error("admin: delete bot conflict", "bot", name, "error", err)
 			http.Error(w, "bot is currently running", http.StatusConflict)
 		} else {
@@ -300,14 +300,4 @@ func toStringSlice(vals []any) []string {
 		}
 	}
 	return result
-}
-
-// isConflictError checks whether the error indicates a conflict
-// (e.g., trying to delete a running bot).
-func isConflictError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "running") || strings.Contains(msg, "conflict")
 }

--- a/internal/admin/bot_config_provider.go
+++ b/internal/admin/bot_config_provider.go
@@ -2,7 +2,12 @@ package admin
 
 import (
 	"context"
+	"errors"
 )
+
+// ErrBotRunning indicates a delete or update was attempted on a bot that is
+// currently running. Callers should check with errors.Is and return 409.
+var ErrBotRunning = errors.New("bot is currently running")
 
 // AgentConfigFileName identifies a recognized agent configuration file.
 type AgentConfigFileName string

--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 )
@@ -69,7 +68,7 @@ func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.cron.CreateJob(r.Context(), body); err != nil {
-		http.Error(w, fmt.Sprintf("create job: %s", err), http.StatusBadRequest)
+		respondStoreError(w, a.log, "admin: create cron job", err)
 		return
 	}
 	a.log.Info("admin: cron job created", "admin", adminKeyPrefix(r))
@@ -92,7 +91,7 @@ func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.cron.UpdateJob(r.Context(), id, body); err != nil {
-		http.Error(w, fmt.Sprintf("update job: %s", err), http.StatusBadRequest)
+		respondStoreError(w, a.log, "admin: update cron job", err)
 		return
 	}
 	a.log.Info("admin: cron job updated", "job_id", id, "admin", adminKeyPrefix(r))

--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -30,7 +30,7 @@ func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := a.cron.ListJobs(r.Context())
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		respondStoreError(w, a.log, "admin: cron list jobs", err)
 		return
 	}
 	respondJSON(w, result)
@@ -48,7 +48,7 @@ func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	result, err := a.cron.GetJob(r.Context(), id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: cron get job", err)
 		return
 	}
 	respondJSON(w, result)
@@ -110,7 +110,7 @@ func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	if err := a.cron.DeleteJob(r.Context(), id); err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: cron delete job", err)
 		return
 	}
 	a.log.Info("admin: cron job deleted", "job_id", id, "admin", adminKeyPrefix(r))
@@ -128,7 +128,7 @@ func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	if err := a.cron.TriggerJob(r.Context(), id); err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		respondStoreError(w, a.log, "admin: cron trigger job", err)
 		return
 	}
 	a.log.Info("admin: cron job triggered", "job_id", id, "admin", adminKeyPrefix(r))
@@ -147,7 +147,7 @@ func (a *AdminAPI) HandleCronRunHistory(w http.ResponseWriter, r *http.Request) 
 	id := r.PathValue("id")
 	result, err := a.cron.RunHistory(r.Context(), id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		respondStoreError(w, a.log, "admin: cron run history", err)
 		return
 	}
 	respondJSON(w, result)

--- a/internal/admin/cron_handlers_test.go
+++ b/internal/admin/cron_handlers_test.go
@@ -298,8 +298,8 @@ func TestHandleCronCreate_SchedulerError(t *testing.T) {
 
 	api.HandleCronCreate(w, r)
 
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "create job")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "internal error")
 }
 
 func TestHandleCronCreate_NilScheduler(t *testing.T) {
@@ -385,8 +385,8 @@ func TestHandleCronUpdate_SchedulerError(t *testing.T) {
 
 	api.HandleCronUpdate(w, r)
 
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "update job")
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "not found")
 }
 
 func TestHandleCronUpdate_NilScheduler(t *testing.T) {

--- a/internal/admin/cron_handlers_test.go
+++ b/internal/admin/cron_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cron"
 )
 
 // --- Mock cron scheduler ---
@@ -207,7 +210,7 @@ func TestHandleCronGet_NotFound(t *testing.T) {
 	t.Parallel()
 	api := cronAPIWithMock(func(mc *mockCronScheduler) {
 		mc.getJobFn = func(_ context.Context, _ string) (any, error) {
-			return nil, errors.New("not found")
+			return nil, fmt.Errorf("%w: missing", cron.ErrJobNotFound)
 		}
 	})
 	w := httptest.NewRecorder()
@@ -372,7 +375,7 @@ func TestHandleCronUpdate_SchedulerError(t *testing.T) {
 	t.Parallel()
 	api := cronAPIWithMock(func(mc *mockCronScheduler) {
 		mc.updateJobFn = func(_ context.Context, _ string, _ map[string]any) error {
-			return errors.New("job not found")
+			return fmt.Errorf("%w: missing", cron.ErrJobNotFound)
 		}
 	})
 	w := httptest.NewRecorder()
@@ -440,7 +443,7 @@ func TestHandleCronDelete_NotFound(t *testing.T) {
 	t.Parallel()
 	api := cronAPIWithMock(func(mc *mockCronScheduler) {
 		mc.deleteJobFn = func(_ context.Context, _ string) error {
-			return errors.New("not found")
+			return fmt.Errorf("%w: missing", cron.ErrJobNotFound)
 		}
 	})
 	w := httptest.NewRecorder()
@@ -507,7 +510,7 @@ func TestHandleCronTrigger_NotFound(t *testing.T) {
 	t.Parallel()
 	api := cronAPIWithMock(func(mc *mockCronScheduler) {
 		mc.triggerJobFn = func(_ context.Context, _ string) error {
-			return errors.New("job not found")
+			return fmt.Errorf("%w: missing", cron.ErrJobNotFound)
 		}
 	})
 	w := httptest.NewRecorder()

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -1,13 +1,17 @@
 package admin
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
+
+	"github.com/hrygo/hotplex/internal/cron"
+	"github.com/hrygo/hotplex/internal/session"
 )
 
 func (a *AdminAPI) HandleStats(w http.ResponseWriter, r *http.Request) {
@@ -324,7 +328,9 @@ func (a *AdminAPI) HandleRestart(w http.ResponseWriter, r *http.Request) {
 // respondStoreError handles store/DB operation errors without leaking internal
 // details. Not-found errors return 404; all others are logged and return 500.
 func respondStoreError(w http.ResponseWriter, log *slog.Logger, op string, err error) {
-	if strings.Contains(err.Error(), "not found") {
+	if errors.Is(err, sql.ErrNoRows) ||
+		errors.Is(err, cron.ErrJobNotFound) ||
+		errors.Is(err, session.ErrSessionNotFound) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -3,8 +3,10 @@ package admin
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -317,4 +319,15 @@ func (a *AdminAPI) HandleRestart(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]any{
 		"status": "restarting",
 	})
+}
+
+// respondStoreError handles store/DB operation errors without leaking internal
+// details. Not-found errors return 404; all others are logged and return 500.
+func respondStoreError(w http.ResponseWriter, log *slog.Logger, op string, err error) {
+	if strings.Contains(err.Error(), "not found") {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	log.Error(op, "error", err)
+	http.Error(w, "internal error", http.StatusInternalServerError)
 }

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -46,7 +47,7 @@ func (m *mockSessionManager) Get(_ context.Context, id string) (any, error) {
 	if m.getFn != nil {
 		return m.getFn(id)
 	}
-	return nil, errors.New("not found")
+	return nil, session.ErrSessionNotFound
 }
 func (m *mockSessionManager) Delete(ctx context.Context, id string) error {
 	if m.deleteFn != nil {

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -220,7 +220,7 @@ func (c *Conn) ReadPump(handler connHandler, sm connSM, auth connAuth) {
 			continue
 		}
 
-		_, span := tracing.SpanFromContext(context.Background()).Start(context.Background(), "conn.recv")
+		_, span := tracing.GetTracer().Start(context.Background(), "conn.recv")
 		span.SetAttributes(
 			attribute.String("session_id", c.sessionID),
 			attribute.String("event_type", string(env.Event.Type)),
@@ -240,7 +240,7 @@ func (c *Conn) ReadPump(handler connHandler, sm connSM, auth connAuth) {
 // performInit reads and processes the AEP init handshake message.
 // It blocks until either an init message is processed or an error occurs.
 func (c *Conn) performInit(auth connAuth, sm connSM) error {
-	_, span := tracing.SpanFromContext(context.Background()).Start(context.Background(), "conn.init")
+	_, span := tracing.GetTracer().Start(context.Background(), "conn.init")
 	defer span.End()
 	start := time.Now()
 	defer func() { metrics.InitHandshakeDuration.Observe(time.Since(start).Seconds()) }()

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -281,7 +281,7 @@ func (h *Hub) sendBroadcast(msg *EnvelopeWithConn) (sent bool) {
 // Control-priority messages bypass the broadcast queue.
 // afterDrain functions are called sequentially after the item is routed by Run.
 func (h *Hub) SendToSession(ctx context.Context, env *events.Envelope, afterDrain ...func()) error {
-	spanCtx, span := tracing.SpanFromContext(ctx).Start(ctx, "hub.send_to_session")
+	spanCtx, span := tracing.GetTracer().Start(ctx, "hub.send_to_session")
 	defer span.End()
 	span.SetAttributes(
 		tracing.Attr("session_id", env.SessionID),
@@ -435,7 +435,7 @@ func (h *Hub) Run() {
 						h.log.Error("hub: panic in routeMessage", "session_id", msg.Env.SessionID, "panic", r, "stack", string(debug.Stack()))
 					}
 				}()
-				_, span := tracing.SpanFromContext(h.ctx).Start(h.ctx, "hub.broadcast")
+				_, span := tracing.GetTracer().Start(h.ctx, "hub.broadcast")
 				span.SetAttributes(
 					tracing.Attr("session_id", msg.Env.SessionID),
 					tracing.Attr("event_type", string(msg.Env.Event.Type)),

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -35,7 +35,7 @@ var (
 func Init(ctx context.Context, log *slog.Logger, serviceName, serviceVersion string) {
 	initOnce.Do(func() {
 		if os.Getenv("OTEL_SDK_DISABLED") == "true" {
-			Tracer = noopTracer()
+			Tracer = noopTracerVal
 			log.Info("tracing: disabled via OTEL_SDK_DISABLED=true")
 			return
 		}
@@ -43,7 +43,7 @@ func Init(ctx context.Context, log *slog.Logger, serviceName, serviceVersion str
 		endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 		if endpoint == "" {
 			// No endpoint configured — install noop tracer (don't fail startup)
-			Tracer = noopTracer()
+			Tracer = noopTracerVal
 			log.Info("tracing: no OTEL_EXPORTER_OTLP_ENDPOINT set, tracing disabled")
 			return
 		}
@@ -53,7 +53,7 @@ func Init(ctx context.Context, log *slog.Logger, serviceName, serviceVersion str
 		exp, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
 		if err != nil {
 			log.Warn("tracing: stdout exporter creation failed, disabling", "err", err)
-			Tracer = noopTracer()
+			Tracer = noopTracerVal
 			return
 		}
 
@@ -65,7 +65,7 @@ func Init(ctx context.Context, log *slog.Logger, serviceName, serviceVersion str
 		)
 		if err != nil {
 			log.Warn("tracing: resource creation failed, disabling", "err", err)
-			Tracer = noopTracer()
+			Tracer = noopTracerVal
 			return
 		}
 
@@ -94,16 +94,14 @@ func Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func noopTracer() trace.Tracer {
-	return noop.NewTracerProvider().Tracer("hotplex")
-}
+var noopTracerVal = noop.NewTracerProvider().Tracer("hotplex")
 
 // GetTracer returns the global Tracer if initialized, otherwise returns a no-op tracer.
 func GetTracer() trace.Tracer {
 	if Tracer != nil {
 		return Tracer
 	}
-	return noop.NewTracerProvider().Tracer("hotplex")
+	return noopTracerVal
 }
 
 // Attr returns a trace attribute for span attributes.

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -32,7 +32,7 @@ var (
 // If OTEL_SDK_DISABLED=true or no OTEL_EXPORTER_OTLP_ENDPOINT is set,
 // a no-op tracer is installed and this function logs a warning.
 // Init is idempotent — subsequent calls are no-ops.
-func Init(ctx context.Context, log *slog.Logger, serviceName string) {
+func Init(ctx context.Context, log *slog.Logger, serviceName, serviceVersion string) {
 	initOnce.Do(func() {
 		if os.Getenv("OTEL_SDK_DISABLED") == "true" {
 			Tracer = noopTracer()
@@ -60,7 +60,7 @@ func Init(ctx context.Context, log *slog.Logger, serviceName string) {
 		res, err := resource.New(ctx,
 			resource.WithAttributes(
 				semconv.ServiceName(serviceName),
-				semconv.ServiceVersion("1.19.0"),
+				semconv.ServiceVersion(serviceVersion),
 			),
 		)
 		if err != nil {
@@ -98,8 +98,8 @@ func noopTracer() trace.Tracer {
 	return noop.NewTracerProvider().Tracer("hotplex")
 }
 
-// SpanFromContext returns Tracer if non-nil, otherwise returns a no-op tracer.
-func SpanFromContext(ctx context.Context) trace.Tracer {
+// GetTracer returns the global Tracer if initialized, otherwise returns a no-op tracer.
+func GetTracer() trace.Tracer {
 	if Tracer != nil {
 		return Tracer
 	}

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -274,6 +274,12 @@ func (w *ExecWorker) readOutput(ctx context.Context, stdout io.Reader, entryConn
 			_ = entryConn.Close()
 		}
 	}()
+	// Drain remaining stdout data in background so the pipe writer (child
+	// process) is never blocked. The goroutine exits when proc.Manager.Close
+	// closes the read end of the pipe.
+	defer func() {
+		go func() { _, _ = io.Copy(io.Discard, stdout) }()
+	}()
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -386,15 +386,9 @@ func (m *Manager) drainStderr() {
 			m.log.Error("proc: drainStderr panic", "panic", r)
 		}
 	}()
-	buf := make([]byte, 4096)
-	for {
-		n, err := m.stderr.Read(buf)
-		if n > 0 {
-			m.log.Info("proc: stderr", "msg", string(buf[:n]))
-		}
-		if err != nil {
-			break
-		}
+	scanner := bufio.NewScanner(m.stderr)
+	for scanner.Scan() {
+		m.log.Info("proc: stderr", "msg", scanner.Text())
 	}
 }
 

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -387,8 +387,12 @@ func (m *Manager) drainStderr() {
 		}
 	}()
 	scanner := bufio.NewScanner(m.stderr)
+	scanner.Buffer(make([]byte, scannerInitSize), scannerMaxSize)
 	for scanner.Scan() {
 		m.log.Info("proc: stderr", "msg", scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		m.log.Warn("proc: drainStderr ended with error", "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

4 high-ROI reliability & security fixes across worker, cmd, tracing, and admin modules.

- **#547**: Fix codexcli stdout pipe FD leak on early return + proc stderr heap allocation
- **#529**: Fix `hotplex dev` missing duplicate-gateway guard
- **#524**: Rename misleading `SpanFromContext` to `GetTracer` + fix hardcoded tracing version
- **#530**: Prevent internal error string leakage across 13 admin HTTP endpoints

## Changes by Issue

### #547 — codexcli FD leak + proc stderr
- `readOutput`: background drain stdout pipe on early return prevents FD leak
- `drainStderr`: replace manual buffer with `bufio.Scanner` for line-level logging

### #529 — dev command guard
- Add `ensureNotRunning()` call before `writeGatewayState` in `dev.go`

### #524 — tracing API fix
- Rename `SpanFromContext(ctx)` → `GetTracer()` (old name implied OTel span extraction)
- Fix hardcoded `"1.19.0"` → accept `serviceVersion` parameter from build-time variable
- Update all 4 callers (hub.go, conn.go, gateway_run.go)

### #530 — admin error leakage
- Add `respondStoreError` helper: not-found → 404, other → 500 (logged server-side)
- Replace all `http.Error(w, err.Error(), ...)` across cron/apikey/bot_config handlers
- Fix health check, JSON decode, and rollback error messages

Closes #547, #529, #524, #530

## Test plan
- [x] `make check` passes (lint + test + build)
- [x] `go test -race ./internal/worker/codexcli/ ./internal/worker/proc/` passes
- [x] `go test -race ./internal/admin/` passes
- [x] `go test -race ./internal/gateway/` passes
- [x] Zero `http.Error(w, err.Error()` remaining in admin package

🤖 Generated with [Claude Code](https://claude.com/claude-code)