### PR TITLE
fix: PR #779 review polish — 全量清理 P2/P3 finding

### DIFF
--- a/docs/specs/Worker-Turn-Summary-Parity-Spec.md
+++ b/docs/specs/Worker-Turn-Summary-Parity-Spec.md
@@ -3,7 +3,7 @@ type: spec
 tags:
   - project/HotPlex
 date: 2026-06-23
-status: draft
+status: analysis
 progress: 0
 related_issues:
   - Turn-Summary-Spec.md (数据流基准)
@@ -72,7 +72,7 @@ Worker 产出事件 ──► SessionAccumulator 聚合 ──► snapshot() 注
 **Gap-C1：context_usage 管道完全断裂**
 - `commands.go:22-31` `get_context_usage` 调用 `thread/read` 后返回 `{"raw": string(resp)}`（未解析的原始 JSON 字符串）。
 - `pkg/events/helpers.go:60-98` `MapContextUsageResponse` 期望顶层 camelCase 键（`totalTokens`/`maxTokens`/`model`），`"raw"` 不匹配任何键 → `TotalTokens=0`。
-- `bridge_forward.go:913-916` 判断 `cu.TotalTokens <= 0` 跳过 `mergeContextUsage`。
+- `bridge_forward.go:913-916` 的守卫是 `cu.MaxTokens > 0 || cu.TotalTokens > 0 || cu.Model != ""` —— 三者皆空才跳过 `mergeContextUsage`（PR #779 review P3-1 勘误：原描述只提 TotalTokens，漏了 MaxTokens/Model 两个短路条件，可能误导修复者只补 TotalTokens）。
 - **后果**：`context_fill` / `context_window` / `context_pct` 三字段恒为 0。
 
 **Gap-C2：token 字段不全且非累计**

--- a/internal/admin/user_handlers.go
+++ b/internal/admin/user_handlers.go
@@ -113,7 +113,19 @@ func (h *UserAdminHandlers) ListInvitations(w http.ResponseWriter, r *http.Reque
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "list failed")
 		return
 	}
-	respondJSON(w, map[string]any{"invitations": invs, "limit": limit, "offset": offset})
+	// Server-computed expiry (PR #779 review P3-5): avoids client clock drift.
+	// Embedded *session.Invitation serializes its fields plus is_expired.
+	now := h.nowUnix()
+	type invitationView struct {
+		*session.Invitation
+		IsExpired bool `json:"is_expired"`
+	}
+	views := make([]invitationView, len(invs))
+	for i := range invs {
+		inv := invs[i]
+		views[i] = invitationView{Invitation: inv, IsExpired: inv.UsedAt == nil && inv.ExpiresAt < now}
+	}
+	respondJSON(w, map[string]any{"invitations": views, "limit": limit, "offset": offset})
 }
 
 // DeleteInvitation: DELETE /api/admin/invitations/{id}

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -24,6 +24,7 @@ import {
   type Workspace,
 } from '@/lib/api/workspaces';
 import { logout, getMe, type User } from '@/lib/api/auth';
