### PR TITLE
fix(batch): error-handling & reliability fixes for #532, #522, #535, #533

### DIFF
--- a/internal/brain/llm/circuit.go
+++ b/internal/brain/llm/circuit.go
@@ -231,6 +231,20 @@ func (cb *CircuitBreaker) Reset() {
 
 	cb.forceOpen.Store(false)
 	cb.forceClosed.Store(false)
+
+	settings := gobreaker.Settings{
+		Name:        cb.config.Name,
+		MaxRequests: cb.config.HalfOpenMaxRequests,
+		Interval:    cb.config.Interval,
+		Timeout:     cb.config.Timeout,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= cb.config.MaxFailures
+		},
+		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+			cb.onStateChange(from, to)
+		},
+	}
+	cb.breaker = gobreaker.NewCircuitBreaker(settings)
 	cb.state.Store(string(CircuitClosed))
 	cb.lastStateChange.Store(time.Now())
 

--- a/internal/brain/llm/circuit.go
+++ b/internal/brain/llm/circuit.go
@@ -97,21 +97,24 @@ func NewCircuitBreaker(config CircuitBreakerConfig) *CircuitBreaker {
 		forceClosed:     atomic.NewBool(false),
 	}
 
-	settings := gobreaker.Settings{
-		Name:        config.Name,
-		MaxRequests: config.HalfOpenMaxRequests,
-		Interval:    config.Interval,
-		Timeout:     config.Timeout,
+	cb.breaker = gobreaker.NewCircuitBreaker(cb.newSettings())
+	return cb
+}
+
+// newSettings returns gobreaker.Settings derived from the current config.
+func (cb *CircuitBreaker) newSettings() gobreaker.Settings {
+	return gobreaker.Settings{
+		Name:        cb.config.Name,
+		MaxRequests: cb.config.HalfOpenMaxRequests,
+		Interval:    cb.config.Interval,
+		Timeout:     cb.config.Timeout,
 		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			return counts.ConsecutiveFailures >= config.MaxFailures
+			return counts.ConsecutiveFailures >= cb.config.MaxFailures
 		},
 		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
 			cb.onStateChange(from, to)
 		},
 	}
-
-	cb.breaker = gobreaker.NewCircuitBreaker(settings)
-	return cb
 }
 
 // onStateChange handles circuit state changes.
@@ -162,8 +165,12 @@ func (cb *CircuitBreaker) Execute(ctx context.Context, fn func() error) error {
 		return fn()
 	}
 
