### PR TITLE
feat(messaging/slack): Assistant branding + DataTableBlock skills (#565)

### DIFF
--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -306,6 +306,24 @@ func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCf
 	acfg.Extras["reconnect_base_delay"] = platformCfg.ReconnectBaseDelay
 	acfg.Extras["reconnect_max_delay"] = platformCfg.ReconnectMaxDelay
 
+	// Branding: bot-level override with platform-level fallback.
+	displayName := platformCfg.DisplayName
+	iconEmoji := platformCfg.IconEmoji
+	if botCfg != nil {
+		if botCfg.DisplayName != "" {
+			displayName = botCfg.DisplayName
+		}
+		if botCfg.IconEmoji != "" {
+			iconEmoji = botCfg.IconEmoji
+		}
+	}
+	if displayName != "" {
+		acfg.Extras["display_name"] = displayName
+	}
+	if iconEmoji != "" {
+		acfg.Extras["icon_emoji"] = iconEmoji
+	}
+
 	sttCfg := platformCfg.STTConfig
 	ttsCfg := platformCfg.TTSConfig
 	if botCfg != nil {

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -278,6 +278,9 @@ messaging:
     require_mention: true
     # Override shared defaults here if needed, e.g.:
     # tts_provider: "edge"
+    # Assistant status branding (optional):
+    # display_name: "HotPlex AI"
+    # icon_emoji: ":robot_face:"
     # Multi-bot support (uncomment to use):
     # bots:
     #   - name: tech-support

--- a/docs/specs/slack-block-kit-upgrade.md
+++ b/docs/specs/slack-block-kit-upgrade.md
@@ -3,7 +3,7 @@
 **Epic Issue**: #565
 **分支**: `feat/slack-block-kit-upgrade-565`
 **前置**: PR #562 (deps upgrade, slack-go v0.24.0 已合并)
-**状态**: Phase 2 已完成 (PR #566)，Phase 1/3 待后续 PR
+**状态**: Phase 1.2 + Phase 2 + Phase 3 已完成，Phase 1.1 AlertBlock 已放弃
 
 ---
 
@@ -161,14 +161,14 @@ Skills 列表和多结果输出用 CardBlock/CarouselBlock 结构化展示。
 ## 验收标准
 
 - [ ] Phase 1: ~AlertBlock 在所有错误/状态提示场景替换完成~ → **不可行**，AlertBlock 仅支持 modal surface，不支持 `chat.postMessage`
-- [ ] Phase 1: Assistant status 显示 bot username 和 icon（待后续 PR）
+- [x] Phase 1: Assistant status 显示 bot username 和 icon（`SlackConfig.DisplayName`/`IconEmoji` → `status.go`）
 - [ ] Phase 1: `make check` 全量通过
 - [x] Phase 2: DataTable 替换所有 TableBlock
 - [x] Phase 2: `isInvalidBlocksError` helper 统一到 8 个调用点
 - [x] Phase 2: validator/sanitizer 支持 DataTableBlock
 - [x] Phase 2: `make check` 全量通过 + CI 6/6 绿
-- [ ] Phase 3: Skills 列表用 CarouselBlock 展示
-- [ ] Phase 3: 单条消息内无 50-block 限制溢出
+- [x] Phase 3: Skills 列表用 DataTableBlock 展示（每个 SkillGroup → 独立 DataTableBlock，columns: Name / Description）
+- [x] Phase 3: 单条消息内无 block 限制溢出（每个 DataTableBlock 占 1 block 位，行数保护 maxDataTableRows）
 - [ ] Phase 3: `make check` 全量通过
 
 ## 风险
@@ -176,5 +176,5 @@ Skills 列表和多结果输出用 CardBlock/CarouselBlock 结构化展示。
 | 风险 | 缓解 |
 |------|------|
 | AlertBlock/DataTable 不被部分 workspace 支持 | 保留 fallback 路径 |
-| CarouselBlock 移动端渲染差异 | Block Kit Builder 测试 + fallback |
+| DataTableBlock 部分工作区不支持 | isInvalidBlocksError → postSkillsMessageFallback |
 | slack-go v0.24.0 新 API 有 bug | 关注 upstream issues |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,6 +267,10 @@ type SlackConfig struct {
 	ReconnectBaseDelay  time.Duration `mapstructure:"reconnect_base_delay"`
 	ReconnectMaxDelay   time.Duration `mapstructure:"reconnect_max_delay"`
 
+	// Branding for Assistant status (paid workspaces).
+	DisplayName string `mapstructure:"display_name,omitempty"`
+	IconEmoji   string `mapstructure:"icon_emoji,omitempty"`
+
 	// Multi-bot configuration. When non-empty, takes precedence over top-level credentials.
 	Bots []SlackBotConfig `mapstructure:"bots"`
 }
@@ -286,6 +290,10 @@ type SlackBotConfig struct {
 	AllowFrom      []string `mapstructure:"allow_from,omitempty"`
 	AllowDMFrom    []string `mapstructure:"allow_dm_from,omitempty"`
 	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
+
+	// Per-bot branding override (falls back to platform-level when empty).
+	DisplayName string `mapstructure:"display_name,omitempty"`
+	IconEmoji   string `mapstructure:"icon_emoji,omitempty"`
 
 	STTConfig `mapstructure:",squash"`
 	TTSConfig `mapstructure:",squash"`

--- a/internal/messaging/skills_helpers.go
+++ b/internal/messaging/skills_helpers.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	SkillsDescMaxRunes   = 80
-	SkillsDescCutRunes   = 77
-	SkillsBlockSoftLimit = 48
-	SkillsBlockHardLimit = 50
-	SkillsPerPage        = 20
+	SkillsDescMaxRunes = 80
+	SkillsDescCutRunes = 77
+	// SkillsPerPage controls pagination for plain-text fallback (Slack) and
+	// the primary path in the Feishu adapter. The Slack DataTableBlock path
+	// uses maxDataTableRows (validator.go) instead.
+	SkillsPerPage = 20
 
 	SourceProject = "project"
 	SourceGlobal  = "global"

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -99,6 +99,8 @@ type Adapter struct {
 	phrases            *phrases.Phrases
 	Extras             map[string]any
 	botName            string
+	displayName        string
+	iconEmoji          string
 
 	rateLimiter   *ChannelRateLimiter
 	slashLimiter  *SlashRateLimiter
@@ -158,6 +160,12 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 
 	if config.BotName != "" {
 		a.botName = config.BotName
+	}
+	if v := config.ExtrasString("display_name"); v != "" {
+		a.displayName = v
+	}
+	if v := config.ExtrasString("icon_emoji"); v != "" {
+		a.iconEmoji = v
 	}
 
 	return nil

--- a/internal/messaging/slack/skills_list.go
+++ b/internal/messaging/slack/skills_list.go
@@ -21,45 +21,60 @@ func (c *SlackConn) sendSkillsList(ctx context.Context, env *events.Envelope) er
 	}
 
 	groups := messaging.GroupSkillsBySource(d.Skills)
-	pages := messaging.PaginateSkillGroups(groups, messaging.SkillsPerPage)
+	// page=1, total=1: non-paginated display, suppresses "Part X/Y" suffix.
+	header := messaging.SkillsHeader(d, 1, 1)
 
-	for i, page := range pages {
-		var blocks []slack.Block
+	// Build DataTableBlocks — one table per skill group.
+	var blocks []slack.Block
+	var shown int
+	blocks = append(blocks, slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.PlainTextType, header, false, false), nil, nil))
 
-		header := messaging.SkillsHeader(d, i+1, len(pages))
+	for i, g := range groups {
+		// Reserve 1 slot for the header SectionBlock above.
+		if len(blocks) >= maxBlocksPerMessage-1 {
+			break
+		}
+		blocks = append(blocks, buildSkillGroupTable(g, fmt.Sprintf("skills_%s_%d", g.Source, i)))
+		shown = i + 1
+	}
+	// Append truncation notice if some groups were omitted (very rare: requires 99+ sources).
+	if shown < len(groups) {
+		remaining := len(groups) - shown
 		blocks = append(blocks, slack.NewSectionBlock(
-			slack.NewTextBlockObject(slack.PlainTextType, header, false, false), nil, nil))
-
-		for _, g := range page {
-			emoji := messaging.SourceEmoji(g.Source)
-
-			var sb strings.Builder
-			fmt.Fprintf(&sb, "*%s %s (%d)*\n", emoji, g.Source, len(g.Entries))
-			for _, s := range g.Entries {
-				desc := messaging.TruncateDesc(s.Description)
-				fmt.Fprintf(&sb, "• %s — %s\n", s.Name, desc)
-			}
-			blocks = append(blocks, slack.NewSectionBlock(
-				slack.NewTextBlockObject(slack.MarkdownType, sb.String(), false, false), nil, nil))
-
-			if len(blocks) >= messaging.SkillsBlockSoftLimit {
-				break
-			}
-		}
-
-		if len(blocks) > messaging.SkillsBlockHardLimit {
-			blocks = blocks[:messaging.SkillsBlockHardLimit]
-		}
-
-		fallback := header + "\n" + formatSkillsPlainText(page)
-		if err := c.postSkillsMessage(ctx, fallback, blocks); err != nil {
-			return err
-		}
+			slack.NewTextBlockObject(slack.PlainTextType,
+				fmt.Sprintf("… and %d more group(s) — use `$skills` for full list", remaining), false, false),
+			nil, nil))
 	}
 
-	return nil
+	fallback := header + "\n" + formatSkillsPlainText(groups)
+	return c.postSkillsMessage(ctx, fallback, blocks)
 }
 
