### PR TITLE
fix(ux): dev mode lockout warning + webchat 401 guidance + font preload trim

### DIFF
--- a/.agents/skills/hotplex-release/SKILL.md
+++ b/.agents/skills/hotplex-release/SKILL.md
@@ -234,7 +234,15 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 | `Makefile:26` | `VERSION := v1.x.x`（LDFLAGS 引用 `$(VERSION)`） | `v1.2.0` |
 | `cmd/hotplex/gateway_run.go` | `tracing.Init(ctx, log, "hotplex-gateway", versionString())` | version from LDFLAGS |
 
-### 4.2 多语言 SDK
+### 4.2 WebChat UI
+
+| 文件 | 模式 | 示例 |
+|:---|:---|:---|
+| `webchat/package.json` | `"version": "1.x.x"` | `1.2.0` |
+
+> **注意**：页面状态栏通过 `import { version } from "../../package.json"` 读取版本号，显示为 `v{version}-stable`。
+
+### 4.3 多语言 SDK
 
 | 文件 | 模式 |
 |:---|:---|
@@ -243,7 +251,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 | `examples/python-client/hotplex_client/__init__.py` | `__version__ = "1.x.x"` |
 | `examples/java-client/pom.xml` | `<version>1.x.x-SNAPSHOT</version>` |
 
-### 4.3 项目文档
+### 4.4 项目文档
 
 | 文件 | 模式 | 示例 |
 |:---|:---|:---|
@@ -254,7 +262,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 
 > **注意**：`CLAUDE.md` 是 `AGENTS.md` 的符号链接，只需编辑 `AGENTS.md`（这是实际文件），`CLAUDE.md` 会自动同步。修改时请同时更新**版本号**和**最后更新日期**。
 
-### 4.4 基础设施
+### 4.5 基础设施
 
 | 文件 | 模式 |
 |:---|:---|
@@ -269,7 +277,7 @@ CommandMenu），Gateway Core 获得了连接稳定性修复（CAS race guard、
 git diff
 
 # 或者使用 grep 确认新版本号已写入所有关键文件（如 1.2.0）
-grep -rn "1\.2\.0" cmd/hotplex/main.go Makefile \
+grep -rn "1\.2\.0" cmd/hotplex/main.go Makefile webchat/package.json \
   examples/typescript-client/package.json examples/python-client/pyproject.toml \
   examples/python-client/hotplex_client/__init__.py examples/java-client/pom.xml \
   Dockerfile README.md README_zh.md AGENTS.md
@@ -315,6 +323,7 @@ git diff --stat
 git add \
   cmd/hotplex/main.go \
   Makefile \
+  webchat/package.json \
   examples/typescript-client/package.json \
   examples/python-client/pyproject.toml \
   examples/python-client/hotplex_client/__init__.py \
@@ -525,8 +534,9 @@ gh release view vX.X.X
 ## 关键提醒
 
 > [!IMPORTANT]
-> **同步检查**：以下位置的版本号必须全部匹配，共 12 处：
+> **同步检查**：以下位置的版本号必须全部匹配，共 13 处：
 > - **Go 核心**：`cmd/hotplex/main.go`、`Makefile`（版本通过 `gateway_run.go` → `tracing.Init` 传入）
+> - **WebChat UI**：`webchat/package.json`（页面状态栏 `v{version}-stable`）
 > - **SDK**：`examples/{typescript,python,java}-client/` 各自的版本文件
 > - **文档**：`README.md` badge、`README_zh.md` badge、`AGENTS.md` 头部
 > - **基础设施**：`Dockerfile`

--- a/.agents/skills/hotplex-release/SKILL.md
+++ b/.agents/skills/hotplex-release/SKILL.md
@@ -534,7 +534,7 @@ gh release view vX.X.X
 ## 关键提醒
 
 > [!IMPORTANT]
-> **同步检查**：以下位置的版本号必须全部匹配，共 13 处：
+> **同步检查**：以下位置的版本号必须全部匹配，共 12 处：
 > - **Go 核心**：`cmd/hotplex/main.go`、`Makefile`（版本通过 `gateway_run.go` → `tracing.Init` 传入）
 > - **WebChat UI**：`webchat/package.json`（页面状态栏 `v{version}-stable`）
 > - **SDK**：`examples/{typescript,python,java}-client/` 各自的版本文件

--- a/.github/actions/setup-go-webchat/action.yml
+++ b/.github/actions/setup-go-webchat/action.yml
@@ -40,7 +40,7 @@ runs:
         path: internal/webchat/out
         key: webchat-v2-${{ hashFiles('webchat/app/**', 'webchat/components/**', 'webchat/context/**', 'webchat/hooks/**', 'webchat/lib/**', 'webchat/public/**', 'webchat/types/**', 'webchat/next.config.*', 'webchat/package.json', 'webchat/pnpm-lock.yaml') }}
 
