### PR TITLE
docs(patrol): 2026-06-20 文档维护 — WebChat 多租户 SSO/认证补齐

### DIFF
--- a/docs/guides/developer/webchat-setup.md
+++ b/docs/guides/developer/webchat-setup.md
@@ -177,16 +177,19 @@ var StaticFS embed.FS
 
 ### 认证
 
-WebChat 支持两种认证模式，根据部署方式自动选择：
+> WebChat 多租户化后（spec ⑥）**强制登录**：废除匿名 `webchat_user` 身份，未登录用户自动重定向到 `/login`。
 
-**同源部署（推荐）**：WebChat 由 Gateway 直接提供服务时，使用 **HMAC Cookie 认证**。Gateway 在首次访问时自动签发 HttpOnly、SameSite=Strict 的签名 cookie，后续 WebSocket 连接自动携带，无需配置 API Key。这是最安全的方式——API Key 不会出现在前端代码中。
+**用户登录方式**（登录成功后签发 HMAC Cookie）：
 
-**跨域部署**：WebChat 部署在不同域名时，回退到以下方式：
+- **内建账号**（spec ①）：username/password 本地账号，由 admin 通过邀请码（`/api/admin/invitations`）创建。首次部署尚无任何账号时，登录页根据 `GET /api/auth/bootstrap-status` 引导创建首个管理员。
+- **企业 SSO**（spec ④）：标准 OIDC Authorization Code flow + PKCE。在 `oauth.providers[]` 配置 IdP（Keycloak / Okta / Azure AD 等）后，登录页渲染对应 SSO 按钮，点击跳转 IdP 完成认证。详见 [配置参考 — oauth](../../reference/configuration.md#314-oauth--webchat--ssooidc)。
+
+**HMAC Cookie 认证**（同源部署推荐）：登录成功后 Gateway 签发 HttpOnly、SameSite=Strict 的签名 cookie，后续 WebSocket 连接自动携带，无需配置 API Key。Cookie HMAC secret 持久化到 `~/.hotplex/data/cookie_secret.key`（权限 0600），重启后仍有效。
+
+**跨域部署 / SDK 集成**：WebChat 部署在不同域名，或客户端 SDK 直连 Gateway 时，回退到 API Key 认证：
 - HTTP Header `X-API-Key`
 - Query Parameter `api_key`（浏览器 WebSocket 的 CORS 兼容方案）
 - Init Envelope 延迟认证（`auth.token` 字段）
-
-开发模式下（未配置 API Key）自动使用 `anonymous` 用户身份。
 
 ---
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -236,6 +236,50 @@ Gateway API（`/api/sessions`）监听在网关主端口（`8888`），面向客
 
 所有 Gateway API 端点启用 CORS（`Access-Control-Allow-Origin: *`），支持 `GET`、`POST`、`DELETE`、`OPTIONS` 方法。
 
+### WebChat 多租户端点（spec ① / ④ / ⑥）
+
+WebChat 多租户登录与工作区管理端点，同样监听在网关主端口 `8888`，使用 **Cookie 认证**（登录后签发的 HMAC Cookie，非 API Key）。仅在启用 WebChat 多租户（`CookieAuth` + `WorkspaceStore` 就绪）时注册，普通 SDK/WebSocket 集成不涉及。
+
+**账号登录（spec ①）**：
+
+| 方法 | 路径 | 认证 | 说明 |
+|------|------|------|------|
+| POST | `/api/auth/login` | 无 | 内建账号登录（username/password），成功签发 Cookie |
+| POST | `/api/auth/logout` | Cookie | 登出并清除 Cookie |
+| GET | `/api/auth/me` | Cookie | 当前登录用户信息 |
+| POST | `/api/auth/accept-invite` | 邀请凭证 | 接受邀请加入 workspace |
+| GET | `/api/auth/bootstrap-status` | 无 | 首次部署引导状态（是否已存在管理员），登录页据此决定是否引导建号 |
+
+**企业 SSO（spec ④，OIDC + PKCE）**：
+
+| 方法 | 路径 | 认证 | 说明 |
+|------|------|------|------|
+| GET | `/api/auth/oauth/providers` | 无 | 列出已配置的 SSO provider（登录页据此渲染按钮） |
+| GET | `/api/auth/oauth/{provider}/login` | 无 | 发起 OIDC 登录，重定向到 IdP（name 须匹配 `[a-z0-9-]+`） |
+| GET | `/api/auth/oauth/{provider}/callback` | state cookie | OIDC 回调，完成 token exchange + ID Token 验证后签发 Cookie |
+
+**Workspace 管理（spec ⑥ A1）**：
+
+| 方法 | 路径 | 认证 | 说明 |
+|------|------|------|------|
+| POST | `/api/workspaces` | Cookie | 创建 workspace |
+| GET | `/api/workspaces` | Cookie | 列出当前用户可访问的 workspace |
+| GET | `/api/workspaces/{id}` | Cookie | workspace 详情（含归属校验） |
+| PATCH | `/api/workspaces/{id}` | Cookie | 更新 workspace |
+| DELETE | `/api/workspaces/{id}` | Cookie | 删除 workspace |
+
+**Workspace 用户与邀请管理（spec ⑥，admin 维度）**：
+
+| 方法 | 路径 | 认证 | 说明 |
+|------|------|------|------|
+| GET | `/api/admin/users` | Cookie | 列出 workspace 用户 |
+| PATCH | `/api/admin/users/{id}` | Cookie | 启用/禁用用户（disable 后 per-request 即时拦截） |
+| POST | `/api/admin/invitations` | Cookie | 创建邀请码 |
+| GET | `/api/admin/invitations` | Cookie | 列出邀请 |
+| DELETE | `/api/admin/invitations/{id}` | Cookie | 删除邀请 |
+
+> ⚠️ **注意区分**：此处的 `/api/admin/*`（端口 `8888`，Cookie 认证，WebChat workspace 维度）与本页上方「认证」章节描述的 Admin API（端口 `9999`，Bearer Token，网关运维维度）是**两套独立端点**，认证模型和作用域完全不同，不要混淆。
+
 **POST /admin/cron/jobs** — JSON body 含 `name`、`schedule`（cron:/every:/at: 前缀）、`message`、`bot_id`、`owner_id`、`enabled`。返回 `201 Created`。
 
 **PATCH /admin/cron/jobs/{id}** — 部分更新，JSON body。返回 `204 No Content`。

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,8 @@ description: "HotPlex Worker Gateway 所有配置项的权威参考，覆盖配�
    - [messaging — 消息平台](#311-messaging--消息平台)
    - [log — 日志](#312-log--日志)
    - [webchat — Web Chat UI](#313-webchat--web-chat-ui)
-   - [inherits — 配置继承](#314-inherits--配置继承)
+   - [oauth — WebChat 企业 SSO（OIDC）](#314-oauth--webchat--ssooidc)
+   - [inherits — 配置继承](#315-inherits--)
 4. [热重载](#4-热重载)
 5. [环境变量速查](#5-环境变量速查)
 
@@ -599,7 +600,51 @@ agent_config.inject_exclude  ──→  messaging.slack.inject_exclude  ──�
 
 ---
 
-### 3.14 inherits — 配置继承
+### 3.14 oauth — WebChat 企业 SSO（OIDC）
+
+WebChat 多租户的企业单点登录（SSO）配置（spec ④）。基于标准 OIDC Authorization Code flow + PKCE，一套实现覆盖全部主流 IdP（Keycloak / Okta / Azure AD / Google Workspace，以及国内的派拉 / 玉符 / 阿里云 IDaaS / 腾讯云 IDaaS / 宁盾 / Authing / 竹云 / 华为 OneAccess / TOPIAM）。
+
+> 该配置块为 **WebChat 专用**，独立于 Slack/Feishu 的 bot 配置（后者属于 Message Channel 轨道）。仅在启用 WebChat 多租户登录时生效。与内建账号登录（spec ①）并存，均为一等公民。
+
+顶层结构：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `external_url` | string | `""` | 构造 OAuth callback URL 的基础地址。为空时从请求 Host 头推导（同源部署）；反向代理后公共 URL 与内部不同时必须显式设置 |
+| `providers` | []OAuthProvider | `nil` | OIDC 身份提供者列表。多个 provider 在登录页渲染为多个 SSO 按钮（spec ⑥） |
+
+**provider 字段**：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `name` | string | — | provider 唯一标识。出现在 URL 路径（`/api/auth/oauth/{name}/login`）和 `user_identities.provider`。必须匹配 `[a-z0-9-]+`（URL 安全 + 防路径穿越） |
+| `display_name` | string | — | 登录页展示的人类可读标签（spec ⑥） |
+| `issuer` | string | — | OIDC issuer URL。discovery 端点自动解析为 `{issuer}/.well-known/openid-configuration` |
+| `client_id` | string | — | 在 IdP 注册的 OAuth2 client id |
+| `client_secret` | string | — | OAuth2 client secret。支持 `${ENV_VAR}` 展开 |
+| `scopes` | []string | `["openid","profile"]` | 请求的 OIDC scopes |
+| `username_claim` | string | `""` | 可选 claim 名覆盖；为空时用 OIDC 标准 claim |
+| `display_name_claim` | string | `""` | 同上，显示名 claim |
+| `email_claim` | string | `""` | 同上，email claim |
+
+**安全设计**：强制 PKCE（S256），即使 authorization code 被截获也无法 exchange；state cookie HMAC 签名（5min TTL）绑定 provider 防 CSRF；ID Token 经 JWKS 签名 + iss/aud/exp 校验；`(provider, subject)` 首次登录自动建号，**不按 email 自动合并账号**。
+
+**配置示例**：
+
+```yaml
+oauth:
+  external_url: "https://hotplex.example.com"
+  providers:
+    - name: "keycloak"
+      display_name: "企业 SSO"
+      issuer: "https://sso.example.com/realms/main"
+      client_id: "hotplex"
+      client_secret: "${OAUTH_KEYCLOAK_SECRET}"
+```
+
+---
+
+### 3.15 inherits — 配置继承
 
 | 字段 | 类型 | 默认值 | 环境变量 | 说明 |
 |------|------|--------|----------|------|


### PR DESCRIPTION
## Summary

自上次巡逻（`5bc8c0ce`, 2026-06-17）以来 main 合入 WebChat 多租户两大功能（#757 企业 SSO / #762 spec⑥ 强制登录 + 后端 A1-A5），变更驱动分析 55 篇文档后修复 3 篇 reference / user 文档：

- **`webchat-setup.md`** — 认证章节反映 spec⑥ 强制登录：原文称「开发模式下自动使用 anonymous 用户身份」，但 #762 已废除匿名 `webchat_user`、强制重定向 `/login`。重写为内建账号 / OAuth SSO / bootstrap 引导 / cookie secret 持久化。
- **`configuration.md`** — 新增 `3.14 oauth` 配置块（顶层 WebChat SSO 专用：`external_url` + OIDC `providers[]` 字段 + 安全设计 + 配置示例），`inherits` 顺延 `3.15`。
- **`admin-api.md`** — Gateway API 端点补充 WebChat 多租户：`/api/auth/*`（login/logout/me/accept-invite/bootstrap-status）、`/api/auth/oauth/*`（providers/login/callback）、`/api/workspaces/*`、`/api/admin/{invitations,users}`，并标注与运维 Admin API（端口 9999 Bearer Token）的区别。

**验证**：`make docs-build` 通过（55 篇文档，无断链，内部锚点已按 build-docs 规则修正）。

> ℹ️ 投递路径调整：`aaronwong1989` fork 账号 token 已失效、`hotplex-ai` 对该 fork 无写权限，本次改为推送至 origin（`hotplex-ai` 对 `hrygo/hotplex` 有 push 权限）创建同仓 PR，交付等价。

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)