### PR TITLE
docs(patrol): 2026-06-29 文档维护 — workspace 权限模式 4 档同步

### DIFF
--- a/docs/guides/developer/remote-coding-agent.md
+++ b/docs/guides/developer/remote-coding-agent.md
@@ -68,7 +68,24 @@ Claude Code 自主执行大部分操作，但敏感操作需你批准：
 
 **自主**：读文件、搜索代码、对话。**需确认**（5 分钟超时）：Bash 命令、文件写入。回复 `允许`/`allow`/`yes` 批准，`拒绝`/`deny`/`no` 拒绝。
 
-### 修改权限模式
+### 权限模式
+
+Workspace 级 4 档统一权限模式（#789），作为 Workspace 属性持久化，通过 WebChat Workspace 设置或 HTTP API 配置。Gateway 启动 Worker 时按各 Worker 原生参数注入：
+
+| 模式 | Claude Code | Codex（sandbox × approval） | OpenCode Server | ACP |
+|------|-------------|----------------------------|-----------------|-----|
+| `read-only` | `plan` | `read-only` × `untrusted` | `plan` | `approve=false` |
+| `workspace` | `acceptEdits` | `workspace-write` × `on-request` | `acceptEdits` | `approve=false` |
+| `auto-edit` | `auto` | `workspace-write` × `never` | `acceptEdits` | `approve=true` |
+| `bypass` | `--dangerously-skip-permissions` | `danger-full-access` × `never` | `bypassPermissions` | `approve=true` |
+
+空值（默认）= "Worker 默认"：CC/OCS 应用 `bypass`，Codex/ACP 沿用 operator 配置。
+
+> `auto-edit` 档要求较新版本的 Claude Code CLI（支持 `--permission-mode auto`）；`hotplex doctor` 的 `worker.claude_auto_mode` 检查项会探测此能力。
+
+### 运行时切换
+
+会话中可用 `/perm <模式>`（或 `$权限模式`）临时切换当前会话的权限行为（值透传至 Worker）：
 
 ```
 /perm bypassPermissions

--- a/docs/guides/developer/security-model.md
+++ b/docs/guides/developer/security-model.md
@@ -44,11 +44,18 @@ HotPlex Gateway 采用纵深防御（Defense in Depth）策略，通过七层安
 
 ### 权限模式
 
+Workspace 级 4 档统一权限模式（#789），跨 Claude Code / Codex / OpenCode Server / ACP 四类 Worker 统一映射。空值（默认）= "Worker 默认"：CC/OCS 应用 `bypass`，Codex/ACP 沿用各自 operator 配置。
+
 | 模式 | 行为 | 适用场景 |
 |------|------|---------|
-| `default` | 敏感操作需用户审批 | 生产环境、日常开发 |
-| `plan` | 仅在规划阶段请求权限 | 复杂项目、需要人工审查 |
-| `bypassPermissions` | 所有操作自动批准 | 受信任的自动化场景、CI/CD |
+| `read-only` | 仅规划与只读，不执行写操作 | 代码审查、只读分析 |
+| `workspace` | 自动接受编辑，其他敏感操作仍需审批 | 日常开发 |
+| `auto-edit` | 全自动执行，无需逐项确认 | 受信任的自动化 |
+| `bypass` | 跳过所有权限确认 | CI/CD、沙箱环境 |
+
+权限模式作为 Workspace 属性持久化，通过 WebChat Workspace 设置或 HTTP API 配置；运行时亦可用 `/perm <模式>` 命令临时切换。各档到 Worker 原生参数的映射见[远程开发指南](remote-coding-agent.md)。
+
+> 全局配置项 `worker.default_permission_mode` 当前为 no-op（接受配置但 Gateway 不注入）；真正生效的是 Workspace 级显式 override。
 
 ### 交互超时
 

--- a/docs/guides/user/chat-with-ai.md
+++ b/docs/guides/user/chat-with-ai.md
@@ -96,6 +96,10 @@ AI 会切换到指定目录开始工作。
 
 ### 设置权限模式
 
+权限模式控制 AI 的自主操作范围，分 4 档：`read-only`（只读）、`workspace`（可编辑）、`auto-edit`（全自动）、`bypass`（跳过所有确认）。默认在 WebChat 的 Workspace 设置中选择；各档对 Claude Code / Codex / OpenCode Server / ACP 的具体映射见[远程开发指南](../developer/remote-coding-agent.md)。
+
+会话中也可用 `/perm` 临时切换（值透传至当前 Worker，如 Claude Code 的 `bypassPermissions`）：
+
 ```
 /perm bypassPermissions
 ```


### PR DESCRIPTION
## Summary

代码来源 **#789**（workspace 权限模式：4 档权限 × 4 worker 统一映射）。引入 `read-only` / `workspace` / `auto-edit` / `bypass` 4 档统一权限模式后，文档中心未同步。本次 docs-patrol 巡逻修复三处：

- **`guides/developer/security-model.md`**：权限模式表从旧 3 档（`default`/`plan`/`bypassPermissions`）更新为新的 4 档（`read-only`/`workspace`/`auto-edit`/`bypass`），注明跨 worker 统一映射、空值="Worker 默认"、`default_permission_mode` 全局项当前为 no-op。
- **`guides/developer/remote-coding-agent.md`**：补充 4 档到各 Worker 原生参数的完整映射表（CC `plan`/`acceptEdits`/`auto`/`--dangerously-skip-permissions` 等），新增"运行时切换"小节说明 `/perm` 命令透传机制。
- **`guides/user/chat-with-ai.md`**：设置权限模式小节补充 4 档说明，指向远程开发指南。

`make docs-build` 验证通过（55 documents，无断链）。

> 注：cron 指定 fork (`aaronwong1989/hotplex-1`) 当前对 hotplex-ai 无推送权限，按惯例回退 myfork (`hotplex-ai/hotplex`)。

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)