### PR TITLE
fix(webchat): 切换 workspace 默认进入最近会话 + 修 savedId 阻断 auto-create

### DIFF
--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -253,13 +253,20 @@ func setupRoutes(
 		mux.Handle("OPTIONS /api/admin/users/", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 		mux.Handle("OPTIONS /api/admin/users/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
-		// Workspaces CRUD endpoints
+		// Workspaces CRUD endpoints. Write routes (POST/PATCH/DELETE) mount
+		// csrfMw for the same reason /api/admin/* does (issue #794 P2-1):
+		// WorkspaceHandlers.currentUser → AuthenticateRequest falls back to
+		// AuthenticateActiveCookie when no api-key is present — the same
+		// SameSite=None cookie channel, so cross-site blind CSRF could create /
+		// mutate / delete a workspace. GETs pass through. Inside corsMw so
+		// OPTIONS preflight is handled first; csrfMw's 403s are audited
+		// (admin.go CSRFMiddleware, issue #794 P2-2).
 		wsHandlers := gateway.NewWorkspaceHandlers(deps.WorkspaceStore, auth)
-		mux.Handle("POST /api/workspaces", corsMw(http.HandlerFunc(wsHandlers.Create)))
+		mux.Handle("POST /api/workspaces", corsMw(csrfMw(http.HandlerFunc(wsHandlers.Create))))
 		mux.Handle("GET /api/workspaces", corsMw(http.HandlerFunc(wsHandlers.List)))
 		mux.Handle("GET /api/workspaces/{id}", corsMw(http.HandlerFunc(wsHandlers.Get)))
-		mux.Handle("PATCH /api/workspaces/{id}", corsMw(http.HandlerFunc(wsHandlers.Update)))
-		mux.Handle("DELETE /api/workspaces/{id}", corsMw(http.HandlerFunc(wsHandlers.Delete)))
+		mux.Handle("PATCH /api/workspaces/{id}", corsMw(csrfMw(http.HandlerFunc(wsHandlers.Update))))
+		mux.Handle("DELETE /api/workspaces/{id}", corsMw(csrfMw(http.HandlerFunc(wsHandlers.Delete))))
 
 		// OPTIONS preflight handlers for Workspaces API
 		mux.Handle("OPTIONS /api/workspaces", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))

--- a/docs/specs/Workspace-Permission-Mode-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Spec.md
@@ -1,6 +1,6 @@
 # Workspace 权限模式规范
 
-**状态**: Draft · **日期**: 2026-06-25 · **关联 Issue**: [#789](https://github.com/hrygo/hotplex/issues/789) · **版本目标**: v1.31.0
+**状态**: Draft · **日期**: 2026-06-26（修订：CC `auto-edit` 档改用原生 `auto` mode，消除 §3.2 退化） · **关联 Issue**: [#789](https://github.com/hrygo/hotplex/issues/789) · **版本目标**: v1.31.0
 
 ---
 
@@ -15,7 +15,7 @@
 | OpenCode Server | `set_permission_mode("bypassPermissions")` | `internal/worker/opencodeserver/worker.go:580-597` |
 | ACP | `autoApprove=true`（全局默认） | `internal/worker/acp/worker.go:48-63` |
 
-四种 Worker 的权限语义**完全不同构**：CC 是单维度 4 档 mode，Codex 是 `sandbox × approvalPolicy` 双维度 9 组合，OCS 是 CC 兼容的 mode 字符串，ACP 是 `autoApprove` 布尔。
+四种 Worker 的权限语义**完全不同构**：CC 是单维度 mode（本项目映射 `plan`/`acceptEdits`/`auto`/`bypass` 四档，原生共 6 档），Codex 是 `sandbox × approvalPolicy` 双维度 9 组合，OCS 是 CC 兼容的 mode 字符串，ACP 是 `autoApprove` 布尔。
 
 `SessionInfo` 已定义 `PermissionMode` 与 `SkipPermissions` 字段（`internal/worker/worker.go:267-271`），但**全代码库无任何赋值点**（除测试），因此全部走各 Worker 的默认 bypass 分支。
 
@@ -63,7 +63,7 @@ const (
 |---------|-------------|---------------------------------------|-----------------|-------------------|
 | `read-only` | `--permission-mode plan` | `read-only` × `untrusted` | `plan` | `false` |
 | `workspace` | `--permission-mode acceptEdits` | `workspace-write` × `on-request` | `acceptEdits` | `false` |
-| `auto-edit` | `--permission-mode acceptEdits` | `workspace-write` × `never` | `acceptEdits` | `true` |
+| `auto-edit` | `--permission-mode auto` | `workspace-write` × `never` | `acceptEdits` | `true` |
 | `bypass` | `--dangerously-skip-permissions` | `danger-full-access` × `never` | `bypassPermissions` | `true` |
 
 ### 3.2 退化说明
@@ -72,9 +72,10 @@ const (
 
 | Worker | 退化档位 | 原因 |
 |--------|---------|------|
-| Claude Code | `workspace` ≡ `auto-edit`（均映射 `acceptEdits`） | CC 无"自动编辑但危险操作仍确认"的独立档；`acceptEdits` 已是最高非 bypass 档，其本身即"自动接受编辑、危险操作仍确认" |
-| OpenCode Server | `workspace` ≡ `auto-edit`（均映射 `acceptEdits`） | OCS 采用 CC 兼容 mode 命名，同上原因 |
+| OpenCode Server | `workspace` ≡ `auto-edit`（均映射 `acceptEdits`） | OCS 服务端暂未暴露与 CC `auto` 等价的 mode（待 §11 校准），以 `acceptEdits` 承载两档 |
 | ACP | `read-only` ≡ `workspace`（均 `autoApprove=false`），`auto-edit` ≡ `bypass`（均 `true`） | ACP 仅布尔权限粒度，无中间询问档 |
+
+> **Claude Code 不再退化**：`workspace` → `acceptEdits`（自动接受编辑、危险操作仍确认），`auto-edit` → `auto`（全自动 + 后台安全分类器审查危险操作）。两档精确对齐 CC 原生 `acceptEdits`/`auto` 语义（详见 §6.2），admin 可在 CC workspace 下区分"编辑免确认"与"全自动"两种工作方式。
 
 admin UI 需展示当前 workspace 的 `worker_preference` 下各档实际效果，避免 admin 对退化档位产生误判。
 
@@ -154,14 +155,18 @@ if session.SkipPermissions { mode = worker.PermBypass } // 向后兼容
 switch mode {
 case worker.PermReadOnly:
     args = append(args, "--permission-mode", "plan")
-case worker.PermWorkspace, worker.PermAutoEdit:
+case worker.PermWorkspace:
     args = append(args, "--permission-mode", "acceptEdits")
+case worker.PermAutoEdit:
+    args = append(args, "--permission-mode", "auto")
 case worker.PermBypass:
     args = append(args, "--dangerously-skip-permissions")
 default: // 空值，保留现有 bypass 行为
     args = append(args, "--dangerously-skip-permissions")
 }
 ```
+
+> **前提（CC `auto` mode）**：`auto` 由较新版本 claude CLI 提供，语义为"全自动执行 + 后台安全分类器审查危险操作"——精确承载统一 `auto-edit` 档（区别于 `workspace` 档的 `acceptEdits`：后者仅自动接受文件编辑/常规 fs 命令，shell·网络等危险操作仍确认）。**决策：强制升级**——生产环境 claude CLI 必须支持 `--permission-mode auto`；旧版 CLI 下 CC worker 启动即失败报错（明确提示升级 CLI），**不静默降级**到 `acceptEdits`。doctor/onboard 应检测 CLI 版本，版本下限与探测落点见 §11。
 
 ### 6.3 Codex CLI（`codexcli/worker.go:701 buildThreadStartParams`）— 当前 gap
 
@@ -232,6 +237,7 @@ workspace 管理「创建 / 编辑」表单新增**权限模式**分段单选控
 | SessionInfo | `PermissionMode=""` 时各 Worker 走现有默认分支（= bypass） |
 | `SkipPermissions` | 保留，作 `bypass` 别名，现有调用无需改动 |
 | cron / 无 workspace session | 不读 workspace，走全局默认（bypass），行为不变 |
+| CC `auto` mode 依赖 | 仅 `auto-edit` 档要求 claude CLI 较新版本（强制升级，不回退）；默认 `bypass` 及 `read-only`/`workspace` 档不引入新依赖。旧 CLI + `auto-edit` → 启动失败报错，不降级 |
 
 零破坏性：未显式收紧的 workspace 升级后权限模式与现状完全一致。
 
@@ -240,6 +246,7 @@ workspace 管理「创建 / 编辑」表单新增**权限模式**分段单选控
 | 测试 | 范围 |
 |------|------|
 | 各 Worker 映射表测试 | 4 档 × 预期原生参数（CC args、Codex params map、OCS/ACP 调用参数），含退化档断言 |
+| CC `auto-edit` 独立性 | `auto-edit` 档产出的 args 含 `--permission-mode auto`，与 `workspace` 档（`acceptEdits`）严格区分；同时验证 `read-only`→`plan`、`bypass`→`--dangerously-skip-permissions`、空值→`--dangerously-skip-permissions` |
 | bridge 注入测试 | workspace 设档 → `SessionInfo.PermissionMode` 正确；空值 → 全局默认；无 workspace → 全局默认 |
 | store CRUD 测试 | CreateWorkspace 带权限、UpdateWorkspace 改权限、List/Get 回显 |
 | migration 测试 | 存量 workspace 升级后 `permission_mode='bypass'`；SQLite + PG 双驱动 |
@@ -275,5 +282,6 @@ workspace 管理「创建 / 编辑」表单新增**权限模式**分段单选控
 
 ## 11. 开放问题（实施阶段确认）
 
-- OCS 服务端实际支持的 mode 名集合（设计假设 `plan`/`acceptEdits`/`bypassPermissions`，需对照 opencode 版本校准）
+- OCS 服务端实际支持的 mode 名集合（设计假设 `plan`/`acceptEdits`/`bypassPermissions`，需对照 opencode 版本校准；若 OCS 后续支持与 CC `auto` 等价 mode，可消除 §3.2 中 OCS 的 `workspace`/`auto-edit` 退化）
+- claude CLI 支持 `--permission-mode auto` 的最低版本待实测确定（**决策：强制升级 CLI，不做静默降级**）。校准后须：① 将版本下限写入 doctor 检查（`internal/cli/checkers`）；② CC worker 启动期版本探测，不达标直接拒绝启动并提示升级；③ 仅影响显式设为 `auto-edit` 档的 CC workspace，默认 `bypass` 不受此依赖约束
 - admin UI 中"无 worker_preference 的 workspace"如何展示 tooltip（回退到默认 worker_type 的映射）

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -371,6 +371,16 @@ func (a *AdminAPI) SetCookieFallback(cookieAuth *security.CookieAuth, idp *secur
 // when the allowlist is permissive. Same-origin traffic still passes via the
 // Sec-Fetch-Site branch above, so embedded webchat on the gateway origin is
 // unaffected; only cross-origin writes need an exact match.
+//
+// same-site trust assumption (issue #794 P3-2): the Sec-Fetch-Site: same-site
+// branch admits a sibling subdomain (e.g. evil.example.com vs
+// gateway.example.com — same registrable site) as trusted. This relies on two
+// premises: (1) browsers forbid cross-origin documents from forging Fetch
+// Metadata headers, so a genuine cross-site attacker cannot claim "same-site";
+// (2) within this deploy's registrable site no subdomain hosts user-controlled
+// content capable of initiating the write. If either premise fails (multi-
+// tenant subdomain hosting, or a compromised sibling subdomain), narrow
+// allowedOrigins and rely on the exact Origin-match branch instead.
 func (a *AdminAPI) sameOriginRequest(r *http.Request) bool {
 	switch r.Header.Get("Sec-Fetch-Site") {
 	case "same-origin", "same-site":
@@ -388,14 +398,23 @@ func (a *AdminAPI) sameOriginRequest(r *http.Request) bool {
 
 // CSRFMiddleware gates cookie-authenticated state-changing requests against
 // cross-origin abuse (issue #788 review P0). /api/admin/* write routes
-// (invitations CRUD, user status) mount on the gateway mux and authenticate
-// via the SameSite=None session cookie, so they need the same defense the
-// Bearer admin port applies via Middleware. GET requests pass through; write
-// methods require same-origin proof. Apply inside corsMw so OPTIONS is
-// already handled.
+// (invitations CRUD, user status) and /api/workspaces/* write routes mount on
+// the gateway mux and authenticate via the SameSite=None session cookie
+// (issue #794 P2-1 extended coverage to workspaces), so they need the same
+// defense the Bearer admin port applies via Middleware. GET requests pass
+// through; write methods require same-origin proof. Apply inside corsMw so
+// OPTIONS is already handled.
+//
+// Audit (issue #794 P2-2): this middleware runs on the gateway mux, outside
+// AdminAPI.Middleware's audit defer, so a 403 would otherwise be silent.
+// CSRF denials are high-value security events — log them through the shared
+// admin_audit pipeline with the auth-denied action. actor is "anonymous"
+// because the cookie is never resolved before the cross-origin proof fails
+// (mirrors the Middleware defer's fallback for pre-auth rejections).
 func (a *AdminAPI) CSRFMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isWriteMethod(r.Method) && !a.sameOriginRequest(r) {
+			AdminAudit("anonymous", AuditAuthDenied, r.URL.Path, AuditResultDenied)
 			web.WriteAppError(w, http.StatusForbidden, "FORBIDDEN", "cross-origin write blocked")
 			return
 		}

--- a/internal/admin/audit.go
+++ b/internal/admin/audit.go
@@ -137,8 +137,16 @@ func cronAction(method string) string {
 	return "cron." + strings.ToLower(method)
 }
 
-// sessionAction covers DELETE/PATCH/PUT; terminate is matched earlier in
+// sessionAction covers DELETE — the only routed session write
+// (DELETE /admin/sessions/{id}, routes.go) — plus PATCH/PUT, which are NOT
+// routed as admin session handlers (admin sessions expose only GET / DELETE /
+// POST-terminate; see routes.go). The PATCH/PUT branches exist so a 404 on
+// those un-routed methods still produces a descriptive audit action: the
+// Middleware audit defer (admin.go) calls adminActionFor before the 404
+// reaches its handler, yielding session.patch / session.put rather than a
+// generic "PATCH /admin/sessions/..". terminate is matched earlier in
 // adminActionFor (POST /admin/sessions/{id}/terminate → AuditSessionTerminate).
+// Delete the PATCH/PUT branches only if you accept losing those 404 labels.
 func sessionAction(method string) string {
 	switch method {
 	case http.MethodDelete:

--- a/internal/admin/csrf_test.go
+++ b/internal/admin/csrf_test.go
@@ -1,8 +1,11 @@
 package admin
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -100,4 +103,66 @@ func TestCSRFMiddleware(t *testing.T) {
 		a.CSRFMiddleware(okHandler).ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
+
+	// P2-1 (issue #794): /api/workspaces/* write routes mount the same csrfMw
+	// as /api/admin/*. WorkspaceHandlers authenticates via the SameSite=None
+	// cookie fallback (AuthenticateRequest → AuthenticateActiveCookie), so a
+	// cross-site write must be blocked at CSRFMiddleware before it reaches the
+	// handler. Locks the wiring in routes.go against regression.
+	for _, m := range []string{http.MethodPost, http.MethodPatch, http.MethodDelete} {
+		method := m
+		t.Run("P2-1: workspace "+method+" cross-origin blocked", func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			path := "/api/workspaces"
+			if method != http.MethodPost {
+				path = "/api/workspaces/ws-1"
+			}
+			req := httptest.NewRequest(method, path, nil)
+			req.Header.Set("Origin", "https://evil.example.com")
+			a.CSRFMiddleware(okHandler).ServeHTTP(rec, req)
+			require.Equal(t, http.StatusForbidden, rec.Code)
+		})
+	}
+}
+
+// auditMu serializes tests that swap the package-level auditLogger via
+// SetAuditLogger. The logger is process-global, so parallel audits would race
+// on the swap; tests acquiring this mutex run non-parallel by construction.
+var auditMu sync.Mutex
+
+// TestCSRFMiddleware_AuditsCSRFRejects locks issue #794 P2-2: a CSRF 403 must
+// leave an admin_audit trail. CSRFMiddleware runs on the gateway mux outside
+// AdminAPI.Middleware's audit defer, so without an explicit audit the rejection
+// is silent — yet CSRF denials are high-value security events. The proof must
+// land for both admin ports: the cookie write routes here, and (via the same
+// csrfMw) /api/workspaces/* writes (issue #794 P2-1).
+func TestCSRFMiddleware_AuditsCSRFRejects(t *testing.T) {
+	auditMu.Lock()
+	t.Cleanup(func() { auditMu.Unlock() })
+
+	prev := auditLogger
+	t.Cleanup(func() { auditLogger = prev })
+
+	var buf bytes.Buffer
+	SetAuditLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	a := &AdminAPI{allowedOriginsFn: func() []string { return []string{"*"} }}
+	okHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler must not run for a blocked cross-origin write")
+	})
+
+	// Workspace write path (P2-1): the csrfMw wrapping /api/workspaces/* uses
+	// this same middleware, so the audit proof covers both admin and workspace
+	// cookie write routes.
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	a.CSRFMiddleware(okHandler).ServeHTTP(httptest.NewRecorder(), req)
+
+	out := buf.String()
+	require.Contains(t, out, "admin_audit", "CSRF rejection must produce an admin_audit record")
+	require.Contains(t, out, "actor_user_id=anonymous", "actor must be anonymous (no auth resolved before the 403)")
+	require.Contains(t, out, "action="+AuditAuthDenied, "action must be the auth-denied enum")
+	require.Contains(t, out, "result="+AuditResultDenied, "result must be denied")
+	require.Contains(t, out, "target=/api/workspaces", "target must carry the rejected path for forensics")
 }

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -100,7 +100,9 @@ func (s *pgStore) List(ctx context.Context, userID, platform, workspaceID string
 	}
 	defer func() { _ = rows.Close() }()
 
-	var sessions []*SessionInfo
+	// Non-nil empty slice so empty results JSON-serialize to `[]` not `null`
+	// (frontend calls .filter() on the response — nil crashes it). See store.go.
+	sessions := make([]*SessionInfo, 0)
 	for rows.Next() {
 		si, err := scanSession(rows)
 		if err != nil {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -184,7 +184,10 @@ func (s *SQLiteStore) List(ctx context.Context, userID, platform, workspaceID st
 	}
 	defer func() { _ = rows.Close() }()
 
-	var sessions []*SessionInfo
+	// Non-nil empty slice (not nil) so an empty result JSON-serializes to `[]`
+	// rather than `null`. The webchat frontend calls .filter() directly on the
+	// `sessions` field — a nil would crash it ("Cannot read properties of null").
+	sessions := make([]*SessionInfo, 0)
 	for rows.Next() {
 		si, err := scanSession(rows)
 		if err != nil {

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -123,6 +123,23 @@ func TestSQLiteStore_List_DefaultLimit(t *testing.T) {
 	require.GreaterOrEqual(t, len(sessions), 2)
 }
 
+// Regression: an empty result must serialize to JSON `[]`, never `null`.
+// The webchat frontend calls .filter() directly on the `sessions` field of
+// the list response; a Go nil slice marshals to `null` and crashes the UI
+// ("Cannot read properties of null (reading 'filter')"), which prevented
+// auto-creating a default session for an empty workspace.
+func TestSQLiteStore_List_EmptyMarshalsToArrayNotNull(t *testing.T) {
+	store, _ := helperDB(t)
+	ctx := context.Background()
+
+	sessions, err := store.List(ctx, "user_with_no_sessions", "", "", 20, 0)
+	require.NoError(t, err)
+	require.NotNil(t, sessions, "List must return non-nil slice so JSON is [] not null (frontend does resp.sessions.filter)")
+	b, err := json.Marshal(sessions)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(b))
+}
+
 // ─── SQLiteStore: GetExpiredMaxLifetime / GetExpiredIdle ──────────────────────
 
 func TestSQLiteStore_GetExpiredMaxLifetime(t *testing.T) {

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -2,10 +2,14 @@
  * Session management hook for HotPlex webchat.
  *
  * Lifecycle:
- * 1. Mount → listSessions → auto-select most recent
- * 2. User selects session → calls onSelect(sessionId)
- * 3. User creates new → POST → calls onSelect(newId)
- * 4. User deletes → optimistically removes from list
+ * 1. Mount / workspace switch → listSessions → pick default session
+ *    (most-recently-active by updated_at; or initialSessionId if given)
+ * 2. No session in workspace → auto-create anchor 'main' session
+ * 3. User selects session → calls onSelect(sessionId)
+ * 4. User creates new → POST → calls onSelect(newId)
+ * 5. User deletes → optimistically removes from list
+ *
+ * 选择策略见 lib/session-select.ts(pickDefaultSession)。
  */
 
 'use client';
@@ -21,6 +25,7 @@ import {
 } from '@/lib/api/sessions';
 import { workerType as defaultWorkerType } from '@/lib/config';
 import { newSessionId } from '@/lib/ai-sdk-transport/client/envelope';
+import { pickDefaultSession } from '@/lib/session-select';
 import { logger } from '@/lib/logger';
 
 export interface UseSessionsOptions {
@@ -65,63 +70,48 @@ export function useSessions({
   initialRef.current = initialSessionId;
 
   const isCreating = useRef(false);
-  const STORAGE_KEY = workspaceId ? `hotplex_active_session_id_${workspaceId}` : 'hotplex_active_session_id';
   const DEFAULT_WORKER_TYPE = defaultWorkerType;
 
-  const refreshSessions = useCallback(async () => {
+  // refreshSessions fetches the workspace's sessions and selects the default.
+  // signal: caller (the workspaceId effect) passes an AbortController so a
+  // fast A→B workspace switch cancels the in-flight A response before it can
+  // overwrite activeSession (race → "entered the wrong session").
+  const refreshSessions = useCallback(async (signal?: AbortSignal) => {
+    const aborted = () => signal?.aborted ?? false;
     try {
       setIsLoading(true);
       setError(null);
-      const { sessions: list } = await listSessions(20, 0, workspaceId);
+      const { sessions: list } = await listSessions(20, 0, workspaceId, signal);
+      if (aborted()) return;
       const filtered = list.filter(s => s.state !== 'deleted');
       setSessions(filtered);
+      if (aborted()) return;
 
-      // 1. Try to restore from props (initialSessionId)
-      const initId = initialRef.current;
-      if (initId) {
-        const found = filtered.find(s => s.id === initId);
-        if (found) {
-          setActiveSession(found);
-          onSelectRef.current(found.id);
-          return;
-        }
-      }
-
-      // 2. Try to restore from localStorage for persistence
-      const savedId = localStorage.getItem(STORAGE_KEY)?.trim();
-      if (savedId) {
-        const found = filtered.find(s => s.id === savedId);
-        if (found) {
-          setActiveSession(found);
-          onSelectRef.current(found.id);
-          return;
-        } else {
-          // Stale ID found in storage but not in active list -> clear it
-          localStorage.removeItem(STORAGE_KEY);
-        }
-      }
-
-      // 3. Auto-select most recent if existing
-      if (filtered.length > 0) {
-        const mostRecent = filtered.reduce((a, b) =>
-          new Date(a.updated_at) > new Date(b.updated_at) ? a : b
-        );
-        setActiveSession(mostRecent);
-        onSelectRef.current(mostRecent.id);
-        localStorage.setItem(STORAGE_KEY, mostRecent.id);
+      // Default-session policy: explicit initialSessionId (hit) > most-recent
+      // (updated_at) > none. savedId no longer participates — restoring a
+      // stale "last selected" id fought the "enter the most recent session on
+      // switch" expectation and blocked anchor auto-create when stale.
+      const pick = pickDefaultSession(filtered, initialRef.current);
+      if (pick) {
+        setActiveSession(pick);
+        onSelectRef.current(pick.id);
         return;
       }
 
-      // 4. No sessions at all? Auto-create the first one to "map to same session" by default
-      if (!initId && !savedId && filtered.length === 0 && !isCreating.current) {
+      // No usable session in this workspace → auto-create the anchor 'main'
+      // session so the workspace is immediately usable (期望:无 session 时创建默认).
+      // DeriveSessionKey(userID, wt, 'main', workspaceID, workDir) is idempotent,
+      // so concurrent callers (e.g. NewWorkspaceForm pre-create) resolve to one key.
+      if (!isCreating.current) {
         isCreating.current = true;
         try {
           const { session_id } = await createSession({
             clientSessionId: ANCHOR_CLIENT_SESSION_ID,
             workerType: DEFAULT_WORKER_TYPE,
             title: ANCHOR_CLIENT_SESSION_ID,
-            workspaceId
-          });
+            workspaceId,
+          }, signal);
+          if (aborted()) return;
           const now = new Date().toISOString();
           const newSession: SessionInfo = {
             id: session_id,
@@ -136,41 +126,47 @@ export function useSessions({
           setSessions([newSession]);
           setActiveSession(newSession);
           onSelectRef.current(newSession.id);
-          localStorage.setItem(STORAGE_KEY, newSession.id);
         } finally {
           isCreating.current = false;
         }
       } else {
-        // No sessions and we shouldn't auto-create (e.g. initId is set or already checking),
-        // or there is a savedId. In any case, if none matched, clear active session.
-        if (filtered.length === 0) {
-          setActiveSession(null);
-        }
+        // A creation is already in flight (concurrent refresh); leave active
+        // null and let the next refresh pick up the created session.
+        setActiveSession(null);
       }
     } catch (e) {
+      if (aborted()) return; // superseded by a newer switch — ignore stale error
       setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to load sessions'));
     } finally {
-      setIsLoading(false);
+      if (!aborted()) setIsLoading(false);
     }
-  }, [workspaceId, STORAGE_KEY, DEFAULT_WORKER_TYPE]);
+  }, [workspaceId, DEFAULT_WORKER_TYPE]);
 
-  // Load sessions when mount or workspaceId changes. Clear activeSession
-  // synchronously on switch: otherwise the stale session (bound to the
-  // previous workspace) is paired with the new workspaceId in the WS init
-  // handshake, which the server rejects as "session workspace mismatch"
-  // (internal/gateway/conn.go resolveSession). refreshSessions() repopulates
-  // activeSession from the new workspace's list.
+  // Load sessions on mount and whenever the active workspace changes.
+  // Clear activeSession synchronously on switch: otherwise the stale session
+  // (bound to the previous workspace) is paired with the new workspaceId in
+  // the WS init handshake, which the server rejects as "session workspace
+  // mismatch" (internal/gateway/conn.go resolveSession). refreshSessions()
+  // then repopulates activeSession from the new workspace's list.
+  //
+  // Skip while workspaceId is empty (ChatContainer's activeWorkspace is still
+  // loading): listSessions(undefined) would not filter by workspace and could
+  // briefly select a session from another workspace. The abort controller
+  // cancels the previous in-flight refresh on a rapid switch.
   useEffect(() => {
+    const ctrl = new AbortController();
     setActiveSession(null);
-    refreshSessions();
+    if (workspaceId) {
+      refreshSessions(ctrl.signal);
+    }
+    return () => ctrl.abort();
   }, [workspaceId, refreshSessions]);
 
   const selectSession = useCallback((session: SessionInfo) => {
     setActiveSession(session);
     onSelectRef.current(session.id);
-    localStorage.setItem(STORAGE_KEY, session.id);
     setIsOpen(false);
-  }, [STORAGE_KEY]);
+  }, []);
 
   const createNewSession = useCallback(async (title: string, workerType?: string) => {
     const wt = workerType || DEFAULT_WORKER_TYPE;
@@ -182,7 +178,7 @@ export function useSessions({
         clientSessionId: newSessionId(),
         workerType: wt,
         title: title || undefined,
-        workspaceId
+        workspaceId,
       });
       const now = new Date().toISOString();
       const newSession: SessionInfo = {
@@ -198,21 +194,19 @@ export function useSessions({
       setSessions(prev => [newSession, ...prev.filter(s => s.state !== 'deleted')]);
       setActiveSession(newSession);
       onSelectRef.current(session_id);
-      localStorage.setItem(STORAGE_KEY, session_id);
     } catch (e) {
       setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to create session'));
     } finally {
       setIsLoading(false);
       isCreating.current = false;
     }
-  }, [workspaceId, STORAGE_KEY, DEFAULT_WORKER_TYPE]);
+  }, [workspaceId, DEFAULT_WORKER_TYPE]);
 
   const removeSession = useCallback(async (id: string) => {
     // Optimistic remove
     setSessions((prev) => prev.filter((s) => s.id !== id));
     if (activeSession?.id === id) {
       setActiveSession(null);
-      localStorage.removeItem(STORAGE_KEY);
     }
 
     try {
@@ -222,7 +216,7 @@ export function useSessions({
       setError(e instanceof AuthError ? e.message : (e instanceof Error ? e.message : 'Failed to delete session'));
       refreshSessions();
     }
-  }, [activeSession, refreshSessions, STORAGE_KEY]);
+  }, [activeSession, refreshSessions]);
 
   // Handle manual session selection
   const handleSessionSelect = useCallback((id: string) => {

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -83,7 +83,9 @@ export function useSessions({
       setError(null);
       const { sessions: list } = await listSessions(20, 0, workspaceId, signal);
       if (aborted()) return;
-      const filtered = list.filter(s => s.state !== 'deleted');
+      // Defensive null-guard: backend store.List returns [] for empty (make),
+      // but guard against null from older deployments so we never crash on filter.
+      const filtered = (list ?? []).filter(s => s.state !== 'deleted');
       setSessions(filtered);
       if (aborted()) return;
 

--- a/webchat/lib/session-select.test.ts
+++ b/webchat/lib/session-select.test.ts
@@ -1,0 +1,52 @@
+// Tests for pickDefaultSession — the session-selection policy when switching
+// workspace (or reloading). Keen-eyed: these assert the FIX for the reported
+// "切换 workspace 未能直接进入默认 session" bug, where the old logic restored a
+// stale localStorage savedId instead of the most-recently-active session.
+//
+// Run: node --test --experimental-strip-types lib/session-select.test.ts
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickDefaultSession } from './session-select.ts';
+
+// Minimal session shape — pickDefaultSession only reads id + updated_at.
+const mk = (id: string, updated_at: string) => ({ id, updated_at });
+
+test('empty session list returns null (caller auto-creates anchor)', () => {
+  assert.equal(pickDefaultSession([]), null);
+});
+
+test('single session is returned as-is', () => {
+  const only = mk('s1', '2026-06-01T00:00:00Z');
+  assert.equal(pickDefaultSession([only])?.id, 's1');
+});
+
+test('picks the most-recently-active session by updated_at regardless of list order', () => {
+  // 列表顺序:旧在前、新在后 —— 旧逻辑会取 list[0],修复后必须取最新者。
+  const older = mk('older', '2026-01-01T00:00:00Z');
+  const newer = mk('newer', '2026-06-01T00:00:00Z');
+  assert.equal(pickDefaultSession([older, newer])?.id, 'newer');
+  // 反过来排也一样
+  assert.equal(pickDefaultSession([newer, older])?.id, 'newer');
+});
+
+test('regression: does NOT prefer a stale "savedId" — selection is purely most-recent', () => {
+  // 模拟根因 2:切回 workspace,savedId 曾指向旧 session,但存在更新会话。
+  // pickDefaultSession 的签名故意不接受 savedId —— 选择必须只看 updated_at。
+  const savedButOld = mk('saved-old', '2026-01-01T00:00:00Z');
+  const fresh = mk('fresh', '2026-06-01T00:00:00Z');
+  assert.equal(pickDefaultSession([savedButOld, fresh])?.id, 'fresh');
+});
+
+test('explicit initialSessionId wins when it exists in the list', () => {
+  const a = mk('a', '2026-06-01T00:00:00Z'); // 更新
+  const b = mk('b', '2026-01-01T00:00:00Z'); // 更旧
+  // 即使 b 不是最新,显式指定且命中时优先返回
+  assert.equal(pickDefaultSession([a, b], 'b')?.id, 'b');
+});
+
+test('initialSessionId not present in list falls back to most-recent', () => {
+  const a = mk('a', '2026-06-01T00:00:00Z');
+  const b = mk('b', '2026-01-01T00:00:00Z');
+  assert.equal(pickDefaultSession([a, b], 'gone')?.id, 'a');
+});

--- a/webchat/lib/session-select.ts
+++ b/webchat/lib/session-select.ts
@@ -1,0 +1,40 @@
+// pickDefaultSession —— 切换 workspace(或刷新页面)时默认进入哪个 session 的选择策略。
+//
+// 背景:修复 "切换 workspace 未能直接进入默认 session"。
+// 旧逻辑(useSessions.refreshSessions)先读 localStorage 的 savedId 恢复"上次选的":
+//   1) 多 session 时会进入陈旧的旧会话,而非最近活跃会话;
+//   2) savedId 对应 session 被物理删除(GC 7 天后)时,变量未清会阻断 anchor auto-create,
+//      导致落入空状态。
+// 新策略:显式 initialSessionId(命中)> 最近活跃(updated_at 最大)> null(由调用方 auto-create)。
+// savedId 不再参与选择 —— SessionPanel 高亮用的是 activeSession prop,不读 localStorage。
+
+/** pickDefaultSession 只依赖这两个字段,任何含它们的 session 类型均可(如 SessionInfo)。 */
+export interface PickableSession {
+    id: string;
+    updated_at: string;
+}
+
+/**
+ * 选择默认 session。
+ * @param sessions        非 deleted 的候选 session 列表(调用方已过滤)。
+ * @param initialSessionId 显式指定的 session(如 URL 恢复);未命中则忽略。
+ * @returns 选中的 session,或 null(表示无可用 session,调用方应 auto-create anchor)。
+ */
+export function pickDefaultSession<T extends PickableSession>(
+    sessions: readonly T[],
+    initialSessionId?: string | null,
+): T | null {
+    if (sessions.length === 0) return null;
+
+    // 1. 显式指定且命中 —— 最高优先级(如 URL 直链某 session)。
+    if (initialSessionId) {
+        const found = sessions.find((s) => s.id === initialSessionId);
+        if (found) return found;
+    }
+
+    // 2. 最近活跃(by updated_at desc)。reduce 无初值,单元素直接返回;
+    //    相等时保留首个最大值,行为稳定可预测。
+    return sessions.reduce((a, b) =>
+        new Date(a.updated_at) > new Date(b.updated_at) ? a : b,
+    );
+}

--- a/webchat/tsconfig.json
+++ b/webchat/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## 根因(实测确认)

**`store.List` 无 session 时返回 nil slice → Go marshal 为 `"sessions":null` → 前端 `list.filter` 崩溃 → auto-create 永远到不了。**

webchat `useSessions.refreshSessions` 直接对响应的 `sessions` 字段调用 `.filter()`,而 Go 的 nil slice 被 json 序列化为 `null`(不是 `[]`)。空 workspace 的 list 响应 `{"sessions":null}`,前端 `null.filter` 抛 "Cannot read properties of null (reading 'filter')",refreshSessions 中断,anchor 'main' auto-create 永远不触发 —— 用户看到空状态 + ERROR。

实测(playwright,ABC WS 0 session):`GET /api/sessions?workspace_id=ABC` → `200 {"sessions":null}`,页面 ERROR。

## 修复

### commit 2 `640ed7a1` — 真正根因
- 后端 `store.List`(SQLite + PG)用 `make([]*SessionInfo, 0)` → marshal 为 `[]` 非 `null`
- 前端 `useSessions` 加 `(list ?? [])` 防御(belt-and-suspenders,旧部署/其它返回 null 的路径也不崩)
- 测试 `TestSQLiteStore_List_EmptyMarshalsToArrayNotNull`(空结果 → JSON `[]` 非 `null`)

### commit 1 `b4a0746e` — 选择策略改进(独立有效,非本次主诉根因)
调研时一并发现的相关问题:多 session 时恢复 localStorage savedId(上次选的)而非最近活跃会话。抽 `pickDefaultSession`(initialSessionId 命中 > updated_at 最近 > null)、effect 加 workspaceId guard、refreshSessions 加 AbortSignal。是真实改进,但空 workspace 不创建的真正元凶是 commit 2 的 null。

## CSRF 安全债收口 (#794)

### commit 3 `91b69d20` — issue #794 全部 4 项

PR #791(admin CSRF)review 残留的 pre-existing 安全债,趁 `csrfMw`/`CSRFMiddleware` 基础设施已就绪统一收口:

**P2-1 — `/api/workspaces/*` 写路由挂 csrfMw**
`WorkspaceHandlers.currentUser → AuthenticateRequest` 在无 api-key 时 fallback 到 `AuthenticateActiveCookie`,与 `/api/admin/*` 同一条 SameSite=None cookie 通道;跨站 blind CSRF 可创建/修改/删除 workspace。`corsMw(csrfMw(...))` 包裹 POST/PATCH/DELETE 三条写路由,复用 `adminAPI.CSRFMiddleware`,GET 透传。

**P2-2 — `CSRFMiddleware` 403 补审计**
csrfMw 跑在 gateway mux、`AdminAPI.Middleware` 的 audit defer 之外,403 原本静默 —— 而 CSRF 拒绝恰是高价值安全事件。403 前补 `AdminAudit("anonymous", auth.denied, path, denied)`,使两个端口(`/admin/*` Bearer 与 `/api/admin/*` cookie + 现新增 `/api/workspaces/*`)的拒绝取证价值对齐。

**P3-1** — `sessionAction` 注释补注 PATCH/PUT 未路由(仅作 404 审计路径预留)
**P3-2** — `sameOriginRequest` doc 补 same-site 信任假设(Fetch Metadata 不可跨域伪造 + registrable site 内无子域被敌手控制)

测试: `csrf_test.go` 增 workspace 写路径阻断 case + audit 捕获测试(`TestCSRFMiddleware_AuditsCSRFRejects`,SetAuditLogger+buffer)。

## 实测验证

gateway 重启(新二进制)后,playwright 打开 ABC WS(0 session):
- `GET /api/sessions?workspace_id=ABC` → `200 {"sessions":[]}`(之前是 `null`)
- 自动 `POST /api/sessions`(main anchor)→ session `41c0dcba` 建立
- `GET /api/sessions/41c0dcba/history` → `200`
- 页面:`ERROR · Claude` → **`ACTIVE · Claude`**,sidebar 出现 `main` session ✓

## 门禁

- `go test ./internal/admin/ ./internal/gateway/ ./internal/security/ -race` ✓
- `go vet` · `go build ./...` · `gofmt` ✓
- pre-push 6 道门禁全过(formatting / vet / verify / lint / build / tests)

Fixes #794