### PR TITLE
fix(gateway): populate metadata in synthetic events (#559)

### DIFF
--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -109,7 +109,17 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 				"session_id", sessionID, "worker_type", workerType, "turn_timeout", b.turnTimeout)
 			b.sendError(sessionID, events.ErrCodeTurnTimeout, "Turn exceeded %v time limit and was terminated.", b.turnTimeout)
 			acc := b.getOrInitAccum(sessionID, "", fc.startTime)
-			b.captureSyntheticEvent(sessionID, "turn_timeout", fmt.Sprintf("Turn exceeded %v time limit", b.turnTimeout), eventstore.SourceTimeout, fc.sessPlatform, fc.sessOwner, acc.ModelName)
+			b.captureSyntheticEvent(syntheticTurnParams{
+				SessionID:  sessionID,
+				Reason:     "turn_timeout",
+				Message:    fmt.Sprintf("Turn exceeded %v time limit", b.turnTimeout),
+				Source:     eventstore.SourceTimeout,
+				Platform:   fc.sessPlatform,
+				Owner:      fc.sessOwner,
+				Model:      acc.ModelName,
+				Generation: acc.Generation,
+				TurnNum:    acc.TurnCount,
+			})
 			_ = w.Terminate(context.Background())
 		})
 		defer fc.turnTimer.Stop()
@@ -419,6 +429,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		if lastInput == "" {
 			lastInput = p.opts.lastInput
 		}
+		acc := b.getOrInitAccum(p.sessionID, "", p.startTime)
 		if b.attemptResumeFallback(fallbackParams{
 			sessionID:     p.sessionID,
 			workDir:       p.opts.workDir,
@@ -429,6 +440,8 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			crashedWorker: w,
 			sessPlatform:  p.sessPlatform,
 			sessOwner:     p.sessOwner,
+			accGeneration: acc.Generation,
+			accModelName:  acc.ModelName,
 		}) {
 			return
 		}
@@ -467,7 +480,17 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			"duration", time.Since(p.startTime).Round(time.Millisecond), "turn_count", acc.TurnCount)
 		metrics.WorkerCrashesTotal.WithLabelValues(string(workerType), fmt.Sprintf("%d", exitCode)).Inc()
 		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