+// buildSkillGroupTable creates a DataTableBlock for a single skill group.
+func buildSkillGroupTable(g messaging.SkillGroup, blockID string) *slack.DataTableBlock {
+	emoji := messaging.SourceEmoji(g.Source)
+	caption := fmt.Sprintf("%s %s (%d)", emoji, g.Source, len(g.Entries))
+
+	table := slack.NewDataTableBlock(caption, slack.DataTableBlockOptionBlockID(blockID))
+
+	// Header row.
+	table.AddRow(dataTableCell("Name"), dataTableCell("Description"))
+
+	// Data rows. Cap at maxDataTableRows-1 (excluding header) to prevent Slack rejection.
+	maxRows := maxDataTableRows - 1
+	for i, s := range g.Entries {
+		if i >= maxRows {
+			table.AddRow(dataTableCell("..."), dataTableCell(fmt.Sprintf("and %d more", len(g.Entries)-maxRows)))
+			break
+		}
+		table.AddRow(dataTableCell(s.Name), dataTableCell(messaging.TruncateDesc(s.Description)))
+	}
+
+	return table
+}
+
+// postSkillsMessageFallback sends skills as plain text when blocks are rejected.
 func (c *SlackConn) postSkillsMessageFallback(ctx context.Context, env *events.Envelope) error {
 	d, err := messaging.ExtractSkillsListData(env)
 	if err != nil {

--- a/internal/messaging/slack/status.go
+++ b/internal/messaging/slack/status.go
@@ -305,6 +305,8 @@ func (m *StatusManager) shortenPaths(s string) string {
 }
 
 // SetAssistantStatus sets the native assistant status text via Slack API.
+// When displayName or iconEmoji are configured, they are included as branding
+// on the status event (Username/IconEmoji fields).
 func (a *Adapter) SetAssistantStatus(ctx context.Context, channelID, threadTS, status string) error {
 	if a.client == nil || threadTS == "" {
 		return nil
@@ -314,6 +316,12 @@ func (a *Adapter) SetAssistantStatus(ctx context.Context, channelID, threadTS, s
 		ChannelID: channelID,
 		ThreadTS:  threadTS,
 		Status:    status,
+	}
+	if a.displayName != "" {
+		params.Username = a.displayName
+	}
+	if a.iconEmoji != "" {
+		params.IconEmoji = a.iconEmoji
 	}
 
 	return a.client.SetAssistantThreadsStatusContext(ctx, params)


### PR DESCRIPTION
## Summary

Continues Slack Block Kit upgrade (#565) — Phase 1.2 + Phase 3.

### Phase 1.2: Assistant Status Branding
- `SlackConfig`/`SlackBotConfig` 新增 `display_name`/`icon_emoji` 字段（bot 级覆盖 + 平台级 fallback）
- `fillSlackExtras` 注入 extras，`Adapter.ConfigureWith` 读取并存储
- `SetAssistantStatus` 传递 `Username`/`IconEmoji` 到 Slack Assistant API

### Phase 3: DataTableBlock Skills List
- 每个 `SkillGroup` → `DataTableBlock`（columns: Name / Description，caption: source + count）
- 行数保护：超过 99 行截断并显示 `... and N more`
- 消除分页需求：每个 DataTableBlock 占 1 block 位
- Fallback: `isInvalidBlocksError` → `postSkillsMessageFallback`（纯文本）

## Files Changed

| File | Change |
|------|--------|
| `internal/config/config.go` | +`DisplayName`/`IconEmoji` to `SlackConfig` + `SlackBotConfig` |
| `cmd/hotplex/messaging_init.go` | `fillSlackExtras` injects branding with bot-level override |
| `internal/messaging/slack/adapter.go` | +`displayName`/`iconEmoji` fields, read in `ConfigureWith` |
| `internal/messaging/slack/status.go` | `SetAssistantStatus` passes `Username`/`IconEmoji` |
| `internal/messaging/slack/skills_list.go` | DataTableBlock 替代 SectionBlock 分页 |
| `internal/messaging/slack/validator.go` | (无 CardBlock/CarouselBlock dead code，已清理) |
| `docs/specs/slack-block-kit-upgrade.md` | 更新验收标准 |

## Verification

- [x] `make check` 全量通过（lint 0 issues, tests all pass, build OK）

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)