### PR TITLE
feat(gateway): workspace 跨通道租户接入 (spec ⑦ Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ skills-lock.json
 .agents/source-study-progress.json
 .agents/arch-analysis/progress.json
 
+# --- Codebase Memory (local knowledge graph index) ---
+.codebase-memory/
+
 # --- Miscellaneous ---
 /.worktrees/
 *.bak

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -241,7 +241,7 @@ func setupRoutes(
 		mux.Handle("OPTIONS /api/admin/users/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
 		// Workspaces CRUD endpoints
-		wsHandlers := gateway.NewWorkspaceHandlers(deps.WorkspaceStore, deps.CookieAuth, auth)
+		wsHandlers := gateway.NewWorkspaceHandlers(deps.WorkspaceStore, auth)
 		mux.Handle("POST /api/workspaces", corsMw(http.HandlerFunc(wsHandlers.Create)))
 		mux.Handle("GET /api/workspaces", corsMw(http.HandlerFunc(wsHandlers.List)))
 		mux.Handle("GET /api/workspaces/{id}", corsMw(http.HandlerFunc(wsHandlers.Get)))

--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -1708,6 +1708,6 @@ curl -X PATCH http://localhost:8888/api/workspaces/7c9f6b2a-3e4d-4a8f-9b1c-2d5e7
 ### 16.4 隔离与安全保证
 
 - **owner-only**：api-key 用户只能访问 `owner_user_id` 等于自己的 workspace，跨 owner 访问返回 `WORKSPACE_FORBIDDEN`
-- **session 绑定不可变**：session 一旦绑定 workspace，不可切换；重连时 init 的 `workspace_id` 必须与首次一致（`session workspace mismatch`）
+- **session 绑定不可变**：同一 session（即重连时携带原 `clientSessionID` 命中已有 session）绑定的 workspace 不可切换；此时 init 的 `workspace_id` 必须与首次一致，否则返回 `session workspace mismatch`。若客户端以新 `clientSessionID` 发起 init，视为创建新 session，可绑定任意归属当前用户的 workspace（`conn.go` 仅在 `preResolved != nil` 路径强制校验）
 - **配额计费**：workspace session 计入 owner 的 per-user 配额（`PoolManager`，api-key 用户与人类用户同等对待）
 - **禁用即拦**：`users.status == "disabled"` 的 api-key 用户，所有 workspace 请求被 per-request 拦截（与 REST session API 同一条 `AuthenticateRequest` 拦截链）

--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -1122,7 +1122,7 @@ curl -H "X-API-Key: your-key" \
       "worker_type": "claude_code",
       "state": "idle",
       "title": "代码审查",
-      "client_key": "550e8400-e29b-41d4-a716-446655440000",
+      "client_key": "ws_abc123",
       "platform": "webchat",
       "work_dir": "/home/user/project",
       "created_at": "2026-06-03T10:00:00Z",
@@ -1646,7 +1646,7 @@ curl -X POST http://localhost:8888/api/workspaces \
 
 ```json
 {
-  "id": "ws_abc123",
+  "id": "7c9f6b2a-3e4d-4a8f-9b1c-2d5e7f8a9b0c",
   "owner_user_id": "u_svc1",
   "name": "my-project",
   "work_dir": "/home/user/project",
@@ -1654,12 +1654,12 @@ curl -X POST http://localhost:8888/api/workspaces \
 }
 ```
 
-`owner_user_id` 自动设为 api-key 对应的 `users.id`；`work_dir` 创建后不可变。
+`owner_user_id` 自动设为 api-key 对应的 `users.id`；`work_dir` 创建后不可变。`id` 为无前缀 UUIDv4（服务端 `uuid.NewString()` 生成，无 `ws_` 等前缀）。
 
 **②（可选）配置偏好 Worker + agent 配置覆盖**：
 
 ```bash
-curl -X PATCH http://localhost:8888/api/workspaces/ws_abc123 \
+curl -X PATCH http://localhost:8888/api/workspaces/7c9f6b2a-3e4d-4a8f-9b1c-2d5e7f8a9b0c \
   -H "X-API-Key: hpk_your_key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1682,7 +1682,7 @@ curl -X PATCH http://localhost:8888/api/workspaces/ws_abc123 \
     "data": {
       "version": "aep/v1",
       "worker_type": "claude_code",
-      "workspace_id": "ws_abc123"
+      "workspace_id": "7c9f6b2a-3e4d-4a8f-9b1c-2d5e7f8a9b0c"
     }
   }
 }

--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -21,6 +21,7 @@ description: 面向第三方开发者，从快速上手到高级特性，完整�
 - [13. 错误码参考](#13-错误码参考)
 - [14. 常见问题](#14-常见问题)
 - [15. SSO 集成最佳实践](#15-sso-集成最佳实践)
+- [16. Workspace：跨通道租户接入（spec ⑦）](#16-workspace跨通道租户接入spec-⑦)
 
 ---
 
@@ -301,6 +302,7 @@ WebSocket 连接建立后，**必须在 30 秒内**发送 `init` 作为第一帧
 | `version`                 | 是   | 固定 `"aep/v1"`                                     |
 | `worker_type`             | 是   | Worker 类型（`claude_code`、`codex_cli`、`acp` 等） |
 | `title`                   | 否   | 会话显示名称，不参与 Session ID 派生。最大 256 字符，自动清洗 |
+| `workspace_id`            | 否   | Workspace ID（spec ⑦）。绑定后 work_dir/配置来自 workspace，并参与 Session ID 派生（§16） |
 | `auth.token`              | 条件 | 无 API Key Header/Query 时必需                      |
 | `auth.bot_id`             | 否   | 多 Bot 隔离，优先级低于 Header/Query                |
 | `config.work_dir`         | 否   | 工作目录，安全校验                                  |
@@ -375,8 +377,10 @@ init { session_id: X }
 **派生公式**：
 
 ```
-Session ID = UUIDv5(userID | workerType | clientSessionID | workDir)
+Session ID = UUIDv5(userID | workerType | clientSessionID | [workspaceID] | workDir)
 ```
+
+> `workspaceID` 仅在 `init.data.workspace_id` 非空时参与派生（spec ⑦，§16）。为空时完全省略，保持平台/cron 调用方的向后兼容——旧 4 字段派生的 Session ID 不变。
 
 **clientSessionID 是什么**：你在 init 信封 `session_id` 字段传入的值。它**不是** Session ID 本身，只是派生函数的一个输入。该值会被 Gateway 持久化为 `client_key`（可通过 `GET /api/sessions` 的 `client_key` 字段取回，见 §11.1）。
 
@@ -523,13 +527,14 @@ init 握手时，Gateway 根据 Session 状态自动决策：
 
 ### 5.6 会话隔离
 
-Session ID 由四个维度派生，任何维度不同都会产生不同的 Session：
+Session ID 由五个维度派生（`workspaceID` 可选），任何维度不同都会产生不同的 Session：
 
 | 维度                | 说明                                       | 隔离效果             |
 | ------------------- | ------------------------------------------ | -------------------- |
 | **userID**          | API Key Resolver 映射（或默认 `api_user`） | 不同用户 -> 不同会话 |
 | **workerType**      | `claude_code` 等                           | 不同引擎 → 不同会话  |
 | **clientSessionID** | 客户端生成的 ID                            | 不同 tab → 不同会话  |
+| **workspaceID**     | `init.data.workspace_id`（可选，spec ⑦）  | 不同 workspace → 不同会话（见 §16） |
 | **workDir**         | 工作目录                                   | 不同项目 → 不同会话  |
 
 **多用户隔离**：使用 API Key 认证时所有用户默认都是 `api_user`，无法隔离。服务端管理员可为不同用户分配不同 API Key，实现用户级隔离：
@@ -1609,3 +1614,100 @@ ws.send(JSON.stringify({
 4. **user_id 隔离**：确保每个 SSO 用户映射到唯一的 `user_id`（≤128 字符），HotPlex 使用此值隔离会话空间
 5. **API Key 轮换**：删除旧 Key → 创建新 Key → 更新 BFF 缓存。无需重启 Gateway
 6. **WebSocket 认证限制**：浏览器无法在 WebSocket 升级请求中设置自定义 HTTP 头。对于方案 B，只能通过 init 信封的 `auth.token` 字段传递 API Key；对于方案 A，BFF 可通过 query param 或代理注入
+
+---
+
+## 16. Workspace：跨通道租户接入（spec ⑦）
+
+Workspace 是 HotPlex 的**跨通道租户锚**：一个 workspace 绑定一个 `work_dir`、一个偏好 Worker 类型、一组 agent 配置覆盖。api-key 机器租户与 WebChat 人类用户**共用同一套 workspace 机制**——同一个 `users.id` 无论通过哪种通道认证，都能拥有并管理自己的 workspace（底层身份统一来自 migration 018：api-key 在 `users` 表是一行 `apikey:*` 用户，`password_hash` 为空仅允许 api-key 通道）。
+
+### 16.1 何时使用 workspace
+
+| 场景 | 用 workspace | 说明 |
+| ---- | ------------ | ---- |
+| 第三方系统接入多项目 | ✅ 推荐 | 每个项目一个 workspace，隔离 work_dir + agent 配置，免每次 init 传 `config.work_dir` |
+| 单项目快速接入 | 可选 | 也可直接用 `config.work_dir`，不建 workspace |
+| 多租户 SaaS | ✅ 推荐 | 每个租户/团队分配独立 api-key + 独立 workspace |
+
+workspace 的价值：`work_dir` / `worker_preference` / `agent_config_overrides` 一次配置、多次复用，且 session 配额/隔离以 workspace 为锚。
+
+### 16.2 api-key 用户端到端示例
+
+**前置**：服务端已通过 `api_key_users` 表为你的 api-key 建立到 `users.id` 的映射（migration 018 模型）。联系管理员或用 Admin API（§15.4）创建。
+
+**① 创建 workspace**（REST，双鉴权：`X-API-Key` 或同源 Cookie 均可）：
+
+```bash
+curl -X POST http://localhost:8888/api/workspaces \
+  -H "X-API-Key: hpk_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-project","work_dir":"/home/user/project"}'
+```
+
+```json
+{
+  "id": "ws_abc123",
+  "owner_user_id": "u_svc1",
+  "name": "my-project",
+  "work_dir": "/home/user/project",
+  "status": "active"
+}
+```
+
+`owner_user_id` 自动设为 api-key 对应的 `users.id`；`work_dir` 创建后不可变。
+
+**②（可选）配置偏好 Worker + agent 配置覆盖**：
+
+```bash
+curl -X PATCH http://localhost:8888/api/workspaces/ws_abc123 \
+  -H "X-API-Key: hpk_your_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "worker_preference":"claude_code",
+    "agent_config_overrides":"{\"SOUL.md\":\"你是一个专注于代码审查的助手\"}"
+  }'
+```
+
+**③ WS init 绑定 workspace**（`init.data.workspace_id`）：
+
+```json
+{
+  "version": "aep/v1",
+  "id": "evt_...",
+  "session_id": "",
+  "seq": 0,
+  "timestamp": 1710000000000,
+  "event": {
+    "type": "init",
+    "data": {
+      "version": "aep/v1",
+      "worker_type": "claude_code",
+      "workspace_id": "ws_abc123"
+    }
+  }
+}
+```
+
+绑定后：
+- session 的 `work_dir` **来自 workspace**（忽略 `config.work_dir`）
+- Session ID 派生纳入 `workspaceID`（§5.2），同 workspace 内用 `clientSessionID` 区分多会话
+- owner 校验：`workspace.owner_user_id` 必须等于 api-key 对应的 `users.id`，否则 `INVALID_MESSAGE: workspace access denied`
+
+### 16.3 workspace CRUD 速查
+
+| 操作 | 方法 | 路径 | 说明 |
+| ---- | ---- | ---- | ---- |
+| 创建 | POST | `/api/workspaces` | body: `{name, work_dir}`；`work_dir` 安全校验 + per-owner 唯一 |
+| 列表 | GET | `/api/workspaces` | 只返回当前身份拥有的（`ListWorkspacesByOwner`） |
+| 查询 | GET | `/api/workspaces/{id}` | owner 或 admin 可读 |
+| 更新 | PATCH | `/api/workspaces/{id}` | `name` / `worker_preference` / `agent_config_overrides`（`work_dir` 不可变） |
+| 删除 | DELETE | `/api/workspaces/{id}` | 仅当无活跃 session 时（`WORKSPACE_NOT_EMPTY` 否则） |
+
+所有端点同时接受 `X-API-Key`（机器通道）与同源 Cookie（WebChat 通道），鉴权链与 `/api/sessions` 一致（spec ⑦ Phase 1）。
+
+### 16.4 隔离与安全保证
+
+- **owner-only**：api-key 用户只能访问 `owner_user_id` 等于自己的 workspace，跨 owner 访问返回 `WORKSPACE_FORBIDDEN`
+- **session 绑定不可变**：session 一旦绑定 workspace，不可切换；重连时 init 的 `workspace_id` 必须与首次一致（`session workspace mismatch`）
+- **配额计费**：workspace session 计入 owner 的 per-user 配额（`PoolManager`，api-key 用户与人类用户同等对待）
+- **禁用即拦**：`users.status == "disabled"` 的 api-key 用户，所有 workspace 请求被 per-request 拦截（与 REST session API 同一条 `AuthenticateRequest` 拦截链）

--- a/internal/gateway/auth_handlers.go
+++ b/internal/gateway/auth_handlers.go
@@ -395,23 +395,3 @@ func (h *AuthHandlers) requireAdmin(w http.ResponseWriter, r *http.Request) (str
 	}
 	return uid, true
 }
-
-// resolveCookieAdmin 解析 cookie 认证用户是否为 active admin，返回 (user, ok)。
-// 供 WorkspaceHandlers.isAdmin 复用，保证包内 admin 判定语义（role==admin && status==active）
-// 单一定义。AuthHandlers.requireAdmin 因需区分错误码（NO_IDP/USER_DISABLED/FORBIDDEN）
-// 保留自有分支，但其判定与此处同源。
-func resolveCookieAdmin(cookieAuth *security.CookieAuth, auth *security.Authenticator, r *http.Request) (*security.User, bool) {
-	idp := auth.IdentityProvider()
-	if idp == nil {
-		return nil, false
-	}
-	uid, ok := cookieAuth.Authenticate(r)
-	if !ok {
-		return nil, false
-	}
-	u, err := idp.Lookup(r.Context(), uid)
-	if err != nil || u.Role != "admin" || u.Status != "active" {
-		return nil, false
-	}
-	return u, true
-}

--- a/internal/gateway/auth_handlers_test.go
+++ b/internal/gateway/auth_handlers_test.go
@@ -40,6 +40,7 @@ type testAuthEnv struct {
 	idp        *security.LocalAccountProvider
 	handlers   *AuthHandlers
 	wsHandlers *WorkspaceHandlers
+	apiKeyMap  map[string]string // accumulated by addAPIKeyUser → fed to MapResolver
 }
 
 func newTestAuthEnv(t *testing.T) *testAuthEnv {
@@ -78,6 +79,25 @@ func (e *testAuthEnv) createUser(t *testing.T, name, pass, role string) {
 	require.NoError(t, e.store.CreateUser(context.Background(), &security.User{
 		ID: "u-" + name, Username: name, PasswordHash: hash, Role: role, Status: "active",
 	}, 1700000000))
+}
+
+// addAPIKeyUser provisions a service-account user reachable only via the api-key
+// channel. password_hash=” blocks the account-login path (migration 018 model),
+// so this user can never log in via /api/auth/login but resolves normally when
+// the X-API-Key header is presented. The key is registered both with the
+// authenticator (AddKey, enabling devModeLocked) and a MapResolver wired via
+// SetKeyResolver so AuthenticateRequest maps it to uid (spec ⑦ Phase 1).
+func (e *testAuthEnv) addAPIKeyUser(t *testing.T, key, uid, username string) {
+	t.Helper()
+	require.NoError(t, e.store.CreateUser(context.Background(), &security.User{
+		ID: uid, Username: username, PasswordHash: "", Role: "user", Status: "active",
+	}, 1700000000))
+	if e.apiKeyMap == nil {
+		e.apiKeyMap = map[string]string{}
+	}
+	e.apiKeyMap[key] = uid
+	e.auth.SetKeyResolver(security.NewMapResolver(e.apiKeyMap))
+	e.auth.AddKey(key)
 }
 
 func TestLoginHandler_SuccessIssuesCookie(t *testing.T) {

--- a/internal/gateway/auth_handlers_test.go
+++ b/internal/gateway/auth_handlers_test.go
@@ -58,7 +58,7 @@ func newTestAuthEnv(t *testing.T) *testAuthEnv {
 	auth.SetCookieAuth(ca)
 	auth.SetIdentityProvider(idp)
 	h := NewAuthHandlers(auth, ca, store, idp)
-	ws := NewWorkspaceHandlers(store, ca, auth)
+	ws := NewWorkspaceHandlers(store, auth)
 	return &testAuthEnv{auth: auth, cookie: ca, store: store, idp: idp, handlers: h, wsHandlers: ws}
 }
 

--- a/internal/gateway/auth_handlers_test.go
+++ b/internal/gateway/auth_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/sqlutil"
 )
 
 // newTestSessionStore builds an isolated SQLite store running all migrations.
@@ -24,7 +25,7 @@ func newTestSessionStore(t *testing.T) session.UserWorkspaceStore {
 	cfg.DB.Path = filepath.Join(t.TempDir(), "test.db")
 	cfg.DB.SQLite.Path = cfg.DB.Path
 	cfg.DB.WALMode = true
-	store, err := session.NewSQLiteStore(context.Background(), cfg, nil)
+	store, err := session.NewSQLiteStore(context.Background(), cfg, sqlutil.NewWriteMu(sqlutil.DialectSQLite))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -347,6 +347,15 @@ func (c *Conn) resolveSession(env *events.Envelope, initData InitData, sm connSM
 				observability.GatewayErrors().Add(c.hub.ctx, 1, metric.WithAttributes(attribute.String("error_code", string(events.ErrCodeInvalidMessage))))
 				return "", nil, fmt.Errorf("init: workspace %s is disabled", initData.WorkspaceID)
 			}
+			// Owner check: workspace is accessible only to its owner. The
+			// "anonymous" carve-out is a dev-mode path — anonymous-owned
+			// workspaces (uid="anonymous", created when no idp is configured)
+			// are treated as platform-shared so dev WS clients can bind to
+			// them. Production configures idp so uid is never "anonymous" and
+			// this branch is unreachable; it MUST NOT be extended to real
+			// identities. REST workspace handlers do not carry this carve-out
+			// (they require a resolved owner via AuthenticateRequest). See
+			// PR #773 review P3 for the security-boundary rationale.
 			if ws.OwnerUserID != "anonymous" && ws.OwnerUserID != c.userID {
 				c.sendInitError(events.ErrCodeInvalidMessage, "workspace access denied")
 				observability.GatewayErrors().Add(c.hub.ctx, 1, metric.WithAttributes(attribute.String("error_code", string(events.ErrCodeInvalidMessage))))

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -121,6 +121,43 @@ func TestValidateInit(t *testing.T) {
 	}
 }
 
+// TestValidateInit_WorkspaceID guards the WS-side tenant anchor binding point
+// (spec ⑦ P1.3). api-key clients authenticate at WS upgrade (hub.go:421) and
+// then bind the session to an owned workspace via init.workspace_id; this field
+// must propagate through ValidateInit into InitData.WorkspaceID for the owner
+// check in resolveSession (conn.go:335-358).
+func TestValidateInit_WorkspaceID(t *testing.T) {
+	t.Parallel()
+	makeInit := func(ws any) map[string]any {
+		m := map[string]any{
+			"version":     events.Version,
+			"worker_type": "claude-code",
+		}
+		if ws != nil {
+			m["workspace_id"] = ws
+		}
+		return m
+	}
+	tests := []struct {
+		name string
+		ws   any
+		want string
+	}{
+		{"absent → empty (platform/cron session)", nil, ""},
+		{"string → propagated to InitData", "ws-abc-123", "ws-abc-123"},
+		{"non-string → empty (type assert fails safe)", 12345, ""},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data, err := ValidateInit(envFromData(makeInit(tt.ws)))
+			require.True(t, err == nil, "ValidateInit error: %v", err)
+			require.Equal(t, tt.want, data.WorkspaceID)
+		})
+	}
+}
+
 func TestBuildInitAck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -32,9 +32,17 @@ func NewWorkspaceHandlers(store session.UserWorkspaceStore, cookieAuth *security
 func (h *WorkspaceHandlers) nowUnix() int64 { return h.now().Unix() }
 
 func (h *WorkspaceHandlers) currentUser(r *http.Request) (string, bool) {
-	// Delegate to AuthenticateActiveCookie so disabled users are rejected on
-	// the cookie path, matching the REST API and WS upgrade enforcement.
-	return h.auth.AuthenticateActiveCookie(r)
+	// Dual-channel auth (spec ⑦ Phase 1): api-key header/query first (machine
+	// integration), cookie second (WebChat UI). AuthenticateRequest already
+	// chains these two with shared disabled-user enforcement, matching the
+	// REST session API (api.go:69) and WS upgrade (hub.go:432). Aligning
+	// workspace REST on the same chain makes workspace a cross-channel tenant
+	// anchor: the same users.id owns workspaces regardless of entry channel.
+	uid, _, err := h.auth.AuthenticateRequest(r)
+	if err != nil {
+		return "", false
+	}
+	return uid, true
 }
 
 func (h *WorkspaceHandlers) requireAuth(w http.ResponseWriter, r *http.Request) (string, bool) {

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -244,6 +244,10 @@ func (h *WorkspaceHandlers) Delete(w http.ResponseWriter, r *http.Request) {
 			writeAppError(w, http.StatusConflict, "WORKSPACE_NOT_EMPTY", "workspace has active sessions")
 			return
 		}
+		if errors.Is(err, session.ErrWorkspaceNotFound) {
+			writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "workspace concurrently deleted")
+			return
+		}
 		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "delete failed")
 		return
 	}

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -33,11 +33,11 @@ func (h *WorkspaceHandlers) nowUnix() int64 { return h.now().Unix() }
 
 func (h *WorkspaceHandlers) currentUser(r *http.Request) (string, bool) {
 	// Dual-channel auth (spec ⑦ Phase 1): api-key header/query first (machine
-	// integration), cookie second (WebChat UI). AuthenticateRequest already
-	// chains these two with shared disabled-user enforcement, matching the
-	// REST session API (api.go:69) and WS upgrade (hub.go:432). Aligning
-	// workspace REST on the same chain makes workspace a cross-channel tenant
-	// anchor: the same users.id owns workspaces regardless of entry channel.
+	// integration), cookie second (WebChat UI). AuthenticateRequest chains these
+	// two with shared disabled-user enforcement — the same enforcement used by
+	// the REST session API and the WS upgrade path. Aligning workspace REST on
+	// the same chain makes workspace a cross-channel tenant anchor: the same
+	// users.id owns workspaces regardless of entry channel.
 	uid, _, err := h.auth.AuthenticateRequest(r)
 	if err != nil {
 		return "", false
@@ -54,8 +54,16 @@ func (h *WorkspaceHandlers) requireAuth(w http.ResponseWriter, r *http.Request) 
 	return uid, true
 }
 
-// isAdmin reports whether the current cookie user is an active admin.
-// 委托 resolveCookieAdmin，使 admin 判定与 AuthHandlers.requireAdmin 同源（spec §11.2）。
+// isAdmin reports whether the request carries an active admin cookie.
+//
+// Channel-binding policy (spec ⑦ Phase 1): the admin bypass is intentionally
+// cookie-only — it reuses resolveCookieAdmin (the same authority check
+// AuthHandlers.requireAdmin applies to /api/admin/*). Identity (currentUser)
+// instead resolves via AuthenticateRequest (api-key first), so the two are
+// independent: a request with both api-key + admin cookie takes uid from the
+// api-key while admin authority still rides on the cookie. Safe today because
+// every api-key user has role=user; Phase 2 P2.7 (issue #772) may unify them
+// on the AuthenticateRequest uid.
 func (h *WorkspaceHandlers) isAdmin(r *http.Request) bool {
 	_, ok := resolveCookieAdmin(h.cookieAuth, h.auth, r)
 	return ok

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -123,19 +123,16 @@ func (h *WorkspaceHandlers) List(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	wss, err := h.store.ListWorkspacesByOwner(r.Context(), uid)
+	limit, offset := web.ParsePagination(r)
+	// LIMIT/OFFSET 下推到 store 层（PR #773 P2）：跨通道租户接入后 api-key 通道可能
+	// 程序化批量创建 workspace，内存分页会退化为无界查询。
+	wss, err := h.store.ListWorkspacesByOwner(r.Context(), uid, limit, offset)
 	if err != nil {
 		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "list failed")
 		return
 	}
-	limit, offset := web.ParsePagination(r)
-	// Per-owner workspace counts are small; the store returns all active rows
-	// (already ordered by created_at ASC), so we paginate in memory and echo
-	// the requested limit/offset to satisfy the ListWorkspacesResponse contract.
-	start := min(offset, len(wss))
-	end := min(start+limit, len(wss))
 	respondJSON(w, map[string]any{
-		"workspaces": wss[start:end],
+		"workspaces": wss,
 		"limit":      limit,
 		"offset":     offset,
 	})

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -18,15 +18,14 @@ import (
 
 // WorkspaceHandlers serves /api/workspaces (spec §9.1, §11.3).
 type WorkspaceHandlers struct {
-	store      session.UserWorkspaceStore
-	cookieAuth *security.CookieAuth
-	auth       *security.Authenticator
-	now        func() time.Time
+	store session.UserWorkspaceStore
+	auth  *security.Authenticator
+	now   func() time.Time
 }
 
 // NewWorkspaceHandlers constructs workspace CRUD handlers.
-func NewWorkspaceHandlers(store session.UserWorkspaceStore, cookieAuth *security.CookieAuth, auth *security.Authenticator) *WorkspaceHandlers {
-	return &WorkspaceHandlers{store: store, cookieAuth: cookieAuth, auth: auth, now: time.Now}
+func NewWorkspaceHandlers(store session.UserWorkspaceStore, auth *security.Authenticator) *WorkspaceHandlers {
+	return &WorkspaceHandlers{store: store, auth: auth, now: time.Now}
 }
 
 func (h *WorkspaceHandlers) nowUnix() int64 { return h.now().Unix() }
@@ -54,19 +53,24 @@ func (h *WorkspaceHandlers) requireAuth(w http.ResponseWriter, r *http.Request) 
 	return uid, true
 }
 
-// isAdmin reports whether the request carries an active admin cookie.
+// isAdmin reports whether uid is an active admin (role==admin && status==active).
 //
-// Channel-binding policy (spec ⑦ Phase 1): the admin bypass is intentionally
-// cookie-only — it reuses resolveCookieAdmin (the same authority check
-// AuthHandlers.requireAdmin applies to /api/admin/*). Identity (currentUser)
-// instead resolves via AuthenticateRequest (api-key first), so the two are
-// independent: a request with both api-key + admin cookie takes uid from the
-// api-key while admin authority still rides on the cookie. Safe today because
-// every api-key user has role=user; Phase 2 P2.7 (issue #772) may unify them
-// on the AuthenticateRequest uid.
-func (h *WorkspaceHandlers) isAdmin(r *http.Request) bool {
-	_, ok := resolveCookieAdmin(h.cookieAuth, h.auth, r)
-	return ok
+// Same-source authority (spec ⑦ P2.7): uid is the identity currentUser already
+// resolved via AuthenticateRequest (api-key first, cookie fallback), so
+// identity and admin authority now derive from the same channel. This closes
+// the cross-channel ambiguity flagged in the PR #773 review (P2-1, finding B):
+// a request carrying both api-key + admin cookie no longer earns the bypass
+// from the cookie alone — the resolved uid itself must be an admin.
+func (h *WorkspaceHandlers) isAdmin(r *http.Request, uid string) bool {
+	idp := h.auth.IdentityProvider()
+	if idp == nil {
+		return false
+	}
+	u, err := idp.Lookup(r.Context(), uid)
+	if err != nil || u.Role != "admin" || u.Status != "active" {
+		return false
+	}
+	return true
 }
 
 type createWorkspaceRequest struct {
@@ -148,7 +152,7 @@ func (h *WorkspaceHandlers) Get(w http.ResponseWriter, r *http.Request) {
 		writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "not found")
 		return
 	}
-	if ws.OwnerUserID != uid && !h.isAdmin(r) {
+	if ws.OwnerUserID != uid && !h.isAdmin(r, uid) {
 		writeAppError(w, http.StatusForbidden, "WORKSPACE_FORBIDDEN", "not your workspace")
 		return
 	}
@@ -182,7 +186,7 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "not found")
 		return
 	}
-	if ws.OwnerUserID != uid && !h.isAdmin(r) {
+	if ws.OwnerUserID != uid && !h.isAdmin(r, uid) {
 		writeAppError(w, http.StatusForbidden, "WORKSPACE_FORBIDDEN", "not your workspace")
 		return
 	}
@@ -230,7 +234,7 @@ func (h *WorkspaceHandlers) Delete(w http.ResponseWriter, r *http.Request) {
 		writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "not found")
 		return
 	}
-	if ws.OwnerUserID != uid && !h.isAdmin(r) {
+	if ws.OwnerUserID != uid && !h.isAdmin(r, uid) {
 		writeAppError(w, http.StatusForbidden, "WORKSPACE_FORBIDDEN", "not your workspace")
 		return
 	}

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -319,3 +319,142 @@ func TestWorkspace_JSONWireContract(t *testing.T) {
 	require.Contains(t, m, "updated_at", "workspace wire contract must carry updated_at")
 	require.NotContains(t, m, "Name", "PascalCase field leaked onto the wire")
 }
+
+// ---------------------------------------------------------------------------
+// spec ⑦ Phase 1: api-key channel workspace access (cross-channel tenant)
+// ---------------------------------------------------------------------------
+
+const testAPIKeyHeader = "X-API-Key"
+
+func (e *testAuthEnv) createWorkspaceWithAPIKey(t *testing.T, key, name, workDir string) *session.Workspace {
+	t.Helper()
+	body := []byte(`{"name":"` + name + `","work_dir":"` + workDir + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", bytes.NewReader(body))
+	req.Header.Set(testAPIKeyHeader, key)
+	w := httptest.NewRecorder()
+	e.wsHandlers.Create(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "create ws (api-key) body=%s", w.Body.String())
+	var ws session.Workspace
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&ws))
+	return &ws
+}
+
+func (e *testAuthEnv) listWorkspacesWithAPIKey(t *testing.T, key string) []*session.Workspace {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	req.Header.Set(testAPIKeyHeader, key)
+	w := httptest.NewRecorder()
+	e.wsHandlers.List(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "list ws (api-key) body=%s", w.Body.String())
+	var resp struct {
+		Workspaces []*session.Workspace `json:"workspaces"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	return resp.Workspaces
+}
+
+// TestWorkspace_APIKey_CRUD: api-key 服务账号可通过 X-API-Key header 完成 workspace
+// 全 CRUD，owner_user_id 落到 api-key 对应的 users.id（migration 018 模型）。
+func TestWorkspace_APIKey_CRUD(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1")
+
+	// Create — owner must be the api-key user, not "api_user" or "anonymous".
+	ws := env.createWorkspaceWithAPIKey(t, "svc1-key", "svc-proj", "/tmp/hotplex-ws-apikey-crud")
+	require.NotEmpty(t, ws.ID)
+	require.Equal(t, "u-svc1", ws.OwnerUserID, "workspace owner must resolve to the api-key user's users.id")
+
+	// List → only this api-key user's workspaces.
+	require.Len(t, env.listWorkspacesWithAPIKey(t, "svc1-key"), 1)
+
+	// Get via api-key.
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID, nil)
+	req.SetPathValue("id", ws.ID)
+	req.Header.Set(testAPIKeyHeader, "svc1-key")
+	w := httptest.NewRecorder()
+	env.wsHandlers.Get(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Update name via api-key.
+	req2 := httptest.NewRequest(http.MethodPatch, "/api/workspaces/"+ws.ID, bytes.NewReader([]byte(`{"name":"svc-renamed"}`)))
+	req2.SetPathValue("id", ws.ID)
+	req2.Header.Set(testAPIKeyHeader, "svc1-key")
+	w2 := httptest.NewRecorder()
+	env.wsHandlers.Update(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	// Delete via api-key.
+	req3 := httptest.NewRequest(http.MethodDelete, "/api/workspaces/"+ws.ID, nil)
+	req3.SetPathValue("id", ws.ID)
+	req3.Header.Set(testAPIKeyHeader, "svc1-key")
+	w3 := httptest.NewRecorder()
+	env.wsHandlers.Delete(w3, req3)
+	require.Equal(t, http.StatusOK, w3.Code)
+}
+
+// TestWorkspace_APIKey_Isolation: two api-key service accounts cannot see each
+// other's workspaces — the owner check (conn.go:350 / workspace_handlers.go:135)
+// enforces per-tenant isolation across the api-key channel just as it does for
+// cookie users (TestWorkspace_Isolation_AcrossUsers).
+func TestWorkspace_APIKey_Isolation(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1")
+	env.addAPIKeyUser(t, "svc2-key", "u-svc2", "apikey:svc2")
+
+	ws1 := env.createWorkspaceWithAPIKey(t, "svc1-key", "svc1-proj", "/tmp/hotplex-ws-apikey-iso1")
+
+	// svc2 lists → sees nothing of svc1's.
+	list := env.listWorkspacesWithAPIKey(t, "svc2-key")
+	require.Len(t, list, 0)
+
+	// svc2 tries to read svc1's workspace → 403.
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws1.ID, nil)
+	req.SetPathValue("id", ws1.ID)
+	req.Header.Set(testAPIKeyHeader, "svc2-key")
+	w := httptest.NewRecorder()
+	env.wsHandlers.Get(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "WORKSPACE_FORBIDDEN")
+}
+
+// TestWorkspace_APIKey_Priority_Over_Cookie: when a request carries BOTH an
+// api-key header and a cookie, the api-key identity wins. This is the spec ⑦
+// contract — the machine channel is authoritative for programmatic integrations
+// and must not silently inherit an operator's browser cookie. Without this
+// guarantee a third-party integration run from an admin's browser would create
+// workspaces owned by the admin instead of the service account.
+func TestWorkspace_APIKey_Priority_Over_Cookie(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1")
+	cookieAdmin := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+
+	body := []byte(`{"name":"dual-channel","work_dir":"/tmp/hotplex-ws-apikey-prio"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", bytes.NewReader(body))
+	req.Header.Set(testAPIKeyHeader, "svc1-key")
+	req.Header.Set("Cookie", cookieAdmin)
+	w := httptest.NewRecorder()
+	env.wsHandlers.Create(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var ws session.Workspace
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&ws))
+	require.Equal(t, "u-svc1", ws.OwnerUserID, "api-key identity must win over cookie when both are present")
+	require.NotEqual(t, "u-admin", ws.OwnerUserID)
+}
+
+// TestWorkspace_APIKey_Invalid_Rejected: an unregistered api-key is rejected
+// with 401, matching the cookie-path enforcement (TestWorkspace_RequiresAuth).
+func TestWorkspace_APIKey_Invalid_Rejected(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1") // lock dev mode via AddKey
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces", nil)
+	req.Header.Set(testAPIKeyHeader, "bogus-key")
+	w := httptest.NewRecorder()
+	env.wsHandlers.List(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -445,6 +445,33 @@ func TestWorkspace_APIKey_Priority_Over_Cookie(t *testing.T) {
 	require.NotEqual(t, "u-admin", ws.OwnerUserID)
 }
 
+// TestWorkspace_MixedCredentials_AdminCookieBypass: documents the current
+// channel-binding behavior of isAdmin (spec ⑦ Phase 1). When a request carries
+// BOTH an api-key (non-owner service account) AND a valid admin cookie, the
+// admin cookie grants the admin bypass even though currentUser resolves the
+// identity to the api-key user. This is intentional — admin authority is
+// cookie-only (see the isAdmin doc) — and safe because the cookie-holder is a
+// proven admin. Phase 2 P2.7 (issue #772) may unify identity/authority on the
+// AuthenticateRequest uid, which would flip this expectation to 403.
+func TestWorkspace_MixedCredentials_AdminCookieBypass(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1")
+	cookieAdmin := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	// admin owns this workspace; svc1 (api-key user) does not.
+	wsAdmin := env.createWorkspace(t, cookieAdmin, "admin-proj", "/tmp/hotplex-ws-mixed-admin")
+
+	// Request carries svc1's api-key (non-owner uid) + admin's cookie.
+	// isAdmin sees the admin cookie → bypass grants access despite non-owner uid.
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+wsAdmin.ID, nil)
+	req.SetPathValue("id", wsAdmin.ID)
+	req.Header.Set(testAPIKeyHeader, "svc1-key")
+	req.Header.Set("Cookie", cookieAdmin)
+	w := httptest.NewRecorder()
+	env.wsHandlers.Get(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "admin cookie bypass grants access even when uid resolves to a non-owner api-key identity (see isAdmin channel-binding policy)")
+}
+
 // TestWorkspace_APIKey_Invalid_Rejected: an unregistered api-key is rejected
 // with 401, matching the cookie-path enforcement (TestWorkspace_RequiresAuth).
 func TestWorkspace_APIKey_Invalid_Rejected(t *testing.T) {

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -445,15 +445,14 @@ func TestWorkspace_APIKey_Priority_Over_Cookie(t *testing.T) {
 	require.NotEqual(t, "u-admin", ws.OwnerUserID)
 }
 
-// TestWorkspace_MixedCredentials_AdminCookieBypass: documents the current
-// channel-binding behavior of isAdmin (spec ⑦ Phase 1). When a request carries
-// BOTH an api-key (non-owner service account) AND a valid admin cookie, the
-// admin cookie grants the admin bypass even though currentUser resolves the
-// identity to the api-key user. This is intentional — admin authority is
-// cookie-only (see the isAdmin doc) — and safe because the cookie-holder is a
-// proven admin. Phase 2 P2.7 (issue #772) may unify identity/authority on the
-// AuthenticateRequest uid, which would flip this expectation to 403.
-func TestWorkspace_MixedCredentials_AdminCookieBypass(t *testing.T) {
+// TestWorkspace_MixedCredentials_NoBypassForNonAdminAPIKey: spec ⑦ P2.7 —
+// identity and admin authority are now same-source (both derive from the
+// AuthenticateRequest uid). A request carrying BOTH an api-key (non-owner
+// service account, role=user) AND a valid admin cookie resolves uid to the
+// api-key user, so the admin bypass does NOT apply — the cookie no longer
+// grants authority on its own. This flips the pre-P2.7 behavior (when isAdmin
+// was cookie-only) documented in the PR #773 review P2-1 finding.
+func TestWorkspace_MixedCredentials_NoBypassForNonAdminAPIKey(t *testing.T) {
 	t.Parallel()
 	env := newTestAuthEnv(t)
 	env.addAPIKeyUser(t, "svc1-key", "u-svc1", "apikey:svc1")
@@ -462,14 +461,36 @@ func TestWorkspace_MixedCredentials_AdminCookieBypass(t *testing.T) {
 	wsAdmin := env.createWorkspace(t, cookieAdmin, "admin-proj", "/tmp/hotplex-ws-mixed-admin")
 
 	// Request carries svc1's api-key (non-owner uid) + admin's cookie.
-	// isAdmin sees the admin cookie → bypass grants access despite non-owner uid.
+	// uid resolves to u-svc1 (role=user) → isAdmin=false → 403, even with the
+	// admin cookie present (authority is now same-source, not cookie-bound).
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+wsAdmin.ID, nil)
 	req.SetPathValue("id", wsAdmin.ID)
 	req.Header.Set(testAPIKeyHeader, "svc1-key")
 	req.Header.Set("Cookie", cookieAdmin)
 	w := httptest.NewRecorder()
 	env.wsHandlers.Get(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "admin cookie bypass grants access even when uid resolves to a non-owner api-key identity (see isAdmin channel-binding policy)")
+	require.Equal(t, http.StatusForbidden, w.Code, "same-source authority: admin cookie must not grant bypass when uid resolves to a non-admin api-key identity")
+	require.Contains(t, w.Body.String(), "WORKSPACE_FORBIDDEN")
+}
+
+// TestWorkspace_AdminCookie_CanReadOthers: spec ⑦ P2.7 — a cookie-authenticated
+// admin (uid resolves to a role=admin user) still earns the admin bypass under
+// same-source authority, so it can read any workspace regardless of owner.
+// Guards against the P2.7 change over-tightening and locking out genuine admins.
+func TestWorkspace_AdminCookie_CanReadOthers(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.createUser(t, "alice", "alicepass1", "user")
+	cookieAlice := env.loginAs(t, "alice", "alicepass1", http.StatusOK)
+	wsAlice := env.createWorkspace(t, cookieAlice, "alice-proj", "/tmp/hotplex-ws-admin-read")
+
+	cookieAdmin := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+wsAlice.ID, nil)
+	req.SetPathValue("id", wsAlice.ID)
+	req.Header.Set("Cookie", cookieAdmin)
+	w := httptest.NewRecorder()
+	env.wsHandlers.Get(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "admin uid (role=admin) must retain the bypass under same-source authority")
 }
 
 // TestWorkspace_APIKey_Invalid_Rejected: an unregistered api-key is rejected

--- a/internal/session/multitenancy_pg_store.go
+++ b/internal/session/multitenancy_pg_store.go
@@ -94,8 +94,8 @@ func (s *pgStore) GetWorkspaceByID(ctx context.Context, id string) (*Workspace, 
 	return w, err
 }
 
-func (s *pgStore) ListWorkspacesByOwner(ctx context.Context, ownerUserID string) ([]*Workspace, error) {
-	rows, err := s.db.QueryContext(ctx, s.queries["workspaces.list_by_owner"], ownerUserID)
+func (s *pgStore) ListWorkspacesByOwner(ctx context.Context, ownerUserID string, limit, offset int) ([]*Workspace, error) {
+	rows, err := s.db.QueryContext(ctx, s.queries["workspaces.list_by_owner"], ownerUserID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +149,13 @@ func (s *pgStore) DeleteWorkspace(ctx context.Context, id string) error {
 }
 
 // DeleteWorkspaceIfEmpty 原子删除：仅当无活跃会话时成功（防 TOCTOU，spec §9.1）。
+//
+// RowsAffected==0 有两种成因，必须区分（与 SQLite 版一致）：
+//   - workspace 存在但有活跃会话 → ErrWorkspaceNotEmpty（HTTP 409）
+//   - workspace 已被并发 actor 删除 → ErrWorkspaceNotFound（HTTP 404）
+//
+// PG 无 writeMu（数据库自身 MVCC 已保证查询隔离），重新检查 GetWorkspaceByID
+// 即可区分两种成因，使 handler 的 ErrWorkspaceNotFound 分支在 PG 下可达。
 func (s *pgStore) DeleteWorkspaceIfEmpty(ctx context.Context, id string) error {
 	res, err := s.db.ExecContext(ctx, s.queries["workspaces.delete_if_empty"], id, id)
 	if err != nil {
@@ -156,6 +163,12 @@ func (s *pgStore) DeleteWorkspaceIfEmpty(ctx context.Context, id string) error {
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
+		if _, err := s.GetWorkspaceByID(ctx, id); err != nil {
+			if errors.Is(err, ErrWorkspaceNotFound) {
+				return ErrWorkspaceNotFound
+			}
+			return err
+		}
 		return ErrWorkspaceNotEmpty
 	}
 	return nil

--- a/internal/session/multitenancy_store.go
+++ b/internal/session/multitenancy_store.go
@@ -76,7 +76,7 @@ type UserWorkspaceStore interface {
 	// workspaces
 	CreateWorkspace(ctx context.Context, w *Workspace, now int64) error
 	GetWorkspaceByID(ctx context.Context, id string) (*Workspace, error)
-	ListWorkspacesByOwner(ctx context.Context, ownerUserID string) ([]*Workspace, error)
+	ListWorkspacesByOwner(ctx context.Context, ownerUserID string, limit, offset int) ([]*Workspace, error)
 	ListAllWorkspaces(ctx context.Context) ([]*Workspace, error)
 	GetWorkspaceByOwnerAndWorkDir(ctx context.Context, ownerUserID, workDir string) (*Workspace, error)
 	UpdateWorkspace(ctx context.Context, w *Workspace, now int64) error
@@ -261,8 +261,8 @@ func (s *SQLiteStore) GetWorkspaceByID(ctx context.Context, id string) (*Workspa
 	return w, err
 }
 
-func (s *SQLiteStore) ListWorkspacesByOwner(ctx context.Context, ownerUserID string) ([]*Workspace, error) {
-	rows, err := s.db.QueryContext(ctx, queries["workspaces.list_by_owner"], ownerUserID)
+func (s *SQLiteStore) ListWorkspacesByOwner(ctx context.Context, ownerUserID string, limit, offset int) ([]*Workspace, error) {
+	rows, err := s.db.QueryContext(ctx, queries["workspaces.list_by_owner"], ownerUserID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/session/multitenancy_store.go
+++ b/internal/session/multitenancy_store.go
@@ -321,6 +321,12 @@ func (s *SQLiteStore) DeleteWorkspace(ctx context.Context, id string) error {
 }
 
 // DeleteWorkspaceIfEmpty 原子删除：仅当无活跃会话时成功（防 TOCTOU，spec §9.1）。
+//
+// RowsAffected==0 有两种成因，必须区分（review P3）：
+//   - workspace 存在但有活跃会话 → ErrWorkspaceNotEmpty（HTTP 409）
+//   - workspace 已被并发 actor 删除 → ErrWorkspaceNotFound（HTTP 404）
+//
+// 重新检查在 writeMu 内进行，关闭 Get↔Delete 之间的 TOCTOU 窗口。
 func (s *SQLiteStore) DeleteWorkspaceIfEmpty(ctx context.Context, id string) error {
 	return s.writeMu.WithLock(func() error {
 		res, err := s.db.ExecContext(ctx, queries["workspaces.delete_if_empty"], id, id)
@@ -329,6 +335,12 @@ func (s *SQLiteStore) DeleteWorkspaceIfEmpty(ctx context.Context, id string) err
 		}
 		n, _ := res.RowsAffected()
 		if n == 0 {
+			if _, err := s.GetWorkspaceByID(ctx, id); err != nil {
+				if errors.Is(err, ErrWorkspaceNotFound) {
+					return ErrWorkspaceNotFound
+				}
+				return err
+			}
 			return ErrWorkspaceNotEmpty
 		}
 		return nil

--- a/internal/session/multitenancy_store_test.go
+++ b/internal/session/multitenancy_store_test.go
@@ -204,6 +204,23 @@ func TestWorkspacesStore_DeleteIfEmpty_BlockedByActiveSession(t *testing.T) {
 	require.Equal(t, "ws-1", got.ID)
 }
 
+func TestWorkspacesStore_DeleteIfEmpty_AlreadyDeletedReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-1", Username: "alice", Role: "user", Status: "active"}, 1700000000))
+	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-1", OwnerUserID: "u-1", Name: "p", WorkDir: "/tmp/x"}, 1700000000))
+
+	// 第一次删除成功。
+	require.NoError(t, store.DeleteWorkspaceIfEmpty(ctx, "ws-1"))
+
+	// 第二次：workspace 已不存在（模拟并发 actor 在 Get↔Delete 间已删除）。
+	// 修复前 RowsAffected==0 一律返回 ErrWorkspaceNotEmpty（误导 409）；
+	// 修复后重新检查存在性，返回 ErrWorkspaceNotFound（404）。
+	err := store.DeleteWorkspaceIfEmpty(ctx, "ws-1")
+	require.ErrorIs(t, err, ErrWorkspaceNotFound, "已删除的 workspace 应返回 ErrWorkspaceNotFound 而非 ErrWorkspaceNotEmpty")
+}
+
 // --- invitations ---
 
 func TestInvitationsStore_CreateAndMarkUsedCAS(t *testing.T) {

--- a/internal/session/multitenancy_store_test.go
+++ b/internal/session/multitenancy_store_test.go
@@ -128,7 +128,7 @@ func TestWorkspacesStore_ListByOwnerIsolated(t *testing.T) {
 	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-2", OwnerUserID: "u-1", Name: "b", WorkDir: "/tmp/b"}, 1700000000))
 	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-3", OwnerUserID: "u-2", Name: "c", WorkDir: "/tmp/c"}, 1700000000))
 
-	list, err := store.ListWorkspacesByOwner(ctx, "u-1")
+	list, err := store.ListWorkspacesByOwner(ctx, "u-1", 100, 0)
 	require.NoError(t, err)
 	require.Len(t, list, 2, "只返回 owner=u-1 的 workspace")
 	for _, w := range list {

--- a/internal/session/pg_multitenancy_test.go
+++ b/internal/session/pg_multitenancy_test.go
@@ -32,10 +32,11 @@ func newPGMultitenancyMock(t *testing.T) (*pgStore, sqlmock.Sqlmock, func()) {
 		"users.touch_last_login":              d.Rebind("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?"),
 		"workspaces.create":                   d.Rebind("INSERT INTO workspaces (id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, NULL, 'active', ?, ?)"),
 		"workspaces.get_by_id":                d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE id = ?"),
-		"workspaces.list_by_owner":            d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE owner_user_id = ? AND status = 'active' ORDER BY created_at ASC"),
+		"workspaces.list_by_owner":            d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE owner_user_id = ? AND status = 'active' ORDER BY created_at ASC LIMIT ? OFFSET ?"),
 		"workspaces.get_by_owner_and_workdir": d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE owner_user_id = ? AND work_dir = ? AND status = 'active'"),
 		"workspaces.update":                   d.Rebind("UPDATE workspaces SET name = ?, agent_config_overrides = ?, worker_preference = ?, updated_at = ? WHERE id = ?"),
 		"workspaces.delete":                   d.Rebind("DELETE FROM workspaces WHERE id = ?"),
+		"workspaces.delete_if_empty":          d.Rebind("DELETE FROM workspaces WHERE id = ? AND NOT EXISTS (SELECT 1 FROM sessions WHERE workspace_id = ? AND state IN ('created','running','idle'))"),
 		"workspaces.count_active_sessions":    d.Rebind("SELECT COUNT(*) FROM sessions WHERE workspace_id = ? AND state IN ('created','running','idle')"),
 		"invitations.create":                  d.Rebind("INSERT INTO invitations (id, code, created_by, role, used_by, expires_at, created_at, used_at) VALUES (?, ?, ?, ?, NULL, ?, ?, NULL)"),
 		"invitations.get_by_code":             d.Rebind("SELECT id, code, created_by, role, used_by, expires_at, created_at, used_at FROM invitations WHERE code = ?"),
@@ -207,8 +208,8 @@ func TestPGMultitenancy_ListWorkspacesByOwner(t *testing.T) {
 	q := store.queries["workspaces.list_by_owner"]
 	rows := sqlmock.NewRows(workspaceColumns()).
 		AddRow("ws-1", "u-1", "a", "/tmp/a", nil, nil, "active", int64(100), int64(100))
-	mock.ExpectQuery(regexp.QuoteMeta(q)).WithArgs("u-1").WillReturnRows(rows)
-	list, err := store.ListWorkspacesByOwner(context.Background(), "u-1")
+	mock.ExpectQuery(regexp.QuoteMeta(q)).WithArgs("u-1", 100, 0).WillReturnRows(rows)
+	list, err := store.ListWorkspacesByOwner(context.Background(), "u-1", 100, 0)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 }
@@ -266,6 +267,44 @@ func TestPGMultitenancy_CountActiveSessionsInWorkspace(t *testing.T) {
 	n, err := store.CountActiveSessionsInWorkspace(context.Background(), "ws-1")
 	require.NoError(t, err)
 	require.Equal(t, 3, n)
+}
+
+// DeleteWorkspaceIfEmpty 三态：成功删除 / 有活跃会话（409）/ 已被并发删除（404）。
+// PG 版必须与 SQLite 版行为一致（PR #773 reviewer P1）。
+
+func TestPGMultitenancy_DeleteWorkspaceIfEmpty(t *testing.T) {
+	t.Parallel()
+	store, mock, cleanup := newPGMultitenancyMock(t)
+	defer cleanup()
+	q := store.queries["workspaces.delete_if_empty"]
+	mock.ExpectExec(regexp.QuoteMeta(q)).WithArgs("ws-1", "ws-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.DeleteWorkspaceIfEmpty(context.Background(), "ws-1"))
+}
+
+func TestPGMultitenancy_DeleteWorkspaceIfEmpty_NotEmpty(t *testing.T) {
+	t.Parallel()
+	store, mock, cleanup := newPGMultitenancyMock(t)
+	defer cleanup()
+	q := store.queries["workspaces.delete_if_empty"]
+	mock.ExpectExec(regexp.QuoteMeta(q)).WithArgs("ws-1", "ws-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	// RowsAffected==0 → 重新检查存在性：workspace 仍存在 → 有活跃会话阻塞 → ErrWorkspaceNotEmpty。
+	getQ := store.queries["workspaces.get_by_id"]
+	rows := sqlmock.NewRows(workspaceColumns()).AddRow("ws-1", "u-1", "p", "/tmp/x", nil, nil, "active", int64(100), int64(100))
+	mock.ExpectQuery(regexp.QuoteMeta(getQ)).WithArgs("ws-1").WillReturnRows(rows)
+	require.ErrorIs(t, store.DeleteWorkspaceIfEmpty(context.Background(), "ws-1"), ErrWorkspaceNotEmpty)
+}
+
+func TestPGMultitenancy_DeleteWorkspaceIfEmpty_AlreadyDeletedReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	store, mock, cleanup := newPGMultitenancyMock(t)
+	defer cleanup()
+	q := store.queries["workspaces.delete_if_empty"]
+	mock.ExpectExec(regexp.QuoteMeta(q)).WithArgs("ws-1", "ws-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	// RowsAffected==0 → 重新检查存在性：workspace 已被并发 actor 删除 → ErrWorkspaceNotFound。
+	// 修复前 PG 版一律返回 ErrWorkspaceNotEmpty（误导 409），handler 的 404 分支不可达。
+	getQ := store.queries["workspaces.get_by_id"]
+	mock.ExpectQuery(regexp.QuoteMeta(getQ)).WithArgs("ws-1").WillReturnError(sql.ErrNoRows)
+	require.ErrorIs(t, store.DeleteWorkspaceIfEmpty(context.Background(), "ws-1"), ErrWorkspaceNotFound)
 }
 
 // --- PG invitations ---

--- a/internal/session/sql/queries/workspaces.list_by_owner.sql
+++ b/internal/session/sql/queries/workspaces.list_by_owner.sql
@@ -1,3 +1,5 @@
 -- workspaces.list_by_owner: list a user's active workspaces (private; spec §9.1).
+-- LIMIT/OFFSET 下推到 store 层（PR #773 P2）：跨通道租户接入后 api-key 通道可能程序化
+-- 批量创建 workspace，内存分页会退化为无界查询。
 SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at
-FROM workspaces WHERE owner_user_id = ? AND status = 'active' ORDER BY created_at ASC
+FROM workspaces WHERE owner_user_id = ? AND status = 'active' ORDER BY created_at ASC LIMIT ? OFFSET ?

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -20,7 +21,7 @@ func helperDB(t *testing.T) (*SQLiteStore, *config.Config) {
 	cfg.DB.SQLite.Path = cfg.DB.Path
 	cfg.DB.WALMode = true
 
-	store, err := NewSQLiteStore(context.Background(), cfg, nil)
+	store, err := NewSQLiteStore(context.Background(), cfg, sqlutil.NewWriteMu(sqlutil.DialectSQLite))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store, cfg


### PR DESCRIPTION
## Summary

spec ⑦ Phase 1 落地：workspace 正式成为**跨通道租户锚**——api-key（第三方集成）与 CookieAuth（WebChat UI）作为两条对等入口，都落到同一个 `users + workspace` 体系。底层身份统一来自 migration 018（api-key = `users` 表一行），本 PR 补上 workspace REST 这最后一块缺口，并将 workspace `isAdmin` 身份/权限同源化（P2.7）。

## 交付清单（#772 Phase 1 + P2.7 workspace 部分）

**Phase 1**：
- **P1.1** `/api/workspaces*` 双鉴权：`currentUser` 改为 `AuthenticateRequest` 三优先级链（api-key header/query → cookie） — b458f6d5
- **P1.2** api-key 用户创建/管理 workspace（owner 落到 api-key 对应的 `users.id`，4 个 api-key 测试覆盖 CRUD/隔离/优先级/无效 key） — b458f6d5
- **P1.3** `TestValidateInit_WorkspaceID`：守护 `init.workspace_id` 解析（WS 路径 tenant anchor 绑定入口） — 6c730649
- **P1.4** 第三方集成文档：`websocket-integration.md` 新增 §16 端到端指南 — 6c730649

**review 闭环**：
- **findings 修复**（607817f6）：isAdmin 通道绑定策略注释 + 混合凭证测试；注释行号漂移修正；文档示例 `ws_abc123` → UUIDv4
- **P2.7 workspace isAdmin 同源化**（a85597b1）：身份/权限统一到 `AuthenticateRequest` uid，闭环 review P2-1 finding 方案 B；删除 dead `resolveCookieAdmin` + `cookieAuth` 字段；混合凭证测试预期翻转（200→403）

## 核心设计决策

1. **api-key 优先级**：双凭证时 api-key 身份胜出（`TestWorkspace_APIKey_Priority_Over_Cookie` 锁定），防止第三方集成从浏览器运行时意外继承操作员 cookie 身份
2. **身份/权限同源**（P2.7）：`isAdmin(r, uid)` 基于 `idp.Lookup(uid)` 判定，而非 cookie-only。混合凭证下 api-key(user) + admin cookie → uid=api-key user(role=user) → 非 admin → 403
3. **完全向后兼容**：无 api-key header 时 `AuthenticateRequest` 回退到 `AuthenticateActiveCookie`，9 个现有 cookie 测试零改动通过
4. **底层早已就绪**：migration 018（身份统一）、`DeriveSessionKey` workspaceID（session 派生）、`conn.go`（WS init owner 校验）、`hub.go`（WS upgrade api-key）

## Test plan

- [x] `go test ./internal/gateway/ -race`：15 个 workspace 测试（9 cookie + 4 api-key + 混合凭证/同源）+ `TestValidateInit_WorkspaceID` 全绿
- [x] `make build` + `golangci-lint`：0 issues
- [x] pre-push 6 项质量门禁全过

## 关联

Refs #772（spec ⑦ epic，三阶段实施；本 PR 交付 Phase 1 + P2.7 workspace 部分）

- 取代: #765（已关闭，PR-2/PR-3 并入 #772 Phase 2/3）
- 后续: Phase 2 剩余（admin 收敛 P2.1-P2.6/P2.8-P2.12）、Phase 3（WebChat Settings Modal P3.1-P3.4）