-		b.captureSyntheticEvent(p.sessionID, "worker_crash", fmt.Sprintf("Worker crashed with exit code %d", exitCode), eventstore.SourceCrash, p.sessPlatform, p.sessOwner, acc.ModelName)
+		b.captureSyntheticEvent(syntheticTurnParams{
+			SessionID:  p.sessionID,
+			Reason:     "worker_crash",
+			Message:    fmt.Sprintf("Worker crashed with exit code %d", exitCode),
+			Source:     eventstore.SourceCrash,
+			Platform:   p.sessPlatform,
+			Owner:      p.sessOwner,
+			Model:      acc.ModelName,
+			Generation: acc.Generation,
+			TurnNum:    acc.TurnCount,
+		})
 	} else if exitCode == -1 {
 		b.sendError(p.sessionID, events.ErrCodeSessionTerminated, "worker terminated (killed)")
 	} else if !p.doneReceived {
@@ -558,38 +581,49 @@ func truncateToolResultOutput(raw json.RawMessage) json.RawMessage {
 	return truncated
 }
 
+// syntheticTurnParams carries metadata for writing a synthetic turn (crash/timeout/fresh_start).
+type syntheticTurnParams struct {
+	SessionID  string
+	Reason     string
+	Message    string
+	Source     string
+	Platform   string
+	Owner      string
+	Model      string
+	Generation int64
+	TurnNum    int
+}
+
 // captureSyntheticEvent writes a synthetic done-like event for crash/timeout/fresh_start scenarios.
 // Allocates a real seq number to avoid colliding with the AEP "unassigned" convention (seq=0).
-func (b *Bridge) captureSyntheticEvent(sessionID, reason, message, source, platform, owner, model string) {
+func (b *Bridge) captureSyntheticEvent(p syntheticTurnParams) {
 	if b.collector == nil {
 		return
 	}
 	data, err := json.Marshal(map[string]any{
 		"success":   false,
-		"reason":    reason,
-		"message":   message,
+		"reason":    p.Reason,
+		"message":   p.Message,
 		"synthetic": true,
 	})
 	if err != nil {
 		return
 	}
-	seq := b.hub.NextSeq(sessionID)
-	b.collector.Capture(sessionID, seq, events.Done, data, "outbound", source)
+	seq := b.hub.NextSeq(p.SessionID)
+	b.collector.Capture(p.SessionID, seq, events.Done, data, "outbound", p.Source)
 
-	// Also write a synthetic assistant turn for crash/timeout.
-	acc := b.getOrInitAccum(sessionID, "", time.Now())
 	sFalse := false
 	turn := &eventstore.TurnWriteRequest{
-		SessionID:  sessionID,
-		Generation: acc.Generation,
-		TurnNum:    acc.TurnCount,
+		SessionID:  p.SessionID,
+		Generation: p.Generation,
+		TurnNum:    p.TurnNum,
 		Seq:        seq,
 		Role:       eventstore.RoleAssistant,
-		Content:    message,
-		Platform:   platform,
-		UserID:     owner,
-		Model:      model,
-		Source:     source,
+		Content:    p.Message,
+		Platform:   p.Platform,
+		UserID:     p.Owner,
+		Model:      p.Model,
+		Source:     p.Source,
 		Success:    &sFalse,
 		CreatedAt:  time.Now().UnixMilli(),
 	}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -65,6 +65,9 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		if si, err := b.sm.Get(context.Background(), sessionID); err == nil {
 			fc.sessPlatform = si.Platform
 			fc.sessOwner = si.OwnerID
+			if fc.sessOwner == "" {
+				fc.sessOwner = si.UserID
+			}
 		}
 	}
 
@@ -105,7 +108,8 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 			b.log.Warn("bridge: turn timeout exceeded, terminating worker",
 				"session_id", sessionID, "worker_type", workerType, "turn_timeout", b.turnTimeout)
 			b.sendError(sessionID, events.ErrCodeTurnTimeout, "Turn exceeded %v time limit and was terminated.", b.turnTimeout)
-			b.captureSyntheticEvent(sessionID, "turn_timeout", fmt.Sprintf("Turn exceeded %v time limit", b.turnTimeout), eventstore.SourceTimeout)
+			acc := b.getOrInitAccum(sessionID, "", fc.startTime)
+			b.captureSyntheticEvent(sessionID, "turn_timeout", fmt.Sprintf("Turn exceeded %v time limit", b.turnTimeout), eventstore.SourceTimeout, fc.sessPlatform, fc.sessOwner, acc.ModelName)
 			_ = w.Terminate(context.Background())
 		})
 		defer fc.turnTimer.Stop()
@@ -423,6 +427,8 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			workerType:    workerType,
 			lastInput:     lastInput,
 			crashedWorker: w,
+			sessPlatform:  p.sessPlatform,
+			sessOwner:     p.sessOwner,
 		}) {
 			return
 		}
@@ -461,7 +467,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			"duration", time.Since(p.startTime).Round(time.Millisecond), "turn_count", acc.TurnCount)
 		metrics.WorkerCrashesTotal.WithLabelValues(string(workerType), fmt.Sprintf("%d", exitCode)).Inc()
 		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
