### PR TITLE
feat(webchat): Phase 3 Settings Modal + 顶部 workspace bar 布局重构 (P3.1-P3.4)

### DIFF
--- a/docs/specs/Worker-Turn-Summary-Parity-Spec.md
+++ b/docs/specs/Worker-Turn-Summary-Parity-Spec.md
@@ -1,0 +1,218 @@
+---
+type: spec
+tags:
+  - project/HotPlex
+date: 2026-06-23
+status: draft
+progress: 0
+related_issues:
+  - Turn-Summary-Spec.md (数据流基准)
+  - Worker-GAP-Analysis-2026-05-15.md (OCS vs CC 能力差距)
+---
+# Worker Turn Summary Parity Spec — codex / acp / opencode 对齐 claudecode
+
+## 概述
+
+Turn summary 卡片（Slack/Feishu/WebChat）的数据质量取决于各 Worker 是否产出了完整的 stats 事件。基准实现 **claudecode worker** 覆盖全部字段；**opencodeserver worker** 作为次基准覆盖 9/11 字段；而 **codexcli** 与 **acp** worker 存在系统性数据缺失。
+
+本 spec 定位三 worker 的 turn summary 数据产出 gap，给出逐字段弥补方案。
+
+> **范围**：仅 turn summary 数据字段（context / token / model / tool / cost）。Worker 能力全景见 `Worker-GAP-Analysis-2026-05-15.md`；turn summary 数据流与渲染见 `Turn-Summary-Spec.md`。
+
+---
+
+## 1. 数据流回顾
+
+```
+Worker 产出事件 ──► SessionAccumulator 聚合 ──► snapshot() 注入 Done.Data.Stats["_session"]
+                                                                    │
+                          messaging.ExtractTurnSummary ◄────────────┘
+                                                                    │
+                         FormatTurnSummary / FormatTurnSummaryRich ◄┘
+                                                                    │
+                         Slack / Feishu / WebChat 渲染 ◄────────────┘
+```
+
+`SessionAccumulator`（`internal/gateway/session_stats.go`）有三个数据入口：
+
+| 入口 | 方法 | 数据来源 |
+|------|------|---------|
+| **Done stats** | `mergePerTurnStats(DoneData)` | Done 事件 `Data.Stats`，当前**仅识别两种格式**：CC 的 `usage`+`model_usage`，OCS 的 `tokens`+`cost` |
+| **ContextUsage 事件** | `mergeContextUsage(ContextUsageData)` | `context_usage` 控制事件，**context_fill 的唯一来源** |
+| **ToolCall 事件** | bridge forwardEvents 累加 | `tool_call` 事件的 `ToolCallData.Name` |
+
+`SessionAccumulator` 假设 **"Workers report cumulative totals"**（`session_stats.go:99`），per-turn delta 由 `computePerTurnDeltas` 从累计值相减得出。
+
+---
+
+## 2. 字段产出矩阵（核心 gap）
+
+| 字段 | claudecode (基准) | opencodeserver (次基准) | codexcli | acp |
+|------|:---:|:---:|:---:|:---:|
+| `context_fill` | ✅ context_usage | ✅ 真实计算 | ❌ **管道断裂** | ⚠️ 依赖 usage_update |
+| `context_window` | ✅ model_usage | ❌ maxTokens=0 | ❌ | ⚠️ 依赖 usage_update |
+| `context_pct` | ✅ | ❌ | ❌ | ⚠️ |
+| `model_name` | ✅ | ✅ 双路径 | ⚠️ **仅 rerouted** | ❌ **完全缺失** |
+| `total_input_tok` | ✅ | ✅ | ⚠️ **字段不全+非累计** | ✅ CC 格式 |
+| `total_output_tok` | ✅ | ✅ | ⚠️ 同上 | ✅ |
+| `turn_input_tok` | ✅ delta | ✅ delta | ⚠️ | ✅ |
+| `turn_output_tok` | ✅ delta | ✅ delta | ⚠️ | ✅ |
+| `tool_call_count` | ✅ | ✅ | ✅ | ✅ |
+| `tool_names` | ✅ | ✅ | ✅ | ⚠️ **仅 CC agent 可靠** |
+| `cost` | ✅ | ✅ | ❌ **缺失** | ✅ |
+
+**严重度统计**：codexcli 6 项缺口（最严重），acp 3 项核心缺口，opencode 2 项（均受限于上游 API）。
+
+---
+
+## 3. codexcli Worker Gap（P1，最严重）
+
+### 3.1 核心问题
+
+**Gap-C1：context_usage 管道完全断裂**
+- `commands.go:22-31` `get_context_usage` 调用 `thread/read` 后返回 `{"raw": string(resp)}`（未解析的原始 JSON 字符串）。
+- `pkg/events/helpers.go:60-98` `MapContextUsageResponse` 期望顶层 camelCase 键（`totalTokens`/`maxTokens`/`model`），`"raw"` 不匹配任何键 → `TotalTokens=0`。
+- `bridge_forward.go:913-916` 判断 `cu.TotalTokens <= 0` 跳过 `mergeContextUsage`。
+- **后果**：`context_fill` / `context_window` / `context_pct` 三字段恒为 0。
+
+**Gap-C2：token 字段不全且非累计**
+- `mapper.go:667-688` `trackedUsageStats` 产出 CC 兼容的 `usage` map，但：
+  - 缺 `cache_creation_input_tokens`（`CodexTokenUsage` 有 `CachedInputTokens` 映射到 `cache_read_input_tokens`，但无 cache_creation 对应字段）。
+  - `m.lastUsage` 来自 `thread/tokenUsage/updated` 的 `last`（per-turn 增量），每次 `turn/started` 清空（`mapper.go:104`），与 SessionAccumulator "cumulative totals" 假设相悖。
+- **后果**：`total_input_tok` 偏低（缺 cache 维度），delta 计算虽然因每轮重置而"碰巧正确"，但累计值失真。
+
+**Gap-C3：model_name 仅在 rerouted 时产出**
+- `mapper.go:657-665` `trackModelRerouted` 仅监听 `model/rerouted` 事件（模型被重路由才触发）。
+- 正常对话路径不产出 model → `model_name` 大多数情况为空。
+
+**Gap-C4：cost 完全缺失**
+- `trackedUsageStats` 不产出任何 cost 字段，`mergePerTurnStats` 读取的 `total_cost_usd`/`cost` 均不存在。
+
+### 3.2 修复方案
+
+| ID | 改点 | 位置 | 方案 |
+|----|------|------|------|
+| C1 | context_usage 解析 | `codexcli/commands.go:22-31` | 解析 `thread/read` 响应 JSON，从最近 assistant message 或 token usage 提取 `totalTokens`/`maxTokens`/`model`，返回 camelCase map（参考 OCS `commands.go:157-168` `queryContextUsage`） |
+| C2a | token 累计修正 | `codexcli/mapper.go:trackedUsageStats` | 优先采用 `thread/tokenUsage/updated` 的 `total`（累计）字段，而非 `last`（增量）；若无 total 则保留 last 但在 stats 标注 `cumulative:false` |
+| C2b | cache 字段补全 | 同上 | 补 `cache_creation_input_tokens`（若 codex 协议无对应字段，标注为 0 并在 spec 注明协议限制） |
+| C3 | model 常态化 | `codexcli/mapper.go` | 从 `thread/tokenUsage/updated` 或 session 元数据提取当前 model（不只靠 rerouted） |
+| C4 | cost 产出 | 同上 | 若 codex `tokenUsage` 含 cost 字段则映射到 `total_cost_usd`；若无则标注协议限制 |
+
+### 3.3 待实现时确认
+
+- codex `thread/read` 响应结构：是否暴露 context 用量与 maxTokens？需对照 codex app-server 协议（`Codex-AppServer-Worker-Spec.md`）。
+- codex `thread/tokenUsage/updated` 的 `total` vs `last` 语义，及是否含 cost。
+
+---
+
+## 4. acp Worker Gap（P2）
+
+### 4.1 核心问题
+
+**Gap-A1：model_name 完全缺失**
+- 全链路无 model 产出：`mapper.go:466-515` `buildStats` 不写 `model_usage`/`model`；`worker.go:798-805` `handleContextUsage` 返回值无 `model` 字段；`client.go:416-419` `PromptResult` 结构体无 model。
+- `mergePerTurnStats` 找不到 `model_usage`，`mergeContextUsage` 收到 `cu.Model==""` → `ModelName` 恒空。
+
+**Gap-A2：tool_names 非 ClaudeCode agent 不可靠**
+- `mapper.go:590-606` `extractToolName` 优先取 `_meta.claudeCode.toolName`，fallback 用 `u.Kind`（`mapper.go:283-288`）。
+- 非 ClaudeCode agent 若 `kind` 为空（仅有 `title`），toolName 聚合到空字符串 key。
+
+**Gap-A3：context 强依赖 agent 主动发 usage_update**
+- `mapper.go:549-553` `usageSnapshot` 仅由 `usage_update` notification 填充，无 fallback。
+- ACP 协议的 `usage_update` 是可选的；若 agent 不发，context_fill/window/pct 全部归零。
+
+### 4.2 修复方案
+
+| ID | 改点 | 位置 | 方案 |
+|----|------|------|------|
+| A1 | model 补全 | `acp/mapper.go:buildStats` | 写 `stats["model_usage"]`（CC 格式）；model 来源优先级：usage_update → session/info → agent card 元数据 |
+| A2 | tool_name 通用化 | `acp/mapper.go:extractToolName` | 扩展 fallback 链：`_meta.claudeCode.toolName` → `kind` → 从 tool call content 解析 tool 名 → `title` |
+| A3 | context fallback | `acp/worker.go:handleContextUsage` | 若 `usageSnapshot` 为空，调用 ACP `session/info`（或等价方法）获取 context 用量；仍不可得则返回空（标注协议限制） |
+
+### 4.3 待实现时确认
+
+- ACP 协议是否提供 session/info 或类似方法暴露 model 与 context 用量？需对照 `ACP-Worker-Spec.md` 与上游 ACP 规范。
+
+---
+
+## 5. opencodeserver Worker Gap（P3，受限于上游）
+
+### 5.1 核心问题
+
+**Gap-O1：context_window 恒为 0**
+- `commands.go:167` `queryContextUsage` 硬编码 `"maxTokens": 0`。
+- OCS HTTP REST API 不暴露模型上下文窗口大小（`session_stats.go:134` 注释 "OCS scenario" 即指此行）。
+- **后果**：`context_pct` 无法计算（`computeContextPct` 在 `ContextWindow<=0` 时返回 0）。
+
+**注**：OCS 的 `context_fill`（`commands.go:161-166`，`lastInput+lastCacheRead+lastCacheWrite`）、token、model、tool、cost 全部正常产出，是三非-CC worker 中的基准。
+
+### 5.2 修复方案
+
+| ID | 改点 | 位置 | 方案 |
+|----|------|------|------|
+| O1 | context_window 补全 | `opencodeserver/commands.go:queryContextUsage` | 优先级：① 查询 OCS model/provider 元数据 API → ② 维护 `model→contextWindow` 静态映射表（参考 `internal/security/model.go` 已有的模型注册） → ③ 标注协议限制 |
+
+### 5.3 待实现时确认
+
+- OCS 是否有 `/model` 或 `/provider` 端点暴露 context window？需对照 `~/opencode` 源码。
+
+---
+
+## 6. SessionAccumulator 适配层（可选增强）
+
+当前 `mergePerTurnStats` 硬编码识别 CC/OCS 两种格式（`session_stats.go:59-96`）。两种修复路径：
+
+| 路径 | 方案 | 优劣 |
+|------|------|------|
+| **A. Worker 侧兼容**（推荐） | 让 codex/acp 产出 CC 或 OCS 兼容格式（acp 已做，codex 部分做了） | 改动局部，无需动核心聚合器 |
+| **B. 聚合器侧适配** | 在 `mergePerTurnStats` 增加 codex/acp 格式分支 | 核心代码膨胀，违反现有"两种格式"简洁假设 |
+
+**推荐路径 A**：Worker 负责产出兼容格式，聚合器保持稳定。本 spec 所有修复方案均遵循此路径。
+
+---
+
+## 7. 实施计划（Batch）
+
+### Batch 1: codexcli P0/P1（最严重，优先）
+
+| ID | 改点 | 优先级 |
+|----|------|:---:|
+| C1 | context_usage 解析修复 | P0 |
+| C2a | token 累计修正（total vs last） | P1 |
+| C3 | model 常态化 | P1 |
+| C2b | cache 字段补全（受协议限制） | P2 |
+| C4 | cost 产出（受协议限制） | P2 |
+
+### Batch 2: acp P0/P1
+
+| ID | 改点 | 优先级 |
+|----|------|:---:|
+| A1 | model_name 补全 | P0 |
+| A2 | tool_name 通用化 | P1 |
+| A3 | context fallback（受协议限制） | P2 |
+
+### Batch 3: opencode P2（受限于上游）
+
+| ID | 改点 | 优先级 |
+|----|------|:---:|
+| O1 | context_window 静态映射表 | P2 |
+
+---
+
+## 8. 验收标准
+
+每个修复项需满足：
+
+1. **单元测试**：对应 worker 的 mapper/converter/commands 测试覆盖新字段产出。
+2. **集成验证**：在真实 codex/acp/ocs agent 对话后，turn summary 卡片显示对应字段非空。
+3. **回归**：claudecode worker 的 turn summary 不受影响（现有 `turn_summary_test.go` 全绿）。
+4. **协议限制透明化**：受上游协议限制无法产出的字段（如 codex cache_creation、ocs context_window），在 spec 与代码注释中明确标注，不得静默归零。
+
+---
+
+## 9. 相关文档
+
+- `Turn-Summary-Spec.md` — turn summary 数据流与渲染设计（§1.3 Worker 兼容性表需补充 codex/acp 列）
+- `Worker-GAP-Analysis-2026-05-15.md` — OCS vs CC 能力全景差距
+- `Codex-AppServer-Worker-Spec.md` — codex app-server 协议参考
+- `ACP-Worker-Spec.md` / `ACP-Worker-Enhancement-Spec.md` — ACP 协议参考

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -157,10 +157,10 @@ func (h *WorkspaceHandlers) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 type updateWorkspaceRequest struct {
-	Name                 string `json:"name"`
-	AgentConfigOverrides string `json:"agent_config_overrides"`
-	WorkerPreference     string `json:"worker_preference"`
-	WorkDir              string `json:"work_dir"` // must be rejected (immutable, spec §6.2)
+	Name                 string  `json:"name"`
+	AgentConfigOverrides string  `json:"agent_config_overrides"`
+	WorkerPreference     *string `json:"worker_preference"` // nil = omit (no change); "" = explicit clear to default
+	WorkDir              string  `json:"work_dir"`          // must be rejected (immutable, spec §6.2)
 }
 
 // Update: PATCH /api/workspaces/{id}