-	// Execute with circuit breaker
-	_, err := cb.breaker.Execute(func() (interface{}, error) {
+	// Snapshot breaker under RLock to prevent data race with Reset()
+	cb.mu.RLock()
+	breaker := cb.breaker
+	cb.mu.RUnlock()
+
+	_, err := breaker.Execute(func() (interface{}, error) {
 		return nil, wrappedFn()
 	})
 
@@ -191,8 +198,12 @@ func (cb *CircuitBreaker) ExecuteWithResult(ctx context.Context, fn func() (inte
 		return fn()
 	}
 
-	// Execute with circuit breaker
-	result, err := cb.breaker.Execute(func() (interface{}, error) {
+	// Snapshot breaker under RLock to prevent data race with Reset()
+	cb.mu.RLock()
+	breaker := cb.breaker
+	cb.mu.RUnlock()
+
+	result, err := breaker.Execute(func() (interface{}, error) {
 		return fn()
 	})
 
@@ -232,19 +243,7 @@ func (cb *CircuitBreaker) Reset() {
 	cb.forceOpen.Store(false)
 	cb.forceClosed.Store(false)
 
-	settings := gobreaker.Settings{
-		Name:        cb.config.Name,
-		MaxRequests: cb.config.HalfOpenMaxRequests,
-		Interval:    cb.config.Interval,
-		Timeout:     cb.config.Timeout,
-		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			return counts.ConsecutiveFailures >= cb.config.MaxFailures
-		},
-		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-			cb.onStateChange(from, to)
-		},
-	}
-	cb.breaker = gobreaker.NewCircuitBreaker(settings)
+	cb.breaker = gobreaker.NewCircuitBreaker(cb.newSettings())
 	cb.state.Store(string(CircuitClosed))
 	cb.lastStateChange.Store(time.Now())
 

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -160,6 +160,7 @@ func (c agentConfigDirChecker) Check(_ context.Context) cli.Diagnostic {
 func (c agentConfigDirChecker) checkSubdir(platformDir, platformName string, warnings *[]string) {
 	entries, err := os.ReadDir(platformDir)
 	if err != nil {
+		*warnings = append(*warnings, fmt.Sprintf("cannot read %s config dir: %v", platformName, err))
 		return
 	}
 	for _, e := range entries {

--- a/internal/cli/checkers/config.go
+++ b/internal/cli/checkers/config.go
@@ -166,8 +166,23 @@ func (c configRequiredChecker) Check(ctx context.Context) cli.Diagnostic {
 
 	var missing []string
 
-	hasWorker := cfg.Messaging.Slack.Enabled || cfg.Messaging.Feishu.Enabled
-	if !hasWorker {
+	if cfg.Messaging.Slack.Enabled {
+		if cfg.Messaging.Slack.BotToken == "" {
+			missing = append(missing, "messaging.slack.bot_token")
+		}
+		if cfg.Messaging.Slack.AppToken == "" {
+			missing = append(missing, "messaging.slack.app_token")
+		}
+	}
+	if cfg.Messaging.Feishu.Enabled {
+		if cfg.Messaging.Feishu.AppID == "" {
+			missing = append(missing, "messaging.feishu.app_id")
+		}
+		if cfg.Messaging.Feishu.AppSecret == "" {
+			missing = append(missing, "messaging.feishu.app_secret")
+		}
+	}
+	if !cfg.Messaging.Slack.Enabled && !cfg.Messaging.Feishu.Enabled {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),

--- a/internal/cli/checkers/config_test.go
+++ b/internal/cli/checkers/config_test.go
@@ -295,6 +295,8 @@ func TestConfigRequired_AllPresent(t *testing.T) {
 	path := filepath.Join(dir, "config.yaml")
 	dbDir := filepath.Join(dir, "data")
 	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	t.Setenv("HOTPLEX_MESSAGING_SLACK_BOT_TOKEN", "xoxb-test-token")
+	t.Setenv("HOTPLEX_MESSAGING_SLACK_APP_TOKEN", "xapp-test-token")
 	content := "gateway:\n  addr: \":8888\"\nadmin:\n  addr: \":9999\"\n  enabled: true\ndb:\n  path: \"" + filepath.Join(dbDir, "test.db") + "\"\nmessaging:\n  slack:\n    enabled: true\n"
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 

--- a/internal/cli/slack/client.go
+++ b/internal/cli/slack/client.go
@@ -43,7 +43,9 @@ func LoadConfigAndClient(configPath string) (*config.Config, *slack.Client, erro
 		return nil, nil, fmt.Errorf("resolve config path: %w", err)
 	}
 
-	loadEnvFile(filepath.Dir(configPath))
+	if err := loadEnvFile(filepath.Dir(configPath)); err != nil {
+		return nil, nil, fmt.Errorf("load env file: %w", err)
+	}
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -62,11 +64,14 @@ func LoadConfigAndClient(configPath string) (*config.Config, *slack.Client, erro
 	return cfg, client, nil
 }
 
-func loadEnvFile(dir string) {
+func loadEnvFile(dir string) error {
 	envPath := filepath.Join(dir, ".env")
 	f, err := os.Open(envPath)
 	if err != nil {
-		return
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("open .env: %w", err)
 	}
 	defer f.Close()
 
@@ -89,4 +94,5 @@ func loadEnvFile(dir string) {
 			os.Setenv(key, val)
 		}
 	}
+	return s.Err()
 }

--- a/internal/cli/slack/download.go
+++ b/internal/cli/slack/download.go
@@ -26,6 +26,8 @@ func DownloadFile(ctx context.Context, client *slack.Client, fileID, outputPath 
 	defer func() { _ = f.Close() }()
 
 	if err := client.GetFileContext(ctx, info.URLPrivateDownload, f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(outputPath)
 		return fmt.Errorf("download file: %w", err)
 	}
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -850,7 +850,8 @@ func (m *Manager) RepairRunningSessions(ctx context.Context) (int, error) {
 	return repaired, nil
 }
 
-// Stats returns the active worker pool utilization.
+// Stats returns the current worker pool counts: total active workers,
+// maximum pool size, and number of unique users with active sessions.
 func (m *Manager) Stats() (totalWorkers, maxWorkers, uniqueUsers int) {
 	total, max, users := m.pool.Stats()
 	return total, max, users

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -496,15 +496,12 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 		var pe *PoolError
 		if !errors.As(poolErr, &pe) {
 			m.log.Warn("session: attach rejected", "err", poolErr, "session_id", id)
-			metrics.PoolAcquireTotal.WithLabelValues("pool_exhausted").Inc()
 			return ErrPoolExhausted
 		}
 		m.log.Warn("session: attach rejected", "kind", pe.Kind, "session_id", id)
 		if pe.Kind == poolErrKindUserQuotaExceeded {
-			metrics.PoolAcquireTotal.WithLabelValues("user_quota_exceeded").Inc()
 			return ErrUserQuotaExceeded
 		}
-		metrics.PoolAcquireTotal.WithLabelValues("pool_exhausted").Inc()
 		return ErrPoolExhausted
 	}
 
@@ -856,9 +853,6 @@ func (m *Manager) RepairRunningSessions(ctx context.Context) (int, error) {
 // Stats returns the active worker pool utilization.
 func (m *Manager) Stats() (totalWorkers, maxWorkers, uniqueUsers int) {
 	total, max, users := m.pool.Stats()
-	if max > 0 {
-		metrics.PoolUtilization.Set(float64(total) / float64(max))
-	}
 	return total, max, users
 }
 


### PR DESCRIPTION
## Summary

Batch of 4 high-ROI error-handling and reliability fixes:

- **#532**: Fix CircuitBreaker `Reset()` state divergence — rebuild underlying gobreaker instance so `Execute()` works immediately after reset
- **#522**: Remove duplicate `PoolAcquireTotal` metrics from manager.go (already counted by `pool.Acquire`) and redundant `PoolUtilization.Set()` in `Stats()`
- **#535**: Fix `loadEnvFile` unchecked scanner error + `DownloadFile` leaves corrupt partial file on failure
- **#533**: Fix `configRequiredChecker` dead-code `missing` slice + silent `ReadDir` error in `checkSubdir`

## Changes by Issue

### #532 — CircuitBreaker Reset() state divergence
- `circuit.go`: `Reset()` now rebuilds `cb.breaker` via `gobreaker.NewCircuitBreaker(settings)` and explicitly stores closed state
- Before: `GetState()` returned "closed" but `Execute()` still returned `gobreaker.ErrOpenState`

### #522 — Pool metrics double-count
- `manager.go`: Removed 3 duplicate `PoolAcquireTotal.Inc()` calls (`pool_exhausted` ×2, `user_quota_exceeded` ×1) — already counted by `pool.Acquire()`
- `manager.go`: Removed redundant `PoolUtilization.Set()` in `Stats()` — already maintained by `pool.go` on every mutation

### #535 — CLI slack error handling
- `client.go`: `loadEnvFile` now returns `error`, checks `s.Err()` after scanner loop, wraps file-open errors
- `download.go`: `DownloadFile` closes and removes partial file on download failure

### #533 — Checkers dead-code + silent error
- `config.go`: `configRequiredChecker` now populates `missing` slice with Slack/Feishu credential fields when platform is enabled
- `agentconfig.go`: `checkSubdir` reports `os.ReadDir` errors as warnings instead of silently returning

## Testing

- [x] `make check` — all quality gates passed
- [x] All affected test suites pass with `-race`
- [x] Updated `config_test.go` to provide required env vars for `TestConfigRequired_AllPresent`

## Impact

- 7 files changed, +45 -11 lines (net code reduction in manager.go)
- No breaking changes — all fixes are backward compatible

Closes #532, #522, #535, #533