-    - uses: pnpm/action-setup@v4.1.0
+    - uses: pnpm/action-setup@v6
       if: steps.webchat-cache.outputs.cache-hit != 'true'
       with:
         version: ${{ inputs.pnpm-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ on:
       - '.github/workflows/**'
 
 env:
+  # TODO: remove after Node 24 becomes the default runtime for GitHub Actions
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ on:
       - 'cmd/build-docs/**'
       - '.github/workflows/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
+	"log/slog"
 	"net/http"
 	"sync"
 
@@ -143,7 +144,11 @@ func (a *Authenticator) AddKey(key string) {
 func (a *Authenticator) RemoveKey(key string) {
 	a.mu.Lock()
 	delete(a.dbKeys, key)
+	empty := len(a.validKey) == 0 && len(a.dbKeys) == 0 && a.devModeLocked
 	a.mu.Unlock()
+	if empty {
+		slog.Warn("security: all API keys removed but dev mode is locked — restart gateway to restore anonymous access")
+	}
 }
 
 // resolveUserID returns the user identity for a valid API key.

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -147,7 +147,8 @@ func (a *Authenticator) RemoveKey(key string) {
 	empty := len(a.validKey) == 0 && len(a.dbKeys) == 0 && a.devModeLocked
 	a.mu.Unlock()
 	if empty {
-		slog.Warn("security: all API keys removed but dev mode is locked — restart gateway to restore anonymous access")
+		slog.Warn("security: all API keys removed but dev mode is locked — restart gateway to restore anonymous access",
+			"dev_mode_locked", true)
 	}
 }
 

--- a/webchat/app/layout.tsx
+++ b/webchat/app/layout.tsx
@@ -5,9 +5,6 @@ import './globals.css';
 
 const inter = localFont({
   src: [
-    { path: '../node_modules/@fontsource/inter/files/inter-latin-100-normal.woff2', weight: '100' },
-    { path: '../node_modules/@fontsource/inter/files/inter-latin-200-normal.woff2', weight: '200' },
-    { path: '../node_modules/@fontsource/inter/files/inter-latin-300-normal.woff2', weight: '300' },
     { path: '../node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2', weight: '400' },
     { path: '../node_modules/@fontsource/inter/files/inter-latin-500-normal.woff2', weight: '500' },
     { path: '../node_modules/@fontsource/inter/files/inter-latin-600-normal.woff2', weight: '600' },
@@ -21,9 +18,6 @@ const inter = localFont({
 
 const outfit = localFont({
   src: [
-    { path: '../node_modules/@fontsource/outfit/files/outfit-latin-100-normal.woff2', weight: '100' },
-    { path: '../node_modules/@fontsource/outfit/files/outfit-latin-200-normal.woff2', weight: '200' },
-    { path: '../node_modules/@fontsource/outfit/files/outfit-latin-300-normal.woff2', weight: '300' },
     { path: '../node_modules/@fontsource/outfit/files/outfit-latin-400-normal.woff2', weight: '400' },
     { path: '../node_modules/@fontsource/outfit/files/outfit-latin-500-normal.woff2', weight: '500' },
     { path: '../node_modules/@fontsource/outfit/files/outfit-latin-600-normal.woff2', weight: '600' },
@@ -37,9 +31,6 @@ const outfit = localFont({
 
 const jetbrainsMono = localFont({
   src: [
-    { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-100-normal.woff2', weight: '100' },
-    { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-200-normal.woff2', weight: '200' },
-    { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-300-normal.woff2', weight: '300' },
     { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2', weight: '400' },
     { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2', weight: '500' },
     { path: '../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-600-normal.woff2', weight: '600' },

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -590,7 +590,7 @@ export function useHotPlexRuntime({
           errorMessage = "You've reached the rate limit. Please wait a moment before sending more messages.";
           break;
         case 'UNAUTHORIZED':
-          errorMessage = "Authentication failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys and restart gateway to use dev mode.";
+          errorMessage = "Authentication failed: 401 — Check your API key configuration or consult the documentation.";
           break;
         case 'WORKER_OUTPUT_LIMIT':
           errorMessage = "The agent produced too much output and was terminated. Try to narrow down your request.";

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -590,7 +590,7 @@ export function useHotPlexRuntime({
           errorMessage = "You've reached the rate limit. Please wait a moment before sending more messages.";
           break;
         case 'UNAUTHORIZED':
-          errorMessage = "Authentication failed. Please check your API key or connection settings.";
+          errorMessage = "Authentication failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys and restart gateway to use dev mode.";
           break;
         case 'WORKER_OUTPUT_LIMIT':
           errorMessage = "The agent produced too much output and was terminated. Try to narrow down your request.";

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -74,7 +74,7 @@ export class AuthError extends Error {
 function throwIfAuthError(prefix: string, status: number): never | void {
   if (status === 401) {
     throw new AuthError(
-      `${prefix} failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys and restart gateway to use dev mode.`
+      `${prefix} failed: 401 — Authentication failed. Check your API key configuration or consult the documentation.`
     );
   }
 }

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -102,6 +102,7 @@ export async function createSession(opts: CreateSessionOptions, signal?: AbortSi
     url += `&work_dir=${encodeURIComponent(opts.workDir)}`;
   }
   const res = await fetch(url, { method: 'POST', headers: AUTH_HEADER, signal });
+  throwIfAuthError('createSession', res.status);
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(body || `createSession failed: ${res.status}`);
@@ -114,6 +115,7 @@ export async function deleteSession(id: string, signal?: AbortSignal): Promise<v
     `${BASE}/api/sessions/${id}`,
     { method: 'DELETE', headers: AUTH_HEADER, signal }
   );
+  throwIfAuthError('deleteSession', res.status);
   if (!res.ok) throw new Error(`deleteSession failed: ${res.status}`);
 }
 
@@ -130,6 +132,7 @@ export async function getSessionHistory(
     url += `&before_id=${options.beforeId}`;
   }
   const res = await fetch(url, { headers: { ...AUTH_HEADER, 'Content-Type': 'application/json' }, signal: options?.signal });
+  throwIfAuthError('getSessionHistory', res.status);
   if (!res.ok) throw new Error(`getSessionHistory failed: ${res.status}`);
   return res.json();
 }

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -64,11 +64,27 @@ export interface GetHistoryResponse {
   has_more: boolean;
 }
 
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+function throwIfAuthError(prefix: string, status: number): never | void {
+  if (status === 401) {
+    throw new AuthError(
+      `${prefix} failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys to use dev mode.`
+    );
+  }
+}
+
 export async function listSessions(limit = 20, offset = 0, signal?: AbortSignal): Promise<ListSessionsResponse> {
   const res = await fetch(
     `${BASE}/api/sessions?limit=${limit}&offset=${offset}`,
     { headers: { ...AUTH_HEADER, 'Content-Type': 'application/json' }, signal }
   );
+  throwIfAuthError('listSessions', res.status);
   if (!res.ok) throw new Error(`listSessions failed: ${res.status}`);
   return res.json();
 }

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -74,7 +74,7 @@ export class AuthError extends Error {
 function throwIfAuthError(prefix: string, status: number): never | void {
   if (status === 401) {
     throw new AuthError(
-      `${prefix} failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys to use dev mode.`
+      `${prefix} failed: 401 — API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY in .env.local or remove gateway API keys and restart gateway to use dev mode.`
     );
   }
 }

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -15,6 +15,7 @@ import {
   listSessions,
   createSession,
   deleteSession,
+  AuthError,
   type SessionInfo,
 } from '@/lib/api/sessions';
 import { workerType as defaultWorkerType, workDir as configWorkDir } from '@/lib/config';
@@ -134,7 +135,7 @@ export function useSessions({
         }
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load sessions');
+      setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to load sessions'));
     } finally {
       setIsLoading(false);
     }
@@ -177,7 +178,7 @@ export function useSessions({
       onSelectRef.current(session_id);
       localStorage.setItem(STORAGE_KEY, session_id);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to create session');
+      setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to create session'));
     } finally {
       setIsLoading(false);
       isCreating.current = false;

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -196,6 +196,7 @@ export function useSessions({
     try {
       await deleteSession(id);
     } catch (e) {
+      logger.error('Sessions', 'Failed to delete session', { error: String(e) });
       setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to delete session'));
       refreshSessions();
     }

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -196,8 +196,7 @@ export function useSessions({
     try {
       await deleteSession(id);
     } catch (e) {
-      logger.error('Sessions', 'Failed to delete session', { error: String(e) });
-      // Revert optimistic remove on failure
+      setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to delete session'));
       refreshSessions();
     }
   }, [activeSession, refreshSessions]);

--- a/webchat/package.json
+++ b/webchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotplex-webchat",
-  "version": "1.8.1",
+  "version": "1.20.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Closes #560 — 三项新用户体验优化，确保 dev mode 闭环畅通。

### P1: RemoveKey 清空后日志警告
- `internal/security/auth.go` — 删除最后一个 API key 后，如果 `devModeLocked=true`，打印 `slog.Warn` 提示用户重启 gateway 恢复匿名访问
- 安全策略不变（devModeLocked 仍为永久锁），仅增加可观测性

### P2: Webchat 401 可操作提示
- `webchat/lib/api/sessions.ts` — 新增 `AuthError` 类和 `throwIfAuthError`，401 时抛出含操作指引的结构化错误
- `webchat/lib/hooks/useSessions.ts` — `refreshSessions` 和 `createNewSession` 的 catch 块优先检测 `AuthError`，显示可操作的配置提示

### P3: 字体 preload 瘦身
- `webchat/app/layout.tsx` — 移除 Inter/Outfit/JetBrains Mono 的 100/200/300 字重（未使用），消除 9 条控制台 preload 警告

## Test plan

- [ ] 全新安装（无 API key）→ webchat 正常工作（dev mode）
- [ ] Admin API 添加 key → 删除最后一个 key → 日志出现 "restart gateway to restore anonymous access" 警告
- [ ] Webchat 使用错误 API key → 显示 "API key mismatch. Check HOTPLEX_WEBCHAT_API_KEY..." 提示
- [ ] 浏览器控制台无字体 preload 警告
- [ ] `go test ./internal/security/` 通过
- [ ] `cd webchat && npx next build` 通过