+import { ApiError } from '@/lib/api/errors';
 
 function ChatInterface({
   sessionId,
@@ -127,7 +128,14 @@ export default function ChatContainer() {
     let mounted = true;
     getMe()
       .then((u) => { if (mounted) { setCurrentUser(u); setAuthError(false); } })
-      .catch(() => { if (mounted) setAuthError(true); });
+      .catch((err) => {
+        if (!mounted) return;
+        // Only surface auth-expired for real 401/403; transient network/5xx
+        // failures are not solvable by re-login (PR #783 review P2).
+        if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
+          setAuthError(true);
+        }
+      });
     return () => { mounted = false; };
   }, []);
 

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -125,18 +125,18 @@ export default function ChatContainer() {
   // loading from auth-error (401) so a stale session surfaces a re-login prompt
   // instead of silently hiding the Members tab (PR #779 review P3-7).
   useEffect(() => {
-    let mounted = true;
-    getMe()
-      .then((u) => { if (mounted) { setCurrentUser(u); setAuthError(false); } })
+    const ctrl = new AbortController();
+    getMe(ctrl.signal)
+      .then((u) => { if (!ctrl.signal.aborted) { setCurrentUser(u); setAuthError(false); } })
       .catch((err) => {
-        if (!mounted) return;
+        if (ctrl.signal.aborted) return;
         // Only surface auth-expired for real 401/403; transient network/5xx
         // failures are not solvable by re-login (PR #783 review P2).
         if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
           setAuthError(true);
         }
       });
-    return () => { mounted = false; };
+    return () => { ctrl.abort(); };
   }, []);
 
   const handleSwitchWorkspace = (ws: Workspace) => {

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -78,6 +78,7 @@ export default function ChatContainer() {
   const [wsDropdownOpen, setWsDropdownOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [authError, setAuthError] = useState(false);
   const [sessionMetrics, setSessionMetrics] = useState<SessionMetrics | null>(null);
 
   // nuqs deep link params
@@ -119,10 +120,14 @@ export default function ChatContainer() {
     loadWorkspaces();
   }, [loadWorkspaces]);
 
-  // Fetch current user profile (Profile tab + Members tab gating)
+  // Fetch current user profile (Profile tab + Members tab gating). Distinguish
+  // loading from auth-error (401) so a stale session surfaces a re-login prompt
+  // instead of silently hiding the Members tab (PR #779 review P3-7).
   useEffect(() => {
     let mounted = true;
-    getMe().then((u) => { if (mounted) setCurrentUser(u); }).catch(() => { /* not logged in or unreachable */ });
+    getMe()
+      .then((u) => { if (mounted) { setCurrentUser(u); setAuthError(false); } })
+      .catch(() => { if (mounted) setAuthError(true); });
     return () => { mounted = false; };
   }, []);
 
@@ -214,10 +219,15 @@ export default function ChatContainer() {
                       onClick={() => handleSwitchWorkspace(ws)}
                       className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${isActive ? 'bg-[var(--accent-gold)]/10 text-[var(--accent-gold)]' : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]'}`}
                     >
-                      <span className={`w-6 h-6 rounded-md flex items-center justify-center text-[10px] font-black uppercase ${isActive ? 'bg-[var(--accent-gold)] text-black' : 'bg-[var(--bg-surface)] text-[var(--text-muted)] border border-[var(--border-subtle)]'}`}>
+                      <span className={`w-6 h-6 rounded-md flex items-center justify-center text-[10px] font-black uppercase flex-shrink-0 ${isActive ? 'bg-[var(--accent-gold)] text-black' : 'bg-[var(--bg-surface)] text-[var(--text-muted)] border border-[var(--border-subtle)]'}`}>
                         {ws.name.slice(0, 2)}
                       </span>
-                      <span className="truncate font-medium">{ws.name}</span>
+                      <span className="min-w-0 flex-1">
+                        <span className="truncate font-medium block">{ws.name}</span>
+                        {isActive && ws.work_dir && (
+                          <span className="block text-[10px] font-mono text-[var(--text-faint)] truncate" title={ws.work_dir}>{ws.work_dir}</span>
+                        )}
+                      </span>
                     </button>
                   );
                 })}
