### PR TITLE
refactor(webchat): Phase 3 契约修复 + UpdateWorkspace 乐观并发

### DIFF
--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -305,7 +305,7 @@ WebChat 多租户登录与工作区管理端点，同样监听在网关主端口
 | 401 | `UNAUTHORIZED` | Token 缺失或无效 |
 | 401 | `INVALID_CREDENTIALS` | Cookie 会话失效或未登录 |
 | 403 | `INSUFFICIENT_SCOPE` | Bearer Token scope 不满足（Admin API） |
-| 403 | `FORBIDDEN` | 非管理员访问管理端点 |
+| 403 | `FORBIDDEN` | 非管理员访问管理端点，或请求 IP 不在白名单（见「安全中间件」IP Whitelist，两类 403 共用同一 code） |
 | 403 | `USER_DISABLED` | 用户已被禁用 |
 | 404 | `NOT_FOUND` | Session/Cron Job/Invitation 未找到 |
 | 409 | `CONFLICT` | 资源状态冲突 |

--- a/docs/specs/WebChat-Multitenancy-Foundation-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Foundation-Design-Spec.md
@@ -513,6 +513,7 @@ per-workspace 并发上限：复用 `config.SecurityConfig` 或新增 `config.Qu
 | `WORK_DIR_TAKEN` | 409 | per-user work_dir 1:1 冲突 |
 | `WORK_DIR_IMMUTABLE` | 400 | 尝试修改 work_dir |
 | `WORKSPACE_NOT_EMPTY` | 409 | 删除时有活跃会话 |
+| `WORKSPACE_VERSION_MISMATCH` | 409 | 并发更新冲突（乐观锁 CAS 失败，客户端应重新 Get 再重试） |
 | `USER_DISABLED` | 403 | 用户已禁用 |
 | `USERNAME_TAKEN` | 409 | 用户名已存在 |
 

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -214,6 +214,10 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		ws.WorkerPreference = req.WorkerPreference
 	}
 	if err := h.store.UpdateWorkspace(r.Context(), ws, h.nowUnix()); err != nil {
+		if errors.Is(err, session.ErrWorkspaceConflict) {
+			writeAppError(w, http.StatusConflict, "WORKSPACE_VERSION_MISMATCH", "workspace concurrently modified, please re-fetch and retry")
+			return
+		}
 		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "update failed")
 		return
 	}

--- a/internal/session/coverage_test.go
+++ b/internal/session/coverage_test.go
@@ -87,10 +87,43 @@ func TestSQLiteStore_UpdateWorkspace(t *testing.T) {
 	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-1", Username: "alice", Role: "user", Status: "active"}, 100))
 	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-1", OwnerUserID: "u-1", Name: "p", WorkDir: "/tmp/x"}, 100))
 
-	require.NoError(t, store.UpdateWorkspace(ctx, &Workspace{ID: "ws-1", Name: "renamed", AgentConfigOverrides: `{"foo":"bar"}`}, 200))
+	// Optimistic concurrency (review P3-1): must Get first to load the current
+	// updated_at, then mutate and Update — the handler's read-modify-write mode.
+	ws, err := store.GetWorkspaceByID(ctx, "ws-1")
+	require.NoError(t, err)
+	ws.Name = "renamed"
+	ws.AgentConfigOverrides = `{"foo":"bar"}`
+	require.NoError(t, store.UpdateWorkspace(ctx, ws, 200))
+	require.Equal(t, int64(200), ws.UpdatedAt, "CAS success should bump in-memory updated_at")
+
 	got, _ := store.GetWorkspaceByID(ctx, "ws-1")
 	require.Equal(t, "renamed", got.Name)
 	require.Equal(t, `{"foo":"bar"}`, got.AgentConfigOverrides)
+	require.Equal(t, int64(200), got.UpdatedAt)
+}
+
+// TestSQLiteStore_UpdateWorkspace_VersionConflict verifies the optimistic-
+// concurrency CAS: a stale writer (cached updated_at) loses to a fresh write
+// and gets ErrWorkspaceConflict, preventing a silent lost update (review P3-1).
+func TestSQLiteStore_UpdateWorkspace_VersionConflict(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-1", Username: "alice", Role: "user", Status: "active"}, 100))
+	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-1", OwnerUserID: "u-1", Name: "p", WorkDir: "/tmp/x"}, 100))
+
+	wsA, _ := store.GetWorkspaceByID(ctx, "ws-1") // updated_at=100
+	wsB, _ := store.GetWorkspaceByID(ctx, "ws-1") // updated_at=100 (stale after A writes)
+
+	wsA.Name = "by-a"
+	require.NoError(t, store.UpdateWorkspace(ctx, wsA, 200)) // bumps to 200
+
+	wsB.Name = "by-b"
+	require.ErrorIs(t, store.UpdateWorkspace(ctx, wsB, 300), ErrWorkspaceConflict)
+
+	got, _ := store.GetWorkspaceByID(ctx, "ws-1")
+	require.Equal(t, "by-a", got.Name, "stale writer's change must be rejected")
+	require.Equal(t, int64(200), got.UpdatedAt)
 }
 
 func TestSQLiteStore_DeleteWorkspace(t *testing.T) {

--- a/internal/session/multitenancy_pg_store.go
+++ b/internal/session/multitenancy_pg_store.go
@@ -137,10 +137,22 @@ func (s *pgStore) GetWorkspaceByOwnerAndWorkDir(ctx context.Context, ownerUserID
 	return w, err
 }
 
+// UpdateWorkspace applies the in-memory workspace fields, guarded by an
+// optimistic-concurrency CAS on updated_at (review P3-1, mirrors SQLiteStore).
+// RowsAffected==0 means a concurrent update bumped updated_at (or the row was
+// deleted between the handler's Get and this write) → ErrWorkspaceConflict.
 func (s *pgStore) UpdateWorkspace(ctx context.Context, w *Workspace, now int64) error {
-	_, err := s.db.ExecContext(ctx, s.queries["workspaces.update"],
-		w.Name, nullableString(w.AgentConfigOverrides), nullableString(w.WorkerPreference), now, w.ID)
-	return err
+	res, err := s.db.ExecContext(ctx, s.queries["workspaces.update"],
+		w.Name, nullableString(w.AgentConfigOverrides), nullableString(w.WorkerPreference), now, w.ID, w.UpdatedAt)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrWorkspaceConflict
+	}
+	w.UpdatedAt = now
+	return nil
 }
 
 func (s *pgStore) DeleteWorkspace(ctx context.Context, id string) error {

--- a/internal/session/multitenancy_store.go
+++ b/internal/session/multitenancy_store.go
@@ -58,6 +58,7 @@ type UserIdentity struct {
 var (
 	ErrWorkspaceNotFound     = errors.New("session: workspace not found")
 	ErrWorkspaceNotEmpty     = errors.New("session: workspace has active sessions")
+	ErrWorkspaceConflict     = errors.New("session: workspace version conflict (concurrent update)")
 	ErrInvitationNotFound    = errors.New("session: invitation not found")
 	ErrInvitationAlreadyUsed = errors.New("session: invitation already used")
 	ErrIdentityNotFound      = errors.New("session: user identity not found")
@@ -305,11 +306,24 @@ func (s *SQLiteStore) GetWorkspaceByOwnerAndWorkDir(ctx context.Context, ownerUs
 	return w, err
 }
 
+// UpdateWorkspace applies the in-memory workspace fields to the row, guarded by
+// an optimistic-concurrency CAS on updated_at (review P3-1): the WHERE clause
+// binds the caller's cached updated_at, so a concurrent update that bumped it
+// makes this affect 0 rows → ErrWorkspaceConflict. The writeMu scope keeps the
+// read-modify-write atomic against other SQLiteStore writers; PG relies on MVCC.
 func (s *SQLiteStore) UpdateWorkspace(ctx context.Context, w *Workspace, now int64) error {
 	return s.writeMu.WithLock(func() error {
-		_, err := s.db.ExecContext(ctx, queries["workspaces.update"],
-			w.Name, nullableString(w.AgentConfigOverrides), nullableString(w.WorkerPreference), now, w.ID)
-		return err
+		res, err := s.db.ExecContext(ctx, queries["workspaces.update"],
+			w.Name, nullableString(w.AgentConfigOverrides), nullableString(w.WorkerPreference), now, w.ID, w.UpdatedAt)
+		if err != nil {
+			return err
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return ErrWorkspaceConflict
+		}
+		w.UpdatedAt = now
+		return nil
 	})
 }
 

--- a/internal/session/pg_multitenancy_test.go
+++ b/internal/session/pg_multitenancy_test.go
@@ -34,7 +34,7 @@ func newPGMultitenancyMock(t *testing.T) (*pgStore, sqlmock.Sqlmock, func()) {
 		"workspaces.get_by_id":                d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE id = ?"),
 		"workspaces.list_by_owner":            d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE owner_user_id = ? AND status = 'active' ORDER BY created_at ASC LIMIT ? OFFSET ?"),
 		"workspaces.get_by_owner_and_workdir": d.Rebind("SELECT id, owner_user_id, name, work_dir, agent_config_overrides, worker_preference, status, created_at, updated_at FROM workspaces WHERE owner_user_id = ? AND work_dir = ? AND status = 'active'"),
-		"workspaces.update":                   d.Rebind("UPDATE workspaces SET name = ?, agent_config_overrides = ?, worker_preference = ?, updated_at = ? WHERE id = ?"),
+		"workspaces.update":                   d.Rebind("UPDATE workspaces SET name = ?, agent_config_overrides = ?, worker_preference = ?, updated_at = ? WHERE id = ? AND updated_at = ?"),
 		"workspaces.delete":                   d.Rebind("DELETE FROM workspaces WHERE id = ?"),
 		"workspaces.delete_if_empty":          d.Rebind("DELETE FROM workspaces WHERE id = ? AND NOT EXISTS (SELECT 1 FROM sessions WHERE workspace_id = ? AND state IN ('created','running','idle'))"),
 		"workspaces.count_active_sessions":    d.Rebind("SELECT COUNT(*) FROM sessions WHERE workspace_id = ? AND state IN ('created','running','idle')"),
@@ -241,11 +241,29 @@ func TestPGMultitenancy_UpdateWorkspace(t *testing.T) {
 	store, mock, cleanup := newPGMultitenancyMock(t)
 	defer cleanup()
 	q := store.queries["workspaces.update"]
+	// ws.UpdatedAt=100 is the cached version from a prior Get (handler pattern);
+	// it binds the CAS WHERE clause's 6th arg.
 	mock.ExpectExec(regexp.QuoteMeta(q)).
-		WithArgs("newname", nil, nil, int64(200), "ws-1").
+		WithArgs("newname", nil, nil, int64(200), "ws-1", int64(100)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	err := store.UpdateWorkspace(context.Background(), &Workspace{ID: "ws-1", Name: "newname"}, 200)
+	ws := &Workspace{ID: "ws-1", Name: "newname", UpdatedAt: 100}
+	err := store.UpdateWorkspace(context.Background(), ws, 200)
 	require.NoError(t, err)
+	require.Equal(t, int64(200), ws.UpdatedAt, "CAS success bumps in-memory updated_at")
+}
+
+// TestPGMultitenancy_UpdateWorkspace_VersionConflict: RowsAffected==0 surfaces
+// as ErrWorkspaceConflict (review P3-1, mirrors SQLite TestSQLiteStore_UpdateWorkspace_VersionConflict).
+func TestPGMultitenancy_UpdateWorkspace_VersionConflict(t *testing.T) {
+	t.Parallel()
+	store, mock, cleanup := newPGMultitenancyMock(t)
+	defer cleanup()
+	q := store.queries["workspaces.update"]
+	mock.ExpectExec(regexp.QuoteMeta(q)).
+		WithArgs("by-b", nil, nil, int64(300), "ws-1", int64(100)). // stale cached updated_at
+		WillReturnResult(sqlmock.NewResult(0, 0))                   // 0 rows → conflict
+	ws := &Workspace{ID: "ws-1", Name: "by-b", UpdatedAt: 100}
+	require.ErrorIs(t, store.UpdateWorkspace(context.Background(), ws, 300), ErrWorkspaceConflict)
 }
 
 func TestPGMultitenancy_DeleteWorkspace(t *testing.T) {

--- a/internal/session/sql/queries/workspaces.update.sql
+++ b/internal/session/sql/queries/workspaces.update.sql
@@ -1,2 +1,6 @@
 -- workspaces.update: update mutable fields. work_dir is NOT updatable (immutable, spec §6.2).
-UPDATE workspaces SET name = ?, agent_config_overrides = ?, worker_preference = ?, updated_at = ? WHERE id = ?
+-- The `AND updated_at = ?` clause is an optimistic-concurrency guard (review P3-1):
+-- concurrent updates race on the same row, and the loser (whose cached updated_at
+-- no longer matches) affects 0 rows and surfaces as ErrWorkspaceConflict → 409,
+-- preventing a silent lost update. The last bind arg is the caller's cached updated_at.
+UPDATE workspaces SET name = ?, agent_config_overrides = ?, worker_preference = ?, updated_at = ? WHERE id = ? AND updated_at = ?

--- a/webchat/lib/api/admin-client.ts
+++ b/webchat/lib/api/admin-client.ts
@@ -7,6 +7,8 @@
 
 import type { AdminConnection } from '@/lib/types/admin';
 
+import { parseApiError } from './errors';
+
 const STORAGE_URL_KEY = 'hotplex_admin_url';
 const STORAGE_TOKEN_KEY = 'hotplex_admin_token';
 
@@ -66,28 +68,22 @@ export async function adminFetch<T>(
 
   if (res.status === 401) {
     clearAdminConnection();
-    throw new Error('Admin authentication failed (401)');
+    // Parse the envelope so the caller gets the real code/message (e.g.
+    // UNAUTHORIZED vs INVALID_CREDENTIALS) instead of a generic string —
+    // avoids silently dropping future 401-scoped codes (PR #774 review P2).
+    const info = await parseApiError(res);
+    const err = new Error(info.message || info.code || 'Admin authentication failed (401)');
+    (err as any).status = 401;
+    if (info.code) (err as any).code = info.code;
+    throw err;
   }
 
   if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    // P2.8: admin API now returns JSON error envelope {"error":{code,message}}.
-    // Parse it to surface the human-readable message; fall back to raw body for
-    // non-JSON responses (backward compat with any plain-text error path).
-    let message = body || `Admin request failed: ${res.status}`;
-    let code: string | undefined;
-    try {
-      const envelope = JSON.parse(body);
-      if (envelope?.error?.message) {
-        message = envelope.error.message;
-        code = envelope.error.code;
-      }
-    } catch {
-      // not JSON — keep raw body as message
-    }
+    const info = await parseApiError(res);
+    const message = info.message || info.raw || `Admin request failed: ${res.status}`;
     const err = new Error(message);
-    (err as any).status = res.status;
-    if (code) (err as any).code = code;
+    (err as any).status = info.status;
+    if (info.code) (err as any).code = info.code;
     throw err;
   }
 

--- a/webchat/lib/api/client.ts
+++ b/webchat/lib/api/client.ts
@@ -11,6 +11,7 @@
  * import from here instead of re-declaring these helpers.
  */
 import { httpBase, apiKey, isSameOrigin } from "@/lib/config";
+import { parseApiError } from "./errors";
 
 export const BASE = httpBase();
 
@@ -40,6 +41,6 @@ export function withAuth(headers?: Record<string, string>): Record<string, strin
 // semantic error code like USER_DISABLED/FORBIDDEN was discarded in favor
 // of a generic "Create invitation failed: 403").
 export async function extractApiError(res: Response, fallback: string): Promise<string> {
-  const errData = await res.json().catch(() => ({}));
-  return errData?.error?.code || errData?.error?.message || fallback;
+  const info = await parseApiError(res);
+  return info.code || info.message || fallback;
 }

--- a/webchat/lib/api/errors.ts
+++ b/webchat/lib/api/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared backend error-envelope parser.
+ *
+ * Both the gateway cookie client (client.ts) and the admin Bearer client
+ * (admin-client.ts) talk to endpoints that emit the same JSON envelope
+ * {"error":{"code":...,"message":...}} written by web.WriteAppError. Parsing
+ * it in one place keeps the two clients from drifting apart (PR #774 review
+ * P3: admin-client and client.ts had opposite extraction priorities). The
+ * parser is priority-agnostic — each caller decides whether to surface code
+ * or message first for its audience.
+ */
+
+export interface ApiErrorInfo {
+  status: number;
+  code?: string;
+  message?: string;
+  /** Raw response body, used as a fallback when the body is not JSON. */
+  raw: string;
+}
+
+export async function parseApiError(res: Response): Promise<ApiErrorInfo> {
+  const raw = await res.text().catch(() => '');
+  let code: string | undefined;
+  let message: string | undefined;
+  const body = raw.trim();
+  if (body) {
+    try {
+      const env = JSON.parse(body);
+      if (env?.error && typeof env.error === 'object') {
+        code = env.error.code;
+        message = env.error.message;
+      } else if (typeof env?.error === 'string') {
+        // Legacy plain-text shape (pre-P2.8 admin): {"error":"not found"}
+        message = env.error;
+      }
+    } catch {
+      // not JSON — raw body becomes the message fallback
+    }
+  }
+  return { status: res.status, code, message, raw };
+}


### PR DESCRIPTION
## Summary
Phase 3 的契约修复 + 后端健壮性部分（issue #772）。Settings Modal（P3.1-P3.4）在后续独立 PR。

### reviewer backlog（PR #774 review findings，非阻塞）
- **P2** `admin-client.ts:67` 401 短路：解析 JSON 信封提取 code/message 再 throw，不再丢弃 `UNAUTHORIZED`/`INVALID_CREDENTIALS` 等细分 code
- **P3** 双 client 解析统一：新建 `lib/api/errors.ts` `parseApiError` 共享解析器，`client.ts` `extractApiError` + `admin-client.ts` 401/!res.ok 均复用（各 client 字段优先级保留 — 受众不同）
- **P3** `admin-api.md` FORBIDDEN 补 IP 白名单场景说明（`admin.go:230` IP 不在白名单也返回 FORBIDDEN，两类 403 共用同一 code）

### P3-1 UpdateWorkspace 乐观并发 CAS（reviewer P3-1）
- `workspaces.update` SQL 加 `AND updated_at = ?` CAS 子句（第 6 bind arg = 调用方缓存的 updated_at）
- 新增 `ErrWorkspaceConflict` 哨兵；SQLite/PG `UpdateWorkspace` 检查 RowsAffected，0 → 冲突，成功 bump 内存 `w.UpdatedAt`
- handler → 409 `WORKSPACE_VERSION_MISMATCH`，客户端重新 Get 再重试
- spec §12.1 登记新码
- 测试：SQLite + PG 各加版本冲突测试（stale writer 被拒，DB 保留 fresh writer 改动，无 lost update）

模式与 `DeleteWorkspaceIfEmpty` 一致。不改 store 接口签名、不改前端 — 服务端 CAS，防 handler 读取-写入期间的并发请求。客户端 If-Match（基于旧数据编辑的严格防护）留待 Settings Modal 编辑 UI 接入。

## Test plan
- [x] `go test ./internal/session/ -race -run Workspace` 通过
- [x] `go test ./internal/gateway/ -run Workspace` 通过
- [x] `tsc --noEmit` 通过
- [x] pre-commit（gofmt + golangci-lint 0 issues）+ pre-push（vet/verify/lint/build/test）全绿
- [ ] CI 绿
- [ ] review approve

Refs #772