@@ -206,12 +206,14 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		}
 		ws.AgentConfigOverrides = req.AgentConfigOverrides
 	}
-	if req.WorkerPreference != "" {
-		if err := worker.ValidateType(worker.WorkerType(req.WorkerPreference)); err != nil {
+	if req.WorkerPreference != nil {
+		// nil = field omitted (no change); "" = explicit clear to default.
+		// ValidateType accepts "" as inherit-default, so clearing needs no special case.
+		if err := worker.ValidateType(worker.WorkerType(*req.WorkerPreference)); err != nil {
 			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
 			return
 		}
-		ws.WorkerPreference = req.WorkerPreference
+		ws.WorkerPreference = *req.WorkerPreference
 	}
 	if err := h.store.UpdateWorkspace(r.Context(), ws, h.nowUnix()); err != nil {
 		if errors.Is(err, session.ErrWorkspaceConflict) {

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -13,6 +13,7 @@ import { Thread } from '@/components/assistant-ui/thread';
 import { BrandIcon, WORKER_DISPLAY } from '@/components/icons';
 import { SessionPanel } from './SessionPanel';
 import { NewSessionModal } from './NewSessionModal';
+import { SettingsModal } from './settings-modal/settings-modal';
 import { MetricsBar } from '@/components/assistant-ui/MetricsBar';
 import { workerType as defaultWorkerType, httpBase, type ConnectionState } from '@/lib/config';
 import type { SessionMetrics } from '@/lib/hooks/useMetrics';
@@ -22,7 +23,7 @@ import {
   createWorkspace,
   type Workspace,
 } from '@/lib/api/workspaces';
-import { logout } from '@/lib/api/auth';
+import { logout, getMe, type User } from '@/lib/api/auth';
 
 function ChatInterface({
   sessionId,
@@ -75,6 +76,8 @@ export default function ChatContainer() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [showNewModal, setShowNewModal] = useState(false);
   const [wsDropdownOpen, setWsDropdownOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [sessionMetrics, setSessionMetrics] = useState<SessionMetrics | null>(null);
 
   // nuqs deep link params
@@ -115,6 +118,13 @@ export default function ChatContainer() {
   useEffect(() => {
     loadWorkspaces();
   }, [loadWorkspaces]);
+
+  // Fetch current user profile (Profile tab + Members tab gating)
+  useEffect(() => {
+    let mounted = true;
+    getMe().then((u) => { if (mounted) setCurrentUser(u); }).catch(() => { /* not logged in or unreachable */ });
+    return () => { mounted = false; };
+  }, []);
 
   const handleSwitchWorkspace = (ws: Workspace) => {
     setActiveWorkspace(ws);
@@ -261,17 +271,17 @@ export default function ChatContainer() {
             </svg>
             <span className="hidden md:inline">Docs</span>
           </a>
-          {/* Settings — Phase 3: opens SettingsModal (linked to /admin until SettingsModal lands) */}
-          <Link
-            href="/admin"
+          {/* Settings — opens SettingsModal (Phase 3) */}
+          <button
+            onClick={() => setSettingsOpen(true)}
             className="p-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
-            title="Settings & Admin"
+            title="Settings"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
-          </Link>
+          </button>
           {/* Logout */}
           <button
             onClick={handleLogout}
@@ -346,6 +356,18 @@ export default function ChatContainer() {
           defaultWorkDir={activeWorkspace?.work_dir}
         />
       )}
+
+      {/* Settings Modal (Phase 3) */}
+      <SettingsModal
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        workspace={activeWorkspace}
+        currentUser={currentUser}
+        onWorkspaceUpdated={(ws) => {
+          setActiveWorkspace(ws);
+          setWorkspaces((prev) => prev.map((w) => (w.id === ws.id ? ws : w)));
+        }}
+      />
     </div>
   );
 }

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -74,6 +74,7 @@ function ChatInterface({
 export default function ChatContainer() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [showNewModal, setShowNewModal] = useState(false);
+  const [wsDropdownOpen, setWsDropdownOpen] = useState(false);
   const [sessionMetrics, setSessionMetrics] = useState<SessionMetrics | null>(null);
 
   // nuqs deep link params
@@ -82,7 +83,7 @@ export default function ChatContainer() {
   // Workspaces State
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [activeWorkspace, setActiveWorkspace] = useState<Workspace | null>(null);
-  
+
   // Fetch workspaces list
   const loadWorkspaces = useCallback(async (selectId?: string) => {
     try {
@@ -101,7 +102,7 @@ export default function ChatContainer() {
       const targetId = selectId || localStorage.getItem('hotplex_active_workspace_id');
       const found = list.find((w) => w.id === targetId);
       const active = found || list[0];
-      
+
       setActiveWorkspace(active);
       if (active) {
         localStorage.setItem('hotplex_active_workspace_id', active.id);
@@ -119,6 +120,7 @@ export default function ChatContainer() {
     setActiveWorkspace(ws);
     localStorage.setItem('hotplex_active_workspace_id', ws.id);
     setSessionMetrics(null); // Reset metrics on workspace switch
+    setWsDropdownOpen(false);
   };
 
   const handleLogout = async () => {
@@ -158,225 +160,185 @@ export default function ChatContainer() {
     setShowNewModal(true);
   }, []);
 
+  const workerLabel = WORKER_DISPLAY[activeSession?.worker_type ?? defaultWorkerType] ?? activeSession?.worker_type ?? defaultWorkerType;
+
   return (
-    <div className="flex h-screen overflow-hidden bg-[var(--bg-base)]">
-      {/* 1. Far-left compact workspace selection navigation bar */}
-      <nav className="w-[72px] bg-[#0b0b0d] border-r border-[var(--border-subtle)] flex flex-col items-center py-4 justify-between z-40 flex-shrink-0">
-        <div className="flex flex-col items-center gap-4 w-full">
-          {/* Logo */}
-          <div className="w-12 h-12 rounded-xl bg-[var(--bg-surface)] border border-[var(--border-subtle)] flex items-center justify-center relative group">
-            <BrandIcon size={32} />
-            <div className="absolute left-[80px] bg-[var(--bg-elevated)] border border-[var(--border-default)] px-2.5 py-1.5 rounded-lg text-xs font-bold font-display whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-all duration-200 z-50 shadow-md">
-              HotPlex WebChat
-            </div>
-          </div>
+    <div className="flex h-screen flex-col overflow-hidden bg-[var(--bg-base)]">
+      {/* Top bar: workspace switcher + brand + actions (P3.1 redesign — replaces the 72px nav) */}
+      <header className="h-14 flex items-center px-3 gap-2 border-b border-[var(--border-subtle)] bg-[rgba(15,15,18,0.6)] backdrop-blur-xl flex-shrink-0 z-30">
+        {/* Sidebar collapse toggle */}
+        <button
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          className="p-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all active:scale-95"
+          title={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
 
-          <div className="w-8 h-[1px] bg-[var(--border-subtle)]" />
-
-          {/* Workspaces list */}
-          <div className="flex flex-col gap-3 w-full items-center max-h-[calc(100vh-280px)] overflow-y-auto custom-scrollbar py-1">
-            {workspaces.map((ws) => {
-              const isActive = activeWorkspace?.id === ws.id;
-              const initials = ws.name.slice(0, 2).toUpperCase();
-              return (
-                <button
-                  key={ws.id}
-                  onClick={() => handleSwitchWorkspace(ws)}
-                  className={`w-12 h-12 rounded-3xl hover:rounded-xl flex items-center justify-center text-sm font-black uppercase tracking-wider relative transition-all duration-300 group ${
-                    isActive
-                      ? 'bg-[var(--accent-gold)] text-black rounded-xl border border-[var(--accent-gold)] shadow-[var(--shadow-glow)]'
-                      : 'bg-[var(--bg-surface)] text-[var(--text-secondary)] border border-[var(--border-subtle)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] hover:border-[var(--border-default)]'
-                  }`}
+        {/* Workspace dropdown */}
+        <div className="relative flex-shrink-0">
+          <button
+            onClick={() => setWsDropdownOpen((v) => !v)}
+            className="flex items-center gap-2 pl-1.5 pr-2 py-1.5 rounded-lg bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)] border border-[var(--border-subtle)] hover:border-[var(--border-default)] text-sm font-bold text-[var(--text-primary)] transition-all"
+          >
+            <span className="w-6 h-6 rounded-md bg-[var(--accent-gold)] text-black flex items-center justify-center text-[10px] font-black uppercase tracking-wider">
+              {(activeWorkspace?.name || '?').slice(0, 2)}
+            </span>
+            <span className="truncate max-w-[140px]">{activeWorkspace?.name || 'Workspace'}</span>
+            <svg className={`w-4 h-4 text-[var(--text-muted)] transition-transform ${wsDropdownOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {wsDropdownOpen && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={() => setWsDropdownOpen(false)} />
+              <div className="absolute top-full left-0 mt-1 w-64 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl shadow-xl py-1.5 z-50">
+                <p className="px-3 py-1 text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-widest">Workspaces</p>
+                {workspaces.map((ws) => {
+                  const isActive = activeWorkspace?.id === ws.id;
+                  return (
+                    <button
+                      key={ws.id}
+                      onClick={() => handleSwitchWorkspace(ws)}
+                      className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${isActive ? 'bg-[var(--accent-gold)]/10 text-[var(--accent-gold)]' : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]'}`}
+                    >
+                      <span className={`w-6 h-6 rounded-md flex items-center justify-center text-[10px] font-black uppercase ${isActive ? 'bg-[var(--accent-gold)] text-black' : 'bg-[var(--bg-surface)] text-[var(--text-muted)] border border-[var(--border-subtle)]'}`}>
+                        {ws.name.slice(0, 2)}
+                      </span>
+                      <span className="truncate font-medium">{ws.name}</span>
+                    </button>
+                  );
+                })}
+                <div className="border-t border-[var(--border-subtle)] my-1" />
+                <Link
+                  href="/admin/workspaces/new"
+                  onClick={() => setWsDropdownOpen(false)}
+                  className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--accent-gold)] transition-colors"
                 >
-                  {/* Active Indicator Bar */}
-                  {isActive && (
-                    <div className="absolute left-0 w-1.5 h-6 bg-black rounded-r-md" />
-                  )}
-                  {initials}
-
-                  {/* Tooltip */}
-                  <div className="absolute left-[80px] bg-[var(--bg-elevated)] border border-[var(--border-default)] px-2.5 py-1.5 rounded-lg text-xs font-bold font-display text-[var(--text-primary)] whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-all duration-200 z-50 shadow-md">
-                    {ws.name}
-                  </div>
-                </button>
-              );
-            })}
-
-            {/* Create Workspace Button → full-page workspace management */}
-            <Link
-              href="/admin/workspaces/new"
-              className="w-12 h-12 rounded-3xl hover:rounded-xl bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)] border border-[var(--border-subtle)] hover:border-[var(--border-default)] flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--accent-gold)] transition-all duration-300 group"
-              title="Create Workspace"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
-              </svg>
-
-              {/* Tooltip */}
-              <div className="absolute left-[80px] bg-[var(--bg-elevated)] border border-[var(--border-default)] px-2.5 py-1.5 rounded-lg text-xs font-bold font-display text-[var(--text-primary)] whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-all duration-200 z-50 shadow-md">
-                Create Workspace
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+                  </svg>
+                  <span className="font-medium">New Workspace</span>
+                </Link>
               </div>
-            </Link>
-          </div>
+            </>
+          )}
         </div>
 
-        {/* Bottom profile actions */}
-        <div className="flex flex-col items-center gap-3 w-full">
-          {/* Settings & Admin button → admin console */}
+        {/* Worker / connection status pill */}
+        <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-[var(--bg-glass)] backdrop-blur-xl border border-[var(--border-default)] flex-shrink-0">
+          <div className={`w-1.5 h-1.5 rounded-full ${sessionsLoading ? 'bg-[var(--accent-gold)] animate-pulse' : sessionError ? 'bg-[var(--accent-coral)]' : 'bg-[var(--accent-emerald)] shadow-[0_0_8px_var(--accent-emerald)]'}`} />
+          <span className="text-[10px] font-bold text-[var(--text-secondary)] uppercase tracking-wider">
+            {sessionsLoading ? 'PREPARING' : sessionError ? 'ERROR' : 'ACTIVE'} · {workerLabel}
+          </span>
+        </div>
+
+        {/* Center brand */}
+        <div className="flex-1 flex items-center justify-center gap-2 min-w-0">
+          <BrandIcon size={18} />
+          <span className="font-display font-bold text-sm text-[var(--text-primary)] tracking-tight hidden sm:inline">HotPlex</span>
+        </div>
+
+        {/* Right actions */}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {sessionMetrics && sessionMetrics.turnCount > 0 && (
+            <MetricsBar session={sessionMetrics} />
+          )}
+          {sessionError && (
+            <span className="text-[10px] font-bold text-[var(--accent-coral)] px-2 truncate max-w-[160px]" title={sessionError}>{sessionError}</span>
+          )}
+          <a
+            href={`${httpBase()}/docs/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[var(--accent-gold)] bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/20 hover:bg-[var(--accent-gold)] hover:text-black rounded-full transition-all font-bold text-[10px] uppercase tracking-wider"
+            title="Documentation"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+            </svg>
+            <span className="hidden md:inline">Docs</span>
+          </a>
+          {/* Settings — Phase 3: opens SettingsModal (linked to /admin until SettingsModal lands) */}
           <Link
             href="/admin"
-            className="w-12 h-12 rounded-xl bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)] border border-[var(--border-subtle)] hover:border-[var(--border-default)] flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-all duration-300 group"
+            className="p-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
             title="Settings & Admin"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
-
-            {/* Tooltip */}
-            <div className="absolute left-[80px] bg-[var(--bg-elevated)] border border-[var(--border-default)] px-2.5 py-1.5 rounded-lg text-xs font-bold font-display text-[var(--text-primary)] whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-all duration-200 z-50 shadow-md">
-              Settings & Admin
-            </div>
           </Link>
-
-          {/* Logout button */}
+          {/* Logout */}
           <button
             onClick={handleLogout}
-            className="w-12 h-12 rounded-xl bg-[var(--bg-surface)] hover:bg-[var(--accent-coral)]/10 border border-[var(--border-subtle)] hover:border-[var(--accent-coral)]/20 flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--accent-coral)] transition-all duration-300 group"
+            className="p-2 text-[var(--text-muted)] hover:text-[var(--accent-coral)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
             title="Log Out"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
             </svg>
-
-            {/* Tooltip */}
-            <div className="absolute left-[80px] bg-[var(--bg-elevated)] border border-[var(--border-default)] px-2.5 py-1.5 rounded-lg text-xs font-bold font-display text-[var(--text-primary)] whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-all duration-200 z-50 shadow-md">
-              Log Out
-            </div>
           </button>
         </div>
-      </nav>
+      </header>
 
-      {/* 2. Main Sessions Sidebar (Workspace Scoped) */}
-      <aside className={`transition-all duration-300 ease-in-out ${sidebarOpen ? 'w-[280px]' : 'w-0'} overflow-hidden flex-shrink-0 relative z-30`}>
-        <SessionPanel
-          sessions={sessions}
-          activeSession={activeSession}
-          isLoading={sessionsLoading}
-          onSelect={selectSession}
-          onCreate={handleCreateNew}
-          onDelete={removeSession}
-        />
-      </aside>
+      {/* Body: session sidebar + chat */}
+      <div className="flex flex-1 overflow-hidden">
+        <aside className={`transition-all duration-300 ease-in-out ${sidebarOpen ? 'w-[280px]' : 'w-0'} overflow-hidden flex-shrink-0 relative z-20`}>
+          <SessionPanel
+            sessions={sessions}
+            activeSession={activeSession}
+            isLoading={sessionsLoading}
+            onSelect={selectSession}
+            onCreate={handleCreateNew}
+            onDelete={removeSession}
+          />
+        </aside>
 
-      {/* 3. Main Chat View Content */}
-      <main className="flex-1 flex flex-col min-w-0 relative">
-        <header className="h-14 flex items-center px-6 border-b border-[var(--border-subtle)] bg-[rgba(15,15,18,0.6)] backdrop-blur-xl flex-shrink-0 z-20">
-          <div className="flex items-center gap-4 w-full">
-            <button
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              className="p-2 -ml-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all active:scale-95"
-              title={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            </button>
-
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-               <div>
-                  <h1 className="text-xs font-display font-bold text-[var(--text-primary)] leading-none mb-0.5 flex items-center gap-2">
-                    <span className="text-[var(--accent-gold)] truncate max-w-[150px]">{activeWorkspace?.name || 'Workspace'}</span>
-                    <span className="text-[10px] text-[var(--text-faint)]">/</span>
-                    <span className="text-[var(--text-secondary)]">HotPlex Agent</span>
-                  </h1>
-                  <p className="text-[9px] text-[var(--text-faint)] font-mono uppercase tracking-widest flex items-center gap-1.5">
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-emerald)] shadow-[0_0_6px_var(--accent-emerald)]" />
-                    Active · {WORKER_DISPLAY[activeSession?.worker_type ?? defaultWorkerType] ?? activeSession?.worker_type ?? defaultWorkerType}
-                  </p>
-                  {(urlDir || activeWorkspace?.work_dir) && (
-                    <p className="text-[9px] text-[var(--text-faint)] font-mono mt-0.5 truncate max-w-[200px]" title={urlDir || activeWorkspace?.work_dir}>
-                      {(() => {
-                        const d = urlDir || activeWorkspace?.work_dir || '';
-                        return d.length > 30 ? `…${d.slice(-28)}` : d;
-                      })()}
-                    </p>
-                  )}
-               </div>
-            </div>
-
-            {/* MetricsBar */}
-            {sessionMetrics && sessionMetrics.turnCount > 0 && (
-              <MetricsBar session={sessionMetrics} />
-            )}
-
-            <div className="flex items-center gap-2 flex-shrink-0">
-                <a
-                  href={`${httpBase()}/docs/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-[var(--accent-gold)] bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/20 hover:bg-[var(--accent-gold)] hover:text-black rounded-full transition-all font-bold text-[10px] uppercase tracking-wider shadow-sm"
-                  title="Documentation"
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                  </svg>
-                  Docs
-                </a>
-                {sessionError && (
-                  <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[rgba(244,63,94,0.1)] border border-[rgba(244,63,94,0.2)]">
-                    <div className="w-1.5 h-1.5 rounded-full bg-[var(--accent-coral)]" />
-                    <span className="text-[10px] font-bold text-[var(--accent-coral)]">{sessionError}</span>
-                  </div>
-                )}
-               <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[var(--bg-glass)] backdrop-blur-xl border border-[var(--border-default)]">
-                  <div className={`w-1.5 h-1.5 rounded-full ${sessionsLoading ? 'bg-[var(--accent-gold)] animate-pulse' : sessionError ? 'bg-[var(--accent-coral)]' : 'bg-[var(--accent-emerald)] shadow-[0_0_8px_var(--accent-emerald)]'}`} />
-                  <span className="text-[10px] font-bold text-[var(--text-secondary)]">{sessionsLoading ? 'PREPARING...' : sessionError ? 'ERROR' : 'GATEWAY ONLINE'}</span>
-               </div>
-            </div>
-          </div>
-        </header>
-
-        {/* Chat Thread */}
-        <div className="flex-1 relative overflow-hidden">
-          {(!activeSessionId && sessionsLoading) ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--bg-base)] z-10 animate-fade-in">
-              <div className="relative mb-6">
-                <div className="absolute inset-0 bg-[var(--accent-gold)] opacity-15 blur-2xl rounded-full animate-pulse" />
-                <BrandIcon size={56} className="relative z-10 animate-float" />
+        <main className="flex-1 flex flex-col min-w-0 relative">
+          <div className="flex-1 relative overflow-hidden">
+            {(!activeSessionId && sessionsLoading) ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--bg-base)] z-10 animate-fade-in">
+                <div className="relative mb-6">
+                  <div className="absolute inset-0 bg-[var(--accent-gold)] opacity-15 blur-2xl rounded-full animate-pulse" />
+                  <BrandIcon size={56} className="relative z-10 animate-float" />
+                </div>
+                <p className="text-sm font-medium text-[var(--text-muted)] animate-pulse">Starting new session...</p>
               </div>
-              <p className="text-sm font-medium text-[var(--text-muted)] animate-pulse">Starting new session...</p>
-            </div>
-          ) : !activeSessionId ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--bg-base)] p-8 text-center">
-               <div className="w-20 h-20 rounded-3xl glass-dark flex items-center justify-center mb-8">
+            ) : !activeSessionId ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-[var(--bg-base)] p-8 text-center">
+                <div className="w-20 h-20 rounded-3xl glass-dark flex items-center justify-center mb-8">
                   <BrandIcon size={60} />
-               </div>
-               <h2 className="text-xl font-display font-bold text-[var(--text-primary)] mb-3">Empower Your Coding</h2>
-               <p className="text-sm text-[var(--text-muted)] max-w-sm mb-10 leading-relaxed">
-                 Select an existing session from the sidebar or start a new high-fidelity coding conversation.
-               </p>
-               <button
-                 onClick={handleCreateNew}
-                 className="px-8 py-3 rounded-full bg-[var(--accent-gold)] text-black text-sm font-bold shadow-[0_8px_32px_rgba(251,191,36,0.15)] hover:scale-105 active:scale-95 transition-all"
-               >
-                 {sessions.length === 0 ? 'Start Your First Project' : 'New Chat'}
-               </button>
-            </div>
-          ) : (
-            <ChatInterface
-              key={activeSessionId}
-              sessionId={activeSessionId}
-              overrideWorkDir={urlDir ?? undefined}
-              onMetricsChange={setSessionMetrics}
-              onSessionStateChange={(state) => activeSessionId && updateSessionState(activeSessionId, state)}
-              workspaceId={activeWorkspace?.id}
-            />
-          )}
-        </div>
-      </main>
+                </div>
+                <h2 className="text-xl font-display font-bold text-[var(--text-primary)] mb-3">Empower Your Coding</h2>
+                <p className="text-sm text-[var(--text-muted)] max-w-sm mb-10 leading-relaxed">
+                  Select an existing session from the sidebar or start a new high-fidelity coding conversation.
+                </p>
+                <button
+                  onClick={handleCreateNew}
+                  className="px-8 py-3 rounded-full bg-[var(--accent-gold)] text-black text-sm font-bold shadow-[0_8px_32px_rgba(251,191,36,0.15)] hover:scale-105 active:scale-95 transition-all"
+                >
+                  {sessions.length === 0 ? 'Start Your First Project' : 'New Chat'}
+                </button>
+              </div>
+            ) : (
+              <ChatInterface
+                key={activeSessionId}
+                sessionId={activeSessionId}
+                overrideWorkDir={urlDir ?? undefined}
+                onMetricsChange={setSessionMetrics}
+                onSessionStateChange={(state) => activeSessionId && updateSessionState(activeSessionId, state)}
+                workspaceId={activeWorkspace?.id}
+              />
+            )}
+          </div>
+        </main>
+      </div>
 
