### PR TITLE
docs(patrol): 2026-06-28 admin 审计 + cookie/CSRF 文档同步

### DIFF
--- a/docs/guides/developer/webchat-setup.md
+++ b/docs/guides/developer/webchat-setup.md
@@ -184,7 +184,7 @@ var StaticFS embed.FS
 - **内建账号**（spec ①）：username/password 本地账号，由 admin 通过邀请码（`/api/admin/invitations`）创建。首次部署尚无任何账号时，登录页根据 `GET /api/auth/bootstrap-status` 引导创建首个管理员。
 - **企业 SSO**（spec ④）：标准 OIDC Authorization Code flow + PKCE。在 `oauth.providers[]` 配置 IdP（Keycloak / Okta / Azure AD 等）后，登录页渲染对应 SSO 按钮，点击跳转 IdP 完成认证。详见 [配置参考 — oauth](../../reference/configuration.md#314-oauth--webchat--ssooidc)。
 
-**HMAC Cookie 认证**：登录成功后 Gateway 签发 HttpOnly、SameSite=None; Secure 的签名 cookie（7 天有效），后续 WebSocket 连接自动携带，无需配置 API Key。SameSite=None 支持跨域 WebChat 部署（CSRF 由 HMAC 签名防护），跨域时网关须 HTTPS（浏览器拒绝非 Secure 的 SameSite=None cookie）。Cookie HMAC secret 持久化到 `~/.hotplex/data/cookie_secret.key`（权限 0600），重启后仍有效。
+**HMAC Cookie 认证**：登录成功后 Gateway 签发 HttpOnly、SameSite=None; Secure 的签名 cookie（7 天有效），后续 WebSocket 连接自动携带，无需配置 API Key。SameSite=None 支持跨域 WebChat 部署——但 SameSite=None cookie 会被跨站请求自动携带，故状态变更方法（`POST`/`PATCH`/`DELETE`）由同源校验中间件防护 CSRF（依据 `Sec-Fetch-Site`/`Origin`，不通过返回 `403 FORBIDDEN`）；HMAC 签名仅保证 cookie 完整性，本身不防 CSRF。跨域时网关须 HTTPS（浏览器拒绝非 Secure 的 SameSite=None cookie）。Cookie HMAC secret 持久化到 `~/.hotplex/data/cookie_secret.key`（权限 0600），重启后仍有效。
 
 **跨域部署 / SDK 集成**：WebChat 部署在不同域名，或客户端 SDK 直连 Gateway 时，回退到 API Key 认证：
 - HTTP Header `X-API-Key`

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -71,6 +71,37 @@ admin:
 
 Rate Limit 和 IP Whitelist 支持配置热重载，无需重启生效。
 
+## 操作审计
+
+所有 admin 写操作（`POST`/`PUT`/`PATCH`/`DELETE`）均通过 `slog` 记录结构化审计事件（`admin_audit`，issue #788 A5），用于合规追溯与事故取证。审计复用网关现有 JSON 日志管道，无独立存储——直接流向标准日志输出，可由日志聚合系统按字段过滤检索，无需额外配置。
+
+**覆盖范围**：
+
+- **`/admin/*`（端口 9999，Bearer Token）**：在 `AdminAPI.Middleware` 的审计 defer 中统一记录——无论请求最终成功或失败，写方法都会产生一条审计记录；`(method, path)` 映射为稳定 action 枚举，未映射路由回退 `"<method> <path>"`，确保无写操作静默丢失。
+- **`/api/admin/*` 与 `/api/workspaces/*`（端口 8888，Cookie）**：在各 handler 的成功/失败路径显式记录；CSRF 同源校验拦截的跨站写请求同样记审计（action `auth.denied`，详见下文「CSRF 同源校验」）。
+
+**审计字段**：
+
+| 字段 | 说明 |
+|------|------|
+| `actor_user_id` | 操作者标识：Cookie 通道为用户 `uid`；Bearer 通道为 `admin-token`；认证未解析或失败时为 `anonymous` |
+| `action` | 稳定动作枚举（见下表），日志看板按此过滤，**不可重命名** |
+| `target` | 请求路径（含资源 id） |
+| `result` | `ok`（成功）/ `failed`（操作失败）/ `denied`（认证或授权拒绝） |
+
+**action 枚举**：
+
+| 资源域 | action |
+|--------|--------|
+| 网关 | `gateway.restart` |
+| Bot | `bot.create` / `bot.update` / `bot.delete` |
+| API Key | `apikey.create` / `apikey.update` / `apikey.delete` |
+| Cron | `cron.create` / `cron.update` / `cron.delete` / `cron.trigger` |
+| Session | `session.delete` / `session.terminate` / `session.patch` / `session.put` |
+| Config | `config.rollback` / `config.validate` |
+| 多租户成员/邀请 | `member.status.update` / `invitation.create` / `invitation.delete` |
+| 认证拒绝 | `auth.denied` |
+
 ## 端点总览
 
 ### 健康检查

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -25,6 +25,8 @@ curl http://localhost:9999/admin/stats?access_token=<token>
 
 Token 使用 `crypto/subtle.ConstantTimeCompare` 进行常量时间比较，防止时序攻击。
 
+> **Cookie 认证兜底（WebChat 多租户部署）**：当请求未携带 Bearer Token 时，若已启用 WebChat 多租户（`CookieAuth` 与本地账号身份提供者就绪），中间件会转而解析 chat session cookie，校验为 **active 且角色为 `admin`** 的用户后放行，并授予完整 scope 集合——嵌入式 WebChat 中已登录的管理员可直接访问 Dashboard/Bots/Cron，无需另发 admin token。Bearer 仍优先；standalone/CLI 部署（未启用多租户）保持仅 Bearer 行为。该 cookie 通道的写方法同样适用下文的「CSRF 同源校验」；跨源 cookie 调用还需在 CORS `allowedOrigins` 显式列出 WebChat origin（`*` 通配会抑制 `Allow-Credentials`，浏览器将拒绝发送 session cookie）。
+
 ### Token 配置
 
 ```yaml
@@ -294,6 +296,8 @@ Workspace CRUD 是**跨通道租户锚**：同一个 `users.id` 无论经 **API 
 > **GET /api/admin/invitations** — 每条邀请额外返回服务器计算的 `is_expired`（`true` 表示邀请码**未被使用且已过期**），客户端无需自行比对 `expires_at` 与本地时钟，规避时钟漂移。
 
 > ⚠️ **注意区分**：此处的 `/api/admin/*`（端口 `8888`，Cookie 认证，WebChat workspace 维度）与本页上方「认证」章节描述的 Admin API（端口 `9999`，Bearer Token，网关运维维度）是**两套独立端点**，认证模型和作用域完全不同，不要混淆。
+
+> 🔒 **CSRF 同源校验（写方法）**：`/api/admin/*` 与 `/api/workspaces/*` 的状态变更方法（`POST`/`PATCH`/`DELETE`）挂载同源验证中间件，防御针对 SameSite=None session cookie 的跨站写请求；`GET` 一律放行。写方法需提供「同源证明」之一——浏览器 `Sec-Fetch-Site` 取值为 `same-origin`/`same-site`，或 `Origin` 精确命中 CORS `allowedOrigins`（`*` 通配**不**满足：SameSite=None cookie 恰在 allowlist 宽松时跨站送达）。未通过返回 `403 FORBIDDEN`（`message`: `cross-origin write blocked`）并记入 admin 审计日志。嵌入式 WebChat SPA 与网关同源，天然通过；跨域前端需将自身 origin 列入 `allowedOrigins`。
 
 ## 错误响应格式
 


### PR DESCRIPTION
## Summary

文档巡逻 2026-06-28，同步 #788 admin 后台收口引入的安全能力到 `docs/reference/admin-api.md`：

- **新增「操作审计」章节** — #788 A5 的 `admin_audit` slog 能力：覆盖范围（`/admin/*` Middleware defer + `/api/admin/*` handler + CSRF 403）、审计字段（`actor_user_id` / `action` / `target` / `result`）、21 项 action 枚举全表
- **补充 Cookie 认证兜底** — `/admin/*` 在 WebChat 多租户部署下的 cookie fallback
- **补充 CSRF 同源校验** — `/api/admin/*` 与 `/api/workspaces/*` 写方法同源校验

变更窗口内 `97a872be`（webchat session 选择 bug 修复）经分析为纯 bug 修复，**无文档影响**，跳过。

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)