### PR TITLE
docs(patrol): add install command + Slack branding config (2026-05-30)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,6 +34,7 @@ hotplex
 ├── config           # 配置管理
 │   └── validate     # 验证配置文件
 ├── onboard          # 交互式配置向导
+├── install          # 安装二进制到 PATH
 ├── update           # 自更新
 ├── service          # 系统服务管理
 │   ├── install      # 安装服务
@@ -293,6 +294,29 @@ hotplex onboard --non-interactive \
 | `--feishu-group-policy` | `string` | `allowlist` | 飞书群组策略：`open`、`allowlist`、`disabled` |
 | `--install-service` | `bool` | `false` | 在非交互模式下同时安装为系统服务 |
 | `--service-level` | `string` | `user` | 服务级别：`user` 或 `system`（配合 `--install-service`） |
+
+---
+
+## 二进制安装
+
+### `hotplex install`
+
+将 hotplex 二进制安装到 PATH 中的目录。若已在 PATH 中且内容相同则为 no-op；若二进制不同则原地更新。
+
+安装到新位置时，自动将目标目录添加到 PATH（通过 shell RC 文件 `~/.zshrc`/`~/.bashrc` 或 Windows 用户环境变量）。
+
+**示例**：
+
+```bash
+hotplex install              # 安装到默认位置 (~/.local/bin)
+hotplex install --path /usr/local/bin  # 安装到指定目录
+hotplex install --force                # 强制重新安装
+```
+
+| 标志 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `--path` | `string` | `~/.local/bin` | 目标安装目录 |
+| `--force` | `bool` | `false` | 即使已安装也重新安装 |
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -412,6 +412,8 @@ AI-native 定时任务引擎：自然语言 prompt 作为 payload，结果投递
 | `app_token` | string | `""` | `HOTPLEX_MESSAGING_SLACK_APP_TOKEN` | Slack App Token（`xapp-...`），Socket Mode 所需（单 bot 模式） |
 | `socket_mode` | bool | `true` | — | 是否使用 Socket Mode（推荐） |
 | `assistant_api_enabled` | *bool | `nil` | — | 是否启用 Slack Assistant API。nil = 未设置 |
+| `display_name` | string | `""` | — | Assistant 状态和消息中显示的名称（用于品牌化） |
+| `icon_emoji` | string | `""` | — | Assistant 状态和消息中显示的 emoji 图标（如 `:robot_face:`） |
 | `reconnect_base_delay` | duration | — | — | 断线重连基础延迟 |
 | `reconnect_max_delay` | duration | — | — | 断线重连最大延迟 |
 | `bots` | []SlackBotConfig | `[]` | — | 多 bot 配置（见 §3.11.8） |
@@ -447,6 +449,8 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `name` | string | Bot 名称（同一平台内唯一，必填） |
 | `bot_token` | string | Slack Bot Token（`xoxb-...`） |
 | `app_token` | string | Slack App Token（`xapp-...`） |
+| `display_name` | string | 覆盖顶层 Assistant 显示名称（bot 级品牌化） |
+| `icon_emoji` | string | 覆盖顶层 Assistant emoji 图标（bot 级品牌化） |
 | `worker_type` | string | 覆盖 Worker 类型 |
 | `stt_*` | — | 覆盖 STT 配置（继承平台级 → messaging 级） |
 | `tts_*` | — | 覆盖 TTS 配置（继承平台级 → messaging 级） |


### PR DESCRIPTION
## 文档巡逻 2026-05-30

自 `a8499cd` 以来 12 个提交，经分析 2 篇文档需要维护。

### 修复内容

```diff
docs/reference/cli.md
  + 命令树添加 install 节点
  + 新增 hotplex install 命令参考段落（--path / --force 标志）

docs/reference/configuration.md
  + §3.11.5 Slack 专有配置：添加 display_name / icon_emoji 字段
  + §3.11.8 SlackBotConfig：添加 display_name / icon_emoji bot 级覆盖字段
```

### 变更来源
- c09422c feat: install command (#555)
- 0ba0550 feat(messaging/slack): Assistant branding + DataTableBlock (#565)

### 未修改（经阅读确认无影响）
- tutorials/slack-integration.md — branding 为配置级行为，教程不涉及
- explanation/* — 无架构变更
- Bug fix 提交（#564, #557, #561, #563）— 内部修复，不影响文档
- ACP Worker spec (#570) — specs/ 不在巡逻范围