-		b.captureSyntheticEvent(p.sessionID, "worker_crash", fmt.Sprintf("Worker crashed with exit code %d", exitCode), eventstore.SourceCrash)
+		b.captureSyntheticEvent(p.sessionID, "worker_crash", fmt.Sprintf("Worker crashed with exit code %d", exitCode), eventstore.SourceCrash, p.sessPlatform, p.sessOwner, acc.ModelName)
 	} else if exitCode == -1 {
 		b.sendError(p.sessionID, events.ErrCodeSessionTerminated, "worker terminated (killed)")
 	} else if !p.doneReceived {
@@ -554,7 +560,7 @@ func truncateToolResultOutput(raw json.RawMessage) json.RawMessage {
 
 // captureSyntheticEvent writes a synthetic done-like event for crash/timeout/fresh_start scenarios.
 // Allocates a real seq number to avoid colliding with the AEP "unassigned" convention (seq=0).
-func (b *Bridge) captureSyntheticEvent(sessionID, reason, message, source string) {
+func (b *Bridge) captureSyntheticEvent(sessionID, reason, message, source, platform, owner, model string) {
 	if b.collector == nil {
 		return
 	}
@@ -580,6 +586,9 @@ func (b *Bridge) captureSyntheticEvent(sessionID, reason, message, source string
 		Seq:        seq,
 		Role:       eventstore.RoleAssistant,
 		Content:    message,
+		Platform:   platform,
+		UserID:     owner,
+		Model:      model,
 		Source:     source,
 		Success:    &sFalse,
 		CreatedAt:  time.Now().UnixMilli(),

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -112,6 +112,8 @@ type fallbackParams struct {
 	crashedWorker worker.Worker
 	sessPlatform  string
 	sessOwner     string
+	accGeneration int64
+	accModelName  string
 }
 
 // attemptResumeFallback handles a crashed resumed worker with a two-step strategy:
@@ -185,8 +187,17 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	}
 
 	// Re-deliver the original input that was lost when the first worker crashed.
-	acc := b.getOrInitAccum(p.sessionID, "", time.Now())
-	b.captureSyntheticEvent(p.sessionID, "fresh_start", "Session restarted with context reset after worker crash", eventstore.SourceFreshStart, p.sessPlatform, p.sessOwner, acc.ModelName)
+	b.captureSyntheticEvent(syntheticTurnParams{
+		SessionID:  p.sessionID,
+		Reason:     "fresh_start",
+		Message:    "Session restarted with context reset after worker crash",
+		Source:     eventstore.SourceFreshStart,
+		Platform:   p.sessPlatform,
+		Owner:      p.sessOwner,
+		Model:      p.accModelName,
+		Generation: p.accGeneration,
+		TurnNum:    0, // fresh start resets turn count
+	})
 	if p.lastInput != "" {
 		b.log.Info("bridge: re-delivering input to fresh worker", "session_id", p.sessionID, "content_len", len(p.lastInput))
 		if err := w.Input(context.Background(), p.lastInput, nil); err != nil {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -110,6 +110,8 @@ type fallbackParams struct {
 	workerType    worker.WorkerType
 	lastInput     string
 	crashedWorker worker.Worker
+	sessPlatform  string
+	sessOwner     string
 }
 
 // attemptResumeFallback handles a crashed resumed worker with a two-step strategy:
@@ -183,7 +185,8 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	}
 
 	// Re-deliver the original input that was lost when the first worker crashed.
-	b.captureSyntheticEvent(p.sessionID, "fresh_start", "Session restarted with context reset after worker crash", eventstore.SourceFreshStart)
+	acc := b.getOrInitAccum(p.sessionID, "", time.Now())
+	b.captureSyntheticEvent(p.sessionID, "fresh_start", "Session restarted with context reset after worker crash", eventstore.SourceFreshStart, p.sessPlatform, p.sessOwner, acc.ModelName)
 	if p.lastInput != "" {
 		b.log.Info("bridge: re-delivering input to fresh worker", "session_id", p.sessionID, "content_len", len(p.lastInput))
 		if err := w.Input(context.Background(), p.lastInput, nil); err != nil {


### PR DESCRIPTION
## Summary

- Synthetic events（`turn_timeout`、`worker_crash`、`fresh_start`）缺少 platform/owner/model 字段，导致 turns 表出现 NULL 空洞
- 扩展 `captureSyntheticEvent` 签名，接收并持久化 platform、owner、model
- OwnerID 为空时 fallback 到 UserID
- 通过 `handleWorkerExit` → `fallbackParams` 传递 `sessPlatform`/`sessOwner`

## Test plan

- [ ] 验证 turns 表中 timeout/crash/fresh_start 事件的 platform、user_id、model 字段不再为 NULL
- [ ] 确认 OwnerID 为空时 UserID 正确填充
- [ ] `make check` 全部通过

Refs: #559