-      {/* 4. New Session Modal (with workspace defaultWorkDir propagation) */}
+      {/* New Session Modal */}
       {showNewModal && (
         <NewSessionModal
           onConfirm={handleModalConfirm}

--- a/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { updateWorkspace, type Workspace } from '@/lib/api/workspaces';
+import { AgentConfigEditor } from '@/components/admin/agent-config-editor';
+
+const WORKER_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: 'Default (inherit team setting)' },
+  { value: 'claude_code', label: 'Claude Code' },
+  { value: 'opencode_server', label: 'OpenCode Server' },
+  { value: 'codex_cli', label: 'Codex CLI' },
+  { value: 'acp', label: 'ACP' },
+];
+
+interface AIConfigTabProps {
+  workspace: Workspace;
+  onUpdated?: (ws: Workspace) => void;
+}
+
+export function AIConfigTab({ workspace, onUpdated }: AIConfigTabProps) {
+  const [worker, setWorker] = useState(workspace.worker_preference || '');
+  const [savingWorker, setSavingWorker] = useState(false);
+  const [workerError, setWorkerError] = useState<string | null>(null);
+  const [workerSaved, setWorkerSaved] = useState(false);
+
+  useEffect(() => {
+    setWorker(workspace.worker_preference || '');
+    setWorkerError(null);
+    setWorkerSaved(false);
+  }, [workspace.id, workspace.worker_preference, workspace.updated_at]);
+
+  const dirty = worker !== (workspace.worker_preference || '');
+
+  const handleSaveWorker = async () => {
+    setSavingWorker(true);
+    setWorkerError(null);
+    setWorkerSaved(false);
+    try {
+      const updated = await updateWorkspace(workspace.id, { workerPreference: worker });
+      onUpdated?.(updated);
+      setWorkerSaved(true);
+      setTimeout(() => setWorkerSaved(false), 2000);
+    } catch (err) {
+      setWorkerError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSavingWorker(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Worker preference */}
+      <div>
+        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+          Worker Engine
+        </label>
+        <p className="text-xs text-[var(--text-muted)] mb-2">
+          Selects which worker binary new sessions use. Existing sessions keep their worker.
+        </p>
+        <div className="flex gap-2">
+          <select
+            value={worker}
+            onChange={(e) => setWorker(e.target.value)}
+            className="flex-1 px-3 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-default)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[rgba(251,191,36,0.1)] transition-all"
+          >
+            {WORKER_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleSaveWorker}
+            disabled={!dirty || savingWorker}
+            className="px-4 py-2 rounded-[var(--radius-md)] bg-[var(--accent-gold)] text-black text-xs font-bold transition-all hover:bg-[var(--accent-gold-bright)] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {savingWorker ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+        {workerError && <p className="mt-2 text-xs text-[var(--accent-coral)] font-bold break-words">{workerError}</p>}
+        {workerSaved && <p className="mt-2 text-xs text-[var(--accent-emerald)] font-bold">Saved</p>}
+      </div>
+
+      {/* Agent config overrides — reuse admin AgentConfigEditor */}
+      <div>
+        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+          Agent Config Overrides
+        </label>
+        <p className="text-xs text-[var(--text-muted)] mb-3">
+          Per-workspace customization (SOUL.md / AGENTS.md / SKILLS.md / USER.md / MEMORY.md). Blank entries inherit the team default.
+        </p>
+        <AgentConfigEditor workspaceId={workspace.id} overrides={workspace.agent_config_overrides || {}} />
+      </div>
+    </div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { updateWorkspace, type Workspace } from '@/lib/api/workspaces';
+import { updateWorkspace, getWorkspace, type Workspace } from '@/lib/api/workspaces';
 import { AgentConfigEditor } from '@/components/admin/agent-config-editor';
 
 const WORKER_OPTIONS: { value: string; label: string }[] = [
@@ -41,7 +41,16 @@ export function AIConfigTab({ workspace, onUpdated }: AIConfigTabProps) {
       setWorkerSaved(true);
       setTimeout(() => setWorkerSaved(false), 2000);
     } catch (err) {
-      setWorkerError(err instanceof Error ? err.message : 'Save failed');
+      if ((err as { status?: number }).status === 409) {
+        setWorkerError('Workspace was modified elsewhere — refreshed to latest, please retry.');
+        try {
+          onUpdated?.(await getWorkspace(workspace.id));
+        } catch {
+          // re-fetch failed; keep the 409 message above
+        }
+      } else {
+        setWorkerError(err instanceof Error ? err.message : 'Save failed');
+      }
     } finally {
       setSavingWorker(false);
     }

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { updateWorkspace, type Workspace } from '@/lib/api/workspaces';
+import { updateWorkspace, getWorkspace, type Workspace } from '@/lib/api/workspaces';
 
 interface GeneralTabProps {
   workspace: Workspace;
@@ -33,7 +33,16 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Save failed');
+      if ((err as { status?: number }).status === 409) {
+        setError('Workspace was modified elsewhere — refreshed to latest, please retry.');
+        try {
+          onUpdated?.(await getWorkspace(workspace.id));
+        } catch {
+          // re-fetch failed; keep the 409 message above
+        }
+      } else {
+        setError(err instanceof Error ? err.message : 'Save failed');
+      }
     } finally {
       setSaving(false);
     }

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { updateWorkspace, type Workspace } from '@/lib/api/workspaces';
+
+interface GeneralTabProps {
+  workspace: Workspace;
+  onUpdated?: (ws: Workspace) => void;
+}
+
+export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
+  const [name, setName] = useState(workspace.name);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Resync when the workspace prop changes (e.g. after a parent re-fetch).
+  useEffect(() => {
+    setName(workspace.name);
+    setError(null);
+    setSuccess(false);
+  }, [workspace.id, workspace.name, workspace.updated_at]);
+
+  const dirty = name.trim() !== workspace.name && name.trim().length > 0;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      const updated = await updateWorkspace(workspace.id, { name: name.trim() });
+      onUpdated?.(updated);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+          Workspace Name
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-default)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[rgba(251,191,36,0.1)] transition-all"
+        />
+      </div>
+
+      <div>
+        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+          Working Directory <span className="normal-case text-[var(--text-faint)]">(immutable)</span>
+        </label>
+        <div className="px-3 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-base)] border border-[var(--border-subtle)] text-sm text-[var(--text-muted)] font-mono break-all">
+          {workspace.work_dir}
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 rounded-[var(--radius-md)] bg-[var(--accent-coral)]/10 border border-[var(--accent-coral)]/20 text-xs text-[var(--accent-coral)] font-bold break-words">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="px-3 py-2 rounded-[var(--radius-md)] bg-[var(--accent-emerald)]/10 border border-[var(--accent-emerald)]/20 text-xs text-[var(--accent-emerald)] font-bold">
+          Saved
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={!dirty || saving}
+          className="px-5 py-2 rounded-[var(--radius-md)] bg-[var(--accent-gold)] text-black text-xs font-bold transition-all hover:bg-[var(--accent-gold-bright)] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/members-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/members-tab.tsx
@@ -19,6 +19,7 @@ export function MembersTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionMsg, setActionMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
 
   const flash = (kind: 'ok' | 'err', text: string) => {
     setActionMsg({ kind, text });
@@ -59,12 +60,15 @@ export function MembersTab() {
 
   const handleToggleUser = async (user: User) => {
     const next = user.status === 'active' ? 'disabled' : 'active';
+    setBusyUserId(user.id);
     try {
       await adminUpdateUserStatus(user.id, next);
       flash('ok', `${user.username} → ${next}`);
       load();
     } catch (err) {
       flash('err', err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setBusyUserId(null);
     }
   };
 
@@ -115,9 +119,10 @@ export function MembersTab() {
               </div>
               <button
                 onClick={() => handleToggleUser(u)}
-                className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all flex-shrink-0 ${u.status === 'active' ? 'bg-[var(--accent-coral)]/10 text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/20' : 'bg-[var(--accent-emerald)]/10 text-[var(--accent-emerald)] hover:bg-[var(--accent-emerald)]/20'}`}
+                disabled={busyUserId === u.id}
+                className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all flex-shrink-0 disabled:opacity-40 disabled:cursor-not-allowed ${u.status === 'active' ? 'bg-[var(--accent-coral)]/10 text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/20' : 'bg-[var(--accent-emerald)]/10 text-[var(--accent-emerald)] hover:bg-[var(--accent-emerald)]/20'}`}
               >
-                {u.status === 'active' ? 'Disable' : 'Enable'}
+                {busyUserId === u.id ? '…' : u.status === 'active' ? 'Disable' : 'Enable'}
               </button>
             </div>
           ))}

--- a/webchat/app/components/chat/settings-modal/members-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/members-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   adminListUsers,
   adminUpdateUserStatus,
@@ -25,24 +25,37 @@ export function MembersTab() {
     setTimeout(() => setActionMsg(null), 2500);
   };
 
+  const abortRef = useRef<AbortController | null>(null);
+
+  // AbortController guards against (a) rapid re-loads racing stale responses
+  // onto fresh state and (b) in-flight requests resolving after unmount (PR #779
+  // review P2-1). Each load() aborts the previous; unmount aborts whatever remains.
   const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
     setLoading(true);
     setError(null);
     try {
       const [u, inv] = await Promise.all([
-        adminListUsers(100, 0),
-        adminListInvitations(100, 0),
+        adminListUsers(100, 0, ctrl.signal),
+        adminListInvitations(100, 0, ctrl.signal),
       ]);
+      if (ctrl.signal.aborted) return;
       setUsers(u.users || []);
       setInvitations(inv.invitations || []);
     } catch (err) {
+      if (ctrl.signal.aborted) return;
       setError(err instanceof Error ? err.message : 'Load failed');
     } finally {
-      setLoading(false);
+      if (!ctrl.signal.aborted) setLoading(false);
     }
   }, []);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+    return () => abortRef.current?.abort();
+  }, [load]);
 
   const handleToggleUser = async (user: User) => {
     const next = user.status === 'active' ? 'disabled' : 'active';

--- a/webchat/app/components/chat/settings-modal/members-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/members-tab.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  adminListUsers,
+  adminUpdateUserStatus,
+  adminListInvitations,
+  adminCreateInvitation,
+  adminDeleteInvitation,
+  type User,
+  type Invitation,
+} from '@/lib/api/auth';
+
+const DEFAULT_INVITE_TTL = 7 * 24 * 3600; // 7 days, matches backend default
+
+export function MembersTab() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionMsg, setActionMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  const flash = (kind: 'ok' | 'err', text: string) => {
+    setActionMsg({ kind, text });
+    setTimeout(() => setActionMsg(null), 2500);
+  };
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [u, inv] = await Promise.all([
+        adminListUsers(100, 0),
+        adminListInvitations(100, 0),
+      ]);
+      setUsers(u.users || []);
+      setInvitations(inv.invitations || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Load failed');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleToggleUser = async (user: User) => {
+    const next = user.status === 'active' ? 'disabled' : 'active';
+    try {
+      await adminUpdateUserStatus(user.id, next);
+      flash('ok', `${user.username} → ${next}`);
+      load();
+    } catch (err) {
+      flash('err', err instanceof Error ? err.message : 'Update failed');
+    }
+  };
+
+  const handleCreateInvitation = async () => {
+    try {
+      await adminCreateInvitation('user', DEFAULT_INVITE_TTL);
+      flash('ok', 'Invitation created');
+      load();
+    } catch (err) {
+      flash('err', err instanceof Error ? err.message : 'Create failed');
+    }
+  };
+
+  const handleDeleteInvitation = async (id: string) => {
+    try {
+      await adminDeleteInvitation(id);
+      flash('ok', 'Invitation deleted');
+      load();
+    } catch (err) {
+      flash('err', err instanceof Error ? err.message : 'Delete failed');
+    }
+  };
+
+  if (loading) {
+    return <div className="text-center py-8 text-sm text-[var(--text-muted)]">Loading…</div>;
+  }
+  if (error) {
+    return <div className="text-center py-8 text-sm text-[var(--accent-coral)] font-bold">{error}</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {actionMsg && (
+        <div className={`px-3 py-2 rounded-[var(--radius-md)] border text-xs font-bold ${actionMsg.kind === 'ok' ? 'bg-[var(--accent-emerald)]/10 border-[var(--accent-emerald)]/20 text-[var(--accent-emerald)]' : 'bg-[var(--accent-coral)]/10 border-[var(--accent-coral)]/20 text-[var(--accent-coral)]'}`}>
+          {actionMsg.text}
+        </div>
+      )}
+
+      {/* Users */}
+      <section>
+        <h3 className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest mb-2">Users</h3>
+        <div className="space-y-1">
+          {users.map((u) => (
+            <div key={u.id} className="flex items-center justify-between py-2 px-3 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] gap-3">
+              <div className="min-w-0">
+                <div className="text-sm font-bold text-[var(--text-primary)] truncate">{u.username}{u.display_name ? ` · ${u.display_name}` : ''}</div>
+                <div className="text-[10px] text-[var(--text-muted)] font-mono">{u.role} · {u.status}</div>
+              </div>
+              <button
+                onClick={() => handleToggleUser(u)}
+                className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all flex-shrink-0 ${u.status === 'active' ? 'bg-[var(--accent-coral)]/10 text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/20' : 'bg-[var(--accent-emerald)]/10 text-[var(--accent-emerald)] hover:bg-[var(--accent-emerald)]/20'}`}
+              >
+                {u.status === 'active' ? 'Disable' : 'Enable'}
+              </button>
+            </div>
+          ))}
+          {users.length === 0 && <p className="text-xs text-[var(--text-muted)] py-2">No users</p>}
+        </div>
+      </section>
+
+      {/* Invitations */}
+      <section>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest">Invitations</h3>
+          <button
+            onClick={handleCreateInvitation}
+            className="px-3 py-1 rounded-md bg-[var(--accent-gold)] text-black text-[10px] font-bold hover:bg-[var(--accent-gold-bright)] transition-all"
+          >
+            + New
+          </button>
+        </div>
+        <div className="space-y-1">
+          {invitations.map((inv) => {
+            const used = !!inv.used_at;
+            const expired = !used && inv.expires_at * 1000 < Date.now();
+            const state = used ? 'used' : expired ? 'expired' : 'active';
+            return (
+              <div key={inv.id} className="flex items-center justify-between py-2 px-3 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] gap-3">
+                <div className="min-w-0">
+                  <div className="text-sm font-mono font-bold text-[var(--text-primary)] truncate">{inv.code}</div>
+                  <div className="text-[10px] text-[var(--text-muted)]">
+                    {inv.role} · {state}{!used && !expired ? ` · expires ${new Date(inv.expires_at * 1000).toLocaleDateString()}` : ''}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleDeleteInvitation(inv.id)}
+                  className="px-2 py-1 rounded-md text-[10px] font-bold text-[var(--text-muted)] hover:text-[var(--accent-coral)] hover:bg-[var(--bg-hover)] transition-all flex-shrink-0"
+                >
+                  Delete
+                </button>
+              </div>
+            );
+          })}
+          {invitations.length === 0 && <p className="text-xs text-[var(--text-muted)] py-2">No invitations</p>}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/profile-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/profile-tab.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { User } from '@/lib/api/auth';
+
+interface ProfileTabProps {
+  user: User;
+}
+
+export function ProfileTab({ user }: ProfileTabProps) {
+  const rows: { label: string; value: string; mono?: boolean }[] = [
+    { label: 'Username', value: user.username },
+    { label: 'Display Name', value: user.display_name || '—' },
+    { label: 'Role', value: user.role },
+    { label: 'Status', value: user.status },
+    { label: 'User ID', value: user.id, mono: true },
+    ...(user.created_at ? [{ label: 'Created', value: new Date(user.created_at * 1000).toLocaleString() }] : []),
+    ...(user.last_login_at ? [{ label: 'Last Login', value: new Date(user.last_login_at * 1000).toLocaleString() }] : []),
+  ];
+
+  return (
+    <div className="space-y-1">
+      {rows.map((row) => (
+        <div key={row.label} className="flex justify-between items-center py-2.5 border-b border-[var(--border-subtle)] last:border-0 gap-4">
+          <span className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest flex-shrink-0">{row.label}</span>
+          <span className={`text-sm text-right break-all ${row.mono ? 'font-mono text-[var(--text-muted)]' : 'text-[var(--text-primary)]'}`}>
+            {row.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/settings-modal.tsx
+++ b/webchat/app/components/chat/settings-modal/settings-modal.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import type { Workspace } from '@/lib/api/workspaces';
+import type { User } from '@/lib/api/auth';
+import { GeneralTab } from './general-tab';
+import { ProfileTab } from './profile-tab';
+
+interface SettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspace: Workspace | null;
+  currentUser: User | null;
+  onWorkspaceUpdated?: (ws: Workspace) => void;
+}
+
+type TabId = 'general' | 'ai' | 'profile' | 'members';
+
+export function SettingsModal({ open, onClose, workspace, currentUser, onWorkspaceUpdated }: SettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<TabId>('general');
+
+  if (!open) return null;
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: 'general', label: 'General' },
+    { id: 'ai', label: 'AI Config' },
+    { id: 'profile', label: 'Profile' },
+    ...(currentUser?.role === 'admin' ? [{ id: 'members' as TabId, label: 'Members' }] : []),
+  ];
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-[300] flex items-center justify-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      <motion.div
+        className="relative w-full max-w-2xl mx-4 rounded-[var(--radius-xl)] border border-[var(--border-default)] bg-[var(--bg-surface)] backdrop-blur-2xl shadow-[0_32px_64px_rgba(0,0,0,0.5)] flex flex-col max-h-[85vh]"
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: 'spring' as const, stiffness: 300, damping: 28 }}
+      >
+        <div className="px-6 pt-6 pb-3 flex items-center justify-between flex-shrink-0">
+          <div>
+            <h2 className="text-lg font-display font-bold text-[var(--text-primary)]">Settings</h2>
+            <p className="text-xs text-[var(--text-muted)] mt-0.5 truncate">{workspace?.name ?? 'Workspace'}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 border-b border-[var(--border-subtle)] flex gap-1 flex-shrink-0">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 text-sm font-bold transition-all border-b-2 -mb-px ${
+                activeTab === tab.id
+                  ? 'text-[var(--accent-gold)] border-[var(--accent-gold)]'
+                  : 'text-[var(--text-muted)] border-transparent hover:text-[var(--text-primary)]'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {activeTab === 'general' && workspace && (
+            <GeneralTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
+          )}
+          {activeTab === 'ai' && (
+            <div className="text-center py-8 text-sm text-[var(--text-muted)]">AI Config — coming soon</div>
+          )}
+          {activeTab === 'profile' && currentUser && <ProfileTab user={currentUser} />}
+          {activeTab === 'members' && currentUser?.role === 'admin' && (
+            <div className="text-center py-8 text-sm text-[var(--text-muted)]">Members — coming soon</div>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/settings-modal.tsx
+++ b/webchat/app/components/chat/settings-modal/settings-modal.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import type { Workspace } from '@/lib/api/workspaces';
 import type { User } from '@/lib/api/auth';
 import { GeneralTab } from './general-tab';
+import { AIConfigTab } from './ai-config-tab';
 import { ProfileTab } from './profile-tab';
 
 interface SettingsModalProps {
@@ -79,8 +80,8 @@ export function SettingsModal({ open, onClose, workspace, currentUser, onWorkspa
           {activeTab === 'general' && workspace && (
             <GeneralTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
           )}
-          {activeTab === 'ai' && (
-            <div className="text-center py-8 text-sm text-[var(--text-muted)]">AI Config — coming soon</div>
+          {activeTab === 'ai' && workspace && (
+            <AIConfigTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
           )}
           {activeTab === 'profile' && currentUser && <ProfileTab user={currentUser} />}
           {activeTab === 'members' && currentUser?.role === 'admin' && (

--- a/webchat/app/components/chat/settings-modal/settings-modal.tsx
+++ b/webchat/app/components/chat/settings-modal/settings-modal.tsx
@@ -7,6 +7,7 @@ import type { User } from '@/lib/api/auth';
 import { GeneralTab } from './general-tab';
 import { AIConfigTab } from './ai-config-tab';
 import { ProfileTab } from './profile-tab';
+import { MembersTab } from './members-tab';
 
 interface SettingsModalProps {
   open: boolean;
@@ -84,9 +85,7 @@ export function SettingsModal({ open, onClose, workspace, currentUser, onWorkspa
             <AIConfigTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
           )}
           {activeTab === 'profile' && currentUser && <ProfileTab user={currentUser} />}
-          {activeTab === 'members' && currentUser?.role === 'admin' && (
-            <div className="text-center py-8 text-sm text-[var(--text-muted)]">Members — coming soon</div>
-          )}
+          {activeTab === 'members' && currentUser?.role === 'admin' && <MembersTab />}
         </div>
       </motion.div>
     </motion.div>

--- a/webchat/lib/api/workspaces.ts
+++ b/webchat/lib/api/workspaces.ts
@@ -1,4 +1,5 @@
 import { BASE, authHeaders, authOpts, withAuth, extractApiError } from "@/lib/api/client";
+import { parseApiError } from "@/lib/api/errors";
 
 export interface Workspace {
   id: string;
@@ -116,7 +117,23 @@ export async function updateWorkspace(id: string, opts: UpdateWorkspaceOptions, 
       signal,
     }
   );
-  if (!res.ok) throw new Error(await extractApiError(res, `updateWorkspace failed: ${res.status}`));
+  if (!res.ok) {
+    // 409 = optimistic-concurrency CAS loss (P3-1 backend): workspace was
+    // modified between the caller's Get and this PATCH. Surface a friendly
+    // message + the WORKSPACE_VERSION_MISMATCH code so UIs can re-fetch+retry.
+    const info = await parseApiError(res);
+    if (res.status === 409) {
+      const err = new Error('Workspace was modified concurrently — please reopen Settings and retry.');
+      (err as any).status = 409;
+      (err as any).code = info.code || 'WORKSPACE_VERSION_MISMATCH';
+      throw err;
+    }
+    const msg = info.code || info.message || info.raw || `updateWorkspace failed: ${res.status}`;
+    const err = new Error(msg);
+    (err as any).status = info.status;
+    if (info.code) (err as any).code = info.code;
+    throw err;
+  }
   return normalizeWorkspace(await res.json());
 }
 


### PR DESCRIPTION
## Summary
issue #772 Phase 3 的 UI 核心：WebChat 主界面内嵌 Settings Modal + 双侧边栏重新设计。无需跳转 `/admin` 即可完成 workspace 配置 / 成员管理 / 个人资料查看。

### P3.1 顶部 workspace bar 布局重构（用户反馈「双侧边栏很别扭」）
- ChatContainer 从三栏（72px workspace nav + 280px session + chat）重构为「顶部全宽 bar + session + chat」
- 删除 72px workspace nav；workspace 切换移到顶部 bar 的 dropdown（发现性更好）
- 顶部 bar 整合 sidebar toggle / workspace dropdown / worker-status pill / HotPlex 品牌 / docs / settings 齿轮 / logout

### P3.2 Settings Modal 四 tab
- **General**：workspace name 编辑（PATCH）+ work_dir 只读
- **AI Config**：worker_preference 下拉（claude_code/opencode_server/codex_cli/acp + 空=继承默认）+ 复用 admin `AgentConfigEditor`（5 文件 overrides，SOUL/AGENTS/SKILLS/USER/MEMORY）
- **Profile**：auth/me 用户信息只读
- **Members**（admin only）：用户列表启用/禁用 + 邀请码创建/删除

### P3.3 workspace 切换 + P3.4 配置 UI
- workspace 切换已存在（ChatContainer + useSessions workspaceId 过滤），后端 session list workspace_id 过滤已就绪
- worker_preference / agent_config_overrides UI 在 AI Config tab

### P3-1 乐观并发前端处理
- workspaces.ts updateWorkspace 加 409 `WORKSPACE_VERSION_MISMATCH` 处理（parseApiError 解析 + 友好消息 + status/code），UI 可 re-fetch+retry

### 附带 commit
- \`db58b7d6 docs(spec): worker turn summary parity\` — 非本次 Settings Modal 范围的 spec 文档（worker turn summary codex/acp/ocs gap 分析），从 base 分支继承，顺带合并

## 关键决策
- Modal 外壳复用 NewSessionModal 的 framer-motion 模式（不抽通用 wrapper，YAGNI）
- AgentConfigEditor 直接 import 复用（无 admin context 依赖）
- Members tab 仅 \`role==='admin'\` 渲染（auth/me role 判断）
- P3.1 布局重构 + Modal 骨架 + 4 tab 分 4 commit

## Test plan
- [x] \`pnpm exec tsc --noEmit\` 通过
- [x] pre-commit + pre-push 全门禁（vet/verify/lint/build/test）绿
- [ ] CI 绿
- [ ] review approve
- [ ] 浏览器测试：齿轮开 Modal / 4 tab 切换 / General 改名 / AI Config 选 worker+编辑 config / Members（admin）/ Profile

Refs #772