@@ -271,12 +281,15 @@ export default function ChatContainer() {
             </svg>
             <span className="hidden md:inline">Docs</span>
           </a>
-          {/* Settings — opens SettingsModal (Phase 3) */}
+          {/* Settings — opens SettingsModal (Phase 3). Red dot on session expiry (PR #779 review P3-7). */}
           <button
             onClick={() => setSettingsOpen(true)}
-            className="p-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
-            title="Settings"
+            className={`relative p-2 rounded-lg transition-all ${authError ? 'text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/10' : 'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]'}`}
+            title={authError ? 'Session expired — please re-login to access Settings' : 'Settings'}
           >
+            {authError && (
+              <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[var(--accent-coral)]" />
+            )}
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />

--- a/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/ai-config-tab.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { updateWorkspace, getWorkspace, type Workspace } from '@/lib/api/workspaces';
+import { ApiError } from '@/lib/api/errors';
 import { AgentConfigEditor } from '@/components/admin/agent-config-editor';
 
 const WORKER_OPTIONS: { value: string; label: string }[] = [
@@ -22,12 +23,18 @@ export function AIConfigTab({ workspace, onUpdated }: AIConfigTabProps) {
   const [savingWorker, setSavingWorker] = useState(false);
   const [workerError, setWorkerError] = useState<string | null>(null);
   const [workerSaved, setWorkerSaved] = useState(false);
+  // Tracked so unmount clears the pending setState (PR #779 review P3-8).
+  const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setWorker(workspace.worker_preference || '');
     setWorkerError(null);
     setWorkerSaved(false);
   }, [workspace.id, workspace.worker_preference, workspace.updated_at]);
+
+  useEffect(() => () => {
+    if (savedTimer.current) clearTimeout(savedTimer.current);
+  }, []);
 
   const dirty = worker !== (workspace.worker_preference || '');
 
@@ -39,9 +46,11 @@ export function AIConfigTab({ workspace, onUpdated }: AIConfigTabProps) {
       const updated = await updateWorkspace(workspace.id, { workerPreference: worker });
       onUpdated?.(updated);
       setWorkerSaved(true);
-      setTimeout(() => setWorkerSaved(false), 2000);
+      if (savedTimer.current) clearTimeout(savedTimer.current);
+      savedTimer.current = setTimeout(() => setWorkerSaved(false), 2000);
     } catch (err) {
-      if ((err as { status?: number }).status === 409) {
+      // CAS 409 (PR #779 review P2-2): re-fetch latest and repopulate.
+      if (err instanceof ApiError && err.status === 409) {
         setWorkerError('Workspace was modified elsewhere — refreshed to latest, please retry.');
         try {
           onUpdated?.(await getWorkspace(workspace.id));

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { updateWorkspace, getWorkspace, type Workspace } from '@/lib/api/workspaces';
+import { ApiError } from '@/lib/api/errors';
 
 interface GeneralTabProps {
   workspace: Workspace;
@@ -13,6 +14,8 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  // Tracked so unmount clears the pending setState (PR #779 review P3-8).
+  const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Resync when the workspace prop changes (e.g. after a parent re-fetch).
   useEffect(() => {
@@ -20,6 +23,10 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
     setError(null);
     setSuccess(false);
   }, [workspace.id, workspace.name, workspace.updated_at]);
+
+  useEffect(() => () => {
+    if (successTimer.current) clearTimeout(successTimer.current);
+  }, []);
 
   const dirty = name.trim() !== workspace.name && name.trim().length > 0;
 
@@ -31,9 +38,12 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
       const updated = await updateWorkspace(workspace.id, { name: name.trim() });
       onUpdated?.(updated);
       setSuccess(true);
-      setTimeout(() => setSuccess(false), 2000);
+      if (successTimer.current) clearTimeout(successTimer.current);
+      successTimer.current = setTimeout(() => setSuccess(false), 2000);
     } catch (err) {
-      if ((err as { status?: number }).status === 409) {
+      // CAS 409 (PR #779 review P2-2): re-fetch latest and repopulate so the
+      // form does not sit on a stale updated_at and 409 again on retry.
+      if (err instanceof ApiError && err.status === 409) {
         setError('Workspace was modified elsewhere — refreshed to latest, please retry.');
         try {
           onUpdated?.(await getWorkspace(workspace.id));

--- a/webchat/app/components/chat/settings-modal/members-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/members-tab.tsx
@@ -7,6 +7,7 @@ import {
   adminListInvitations,
   adminCreateInvitation,
   adminDeleteInvitation,
+  logout,
   type User,
   type Invitation,
 } from '@/lib/api/auth';
@@ -83,6 +84,14 @@ export function MembersTab({ currentUser }: MembersTabProps) {
     setBusyUserId(user.id);
     try {
       await adminUpdateUserStatus(user.id, next);
+      if (currentUser?.id === user.id && next === 'disabled') {
+        // Honor the confirm promise "logged out immediately" (PR #784 review P1):
+        // self-disable invalidates the session — redirect instead of reloading
+        // the list, which would 403 USER_DISABLED and strand the user on an error page.
+        try { await logout(); } catch { /* session already invalidated */ }
+        window.location.replace('/login');
+        return;
+      }
       flash('ok', `${user.username} → ${next}`);
       load();
     } catch (err) {

--- a/webchat/app/components/chat/settings-modal/members-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/members-tab.tsx
@@ -13,17 +13,27 @@ import {
 
 const DEFAULT_INVITE_TTL = 7 * 24 * 3600; // 7 days, matches backend default
 
-export function MembersTab() {
+interface MembersTabProps {
+  currentUser: User | null;
+}
+
+export function MembersTab({ currentUser }: MembersTabProps) {
   const [users, setUsers] = useState<User[]>([]);
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionMsg, setActionMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  // busyUserId !== null disables every toggle button globally (PR #779 review
+  // P3-5): a second concurrent PATCH on a different user would mutate against a
+  // stale list snapshot. Serializing writes one-at-a-time is the simple fix.
   const [busyUserId, setBusyUserId] = useState<string | null>(null);
 
+  // Flash timer ref so unmount clears the pending setState (PR #779 review P3-8).
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flash = (kind: 'ok' | 'err', text: string) => {
     setActionMsg({ kind, text });
-    setTimeout(() => setActionMsg(null), 2500);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setActionMsg(null), 2500);
   };
 
   const abortRef = useRef<AbortController | null>(null);
@@ -55,10 +65,20 @@ export function MembersTab() {
 
   useEffect(() => {
     load();
-    return () => abortRef.current?.abort();
+    return () => {
+      abortRef.current?.abort();
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+    };
   }, [load]);
 
   const handleToggleUser = async (user: User) => {
+    // Self-lock guard (PR #779 review P3-3): disabling your own account logs
+    // you out and blocks sign-in. Confirm before the destructive action.
+    if (currentUser?.id === user.id && user.status === 'active') {
+      if (!window.confirm('Disable your own account? You will be logged out immediately and unable to sign back in.')) {
+        return;
+      }
+    }
     const next = user.status === 'active' ? 'disabled' : 'active';
     setBusyUserId(user.id);
     try {
@@ -114,12 +134,12 @@ export function MembersTab() {
           {users.map((u) => (
             <div key={u.id} className="flex items-center justify-between py-2 px-3 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] gap-3">
               <div className="min-w-0">
-                <div className="text-sm font-bold text-[var(--text-primary)] truncate">{u.username}{u.display_name ? ` · ${u.display_name}` : ''}</div>
+                <div className="text-sm font-bold text-[var(--text-primary)] truncate">{u.username}{u.display_name ? ` · ${u.display_name}` : ''}{currentUser?.id === u.id ? ' (you)' : ''}</div>
                 <div className="text-[10px] text-[var(--text-muted)] font-mono">{u.role} · {u.status}</div>
               </div>
               <button
                 onClick={() => handleToggleUser(u)}
-                disabled={busyUserId === u.id}
+                disabled={busyUserId !== null}
                 className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all flex-shrink-0 disabled:opacity-40 disabled:cursor-not-allowed ${u.status === 'active' ? 'bg-[var(--accent-coral)]/10 text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/20' : 'bg-[var(--accent-emerald)]/10 text-[var(--accent-emerald)] hover:bg-[var(--accent-emerald)]/20'}`}
               >
                 {busyUserId === u.id ? '…' : u.status === 'active' ? 'Disable' : 'Enable'}
@@ -144,7 +164,9 @@ export function MembersTab() {
         <div className="space-y-1">
           {invitations.map((inv) => {
             const used = !!inv.used_at;
-            const expired = !used && inv.expires_at * 1000 < Date.now();
+            // Prefer server-computed is_expired (clock-source-of-truth, PR #779
+            // review P3-5); fall back to client calc for older backends.
+            const expired = !used && (inv.is_expired ?? inv.expires_at * 1000 < Date.now());
             const state = used ? 'used' : expired ? 'expired' : 'active';
             return (
               <div key={inv.id} className="flex items-center justify-between py-2 px-3 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] gap-3">

--- a/webchat/app/components/chat/settings-modal/settings-modal.tsx
+++ b/webchat/app/components/chat/settings-modal/settings-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { motion } from 'framer-motion';
+import { useState, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import type { Workspace } from '@/lib/api/workspaces';
 import type { User } from '@/lib/api/auth';
 import { GeneralTab } from './general-tab';
@@ -22,8 +22,6 @@ type TabId = 'general' | 'ai' | 'profile' | 'members';
 export function SettingsModal({ open, onClose, workspace, currentUser, onWorkspaceUpdated }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<TabId>('general');
 
-  if (!open) return null;
-
   const tabs: { id: TabId; label: string }[] = [
     { id: 'general', label: 'General' },
     { id: 'ai', label: 'AI Config' },
@@ -31,63 +29,80 @@ export function SettingsModal({ open, onClose, workspace, currentUser, onWorkspa
     ...(currentUser?.role === 'admin' ? [{ id: 'members' as TabId, label: 'Members' }] : []),
   ];
 
+  // Fall back to General if the active tab left the list — e.g. currentUser
+  // resolved non-admin while on Members, so the panel never renders empty
+  // (PR #779 review P3-2).
+  useEffect(() => {
+    const hasTab = (id: TabId) =>
+      id === 'general' || id === 'ai' || id === 'profile' ||
+      (id === 'members' && currentUser?.role === 'admin');
+    if (!hasTab(activeTab)) setActiveTab('general');
+  }, [activeTab, currentUser?.role]);
+
   return (
-    <motion.div
-      className="fixed inset-0 z-[300] flex items-center justify-center"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-    >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-[300] flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
 
-      <motion.div
-        className="relative w-full max-w-2xl mx-4 rounded-[var(--radius-xl)] border border-[var(--border-default)] bg-[var(--bg-surface)] backdrop-blur-2xl shadow-[0_32px_64px_rgba(0,0,0,0.5)] flex flex-col max-h-[85vh]"
-        initial={{ opacity: 0, scale: 0.95, y: 20 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        transition={{ type: 'spring' as const, stiffness: 300, damping: 28 }}
-      >
-        <div className="px-6 pt-6 pb-3 flex items-center justify-between flex-shrink-0">
-          <div>
-            <h2 className="text-lg font-display font-bold text-[var(--text-primary)]">Settings</h2>
-            <p className="text-xs text-[var(--text-muted)] mt-0.5 truncate">{workspace?.name ?? 'Workspace'}</p>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
+          <motion.div
+            className="relative w-full max-w-2xl mx-4 rounded-[var(--radius-xl)] border border-[var(--border-default)] bg-[var(--bg-surface)] backdrop-blur-2xl shadow-[0_32px_64px_rgba(0,0,0,0.5)] flex flex-col max-h-[85vh]"
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.97, y: 10 }}
+            transition={{ type: 'spring' as const, stiffness: 300, damping: 28 }}
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+            <div className="px-6 pt-6 pb-3 flex items-center justify-between flex-shrink-0">
+              <div>
+                <h2 className="text-lg font-display font-bold text-[var(--text-primary)]">Settings</h2>
+                <p className="text-xs text-[var(--text-muted)] mt-0.5 truncate">{workspace?.name ?? 'Workspace'}</p>
+              </div>
+              <button
+                onClick={onClose}
+                className="p-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] rounded-lg transition-all"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
 
-        <div className="px-6 border-b border-[var(--border-subtle)] flex gap-1 flex-shrink-0">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`px-4 py-2 text-sm font-bold transition-all border-b-2 -mb-px ${
-                activeTab === tab.id
-                  ? 'text-[var(--accent-gold)] border-[var(--accent-gold)]'
-                  : 'text-[var(--text-muted)] border-transparent hover:text-[var(--text-primary)]'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
+            <div className="px-6 border-b border-[var(--border-subtle)] flex gap-1 flex-shrink-0">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-4 py-2 text-sm font-bold transition-all border-b-2 -mb-px ${
+                    activeTab === tab.id
+                      ? 'text-[var(--accent-gold)] border-[var(--accent-gold)]'
+                      : 'text-[var(--text-muted)] border-transparent hover:text-[var(--text-primary)]'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-5">
-          {activeTab === 'general' && workspace && (
-            <GeneralTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
-          )}
-          {activeTab === 'ai' && workspace && (
-            <AIConfigTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
-          )}
-          {activeTab === 'profile' && currentUser && <ProfileTab user={currentUser} />}
-          {activeTab === 'members' && currentUser?.role === 'admin' && <MembersTab />}
-        </div>
-      </motion.div>
-    </motion.div>
+            <div className="flex-1 overflow-y-auto px-6 py-5">
+              {activeTab === 'general' && workspace && (
+                <GeneralTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
+              )}
+              {activeTab === 'ai' && workspace && (
+                <AIConfigTab workspace={workspace} onUpdated={onWorkspaceUpdated} />
+              )}
+              {activeTab === 'profile' && currentUser && <ProfileTab user={currentUser} />}
+              {activeTab === 'members' && currentUser?.role === 'admin' && (
+                <MembersTab currentUser={currentUser} />
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/webchat/lib/api/auth.ts
+++ b/webchat/lib/api/auth.ts
@@ -19,6 +19,9 @@ export interface Invitation {
   expires_at: number;
   created_at?: number;
   used_at?: number;
+  // Server-computed expiry flag (clock-source-of-truth, avoids client drift;
+  // PR #779 review P3-5). Undefined on older backends → caller falls back.
+  is_expired?: boolean;
 }
 
 export interface OAuthProvider {
@@ -120,6 +123,13 @@ export async function getOAuthProviders(signal?: AbortSignal): Promise<OAuthProv
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Admin endpoints (/api/admin/*). These run through the webchat cookie channel
+// (same-origin credentials), NOT the admin-client Bearer-token path used by the
+// standalone /admin pages. Backend requireAdmin enforces role==admin &&
+// status==active regardless of channel (PR #779 review P3-5).
+// ---------------------------------------------------------------------------
 
 // Admin: Create Invitation
 export async function adminCreateInvitation(role: 'admin' | 'user', ttlSeconds?: number, signal?: AbortSignal): Promise<Invitation> {

--- a/webchat/lib/api/auth.ts
+++ b/webchat/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import { BASE, authHeaders, authOpts, withAuth, extractApiError } from "@/lib/api/client";
+import { ApiError } from "./errors";
 
 export interface User {
   id: string;
@@ -62,7 +63,7 @@ export async function getMe(signal?: AbortSignal): Promise<User> {
     signal,
   });
   if (!res.ok) {
-    throw new Error(await extractApiError(res, `getMe failed: ${res.status}`));
+    throw await ApiError.fromResponse(res);
   }
   return res.json();
 }

--- a/webchat/lib/api/errors.ts
+++ b/webchat/lib/api/errors.ts
@@ -39,3 +39,25 @@ export async function parseApiError(res: Response): Promise<ApiErrorInfo> {
   }
   return { status: res.status, code, message, raw };
 }
+
+/**
+ * Typed API error — carries the parsed status/code/message so callers branch on
+ * `instanceof ApiError` instead of probing `(err as any).status`. Replaces the
+ * ad-hoc field-attachment pattern flagged in PR #779 review P3-4.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly info: ApiErrorInfo;
+  constructor(info: ApiErrorInfo, message?: string) {
+    super(message || info.code || info.message || `API error ${info.status}`);
+    this.name = 'ApiError';
+    this.status = info.status;
+    this.code = info.code;
+    this.info = info;
+  }
+  /** Build from a Response, parsing the envelope exactly once. */
+  static async fromResponse(res: Response): Promise<ApiError> {
+    return new ApiError(await parseApiError(res));
+  }
+}

--- a/webchat/lib/api/errors.ts
+++ b/webchat/lib/api/errors.ts
@@ -50,7 +50,7 @@ export class ApiError extends Error {
   readonly code?: string;
   readonly info: ApiErrorInfo;
   constructor(info: ApiErrorInfo, message?: string) {
-    super(message || info.code || info.message || `API error ${info.status}`);
+    super(message || info.code || info.message || info.raw || `API error ${info.status}`);
     this.name = 'ApiError';
     this.status = info.status;
     this.code = info.code;

--- a/webchat/lib/api/workspaces.ts
+++ b/webchat/lib/api/workspaces.ts
@@ -1,5 +1,5 @@
 import { BASE, authHeaders, authOpts, withAuth, extractApiError } from "@/lib/api/client";
-import { parseApiError } from "@/lib/api/errors";
+import { parseApiError, ApiError } from "@/lib/api/errors";
 
 export interface Workspace {
   id: string;
@@ -123,16 +123,12 @@ export async function updateWorkspace(id: string, opts: UpdateWorkspaceOptions, 
     // message + the WORKSPACE_VERSION_MISMATCH code so UIs can re-fetch+retry.
     const info = await parseApiError(res);
     if (res.status === 409) {
-      const err = new Error('Workspace was modified concurrently — please reopen Settings and retry.');
-      (err as any).status = 409;
-      (err as any).code = info.code || 'WORKSPACE_VERSION_MISMATCH';
-      throw err;
+      throw new ApiError(
+        { ...info, code: info.code || 'WORKSPACE_VERSION_MISMATCH' },
+        'Workspace was modified concurrently — please reopen Settings and retry.',
+      );
     }
-    const msg = info.code || info.message || info.raw || `updateWorkspace failed: ${res.status}`;
-    const err = new Error(msg);
-    (err as any).status = info.status;
-    if (info.code) (err as any).code = info.code;
-    throw err;
+    throw new ApiError(info);
   }
   return normalizeWorkspace(await res.json());
 }


### PR DESCRIPTION
spec ⑦ Phase 3 PR #779 review polish — 清理三轮 review 的非阻塞 P2/P3 finding（13 项去重：**11 项修**，1 项开 #782，1 项接受）。

> 重建自 #783（作者误为 hotplex-ai 致 self-approve 限制）。已整合 #783 review 的 P2/P3 修复（commit `418d977f`）。

## 修复清单

### MembersTab
- **P3-3** admin disable 自己加 confirm（自锁风险）
- **P3-5** busyUserId 全局 disable（防并发 PATCH 基于陈旧 list）
- **P3-8** flash setTimeout useRef + unmount cleanup
- **P3-5** invitation is_expired 前端 fallback

### SettingsModal
- **P3-2** activeTab 回落 general（tab 消失时空状态）
- **R1-P3-3** AnimatePresence exit 动画

### GeneralTab / AIConfigTab
- **P3-4** ApiError 替代 `(err as any)` 反模式
- **P3-8** success setTimeout cleanup

### ChatContainer
- **P3-4** dropdown active 项显示 work_dir（三轮提的 UX 回归）
- **P3-7** currentUser 401 区分（settings 红点 + re-login 提示）
- **P2（#783 review）** getMe catch 仅 401/403 setAuthError（网络/5xx 静默，re-login 解决不了）

### API 层
- **P3-4** `errors.ts` 新增 `ApiError` 类（status/code/info 类型安全）+ raw 回退
- **P3-4** `workspaces.ts` updateWorkspace 抛 ApiError
- **P3-5** `auth.ts` Invitation is_expired 接口 + admin* cookie 通道注释
- **P3-2（#783 review）** `ApiError.fromResponse` 接入 getMe（消除死代码）

### 后端
- **P3-5** `ListInvitations` 响应加 `is_expired`（服务器计算，避免客户端时钟漂移）

### spec
- **P3-1** §3.1 Gap-C1 条件勘误（三者皆空才跳过 mergeContextUsage）
- **P3-7** status: draft → analysis

## 后续 issue
- #782 settings-modal tab 与 admin 组件复用（架构重构，P2-1）

## 接受（历史已定）
- spec 混入 PR #779（已合并，无法拆分）

## 验证
- `go vet ./internal/admin/...` + `gofmt` + `go test ./internal/admin/...` ✓
- `pnpm exec tsc --noEmit` ✓
- pre-commit golangci-lint 0 issues ✓

Refs #772