### PR TITLE
feat(workspace): permission mode 收紧为 admin-only + 默认 workspace (r3)

### DIFF
--- a/cmd/hotplex/config_cmd.go
+++ b/cmd/hotplex/config_cmd.go
@@ -33,7 +33,7 @@ func newConfigValidateCmd() *cobra.Command {
 				return err
 			}
 
-			warns := cfg.Validate()
+			warns := append(cfg.Validate(), cfg.Warnings()...)
 			for _, w := range warns {
 				fmt.Fprintf(os.Stderr, "  ⚠ %s\n", w)
 			}

--- a/cmd/hotplex/config_cmd.go
+++ b/cmd/hotplex/config_cmd.go
@@ -33,11 +33,22 @@ func newConfigValidateCmd() *cobra.Command {
 				return err
 			}
 
-			warns := append(cfg.Validate(), cfg.Warnings()...)
+			// Hard errors (Validate) abort — mirrors gateway_run.go, which fatally
+			// rejects these at startup. Advisory warnings (Warnings, e.g. TLS off on
+			// a non-local address) print but never block, so an operator running a
+			// TLS-terminated reverse proxy isn't forced to flip tls_enabled.
+			errs := cfg.Validate()
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "  ✗ %s\n", e)
+			}
+			warns := cfg.Warnings()
 			for _, w := range warns {
 				fmt.Fprintf(os.Stderr, "  ⚠ %s\n", w)
 			}
-
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stderr, "\nConfiguration INVALID: %d error(s), %d warning(s).\n", len(errs), len(warns))
+				return fmt.Errorf("configuration has %d validation error(s)", len(errs))
+			}
 			if len(warns) > 0 {
 				fmt.Fprintf(os.Stderr, "\nConfiguration loaded with %d warning(s).\n", len(warns))
 			} else {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -104,9 +104,10 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	}
 
 	if validationErrs := cfg.Validate(); len(validationErrs) > 0 {
-		for _, ve := range validationErrs {
-			fmt.Fprintf(os.Stderr, "config validation warning: %s\n", ve)
-		}
+		return fmt.Errorf("config validation failed: %v", validationErrs)
+	}
+	for _, w := range cfg.Warnings() {
+		fmt.Fprintf(os.Stderr, "config warning: %s\n", w)
 	}
 
 	// Extract embedded Python scripts to ~/.hotplex/scripts

--- a/docs/guides/developer/security-model.md
+++ b/docs/guides/developer/security-model.md
@@ -55,7 +55,7 @@ Workspace 级 4 档统一权限模式（#789），跨 Claude Code / Codex / Open
 
 权限模式作为 Workspace 属性持久化，通过 WebChat Workspace 设置或 HTTP API 配置；运行时亦可用 `/perm <模式>` 命令临时切换。各档到 Worker 原生参数的映射见[远程开发指南](remote-coding-agent.md)。
 
-> 全局配置项 `worker.default_permission_mode` 当前为 no-op（接受配置但 Gateway 不注入）；真正生效的是 Workspace 级显式 override。
+> 全局配置项 `worker.default_permission_mode`（缺省 `workspace`）由 bridge 在 workspace 无显式 override 时注入；workspace 级显式 override 优先级更高。运维想全局放开权限须显式设为 `bypass`。
 
 ### 交互超时
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -310,6 +310,8 @@ Workspace CRUD 是**跨通道租户锚**：同一个 `users.id` 无论经 **API 
 | PATCH | `/api/workspaces/{id}` | API Key / Cookie | 更新 workspace（乐观并发，见下） |
 | DELETE | `/api/workspaces/{id}` | API Key / Cookie | 删除 workspace |
 
+> 🔒 **`permission_mode` 为 admin-only 字段（r3 #804）**：POST `/api/workspaces` 与 PATCH `/api/workspaces/{id}` 仅 admin 可设置/修改 `permission_mode`。非 admin 请求体携带该字段（含空串清空）一律返回 `403 PERMISSION_DENIED`（`message`: `permission_mode can only be configured by admins`）；非 admin 仍可改 `name` / `work_dir` / `agent_config_overrides` / `worker_preference`。未显式配置的 workspace 由 bridge 注入 `config.worker.default_permission_mode`（缺省 `workspace`）。
+
 > **PATCH 乐观并发（CAS）**：更新基于 `updated_at` 做乐观锁——服务端 `UPDATE ... WHERE id = ? AND updated_at = ?`，调用方缓存的 `updated_at` 不再匹配（被并发修改）时影响 0 行，返回 `409 WORKSPACE_VERSION_MISMATCH`（"workspace concurrently modified, please re-fetch and retry"）。客户端无需在 body 显式传版本字段（先 GET 取最新值再 PATCH），收到 409 后应重新 GET 再重试，避免静默 lost update。
 
 > **PATCH body 字段语义**：`name`、`agent_config_overrides` 传空字符串表示**不更新**（无法通过 PATCH 清空这两项）；`worker_preference` 为指针类型以区分三态——**省略**（字段未传）不更新、**空字符串** `""` 显式清除回默认 worker、**非空**设为指定类型（校验失败返回 `400 INVALID_WORKER_TYPE`）；`work_dir` 为 workspace 级可变字段——**省略/空字符串**不更新，**非空**时校验 owner 沙箱（`403 WORK_DIR_OUTSIDE_SANDBOX`）、值变更须 workspace 无活跃会话（`409 WORKSPACE_NOT_EMPTY`，因 work_dir 进 session key 派生）、且未被该 owner 其他 workspace 占用（`409 WORK_DIR_TAKEN`）后更新（见上）。
@@ -359,6 +361,7 @@ Workspace CRUD 是**跨通道租户锚**：同一个 `users.id` 无论经 **API 
 | 403 | `WORKSPACE_FORBIDDEN` | 非所有者访问他人 workspace（且非 admin） |
 | 403 | `WORK_DIR_FORBIDDEN` | workspace `work_dir` 命中安全黑名单（系统目录等） |
 | 403 | `WORK_DIR_OUTSIDE_SANDBOX` | workspace `work_dir` 不在 owner 沙箱前缀下 |
+| 403 | `PERMISSION_DENIED` | 非 admin 试图在 workspace Create/Update 设置或修改 `permission_mode`（admin-only 字段，r3 #804） |
 | 404 | `NOT_FOUND` | Session/Cron Job/Invitation 未找到 |
 | 404 | `WORKSPACE_NOT_FOUND` | workspace id 不存在 |
 | 409 | `CONFLICT` | 资源状态冲突 |

--- a/docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md
+++ b/docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md
@@ -1,0 +1,254 @@
+# Admin 控制台 — Workspace Permission Mode 管理
+
+**状态**: Draft · **日期**: 2026-06-29 · **关联**: [Workspace-Permission-Mode-Spec.md](./Workspace-Permission-Mode-Spec.md)、[Workspace-Permission-Mode-Admin-Only-Revision-Spec.md](./Workspace-Permission-Mode-Admin-Only-Revision-Spec.md)（r3）· **版本目标**: v1.31.x
+
+---
+
+## 1. 背景与动机
+
+r3（PR #805）已把 workspace `permission_mode` 收紧为 **admin-only**：
+
+- 配置层：`config.worker.default_permission_mode` 真正被 bridge 消费，缺省 `bypass` → `workspace`。
+- 接口层：`PATCH /api/workspaces/{id}` 对非 admin 改 `permission_mode` 返回 403 `PERMISSION_DENIED`。
+
+但 r3 只解决了"谁能改"的**权限**问题，没解决"admin 怎么改"的**操作面**问题：
+
+1. **没有 admin 入口**：`/admin` 视图（Dashboard / Bots / Sessions / Cron / API Keys / Settings）没有 Workspaces 页面。admin 想给某个用户的 workspace 设 `permission_mode`，只能用 `curl PATCH /api/workspaces/{id}` 手敲——既不直观，也走错了鉴权通道（`/api/workspaces` 是用户自助 REST，走 `Authenticator`；admin 视图应走 `admin-client` 双通道）。
+2. **没有全局视图**：`GET /api/workspaces` 只返回 caller 自己的 workspace（`ListWorkspacesByOwner(uid)`）。store 层有 `ListAllWorkspaces` 但 HTTP 层从未暴露给 admin。admin 无法一眼看到"全平台所有 workspace 当前跑在什么权限档"。
+3. **没有可读标识**：workspace 的 `OwnerUserID` 是 UUID，admin 无法从 UUID 识别"这是谁的 workspace"。
+
+本 spec 解决这三点：给 admin 一个**只读列表 + 可改 permission_mode** 的 `/admin/workspaces` 控制台页面，列表带 owner 可读标识（display_name + username）。
+
+## 2. 范围（已与 stakeholder 确认）
+
+| 决策点 | 选择 | 理由 |
+|---|---|---|
+| 管理范围 | **最小化**：列表 + inline 改 permission_mode | 聚焦诉求，不做删除/详情页（YAGNI；删除已有 `/api/workspaces/{id}` 路径） |
+| 生效时机 | **仅影响新建 session** | 与 `resolveWorkspacePermissionMode` 现有热重载语义一致；不打断用户进行中的对话 |
+| 用户侧可见性 | **只读展示当前 mode** | 用户知情权，避免"为什么我不能改文件"的困惑；r3 的"完全隐藏"改为"只读 badge" |
+
+**明确不做**：
+- ❌ admin 删除 workspace（复用现有 `/api/workspaces/{id}` DELETE 即可，不进 admin 控制台）
+- ❌ "立即生效"按钮（kill 活跃 session 重启）——会中断用户对话，超出最小化范围
+- ❌ workspace 详情页（owner/创建时间/活跃 session 数等只读视图）——后续可加，本期 YAGNI
+
+## 3. 核心改动
+
+### 3.1 后端：`GET /admin/workspaces`（列出所有 workspace + owner 标识）
+
+**路由**：`GET /admin/workspaces`（注册于 `cmd/hotplex/routes.go` 的 `adminMux`，走 `AdminAPI.Middleware` 鉴权——Bearer + cookie fallback，admin-only）。
+
+**store 层新增**（`internal/session/multitenancy_store.go`，SQLiteStore + pgStore 双实现）：
+
+```go
+// AdminWorkspaceView 是 admin 列表的投影：workspace 字段 + owner 可读标识。
+// 避免 admin 拿着 UUID 无法识别归属（spec §1 动机 3）。
+type AdminWorkspaceView struct {
+    Workspace               // 嵌入：ID/OwnerUserID/Name/WorkDir/PermissionMode/Status/...
+    OwnerDisplayName string // join users.display_name
+    OwnerUsername    string // join users.username
+}
+
+// ListAllWorkspacesWithOwner 返回所有 workspace 并 join users 带可读标识。
+// 供 admin 控制台全局视图使用（区别于 ListAllWorkspaces 的纯裸行，用于
+// gateway 启动扫描的 stale override 检测，不带 owner）。
+func (s *SQLiteStore) ListAllWorkspacesWithOwner(ctx context.Context) ([]*AdminWorkspaceView, error)
+```
+
+SQL（SQLiteStore，pgStore 同构换占位符）：
+
+```sql
+SELECT w.id, w.owner_user_id, w.name, w.work_dir, w.agent_config_overrides,
+       w.worker_preference, w.permission_mode, w.status, w.created_at, w.updated_at,
+       u.display_name, u.username
+FROM workspaces w
+LEFT JOIN users u ON u.id = w.owner_user_id
+ORDER BY u.display_name, w.name;
+```
+
+> `LEFT JOIN` 而非 `INNER`：防御性地容忍 owner user 行被并发删除的窗口（workspace 仍应可见，owner 字段为空字符串）。正常路径下 FK 保证 owner 存在。
+
+**响应**（`admin.WorkspaceListResponse`，定义于 `internal/admin/models.go`）：
+
+```jsonc
+{
+  "workspaces": [
+    {
+      "id": "ws-uuid",
+      "owner_user_id": "user-uuid",
+      "owner_display_name": "张三",
+      "owner_username": "zhangsan",
+      "name": "我的项目",
+      "work_dir": "/home/u/.hotplex/workspaces/user-uuid/my-project",
+      "permission_mode": "workspace",       // "" = 走 config 默认
+      "status": "active",
+      "created_at": 1719600000,
+      "updated_at": 1719600000
+    }
+  ]
+}
+```
+
+**分页**：workspace 总量预期不大（admin 后台），首版**不分页**，全量返回（与 `ListAllWorkspaces` 现状一致）。若后续 api-key 通道程序化创建导致量级膨胀，再加 `web.ParsePagination` 下推——届时同步改 `ListAllWorkspacesWithOwner` 签名。
+
+### 3.2 后端：`PATCH /admin/workspaces/{id}`（admin 改 permission_mode）
+
+**路由**：`PATCH /admin/workspaces/{id}`（`adminMux`，admin-only）。
+
+**请求体**（仅允许改 permission_mode，最小化范围）：
+
+```jsonc
+{ "permission_mode": "read-only" }   // 4 档之一；"" = 清除覆盖，回落 config 默认
+```
+
+**handler 逻辑**（新文件 `internal/admin/workspace_handlers.go`）：
+
+```go
+type updateAdminWorkspaceRequest struct {
+    PermissionMode *string `json:"permission_mode"` // nil = omit (400); 必须显式提供
+}
+
+func (h *AdminWorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
+    // 1. 解析 body：permission_mode 字段必须存在（nil → 400，避免误以为能改其它字段）
+    // 2. worker.ValidatePermissionMode(*req.PermissionMode) → 400 INVALID_PERMISSION_MODE
+    // 3. store.GetWorkspaceByID → 404 WORKSPACE_NOT_FOUND
+    // 4. ws.PermissionMode = *req.PermissionMode
+    // 5. store.UpdateWorkspace(ws, now) → CAS 冲突 409 WORKSPACE_VERSION_MISMATCH
+    // 6. respondJSON(ws) —— 返回更新后的 workspace 裸行（不带 owner join，足够）
+}
+```
+
+**与 `/api/workspaces/{id}` PATCH 的关系**：
+- `/api/workspaces/{id}` 是**用户自助**端点（owner 自己改 name/work_dir/agent_config 等；permission_mode 字段对非 admin 403，对 admin 放行）。保留不动。
+- `/admin/workspaces/{id}` 是**admin 控制台**端点（**只**能改 permission_mode，走 admin 鉴权通道）。
+- 两者职责不同，不合并。admin 控制台不暴露 name/work_dir 修改，避免 admin 误改用户的工作目录。
+
+**生效语义**：`UpdateWorkspace` 写库后，**运行中 session 不受影响**（worker 进程已启动，权限参数已注入）。新 session（新对话 / `/reset` 后）初始化时 `resolveWorkspacePermissionMode` 会读到新值。UI 上对 admin 标注"对新会话生效"。
+
+### 3.3 后端：审计接入
+
+`internal/admin/audit.go`：
+
+1. 新增动作枚举：
+   ```go
+   AuditWorkspacePermissionModeUpdate = "workspace.permission_mode.update"
+   ```
+2. `adminActionFor` 注册路径匹配（新增 `workspaceAction` helper，或直接在 switch 加 case）：
+   ```go
+   case strings.Contains(path, "/workspaces") && method == http.MethodPatch:
+       return AuditWorkspacePermissionModeUpdate
+   ```
+   > 注意顺序：`/workspaces` 不与现有 `/sessions`/`/bots`/`/cron`/`/api-keys` 子串冲突，放在 switch 末尾即可。
+
+写操作由 middleware 级 `admin_audit` slog 统一记录（`actor` = uid 或 `admin-token`，`target` = `/admin/workspaces/{id}`，`result` = ok/failed）。**读操作（GET list）不审计**（与现有 admin 读端点一致）。
+
+### 3.4 前端：`/admin/workspaces` 页面
+
+**新页面** `webchat/app/admin/workspaces/page.tsx`：
+
+表格列：
+
+| 列 | 字段 | 说明 |
+|---|---|---|
+| Owner | `owner_display_name (owner_username)` | **主标识**，admin 据此识别归属 |
+| Workspace | `name` | 用户起的工作区名 |
+| Work Dir | `work_dir` | 截断展示，title 显全路径 |
+| Permission Mode | `permission_mode` | 当前档位；inline 下拉选择器 |
+| 操作 | — | 下拉选档 + 保存按钮 |
+
+**Permission Mode 下拉**：5 个选项（4 档 + "默认（workspace）"）。`""` 在 UI 显示为"默认（workspace）"并标注"= config 全局默认"。
+
+**交互**：admin 在某行下拉选档 → 点保存 → 调 `PATCH /admin/workspaces/{id}` → 成功后该行 badge 更新 + toast 提示"已更新，对新会话生效"；失败 toast 显错误码。
+
+**权限提示**：页面顶部固定提示条"修改仅对新会话生效；运行中的会话保持原权限模式"。
+
+**admin-nav 入口**：`webchat/components/admin/admin-nav.tsx` 的 `NAV_ITEMS` 加一项（图标用 folder/document 集，置于 Sessions 之后）：
+```ts
+{ label: 'Workspaces', href: '/admin/workspaces', exact: false }
+```
+
+### 3.5 前端：API 模块
+
+新文件 `webchat/lib/api/admin-workspaces.ts`（走 `adminFetch` 双通道）：
+
+```ts
+export async function listAdminWorkspaces(): Promise<AdminWorkspace[]>
+export async function updateAdminWorkspacePermissionMode(
+  id: string, permissionMode: string,
+): Promise<Workspace>
+```
+
+类型定义补到 `webchat/lib/types/admin.ts`：`AdminWorkspace`（含 owner_display_name/owner_username）。
+
+### 3.6 前端：普通用户侧 GeneralTab 只读展示
+
+r3 把 `permission_mode` 控制从 `GeneralTab` **完全隐藏**（非 admin 不渲染）。本 spec 改为**只读 badge 展示**：
+
+- admin 用户：保持 r3 的可编辑下拉（不变）。
+- 非 admin 用户：渲染只读 badge（如 `权限模式: workspace`），**无修改入口**。值来自 workspace 的 `permission_mode`（`""` 显示"默认"）。
+
+> 落点：`webchat/app/components/chat/` 下 GeneralTab 相关组件。需读 workspace 当前 `permission_mode`（用户侧 `GET /api/workspaces/{id}` 已返回该字段）。
+
+## 4. 安全考量
+
+| 威胁 | 缓解 |
+|---|---|
+| 非 admin 越权调 `PATCH /admin/workspaces/{id}` | `AdminAPI.Middleware` 强制 admin（role==admin && status==active）；handler 层不重复校验（middleware 已保证） |
+| 非 admin 越权调 `GET /admin/workspaces` | 同上，middleware 拦截 |
+| admin 误改用户 work_dir | `/admin/workspaces/{id}` PATCH **只接受** `permission_mode` 字段，work_dir/name 等忽略；改 work_dir 仍走用户自助 `/api/workspaces/{id}` |
+| owner 隔离破坏 | admin 改 permission_mode 不涉及 sandbox 路径校验（permission_mode 是 worker 行为参数，非文件系统权限），无越权风险 |
+| 普通用户侧只读展示泄露 | 非 admin 只读展示的是**自己的** workspace mode（已属己有数据），无越权；不展示他人 workspace |
+
+## 5. 数据契约汇总
+
+| 端点 | 方法 | 鉴权 | 用途 |
+|---|---|---|---|
+| `/admin/workspaces` | GET | admin（middleware） | 列出所有 workspace + owner 标识 |
+| `/admin/workspaces/{id}` | PATCH | admin（middleware） | 改单个 workspace 的 permission_mode |
+| `/api/workspaces` | GET | 用户（Authenticator） | 不变：列自己的 |
+| `/api/workspaces/{id}` | PATCH | 用户（Authenticator） | 不变：改自己的；permission_mode 仍 admin-only 403 |
+
+错误码（`/admin/workspaces/{id}` PATCH）：
+- `400 INVALID_PERMISSION_MODE` — 档位非法
+- `400 BAD_REQUEST` — body 缺 `permission_mode` 字段
+- `404 WORKSPACE_NOT_FOUND` — id 不存在
+- `409 WORKSPACE_VERSION_MISMATCH` — CAS 冲突，提示重新拉取
+
+## 6. 测试
+
+**后端**（`internal/admin/workspace_handlers_test.go` + store test）：
+- `GET /admin/workspaces`：admin 返回全量 + owner join；非 admin 401/403；owner user 缺失时（LEFT JOIN）owner 字段为空且 workspace 仍返回。
+- `PATCH /admin/workspaces/{id}`：4 档合法值通过；非法值 400；缺失字段 400；不存在 404；CAS 冲突 409；审计记录写入（`workspace.permission_mode.update`）。
+- store：`ListAllWorkspacesWithOwner` SQLite + PG 双实现一致性（table-driven）。
+
+**前端**：
+- `/admin/workspaces` 页面渲染列表 + inline 修改流程（mock adminFetch）。
+- GeneralTab 非 admin 只读 badge 渲染、无修改入口。
+- admin-nav 新入口高亮。
+
+## 7. 文档
+
+- `docs/reference/admin-api.md`：补充 `GET /admin/workspaces` 与 `PATCH /admin/workspaces/{id}` 契约（请求/响应/错误码），标注 admin-only + permission_mode 4 档语义。
+- 本 spec 实施后状态改 `Implemented`，关联 PR。
+
+## 8. 实施清单
+
+**后端**
+- [ ] `internal/session/multitenancy_store.go`：新增 `AdminWorkspaceView` + `ListAllWorkspacesWithOwner`（SQLiteStore + pgStore）
+- [ ] `internal/admin/workspace_handlers.go`：新增 `AdminWorkspaceHandlers`（List + Update）
+- [ ] `internal/admin/models.go`：新增 `WorkspaceListResponse`
+- [ ] `internal/admin/audit.go`：新增 `AuditWorkspacePermissionModeUpdate` + `adminActionFor` 路径匹配
+- [ ] `cmd/hotplex/routes.go`：注册 `GET /admin/workspaces` + `PATCH /admin/workspaces/{id}`
+- [ ] 后端测试 + `make check`
+
+**前端**
+- [ ] `webchat/lib/types/admin.ts`：`AdminWorkspace` 类型
+- [ ] `webchat/lib/api/admin-workspaces.ts`：list + patch
+- [ ] `webchat/app/admin/workspaces/page.tsx`：表格 + inline 修改
+- [ ] `webchat/components/admin/admin-nav.tsx`：加 Workspaces 入口
+- [ ] `webchat/app/components/chat/` GeneralTab：非 admin 只读 badge
+- [ ] `cd webchat && npx tsc --noEmit`
+
+**文档**
+- [ ] `docs/reference/admin-api.md` 补两端点契约
+- [ ] 本 spec 状态 → Implemented

--- a/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
@@ -17,18 +17,29 @@
 - **决策 B**：`permission_mode` 的设置/修改权限收归 **admin-only**，非 admin 传该字段 → 403（fail-closed）。
 - **决策 C**：config 默认仅在 **workspace session** 生效；无 workspace session（cron / Slack / Feishu 平台 channel）保持注入 `""`，保留 r2 §8 对操作员受限 Codex/ACP 配置的保护。
 
-## 2. 安全权衡（化解 r2 §8 担忧）
+## 2. 安全权衡（ceiling 语义化解 r2 §8 担忧）
 
-r2 §8 不注入全局默认的核心动机：避免覆盖操作员为受限环境配的 `codex.sandbox=read-only` / `acp.auto_approve=false`。本次把默认值**同时**从 `bypass` 降为 `workspace`，使"注入全局默认"在所有 Worker 上都变为**收紧**而非提权：
+r2 §8 不注入全局默认的核心动机：避免覆盖操作员为受限环境配的 `codex.sandbox=read-only` / `acp.auto_approve=false`。r3 把默认值**同时**从 `bypass` 降为 `workspace`，并把注入语义定义为 **ceiling（权限上限）**：注入值只能**收紧**操作员配置，绝不放宽。
 
-| 场景 | r2 行为（无覆盖） | r3 行为（无覆盖） | 方向 |
+**ceiling 落地点在各 Worker 内部**（`session.PermissionMode` 是 gateway 的意图，Worker 把它与操作员配置取**更严**者）：
+
+| Worker | ceiling 实现 | 例：注入 `workspace` + 操作员 `codex.sandbox=read-only` |
+|---|---|---|
+| CC / OCS | 无独立操作员权限配置，`""`→bypass 即被注入值替换 | `workspace` → acceptEdits（收紧） |
+| **Codex** | `buildThreadStartParams` 取 `max(rank(session tier), rank(cfg.Sandbox/ApprovalMode))` | sandbox 保持 `read-only`（操作员更严，**不提权**）；approval 取更严者 |
+| ACP | `auto_approve` 二值，`workspace`→false 已是严极 | `false`（收紧），不可能从 false 升 true |
+
+| 场景 | r2 行为（无覆盖） | r3 行为（无覆盖，ceiling） | 方向 |
 |---|---|---|---|
 | CC / OCS workspace | `""` → bypass | `workspace` → acceptEdits | 收紧 ✓ |
-| Codex workspace | `""` → 操作员配置（常 danger-full-access） | `workspace` → workspace-write × on-request | 收紧 ✓ |
-| ACP workspace | `""` → 操作员配置（常 approve=true） | `workspace` → approve=false | 收紧 ✓ |
+| Codex workspace（操作员默认 danger-full-access） | `""` → danger-full-access | `workspace` → workspace-write × on-request | 收紧 ✓ |
+| Codex workspace（操作员 read-only） | `""` → read-only | `workspace` ceiling → 仍 read-only | 不变 ✓（ceiling 保护） |
+| ACP workspace | `""` → 操作员配置 | `workspace` → approve=false | 收紧 ✓ |
 | cron / 平台 channel | `""` | `""`（不变） | 不变 ✓ |
 
-**结论**：因默认值同档下调，注入 config 默认不再含提权路径；存量 `permission_mode IS NULL` 的 workspace 升级后自动收紧到 workspace 档。
+**结论**：注入值作为 permissiveness ceiling，由各 Worker clamp——对操作员默认配置是收紧，对操作员更严配置保持不变，**无提权路径**。这正是 r3 review P1（codex 注入 workspace 覆盖 read-only 操作员配置）的修复。
+
+**fail-closed 降级**：`resolveWorkspacePermissionMode` 在 `GetWorkspaceByID` 出错（DB 抖动）时也返回 bridge 默认值（workspace），而非 `""`——对 CC/OCS 而言 `""`→bypass，空降级会在 DB 故障期把 workspace session 静默升到 bypass（r2 P1）。返回默认值即 fail-closed。
 
 ## 3. 核心改动
 
@@ -124,6 +135,8 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 
 **零数据迁移**：不改 DB schema，不改存量行，纯运行时默认值切换。
 
+> **存量 bypass 残留（已知项，非自动迁移）**：r2 UI 把 `Bypass — Full access (default)` 作为下拉首选项，故升级前打开过 General 选项卡并保存的 workspace 多数存了显式 `permission_mode="bypass"`。r3 的 ceiling 注入只覆盖 `PermissionMode==""` 的 workspace；**显式存了 `bypass` 的 workspace 升级后仍跑 bypass**——r3 收紧不触及它们。运维若要对这些 workspace 也收紧，需由 admin 显式 PATCH 清空（`permission_mode=""`）以回落到 workspace 默认。不做自动数据迁移，因静默改写存储值可能违背 operator 当初的显式选择。
+
 ## 7. 测试策略
 
 | 测试 | 文件 | 断言 |
@@ -162,9 +175,23 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 - [x] `docs/specs/Workspace-Permission-Mode-Spec.md` 顶部加 r3 横幅（r2 正文保留作历史记录，引用本 spec）
 - [x] `docs/reference/admin-api.md`：补 `PERMISSION_DENIED` 错误码 + `permission_mode` admin-only 标注
 
+### 8.1 r3 code-review 修复（max effort review）
+
+| 修复 | 文件 | 改动 |
+|---|---|---|
+| **P1 codex 提权** | `internal/worker/codexcli/worker.go` | `buildThreadStartParams` 把 session tier 从"无条件覆盖"改为 **ceiling**：`codexSandboxRank`/`codexApprovalRank` 取 `max(rank(session), rank(operator))`，杜绝注入 workspace 覆盖操作员 read-only |
+| **P1 DB 抖动 fail-open** | `internal/gateway/bridge_worker.go` | `GetWorkspaceByID` 出错分支返回 bridge 默认值（workspace）而非 `""`（CC/OCS `""`→bypass），fail-closed |
+| **P2 config validate 误绿** | `cmd/hotplex/config_cmd.go` | `Validate()` 硬错误与 `Warnings()` 拆分：硬错误 `✗` + 非零退出（对齐 `gateway_run`），警告 `⚠` 不阻断 |
+| **P3 webchat 无条件发送 permMode** | `webchat/.../general-tab.tsx` | `permissionMode` 仅在 dirty 时发送，name-only save 不触 admin 门字段 |
+| **P3 Update 重复 isAdmin** | `internal/gateway/workspace_handlers.go` | admin 权威 memoize（`resolveAdmin` 闭包），admin 改他人 workspace 带 permMode 仅 1 次 idp.Lookup |
+| **P3 注释去 stale** | `worker.go` / `bridge_worker.go` | 删 "not an escalation" 伪断言，改为 ceiling 契约描述 |
+
+**新增测试**：`TestBuildThreadStartParams_PermissionCeiling`（4 例：收紧/不提权/空/显式 bypass 不放宽）；`TestResolveWorkspacePermissionMode` 的 fetch-error 用例改为断言降级到默认值。
+
 ## 9. 非目标
 
 - 不改 DB schema（不加列、不改 migration）。
 - 不引入 per-worker-type 默认（`config.worker.default_permission_mode` 仍是单值；r2 §11 留的"按 worker-type 细化"留待将来）。
 - 不改 cron / 平台 channel session 的权限行为。
 - 不做运行时实时切换（启动锁定语义不变）。
+- **不改 `/perm` 运行时命令**：`worker_cmds.go:handleSetPermMode` 是 pre-existing 的运行时 per-session worker IPC（`/perm bypass` / `$perm`），作用于**当前 live session 的 worker 进程**，不落库、不写持久 `Workspace.PermissionMode`。r3 的 admin-only 范围仅覆盖持久字段的 Create/Update（决策 B）；`/perm` 是另一安全边界，其是否收归 admin 留作单独 follow-up，不在本 PR。

--- a/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
@@ -107,8 +107,8 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 | `internal/config/config_types.go` | `:475` `DefaultPermissionMode` mapstructure 注释 | 删 "no-op"，改为"workspace 无覆盖时注入；缺省 workspace（r3）" |
 | `cmd/hotplex/gateway_run.go` | `:362` 热重载日志附近 | 无需改逻辑，注释如有"no-op"一并清 |
 | `internal/worker/worker.go` | `:275` `NormalizePermissionMode` doc | consumer 列表追加 `resolveWorkspacePermissionMode` |
-| `docs/specs/Workspace-Permission-Mode-Spec.md` | §5 / §7 / §8 | 改写"全局默认 no-op"语义；§8 补 r3 安全说明（指向本 spec §2） |
-| `docs/reference/admin-api.md` | （当前仓库无此文件） | 若后续建立 admin API 参考，需标注 `permission_mode` admin-only（非 admin 传 → 403 PERMISSION_DENIED） |
+| `docs/specs/Workspace-Permission-Mode-Spec.md` | 顶部 | 加 r3 横幅声明（r2 正文 §5/§7/§8 保留作历史记录，引用本 spec §2），不逐节改写正文 |
+| `docs/reference/admin-api.md` | 错误码表 + Workspace 管理端点 | 补 `PERMISSION_DENIED`（403）错误码 + `permission_mode` admin-only 标注（非 admin 传 → 403） |
 
 ## 6. 向后兼容
 
@@ -159,8 +159,8 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 - [ ] handler admin-only 四象限（非admin传/不传 × Create/Update）
 
 **文档**
-- [ ] `docs/specs/Workspace-Permission-Mode-Spec.md` §5/§7/§8 修订（标注 r3，引用本 spec）
-- [ ] `docs/reference/admin-api.md`：`permission_mode` admin-only 标注（当前仓库无此文件，建立时补）
+- [x] `docs/specs/Workspace-Permission-Mode-Spec.md` 顶部加 r3 横幅（r2 正文保留作历史记录，引用本 spec）
+- [x] `docs/reference/admin-api.md`：补 `PERMISSION_DENIED` 错误码 + `permission_mode` admin-only 标注
 
 ## 9. 非目标
 

--- a/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
@@ -108,7 +108,7 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 | `cmd/hotplex/gateway_run.go` | `:362` 热重载日志附近 | 无需改逻辑，注释如有"no-op"一并清 |
 | `internal/worker/worker.go` | `:275` `NormalizePermissionMode` doc | consumer 列表追加 `resolveWorkspacePermissionMode` |
 | `docs/specs/Workspace-Permission-Mode-Spec.md` | §5 / §7 / §8 | 改写"全局默认 no-op"语义；§8 补 r3 安全说明（指向本 spec §2） |
-| `docs/reference/admin-api.md` | workspace Create/PATCH 段 | 标注 `permission_mode` 字段 admin-only（非 admin 传 → 403 PERMISSION_DENIED） |
+| `docs/reference/admin-api.md` | （当前仓库无此文件） | 若后续建立 admin API 参考，需标注 `permission_mode` admin-only（非 admin 传 → 403 PERMISSION_DENIED） |
 
 ## 6. 向后兼容
 
@@ -160,7 +160,7 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 
 **文档**
 - [ ] `docs/specs/Workspace-Permission-Mode-Spec.md` §5/§7/§8 修订（标注 r3，引用本 spec）
-- [ ] `docs/reference/admin-api.md`：`permission_mode` admin-only 标注
+- [ ] `docs/reference/admin-api.md`：`permission_mode` admin-only 标注（当前仓库无此文件，建立时补）
 
 ## 9. 非目标
 

--- a/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
@@ -1,0 +1,170 @@
+# Workspace 权限模式 — Admin-Only 配置 + 默认收紧修订
+
+**状态**: Draft · **日期**: 2026-06-29 · **修订**: r3（针对 [Workspace-Permission-Mode-Spec.md](./Workspace-Permission-Mode-Spec.md) r2）· **关联**: 原 issue [#789](https://github.com/hrygo/hotplex/issues/789) · **版本目标**: v1.31.x
+
+---
+
+## 1. 背景
+
+原 spec（r2）落地了 4 档统一 Permission Mode，但留下两点宽松默认：
+
+1. **默认值偏高**：`config.worker.default_permission_mode` 被设为 `"bypass"` 且刻意做成 **no-op**（spec §5/§8：bridge `resolveWorkspacePermissionMode` 在 workspace 无显式覆盖时注入 `""`，让各 Worker 走自身默认——CC/OCS→bypass）。结果是绝大多数未显式配置的 workspace 实际跑在最高权限。
+2. **配置入口过宽**：`workspace_handlers.go` 的 Create/Update 仅做格式校验（`ValidatePermissionMode`），**owner 自己**就能给自己的 workspace 设/改 `permission_mode`，无需 admin。
+
+本次修订（r3）针对这两点收紧：
+
+- **决策 A**：`config.worker.default_permission_mode` 从 no-op 转为**真正被 bridge 消费**，缺省值 `bypass` → `workspace`。
+- **决策 B**：`permission_mode` 的设置/修改权限收归 **admin-only**，非 admin 传该字段 → 403（fail-closed）。
+- **决策 C**：config 默认仅在 **workspace session** 生效；无 workspace session（cron / Slack / Feishu 平台 channel）保持注入 `""`，保留 r2 §8 对操作员受限 Codex/ACP 配置的保护。
+
+## 2. 安全权衡（化解 r2 §8 担忧）
+
+r2 §8 不注入全局默认的核心动机：避免覆盖操作员为受限环境配的 `codex.sandbox=read-only` / `acp.auto_approve=false`。本次把默认值**同时**从 `bypass` 降为 `workspace`，使"注入全局默认"在所有 Worker 上都变为**收紧**而非提权：
+
+| 场景 | r2 行为（无覆盖） | r3 行为（无覆盖） | 方向 |
+|---|---|---|---|
+| CC / OCS workspace | `""` → bypass | `workspace` → acceptEdits | 收紧 ✓ |
+| Codex workspace | `""` → 操作员配置（常 danger-full-access） | `workspace` → workspace-write × on-request | 收紧 ✓ |
+| ACP workspace | `""` → 操作员配置（常 approve=true） | `workspace` → approve=false | 收紧 ✓ |
+| cron / 平台 channel | `""` | `""`（不变） | 不变 ✓ |
+
+**结论**：因默认值同档下调，注入 config 默认不再含提权路径；存量 `permission_mode IS NULL` 的 workspace 升级后自动收紧到 workspace 档。
+
+## 3. 核心改动
+
+### 3.1 config 默认值（1 处）
+
+`internal/config/config_defaults.go:82`：
+
+```go
+// 原
+DefaultPermissionMode: "bypass", // no-op since #789 r2 P2 ...
+// 新
+DefaultPermissionMode: "workspace", // bridge 在 workspace 无显式覆盖时注入此值（r3）
+```
+
+> 注：`config` 包不可 import `internal/worker`（依赖方向），沿用现有字面量风格（与 `"claude_code"` / `"sqlite"` 一致），不引入常量引用。
+
+`NormalizePermissionMode`（`worker.go:275`）**不变**：仍 `empty → bypass`，作为运维显式设空时的向后兼容 fallback。Default 既已非空（`"workspace"`），Normalize 后保持 workspace。
+
+### 3.2 bridge 真正消费默认（spec §5 no-op 落地）
+
+`internal/gateway/bridge_worker.go:resolveWorkspacePermissionMode` 的"workspace 无显式覆盖"分支：
+
+```go
+if ws.PermissionMode != "" {
+    return ws.PermissionMode // 显式覆盖优先（不变）
+}
+// r3：返回 config 全局默认（workspace），而非 ""。
+// 因默认值同档下调，注入即收紧，无提权（见本 spec §2）。
+return b.defaultPermissionMode.Load().(string)
+```
+
+`workspaceID == ""` 分支（cron / 平台 channel）**保持 `return ""`**（决策 C）。
+
+bridge 侧无需新增接线——`defaultPermissionMode atomic.Value` 已存在（`bridge.go:68`），由 `NewBridge:122` 经 `worker.NormalizePermissionMode` 初始化、`UpdateDefaultPermissionMode:140` 热重载、`gateway_run.go:360-362` 监听 config 变更触发。
+
+### 3.3 handler admin-only 校验（fail-closed）
+
+`internal/gateway/workspace_handlers.go` 的 **Create** 与 **Update**，在现有 `ValidatePermissionMode` 之前加一道 admin 门：
+
+```go
+if req.PermissionMode != nil && !h.isAdmin(r, uid) {
+    writeAppError(w, http.StatusForbidden, "PERMISSION_DENIED",
+        "permission_mode can only be configured by admins")
+    return
+}
+```
+
+语义：
+
+- 非 admin **不传**该字段（`nil`）→ 正常；workspace 走 config 默认 workspace。
+- 非 admin **传任意值**（含 `""` 清空）→ **403**。
+- admin 可选 4 档 + `""`（清空回默认）。
+- `isAdmin` 复用现有 `h.isAdmin(r, uid)`（`workspace_handlers.go:64`，`role==admin && status==active`，同一 channel 身份源）。
+- Update 路径 owner 非 admin 仍可改 `name` / `work_dir` / `agent_config_overrides` / `worker_preference`，仅 `permission_mode` 被门控。
+
+## 4. 前端
+
+`webchat/app/components/chat/settings-modal/general-tab.tsx`：
+
+1. `GeneralTabProps` 增 `isAdmin: boolean`；由 `webchat/app/settings/page.tsx` 传入（已有 `currentUser?.role === 'admin'`，参考 `settings/page.tsx:86`）。
+2. 非 admin：**隐藏** Permission Mode 控件整块；`handleSave` 在非 admin 时不发送 `permissionMode` 字段（避免触发 403）。
+3. 默认选中值 `'bypass'` → `'workspace'`（`useState` 初始值 `:47`、`useEffect` 同步 `:60`、`dirty` 比较 `:74`）。
+4. `PERMISSION_MODE_OPTIONS`（`:23-28`）：把 `"(default)"` 标签从 `bypass` 移到 `workspace` 档；`bypass` 文案改为 `Bypass — Full access`。
+5. 存量展示：`workspace.permission_mode === ""` 时，非 admin 看到的是隐藏；admin 看到下拉停在 workspace 档（因后端默认即 workspace，UI 与实际生效一致）。
+
+`webchat/app/settings/page.tsx`：定位渲染 `<GeneralTab>` 处，把 `currentUser?.role === 'admin'` 作为 `isAdmin` 传入。
+
+## 5. 注释与文档同步（no-op → 生效）
+
+r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
+
+| 文件 | 位置 | 改动 |
+|---|---|---|
+| `internal/gateway/bridge.go` | `:68` `defaultPermissionMode` 字段注释 | 删 "NOT consumed by resolveWorkspacePermissionMode"，改为"workspace 无显式覆盖时注入此值（r3）" |
+| `internal/gateway/deps.go` | `:46` `DefaultPermissionMode` 注释 | 同上 |
+| `internal/config/config_types.go` | `:475` `DefaultPermissionMode` mapstructure 注释 | 删 "no-op"，改为"workspace 无覆盖时注入；缺省 workspace（r3）" |
+| `cmd/hotplex/gateway_run.go` | `:362` 热重载日志附近 | 无需改逻辑，注释如有"no-op"一并清 |
+| `internal/worker/worker.go` | `:275` `NormalizePermissionMode` doc | consumer 列表追加 `resolveWorkspacePermissionMode` |
+| `docs/specs/Workspace-Permission-Mode-Spec.md` | §5 / §7 / §8 | 改写"全局默认 no-op"语义；§8 补 r3 安全说明（指向本 spec §2） |
+| `docs/reference/admin-api.md` | workspace Create/PATCH 段 | 标注 `permission_mode` 字段 admin-only（非 admin 传 → 403 PERMISSION_DENIED） |
+
+## 6. 向后兼容
+
+| 维度 | r3 行为 |
+|---|---|
+| 存量 `permission_mode IS NULL` 的 workspace | 自动按 workspace 档运行（收紧） |
+| 显式配置过 `permission_mode` 的 workspace | 不变（显式覆盖优先） |
+| cron / 无 workspace session | 不变（注入 `""`） |
+| `SkipPermissions` 别名 | 不变 |
+| 运维 `config.worker.default_permission_mode: ""` | `NormalizePermissionMode` → bypass（向后兼容 fallback） |
+| 运维想全局回到 bypass | 显式 `config.worker.default_permission_mode: bypass` 即可（workspace session 全跑 bypass） |
+| 非 admin 已持有 permission_mode 的 workspace | 数据不动；下次该 workspace 起session 按库里值；非 admin 仅失去"改"的权限 |
+
+**零数据迁移**：不改 DB schema，不改存量行，纯运行时默认值切换。
+
+## 7. 测试策略
+
+| 测试 | 文件 | 断言 |
+|---|---|---|
+| config 默认值 | `internal/config` | `Default().Worker.DefaultPermissionMode == "workspace"` |
+| bridge 无覆盖 → 默认 | `internal/gateway/bridge_worker_test.go` | workspace 存在且 `PermissionMode==""` → 返回 `"workspace"`（或 bridge 配置的默认值） |
+| bridge 显式覆盖优先 | 同上 | workspace `PermissionMode=="auto-edit"` → 返回 `"auto-edit"` |
+| bridge 无 workspace → `""` | 同上 | `workspaceID==""` → `""`（cron/平台保护） |
+| bridge 热重载默认 | 同上 | `UpdateDefaultPermissionMode("read-only")` 后，无覆盖 workspace 返回 `"read-only"` |
+| handler 非 admin Create 传字段 → 403 | `internal/gateway/workspace_handlers_test.go` | `PERMISSION_DENIED` |
+| handler 非 admin Update 传字段 → 403 | 同上 | `PERMISSION_DENIED` |
+| handler admin Create/Update 传字段 → OK | 同上 | 4 档 + `""` 均通过 |
+| handler 非 admin 不传字段 → OK | 同上 | workspace 创建成功，走默认 |
+| 现有"无覆盖→empty"断言回归 | `permission_mode_test.go` / `bridge_worker_test.go` | 凡断言"无覆盖返回空串"的用例改为返回默认值（r3 语义） |
+
+## 8. 实施清单
+
+**后端**
+- [ ] `internal/config/config_defaults.go`：`DefaultPermissionMode` `"bypass"` → `"workspace"` + 注释
+- [ ] `internal/gateway/bridge_worker.go`：`resolveWorkspacePermissionMode` 无覆盖分支改返回 `b.defaultPermissionMode.Load().(string)`
+- [ ] `internal/gateway/workspace_handlers.go`：Create + Update 增 admin-only 门（`PERMISSION_DENIED` 403）
+- [ ] `internal/gateway/bridge.go` / `deps.go`：`defaultPermissionMode` 相关注释去 no-op
+- [ ] `internal/config/config_types.go` / `cmd/hotplex/gateway_run.go`：注释去 no-op
+- [ ] `internal/worker/worker.go`：`NormalizePermissionMode` doc 更新 consumer
+
+**前端**
+- [ ] `webchat/app/components/chat/settings-modal/general-tab.tsx`：`isAdmin` prop + 非 admin 隐藏控件 + 默认 workspace + options 标签
+- [ ] `webchat/app/settings/page.tsx`：传 `isAdmin` 给 `<GeneralTab>`
+
+**测试**
+- [ ] config 默认值断言
+- [ ] bridge resolve 三分支（无覆盖/覆盖/无 workspace）+ 热重载
+- [ ] handler admin-only 四象限（非admin传/不传 × Create/Update）
+
+**文档**
+- [ ] `docs/specs/Workspace-Permission-Mode-Spec.md` §5/§7/§8 修订（标注 r3，引用本 spec）
+- [ ] `docs/reference/admin-api.md`：`permission_mode` admin-only 标注
+
+## 9. 非目标
+
+- 不改 DB schema（不加列、不改 migration）。
+- 不引入 per-worker-type 默认（`config.worker.default_permission_mode` 仍是单值；r2 §11 留的"按 worker-type 细化"留待将来）。
+- 不改 cron / 平台 channel session 的权限行为。
+- 不做运行时实时切换（启动锁定语义不变）。

--- a/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md
@@ -118,7 +118,7 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 | 显式配置过 `permission_mode` 的 workspace | 不变（显式覆盖优先） |
 | cron / 无 workspace session | 不变（注入 `""`） |
 | `SkipPermissions` 别名 | 不变 |
-| 运维 `config.worker.default_permission_mode: ""` | `NormalizePermissionMode` → bypass（向后兼容 fallback） |
+| 运维 `config.worker.default_permission_mode: ""` | `NormalizePermissionMode` → workspace（与 Default 种子一致；r2 的 ""→bypass 回退已退役——显式设空不应重新引入 bypass 注入） |
 | 运维想全局回到 bypass | 显式 `config.worker.default_permission_mode: bypass` 即可（workspace session 全跑 bypass） |
 | 非 admin 已持有 permission_mode 的 workspace | 数据不动；下次该 workspace 起session 按库里值；非 admin 仅失去"改"的权限 |
 
@@ -142,21 +142,21 @@ r2 在多处注释里标注了"no-op / NOT injected"，r3 需逐一修订：
 ## 8. 实施清单
 
 **后端**
-- [ ] `internal/config/config_defaults.go`：`DefaultPermissionMode` `"bypass"` → `"workspace"` + 注释
-- [ ] `internal/gateway/bridge_worker.go`：`resolveWorkspacePermissionMode` 无覆盖分支改返回 `b.defaultPermissionMode.Load().(string)`
-- [ ] `internal/gateway/workspace_handlers.go`：Create + Update 增 admin-only 门（`PERMISSION_DENIED` 403）
-- [ ] `internal/gateway/bridge.go` / `deps.go`：`defaultPermissionMode` 相关注释去 no-op
-- [ ] `internal/config/config_types.go` / `cmd/hotplex/gateway_run.go`：注释去 no-op
-- [ ] `internal/worker/worker.go`：`NormalizePermissionMode` doc 更新 consumer
+- [x] `internal/config/config_defaults.go`：`DefaultPermissionMode` `"bypass"` → `"workspace"` + 注释
+- [x] `internal/gateway/bridge_worker.go`：`resolveWorkspacePermissionMode` 无覆盖分支改返回 `b.defaultPermissionMode.Load().(string)`
+- [x] `internal/gateway/workspace_handlers.go`：Create + Update 增 admin-only 门（`PERMISSION_DENIED` 403）
+- [x] `internal/gateway/bridge.go` / `deps.go`：`defaultPermissionMode` 相关注释去 no-op
+- [x] `internal/config/config_types.go` / `cmd/hotplex/gateway_run.go`：注释去 no-op
+- [x] `internal/worker/worker.go`：`NormalizePermissionMode` doc 更新 consumer
 
 **前端**
-- [ ] `webchat/app/components/chat/settings-modal/general-tab.tsx`：`isAdmin` prop + 非 admin 隐藏控件 + 默认 workspace + options 标签
-- [ ] `webchat/app/settings/page.tsx`：传 `isAdmin` 给 `<GeneralTab>`
+- [x] `webchat/app/components/chat/settings-modal/general-tab.tsx`：`isAdmin` prop + 非 admin 隐藏控件 + 默认 workspace + options 标签
+- [x] `webchat/app/settings/page.tsx`：传 `isAdmin` 给 `<GeneralTab>`
 
 **测试**
-- [ ] config 默认值断言
-- [ ] bridge resolve 三分支（无覆盖/覆盖/无 workspace）+ 热重载
-- [ ] handler admin-only 四象限（非admin传/不传 × Create/Update）
+- [x] config 默认值断言
+- [x] bridge resolve 三分支（无覆盖/覆盖/无 workspace）+ 热重载
+- [x] handler admin-only 四象限（非admin传/不传 × Create/Update）
 
 **文档**
 - [x] `docs/specs/Workspace-Permission-Mode-Spec.md` 顶部加 r3 横幅（r2 正文保留作历史记录，引用本 spec）

--- a/docs/specs/Workspace-Permission-Mode-Spec.md
+++ b/docs/specs/Workspace-Permission-Mode-Spec.md
@@ -4,6 +4,13 @@
 
 ---
 
+> **⚠️ r3 修订（2026-06-29，issue [#804](https://github.com/hrygo/hotplex/issues/804)）**：本 spec 的以下 r2 语义已被 r3 推翻，详见 [Workspace-Permission-Mode-Admin-Only-Revision-Spec](./Workspace-Permission-Mode-Admin-Only-Revision-Spec.md)：
+> - **§5 配置链路**：`config.worker.default_permission_mode`（缺省 `workspace`）**真正被 bridge 消费** —— workspace 无显式覆盖时注入该默认值（r2 的"全局默认不注入"作废）。因默认值同档下调（bypass→workspace），注入即收紧。
+> - **§7 admin UI**：控件默认选中改为 `workspace`；`permission_mode` 配置收归 **admin-only**（非 admin 传字段 → 403 PERMISSION_DENIED；前端非 admin 隐藏控件）。
+> - **§8 安全说明**：r2"不注入全局 bypass"的动机被 r3 化解（默认值已是 workspace，注入是收紧非提权）。
+>
+> 下方 r2 文案保留作历史记录。
+
 ## 1. 背景与动机
 
 当前 HotPlex 以任意模式启动 Worker 时，四种 Worker 适配器全部默认使用最高权限（bypass）模式：

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,13 +95,6 @@ func (c *Config) Validate() []string {
 	if c.Pool.MaxMemoryPerUser < 0 {
 		errs = append(errs, "pool.max_memory_per_user must be non-negative")
 	}
-	// Warn (not error) for TLS on non-local address.
-	if !c.Security.TLSEnabled &&
-		!strings.Contains(c.Gateway.Addr, "localhost") &&
-		!strings.Contains(c.Gateway.Addr, "127.0.0.1") &&
-		!strings.Contains(c.Gateway.Addr, "[::1]") {
-		errs = append(errs, "TLS is disabled on non-local address; enable tls_enabled for production")
-	}
 	if c.Log.Format != "" && c.Log.Format != "json" && c.Log.Format != "text" {
 		errs = append(errs, "log.format must be either 'json' or 'text'")
 	}
@@ -118,6 +111,21 @@ func (c *Config) Validate() []string {
 	}
 
 	return errs
+}
+
+// Warnings returns non-fatal deployment advisories (e.g. TLS off on a non-local
+// address). Surfaced at startup and by `hotplex config validate`, but never aborts
+// startup or blocks hot-reload — an operator may intentionally run TLS-terminated
+// behind a reverse proxy. See Validate for hard errors.
+func (c *Config) Warnings() []string {
+	var warns []string
+	if !c.Security.TLSEnabled &&
+		!strings.Contains(c.Gateway.Addr, "localhost") &&
+		!strings.Contains(c.Gateway.Addr, "127.0.0.1") &&
+		!strings.Contains(c.Gateway.Addr, "[::1]") {
+		warns = append(warns, "TLS is disabled on non-local address; enable tls_enabled for production")
+	}
+	return warns
 }
 
 // DefaultConfigPath is the default configuration file path used by the CLI

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,12 @@ func (c *Config) Validate() []string {
 		slog.Warn("config: codex_cli.use_app_server is deprecated, forcing app-server mode")
 		c.Worker.CodexCLI.UseAppServer = true
 	}
+	// r3 (#804): reject typos at the boundary (mirrors worker.ValidatePermissionMode) — an invalid tier falls through every worker switch to its widest default (fail-open).
+	switch c.Worker.DefaultPermissionMode {
+	case "", "read-only", "workspace", "auto-edit", "bypass":
+	default:
+		errs = append(errs, "worker.default_permission_mode must be one of read-only|workspace|auto-edit|bypass (or empty for worker default)")
+	}
 
 	return errs
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -79,7 +79,7 @@ func Default() *Config {
 				UseAppServer:    true,
 				IdleDrainPeriod: 30 * time.Minute,
 			},
-			DefaultPermissionMode: "bypass", // no-op since #789 r2 P2: accepted but NOT injected by bridge (would override restricted codex/ACP config); retained for future per-worker-type use
+			DefaultPermissionMode: "workspace", // r3 (#804): bridge injects this when a workspace has no explicit override; default tightened from bypass→workspace so injection is a blast-radius reduction, not an escalation
 		},
 		Security: SecurityConfig{
 			APIKeyHeader:    "X-API-Key",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,10 +54,7 @@ func TestDefaultPermissionMode(t *testing.T) {
 	require.Equal(t, "workspace", Default().Worker.DefaultPermissionMode)
 }
 
-// TestValidateDefaultPermissionMode: r3 (#804) — a typo in default_permission_mode
-// must be rejected at Validate (covers startup + hot-reload, since watcher.go calls
-// Validate before applying). Otherwise the invalid tier falls through every worker
-// switch to its widest default (fail-open).
+// TestValidateDefaultPermissionMode: r3 (#804) — invalid tiers silently fail-open, so Validate must reject them (covers startup + hot-reload).
 func TestValidateDefaultPermissionMode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,7 +109,7 @@ func TestConfig_Validate(t *testing.T) {
 				c.Gateway.Addr = ""
 				return c
 			}(),
-			errCnt: 2, // missing addr + TLS warning (empty addr is non-local)
+			errCnt: 1, // missing addr only (TLS advisory moved to Warnings)
 		},
 		{
 			name: "missing db path",
@@ -184,16 +184,16 @@ func TestConfig_Validate(t *testing.T) {
 				c.DB.SQLite.Path = ""
 				return c
 			}(),
-			errCnt: 3, // missing addr + missing path + TLS warning
+			errCnt: 2, // missing addr + missing path (TLS moved to Warnings)
 		},
 		{
-			name: "non-local address TLS warning",
+			name: "non-local address: Validate returns no error (TLS is a warning, see Warnings)",
 			cfg: func() Config {
 				c := *Default()
 				c.Gateway.Addr = ":8888"
 				return c
 			}(),
-			errCnt: 1, // TLS warning for non-local address
+			errCnt: 0,
 		},
 	}
 
@@ -205,6 +205,22 @@ func TestConfig_Validate(t *testing.T) {
 			require.Len(t, errs, tt.errCnt)
 		})
 	}
+}
+
+// TestConfig_Warnings: r3 (#804) split — TLS-off-on-non-local is a non-fatal advisory
+// (operator may run TLS-terminated behind a reverse proxy), surfaced via Warnings not Validate.
+func TestConfig_Warnings(t *testing.T) {
+	t.Parallel()
+	t.Run("non-local + no TLS → advisory", func(t *testing.T) {
+		t.Parallel()
+		c := *Default()
+		c.Gateway.Addr = ":8888"
+		require.Len(t, c.Warnings(), 1)
+	})
+	t.Run("localhost → no advisory", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, (*Default()).Warnings())
+	})
 }
 
 func TestExpandEnv(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,44 @@ func TestDefaultPermissionMode(t *testing.T) {
 	require.Equal(t, "workspace", Default().Worker.DefaultPermissionMode)
 }
 
+// TestValidateDefaultPermissionMode: r3 (#804) — a typo in default_permission_mode
+// must be rejected at Validate (covers startup + hot-reload, since watcher.go calls
+// Validate before applying). Otherwise the invalid tier falls through every worker
+// switch to its widest default (fail-open).
+func TestValidateDefaultPermissionMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  string
+		valid bool
+	}{
+		{"empty (worker default)", "", true},
+		{"read-only", "read-only", true},
+		{"workspace", "workspace", true},
+		{"auto-edit", "auto-edit", true},
+		{"bypass", "bypass", true},
+		{"typo workspce", "workspce", false},
+		{"uppercase BYPASS (case-sensitive)", "BYPASS", false},
+		{"legacy default", "default", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := *Default()
+			c.Worker.DefaultPermissionMode = tt.mode
+			errs := c.Validate()
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e, "default_permission_mode") {
+					found = true
+				}
+			}
+			require.Equal(t, tt.valid, !found, "errs=%v", errs)
+		})
+	}
+}
+
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,14 @@ func TestDefault(t *testing.T) {
 	require.False(t, cfg.Messaging.Feishu.Enabled)
 }
 
+// TestDefaultPermissionMode: r3 (#804) — config.worker.default_permission_mode
+// 缺省 "workspace"（r2 的 "bypass" no-op 已退役）。bridge 在 workspace 无显式覆盖时
+// 注入此值；因默认值同档下调，注入即收紧。
+func TestDefaultPermissionMode(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "workspace", Default().Worker.DefaultPermissionMode)
+}
+
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -472,7 +472,7 @@ type WorkerConfig struct {
 	CodexCLI              CodexCLIConfig       `mapstructure:"codex_cli"`
 	ACP                   ACPConfig            `mapstructure:"acp"`
 	Environment           []string             `mapstructure:"environment"`
-	DefaultPermissionMode string               `mapstructure:"default_permission_mode"` // accepted but NOT injected by bridge since #789 r2 P2 (no-op); retained for future per-worker-type refinement
+	DefaultPermissionMode string               `mapstructure:"default_permission_mode"` // r3 (#804): bridge injects this for workspaces with no explicit override; seeded "workspace" by Default()
 }
 
 // MCPServerConfig defines a single MCP server for worker startup.

--- a/internal/config/permmode_pin_test.go
+++ b/internal/config/permmode_pin_test.go
@@ -1,0 +1,25 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+// TestConfigAgreesWithWorkerPermissionModes pins config.Validate's valid-set to the worker.PermissionMode* constants (config can't import worker; drift would silently fail-open).
+func TestConfigAgreesWithWorkerPermissionModes(t *testing.T) {
+	t.Parallel()
+	for _, tier := range []string{
+		worker.PermissionModeReadOnly,
+		worker.PermissionModeWorkspace,
+		worker.PermissionModeAutoEdit,
+		worker.PermissionModeBypass,
+	} {
+		c := *config.Default()
+		c.Worker.DefaultPermissionMode = tier
+		require.Empty(t, c.Validate(), "worker tier %q should be accepted by config.Validate", tier)
+	}
+}

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -65,7 +65,7 @@ type Bridge struct {
 	workerEnvBlocklist    []string                 // extra blocklist entries from worker.env_blocklist config
 	cronEnv               []string                 // env vars injected only into cron platform sessions
 	mcpConfigJSON         atomic.Value             // pre-serialized MCP config JSON string; "" = not configured
-	defaultPermissionMode atomic.Value             // worker.PermissionMode* tier maintained via UpdateDefaultPermissionMode + hot-reload. NOT consumed by resolveWorkspacePermissionMode (review r2 P2: injecting a global default would override a restricted operator codex.sandbox / acp.auto_approve); retained for future per-worker-type refinement.
+	defaultPermissionMode atomic.Value             // worker.PermissionMode* tier maintained via UpdateDefaultPermissionMode + hot-reload. Consumed by resolveWorkspacePermissionMode for workspaces with no explicit override (r3 #804); seeded "workspace" by Default().
 	agentConfigExclude    atomic.Value             // map[string][]string: platform → inject_exclude (global default at "" key)
 	wsStore               WorkspaceOverridesReader // per-workspace agent-config overrides resolver (spec ②); nil = Message Channel track
 	warnedOverrides       sync.Map                 // workspaceID → struct{}: dedup override-degrade warnings (#749)

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -136,7 +136,8 @@ func (b *Bridge) UpdateMCPConfig(json string) {
 }
 
 // UpdateDefaultPermissionMode atomically updates the global default permission mode
-// tier. Empty/unknown normalizes to bypass. Used by config hot-reload (issue #789).
+// tier. Empty normalizes to workspace (the r3 Default seed); non-empty passes through
+// unchanged — callers must pass a config.Validate'd value. Used by config hot-reload (#789).
 func (b *Bridge) UpdateDefaultPermissionMode(mode string) {
 	b.defaultPermissionMode.Store(worker.NormalizePermissionMode(mode))
 }

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -345,21 +345,23 @@ func (b *Bridge) resolveWorkspaceOverrides(ctx context.Context, workspaceID stri
 }
 
 // resolveWorkspacePermissionMode returns the effective permission mode tier for a
-// session (#789, r3 #804). Precedence:
+// session (#789, r3 #804). The returned tier is a CEILING on permissiveness — each
+// worker clamps its operator config to never exceed it (codex: most-restrictive of
+// session tier vs cfg.Sandbox/ApprovalMode; ACP: auto_approve gated off for tiers
+// stricter than bypass), so an injected default can tighten but never escalate.
+// Precedence:
 //
 //   - Sessions WITHOUT a workspace (platform/cron: Slack/Feishu/cron-driven) → "".
-//     Each worker applies its OWN default/config: codex permissionModeFromSession("")
-//     → ok=false → honors cfg.Sandbox/ApprovalMode; ACP skips the override; CC/OCS
-//     map "" to their own bypass default. Injecting the global default here would
-//     override an operator's restricted codex.sandbox / acp.auto_approve (#789 P1).
+//     Each worker applies its OWN default/config (codex honors cfg.Sandbox, ACP
+//     honors cfg.AutoApprove; CC/OCS map "" to their own bypass). Injecting a global
+//     default here would override an operator's restricted codex.sandbox /
+//     acp.auto_approve (#789 P1).
 //   - Workspace with an explicit override → that tier wins.
-//   - Workspace with NO explicit override → the bridge's global default
-//     (config.worker.default_permission_mode, seeded "workspace" in r3). Because the
-//     default dropped from bypass→workspace in the same revision injection was
-//     enabled, this is a tightening across all workers (CC acceptEdits, codex
-//     workspace-write×on-request, ACP approve=false), not an escalation (#804 r3 —
-//     supersedes the #789 r2 P2 "do not inject" stance, which existed only because
-//     the prior default was bypass).
+//   - Workspace with NO explicit override, or a fetch error → the bridge's global
+//     default (config.worker.default_permission_mode, seeded "workspace" in r3).
+//     Returning the default (not "") on fetch error is fail-closed: for CC/OCS ""
+//     maps to bypass, so an empty degrade would re-open the r2 P1 escalation on a
+//     transient DB outage.
 //
 // ctx note: GetWorkspaceByID uses shutdownCtx rather than a request-scoped ctx because
 // buildWorkerInfo/prepareWorkerInfo intentionally carry no ctx (see #714); the query is
@@ -369,10 +371,14 @@ func (b *Bridge) resolveWorkspacePermissionMode(workspaceID string) string {
 	if workspaceID == "" || b.wsStore == nil {
 		return ""
 	}
+	defaultMode, _ := b.defaultPermissionMode.Load().(string)
 	ws, err := b.wsStore.GetWorkspaceByID(b.shutdownCtx, workspaceID)
 	if err != nil {
-		b.warnOverrideDegrade(workspaceID, "fetch workspace permission_mode failed, degrading to worker default", err)
-		return ""
+		// Fail-closed (#804 r3 review): degrade to the bridge default (workspace)
+		// rather than "". For CC/OCS "" maps to bypass, so an empty degrade would
+		// silently escalate a workspace session to full bypass during a DB blip.
+		b.warnOverrideDegrade(workspaceID, "fetch workspace permission_mode failed, degrading to bridge default", err)
+		return defaultMode
 	}
 	// fetch succeeded: clear any prior degrade flag so a future regression warns again
 	// (#749, mirrors resolveWorkspaceOverrides 成功路径的 Delete).
@@ -380,13 +386,7 @@ func (b *Bridge) resolveWorkspacePermissionMode(workspaceID string) string {
 	if ws.PermissionMode != "" {
 		return ws.PermissionMode // explicit workspace override wins
 	}
-	// r3 (#804): no explicit override → return the bridge's global default
-	// (config.worker.default_permission_mode). Because the default dropped from
-	// bypass→workspace in the same revision injection was enabled, this is a
-	// tightening across all workers, not an escalation. The no-workspace branch
-	// above still returns "" so cron/platform sessions honor operator-tuned config.
-	mode, _ := b.defaultPermissionMode.Load().(string)
-	return mode
+	return defaultMode
 }
 
 // warnOverrideDegrade logs a degrading warning at most once per workspaceID per

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -345,18 +345,21 @@ func (b *Bridge) resolveWorkspaceOverrides(ctx context.Context, workspaceID stri
 }
 
 // resolveWorkspacePermissionMode returns the effective permission mode tier for a
-// session (issue #789). Only an explicit workspace-level override is force-injected;
-// everything else returns "" so each worker applies its OWN default/config:
+// session (#789, r3 #804). Precedence:
 //
 //   - Sessions WITHOUT a workspace (platform/cron: Slack/Feishu/cron-driven) → "".
-//     Injecting the global bypass here would silently upgrade an operator's
-//     restricted codex.sandbox or acp.auto_approve — a security downgrade (#789 P1).
-//     codex permissionModeFromSession("") → ok=false → honors cfg.Sandbox/ApprovalMode;
-//     ACP skips the override; CC/OCS map "" to their own bypass default.
-//   - Workspace with no explicit override → "" (each worker applies its own
-//     default/config; admins set permission_mode explicitly per workspace to tighten
-//     blast radius). NOT injecting the global default keeps this symmetric with the
-//     no-workspace branch and avoids overriding a restricted codex/ACP config (#789 r2 P2).
+//     Each worker applies its OWN default/config: codex permissionModeFromSession("")
+//     → ok=false → honors cfg.Sandbox/ApprovalMode; ACP skips the override; CC/OCS
+//     map "" to their own bypass default. Injecting the global default here would
+//     override an operator's restricted codex.sandbox / acp.auto_approve (#789 P1).
+//   - Workspace with an explicit override → that tier wins.
+//   - Workspace with NO explicit override → the bridge's global default
+//     (config.worker.default_permission_mode, seeded "workspace" in r3). Because the
+//     default dropped from bypass→workspace in the same revision injection was
+//     enabled, this is a tightening across all workers (CC acceptEdits, codex
+//     workspace-write×on-request, ACP approve=false), not an escalation (#804 r3 —
+//     supersedes the #789 r2 P2 "do not inject" stance, which existed only because
+//     the prior default was bypass).
 //
 // ctx note: GetWorkspaceByID uses shutdownCtx rather than a request-scoped ctx because
 // buildWorkerInfo/prepareWorkerInfo intentionally carry no ctx (see #714); the query is
@@ -377,13 +380,13 @@ func (b *Bridge) resolveWorkspacePermissionMode(workspaceID string) string {
 	if ws.PermissionMode != "" {
 		return ws.PermissionMode // explicit workspace override wins
 	}
-	// No explicit override: return "" so each worker applies its own default/config,
-	// consistent with the no-workspace branch above. The admin-controlled global
-	// default (worker.default_permission_mode) is NOT injected here — injecting bypass
-	// would override a restricted codex.sandbox / acp.auto_approve for workspace
-	// sessions on those worker types. Admins set permission_mode explicitly per
-	// workspace to tighten blast radius. (#789 review r2 P2)
-	return ""
+	// r3 (#804): no explicit override → return the bridge's global default
+	// (config.worker.default_permission_mode). Because the default dropped from
+	// bypass→workspace in the same revision injection was enabled, this is a
+	// tightening across all workers, not an escalation. The no-workspace branch
+	// above still returns "" so cron/platform sessions honor operator-tuned config.
+	mode, _ := b.defaultPermissionMode.Load().(string)
+	return mode
 }
 
 // warnOverrideDegrade logs a degrading warning at most once per workspaceID per

--- a/internal/gateway/bridge_worker_test.go
+++ b/internal/gateway/bridge_worker_test.go
@@ -179,12 +179,14 @@ func TestResolveWorkspacePermissionMode(t *testing.T) {
 		require.Equal(t, "auto-edit", b.resolveWorkspacePermissionMode("ws-1"))
 	})
 
-	t.Run("fetch error degrades to empty, not bypass (#789 P1)", func(t *testing.T) {
+	t.Run("fetch error degrades to bridge default, not bypass (r3 #804 fail-closed)", func(t *testing.T) {
 		t.Parallel()
-		// Degrade must NOT inject bypass — keep the worker's own config rather than
-		// silently upgrading a restricted operator setup.
+		// Fail-closed: a transient DB outage must NOT degrade to "" (which CC/OCS
+		// map to bypass, re-opening the r2 P1 escalation). The helper seeds
+		// "workspace" — the r3 bridge default — so a fetch failure keeps the
+		// session bounded at workspace, the same tier a no-override workspace gets.
 		b := newBridgeForOverrideTest(t, nil, errors.New("db down"))
-		require.Equal(t, "", b.resolveWorkspacePermissionMode("ws-1"))
+		require.Equal(t, "workspace", b.resolveWorkspacePermissionMode("ws-1"))
 	})
 
 	t.Run("warn dedup: success re-arms warning (#789 P2, mirrors #749)", func(t *testing.T) {

--- a/internal/gateway/bridge_worker_test.go
+++ b/internal/gateway/bridge_worker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
 )
 
 // testLogger returns a minimal logger for bridge unit tests.
@@ -40,10 +41,16 @@ func (s *stubWSStore) ListAllWorkspaces(_ context.Context) ([]*session.Workspace
 // enough to exercise resolveWorkspaceOverrides without the full dependency graph.
 func newBridgeForOverrideTest(t *testing.T, ws *session.Workspace, err error) *Bridge {
 	t.Helper()
-	return &Bridge{
+	b := &Bridge{
 		log:     testLogger(t),
 		wsStore: &stubWSStore{ws: ws, err: err},
 	}
+	// r3 (#804): resolveWorkspacePermissionMode now consumes the bridge default
+	// when a workspace has no explicit override, mirroring NewBridge (bridge.go).
+	// Seed the r3 production default so tests that hit the no-override branch see
+	// "workspace"; tests needing a different value Store their own.
+	b.defaultPermissionMode.Store(worker.PermissionModeWorkspace)
+	return b
 }
 
 func TestResolveWorkspaceOverrides(t *testing.T) {
@@ -142,23 +149,34 @@ func TestResolveWorkspacePermissionMode(t *testing.T) {
 		require.Equal(t, "read-only", b.resolveWorkspacePermissionMode("ws-1"))
 	})
 
-	t.Run("workspace unset returns empty (global default NOT injected, #789 r2 P2)", func(t *testing.T) {
+	t.Run("workspace unset returns bridge default (r3: global default now injected, #804)", func(t *testing.T) {
 		t.Parallel()
-		// No explicit override → "" so each worker applies its own default/config.
-		// The admin global default is intentionally NOT injected here — injecting
-		// bypass would override a restricted codex.sandbox / acp.auto_approve. Admins
-		// set permission_mode explicitly per workspace to tighten blast radius.
+		// r3: a workspace with no explicit override returns the bridge's global
+		// default (config.worker.default_permission_mode). The helper seeds
+		// "workspace" — the r3 production default. Because the default dropped from
+		// bypass→workspace in the same revision that injection was enabled, this is
+		// a tightening (CC acceptEdits, codex workspace-write, ACP approve=false),
+		// not an escalation — see Workspace-Permission-Mode-Admin-Only-Revision-Spec §2.
 		b := newBridgeForOverrideTest(t, &session.Workspace{PermissionMode: ""}, nil)
-		require.Equal(t, "", b.resolveWorkspacePermissionMode("ws-1"))
+		require.Equal(t, "workspace", b.resolveWorkspacePermissionMode("ws-1"))
 	})
 
-	t.Run("custom global default is NOT injected (stays empty, #789 r2 P2)", func(t *testing.T) {
+	t.Run("custom global default is injected for workspace without override (r3, #804)", func(t *testing.T) {
 		t.Parallel()
 		b := newBridgeForOverrideTest(t, &session.Workspace{PermissionMode: ""}, nil)
-		b.defaultPermissionMode.Store("workspace")
-		// Even with a custom global default configured, a workspace without explicit
-		// override returns "" — default injection would override restricted worker config.
-		require.Equal(t, "", b.resolveWorkspacePermissionMode("ws-1"))
+		b.defaultPermissionMode.Store("read-only")
+		// r3: operators tune config.worker.default_permission_mode (or call
+		// UpdateDefaultPermissionMode); a workspace without explicit override
+		// returns that configured default rather than "".
+		require.Equal(t, "read-only", b.resolveWorkspacePermissionMode("ws-1"))
+	})
+
+	t.Run("hot-reload default via UpdateDefaultPermissionMode applies to next resolve (r3, #804)", func(t *testing.T) {
+		t.Parallel()
+		b := newBridgeForOverrideTest(t, &session.Workspace{PermissionMode: ""}, nil)
+		require.Equal(t, "workspace", b.resolveWorkspacePermissionMode("ws-1"))
+		b.UpdateDefaultPermissionMode("auto-edit")
+		require.Equal(t, "auto-edit", b.resolveWorkspacePermissionMode("ws-1"))
 	})
 
 	t.Run("fetch error degrades to empty, not bypass (#789 P1)", func(t *testing.T) {

--- a/internal/gateway/deps.go
+++ b/internal/gateway/deps.go
@@ -43,7 +43,7 @@ type BridgeDeps struct {
 	WorkerEnvBlocklist    []string                 // extra blocklist entries from worker.env_blocklist config
 	CronEnv               []string                 // env vars injected only into cron platform sessions (e.g. admin API creds)
 	MCPConfigJSON         string                   // pre-serialized MCP config JSON; "" = not configured → Claude Code default discovery
-	DefaultPermissionMode string                   // worker.PermissionMode* tier; accepted + hot-reloaded but NOT injected by resolveWorkspacePermissionMode since #789 r2 P2 (injection would override restricted codex.sandbox / acp.auto_approve); effectively a no-op today, retained for future per-worker-type use
+	DefaultPermissionMode string                   // worker.PermissionMode* tier; consumed by resolveWorkspacePermissionMode for workspaces with no explicit override (r3 #804). Seeded "workspace" by Default(); hot-reloadable via UpdateDefaultPermissionMode.
 	AgentConfigExclude    map[string][]string      // platform → inject_exclude (global default at "" key)
 	WSStore               WorkspaceOverridesReader // WebChat per-workspace agent-config overrides (spec ②); nil = disabled
 }

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -202,7 +202,20 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "not found")
 		return
 	}
-	if ws.OwnerUserID != uid && !h.isAdmin(r, uid) {
+	// Admin authority is needed in two places: the owner check (only when the acting
+	// user isn't the owner) and the permission_mode gate (whenever the field is
+	// present). Memoize so an admin editing another's workspace with permission_mode
+	// pays one idp.Lookup, not two — and an owner editing their own workspace without
+	// permission_mode pays zero.
+	var admin bool
+	var adminResolved bool
+	resolveAdmin := func() bool {
+		if !adminResolved {
+			admin, adminResolved = h.isAdmin(r, uid), true
+		}
+		return admin
+	}
+	if ws.OwnerUserID != uid && !resolveAdmin() {
 		writeAppError(w, http.StatusForbidden, "WORKSPACE_FORBIDDEN", "not your workspace")
 		return
 	}
@@ -274,7 +287,7 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		// r3 (#804): permission_mode is admin-only. nil = field omitted (no change);
 		// "" = clear to default. Fail-closed 403 before format validation; a non-admin
 		// owner can still PATCH other fields (name/work_dir/etc) — only this field is gated.
-		if !h.isAdmin(r, uid) {
+		if !resolveAdmin() {
 			writeAppError(w, http.StatusForbidden, "PERMISSION_DENIED", "permission_mode can only be configured by admins")
 			return
 		}

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -98,6 +98,12 @@ func (h *WorkspaceHandlers) Create(w http.ResponseWriter, r *http.Request) {
 	// explicit override). Validate before construction so an invalid tier is rejected early (issue #789).
 	var permMode string
 	if req.PermissionMode != nil {
+		// r3 (#804): permission_mode is admin-only. Fail-closed 403 before format
+		// validation so a non-admin never learns whether their value was valid.
+		if !h.isAdmin(r, uid) {
+			writeAppError(w, http.StatusForbidden, "PERMISSION_DENIED", "permission_mode can only be configured by admins")
+			return
+		}
 		if err := worker.ValidatePermissionMode(*req.PermissionMode); err != nil {
 			writeAppError(w, http.StatusBadRequest, "INVALID_PERMISSION_MODE", err.Error())
 			return
@@ -265,8 +271,13 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		ws.WorkerPreference = *req.WorkerPreference
 	}
 	if req.PermissionMode != nil {
-		// nil = field omitted (no change); "" = clear to "worker default" (stored as "", no override).
-		// ValidatePermissionMode accepts "" as the valid "worker default" value (issue #789).
+		// r3 (#804): permission_mode is admin-only. nil = field omitted (no change);
+		// "" = clear to default. Fail-closed 403 before format validation; a non-admin
+		// owner can still PATCH other fields (name/work_dir/etc) — only this field is gated.
+		if !h.isAdmin(r, uid) {
+			writeAppError(w, http.StatusForbidden, "PERMISSION_DENIED", "permission_mode can only be configured by admins")
+			return
+		}
 		if err := worker.ValidatePermissionMode(*req.PermissionMode); err != nil {
 			writeAppError(w, http.StatusBadRequest, "INVALID_PERMISSION_MODE", err.Error())
 			return

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -360,6 +360,57 @@ func TestWorkspace_PatchPermissionMode_Persists(t *testing.T) {
 	require.Equal(t, "read-only", got.PermissionMode)
 }
 
+// TestWorkspace_PatchPermissionMode_AdminOnly: r3 (#804) — permission_mode 配置
+// 收归 admin-only。非 admin PATCH 该字段（任意档 + 清空）→ 403 PERMISSION_DENIED
+// （fail-closed）；非 admin PATCH 其他字段不受影响；admin 仍可配。
+func TestWorkspace_PatchPermissionMode_AdminOnly(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+
+	env.createUser(t, "alice", "alicepass1", "user")
+	cookieAlice := env.loginAs(t, "alice", "alicepass1", http.StatusOK)
+	wsAlice := env.createWorkspace(t, cookieAlice, "u-alice", "alice-proj", "pm-admin")
+
+	// 非 admin PATCH permission_mode（任意档 + 清空）→ 403。
+	for _, mode := range []string{"read-only", "workspace", "auto-edit", "bypass", ""} {
+		w := env.patchWorkspace(t, cookieAlice, wsAlice.ID, `{"permission_mode":"`+mode+`"}`)
+		require.Equal(t, http.StatusForbidden, w.Code, "non-admin must not set permission_mode (%q) body=%s", mode, w.Body.String())
+		require.Contains(t, w.Body.String(), "PERMISSION_DENIED")
+	}
+
+	// 非 admin PATCH 其他字段（name）→ 200（permission_mode 门不阻断其他字段）。
+	w := env.patchWorkspace(t, cookieAlice, wsAlice.ID, `{"name":"alice-renamed"}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// admin PATCH permission_mode → 200（admin 仍可配，含代改别人的 workspace）。
+	cookieAdmin := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	w2 := env.patchWorkspace(t, cookieAdmin, wsAlice.ID, `{"permission_mode":"read-only"}`)
+	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+}
+
+// TestWorkspace_CreatePermissionMode_AdminOnly: r3 (#804) — Create 路径同样
+// admin-only。非 admin POST 带 permission_mode → 403；不带 → 200（走默认 workspace）。
+func TestWorkspace_CreatePermissionMode_AdminOnly(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.createUser(t, "alice", "alicepass1", "user")
+	cookieAlice := env.loginAs(t, "alice", "alicepass1", http.StatusOK)
+
+	// 非 admin Create 带 permission_mode → 403。
+	workDir := wsSandboxDir(t, "u-alice", "pm-create")
+	body := []byte(`{"name":"with-perm","work_dir":"` + workDir + `","permission_mode":"bypass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", bytes.NewReader(body))
+	req.Header.Set("Cookie", cookieAlice)
+	w := httptest.NewRecorder()
+	env.wsHandlers.Create(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "PERMISSION_DENIED")
+
+	// 非 admin Create 不带 permission_mode → 200。
+	ws := env.createWorkspace(t, cookieAlice, "u-alice", "no-perm", "pm-create-ok")
+	require.NotEmpty(t, ws.ID)
+}
+
 // TestWorkspace_JSONWireContract guards the snake_case wire contract consumed by
 // webchat (webchat/lib/api/workspaces.ts). Decode into a raw map — NOT
 // session.Workspace — so the assertion sees the actual on-wire keys. A struct

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -411,6 +411,26 @@ func TestWorkspace_CreatePermissionMode_AdminOnly(t *testing.T) {
 	require.NotEmpty(t, ws.ID)
 }
 
+// TestWorkspace_CreatePermissionMode_AdminExplicitEmpty: r3 (#804) — admin Create
+// 显式传 permission_mode=""（清空回默认）也应通过：ValidatePermissionMode 接受 ""，
+// admin 门放行。补 Create 路径的 "" 盲区（Update 路径已在 PatchPermissionMode_Whitelist 覆盖）。
+func TestWorkspace_CreatePermissionMode_AdminExplicitEmpty(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookieAdmin := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+
+	workDir := wsSandboxDir(t, "u-admin", "pm-empty")
+	body := []byte(`{"name":"explicit-empty","work_dir":"` + workDir + `","permission_mode":""}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", bytes.NewReader(body))
+	req.Header.Set("Cookie", cookieAdmin)
+	w := httptest.NewRecorder()
+	env.wsHandlers.Create(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var ws session.Workspace
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&ws))
+	require.Equal(t, "", ws.PermissionMode)
+}
+
 // TestWorkspace_JSONWireContract guards the snake_case wire contract consumed by
 // webchat (webchat/lib/api/workspaces.ts). Decode into a raw map — NOT
 // session.Workspace — so the assertion sees the actual on-wire keys. A struct

--- a/internal/worker/codexcli/permission_test.go
+++ b/internal/worker/codexcli/permission_test.go
@@ -32,3 +32,62 @@ func TestPermissionModeFromSession(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildThreadStartParams_PermissionCeiling: r3 #804 review P1 — a session
+// PermissionMode (workspace override or bridge-injected default) is a CEILING on
+// permissiveness. It must tighten the operator's cfg.Sandbox/ApprovalMode but never
+// relax it, so injecting "workspace" cannot clobber an operator's read-only sandbox.
+func TestBuildThreadStartParams_PermissionCeiling(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		permMode     string
+		cfgSandbox   string
+		cfgApproval  string
+		wantSandbox  string
+		wantApproval string
+	}{
+		{
+			name:         "injected workspace must not escalate a restricted operator sandbox",
+			permMode:     worker.PermissionModeWorkspace, // → workspace-write / on-request
+			cfgSandbox:   "read-only",                    // operator: stricter than workspace-write
+			cfgApproval:  "untrusted",
+			wantSandbox:  "read-only", // operator floor honored (no escalation)
+			wantApproval: "untrusted", // operator floor honored
+		},
+		{
+			name:         "injected workspace tightens the default YOLO operator config",
+			permMode:     worker.PermissionModeWorkspace,
+			cfgSandbox:   "danger-full-access", // operator default (least restrictive)
+			cfgApproval:  "never",
+			wantSandbox:  "workspace-write", // tier wins (tightening)
+			wantApproval: "on-request",      // tier wins
+		},
+		{
+			name:         "empty session tier honors operator config verbatim",
+			permMode:     "",
+			cfgSandbox:   "read-only",
+			cfgApproval:  "untrusted",
+			wantSandbox:  "read-only",
+			wantApproval: "untrusted",
+		},
+		{
+			name:         "explicit bypass tier still cannot relax a restricted operator floor",
+			permMode:     worker.PermissionModeBypass, // → danger-full-access / never
+			cfgSandbox:   "workspace-write",           // operator: stricter than danger-full-access
+			cfgApproval:  "on-failure",                // operator: stricter than never
+			wantSandbox:  "workspace-write",           // operator floor honored
+			wantApproval: "on-failure",                // operator floor honored
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			session := worker.SessionInfo{ProjectDir: "/tmp/proj", PermissionMode: tt.permMode}
+			cfg := Config{Sandbox: tt.cfgSandbox, ApprovalMode: tt.cfgApproval}
+			params := buildThreadStartParams(session, cfg)
+			require.Equal(t, tt.wantSandbox, params["sandbox"], "sandbox")
+			require.Equal(t, tt.wantApproval, params["approvalPolicy"], "approvalPolicy")
+		})
+	}
+}

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -709,6 +709,37 @@ func permissionModeFromSession(mode string) (sandbox, approval string, ok bool) 
 	}
 }
 
+// codexSandboxRank returns a restrictiveness rank for a Codex sandbox mode
+// (higher = more restrictive). Unknown values return 0 so a recognized session
+// tier is always preferred over an unrecognized operator value.
+func codexSandboxRank(s string) int {
+	switch s {
+	case "read-only":
+		return 3
+	case "workspace-write":
+		return 2
+	case "danger-full-access":
+		return 1
+	}
+	return 0
+}
+
+// codexApprovalRank returns a restrictiveness rank for a Codex approval policy
+// (higher = more restrictive). Unknown values return 0.
+func codexApprovalRank(s string) int {
+	switch s {
+	case "untrusted":
+		return 4
+	case "on-request":
+		return 3
+	case "on-failure":
+		return 2
+	case "never":
+		return 1
+	}
+	return 0
+}
+
 // buildThreadStartParams constructs the JSON-RPC params for "thread/start".
 // Shared by Start() and ResetContext() to avoid duplication.
 //
@@ -727,11 +758,19 @@ func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]a
 	if session.SkipPermissions {
 		approvalMode = "never"
 	}
-	// Issue #789: a non-empty PermissionMode tier overrides both sandbox and approval
-	// (takes precedence over config defaults and SkipPermissions), mapping the unified
-	// 4 tiers onto Codex's native (sandbox, approvalPolicy) pair.
+	// #789 / r3 #804 review: a non-empty PermissionMode tier (workspace override or
+	// bridge-injected default) is a CEILING on permissiveness — it tightens the
+	// operator's config but never relaxes it. Take the more-restrictive of (operator
+	// config, session tier) per axis, so injecting "workspace" cannot override an
+	// operator's read-only sandbox (the prior unconditional overwrite was an
+	// escalation: it clobbered any cfg.Sandbox stricter than workspace-write).
 	if sb, ap, ok := permissionModeFromSession(session.PermissionMode); ok {
-		sandbox, approvalMode = sb, ap
+		if codexSandboxRank(sb) > codexSandboxRank(sandbox) {
+			sandbox = sb
+		}
+		if codexApprovalRank(ap) > codexApprovalRank(approvalMode) {
+			approvalMode = ap
+		}
 	}
 	params := map[string]any{
 		"cwd":            session.ProjectDir,

--- a/internal/worker/permission_mode_test.go
+++ b/internal/worker/permission_mode_test.go
@@ -37,7 +37,9 @@ func TestValidatePermissionMode(t *testing.T) {
 
 func TestNormalizePermissionMode(t *testing.T) {
 	t.Parallel()
-	// NormalizePermissionMode maps "" → bypass (its own contract; the bridge does NOT inject this — #789 r2).
+	// NormalizePermissionMode maps "" → bypass (its own contract). r3 (#804): NewBridge
+	// normalizes the bridge default through this, and resolveWorkspacePermissionMode now
+	// injects that default for workspace sessions with no explicit override.
 	require.Equal(t, PermissionModeBypass, NormalizePermissionMode(""))
 	// Valid tiers pass through unchanged.
 	require.Equal(t, PermissionModeReadOnly, NormalizePermissionMode(PermissionModeReadOnly))

--- a/internal/worker/permission_mode_test.go
+++ b/internal/worker/permission_mode_test.go
@@ -37,10 +37,10 @@ func TestValidatePermissionMode(t *testing.T) {
 
 func TestNormalizePermissionMode(t *testing.T) {
 	t.Parallel()
-	// NormalizePermissionMode maps "" → bypass (its own contract). r3 (#804): NewBridge
-	// normalizes the bridge default through this, and resolveWorkspacePermissionMode now
-	// injects that default for workspace sessions with no explicit override.
-	require.Equal(t, PermissionModeBypass, NormalizePermissionMode(""))
+	// r3 (#804): empty maps to workspace (NOT bypass) so an operator who explicitly
+	// sets default_permission_mode: "" lands on the tightened default — bypass would
+	// be injected and override restricted worker configs (the r2 P1 escalation).
+	require.Equal(t, PermissionModeWorkspace, NormalizePermissionMode(""))
 	// Valid tiers pass through unchanged.
 	require.Equal(t, PermissionModeReadOnly, NormalizePermissionMode(PermissionModeReadOnly))
 	require.Equal(t, PermissionModeWorkspace, NormalizePermissionMode(PermissionModeWorkspace))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -270,11 +270,12 @@ func ValidatePermissionMode(mode string) error {
 }
 
 // NormalizePermissionMode returns the effective tier for a (possibly empty) mode.
-// Empty → PermissionModeWorkspace (aligns with the r3 Default() seed): an operator who
-// explicitly sets default_permission_mode: "" must land on the tightened default, not
-// bypass — otherwise the injected bypass would override restricted worker configs and
-// reintroduce the r2 P1 escalation. Valid tiers pass through unchanged. Called by
-// NewBridge/UpdateDefaultPermissionMode; consumed via Load by resolveWorkspacePermissionMode.
+// Empty → PermissionModeWorkspace (the r3 Default() seed). Valid tiers pass through
+// unchanged. Called by NewBridge/UpdateDefaultPermissionMode; consumed via Load by
+// resolveWorkspacePermissionMode, which treats the result as a permissiveness CEILING
+// — each worker clamps its operator config to never exceed it (codexcli takes the
+// more-restrictive of session tier vs cfg.Sandbox/ApprovalMode), so an injected
+// default can tighten but never escalate past operator config.
 func NormalizePermissionMode(mode string) string {
 	if mode == "" {
 		return PermissionModeWorkspace

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -269,14 +269,15 @@ func ValidatePermissionMode(mode string) error {
 	return nil
 }
 
-// NormalizePermissionMode returns the effective tier for a (possibly empty) mode:
-// empty → PermissionModeBypass (backward-compat fallback when an operator leaves
-// config.worker.default_permission_mode unset). Valid tiers pass through unchanged.
-// Called by NewBridge/UpdateDefaultPermissionMode to normalize the bridge default;
-// resolveWorkspacePermissionMode consumes the result via Load (not by calling this).
+// NormalizePermissionMode returns the effective tier for a (possibly empty) mode.
+// Empty → PermissionModeWorkspace (aligns with the r3 Default() seed): an operator who
+// explicitly sets default_permission_mode: "" must land on the tightened default, not
+// bypass — otherwise the injected bypass would override restricted worker configs and
+// reintroduce the r2 P1 escalation. Valid tiers pass through unchanged. Called by
+// NewBridge/UpdateDefaultPermissionMode; consumed via Load by resolveWorkspacePermissionMode.
 func NormalizePermissionMode(mode string) string {
 	if mode == "" {
-		return PermissionModeBypass
+		return PermissionModeWorkspace
 	}
 	return mode
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -231,10 +231,12 @@ type SystemPromptUpdater interface {
 	UpdateSystemPrompt(prompt string)
 }
 
-// PermissionMode tiers (issue #789). The gateway maps each tier to the worker's
-// native permission parameters at startup. Admin picks one per workspace; an empty
-// value means "worker default" (CC/OCS apply bypass; Codex/ACP honor operator config —
-// the admin global default is intentionally NOT injected; see resolveWorkspacePermissionMode).
+// PermissionMode tiers (#789, r3 #804). The gateway maps each tier to the worker's
+// native permission parameters at startup. Admin picks one per workspace. An empty
+// workspace value means "no explicit override" — the bridge then injects its global
+// default (config.worker.default_permission_mode, seeded "workspace" in r3) for
+// workspace sessions, or "" for cron/platform sessions so they honor operator config.
+// See resolveWorkspacePermissionMode for the full precedence.
 // Mapping lives inside each worker (not a central table) — see claudecode/codexcli/
 // opencodeserver/acp workers for the per-runtime translation.
 const (
@@ -268,10 +270,10 @@ func ValidatePermissionMode(mode string) error {
 }
 
 // NormalizePermissionMode returns the effective tier for a (possibly empty) mode:
-// empty → PermissionModeBypass. Valid tiers pass through unchanged. Its only consumer
-// today is NewBridge/UpdateDefaultPermissionMode normalizing the (currently no-op)
-// defaultPermissionMode field; resolveWorkspacePermissionMode does NOT call it —
-// explicit workspace overrides pass through verbatim and empty means "worker default" (#789 r2).
+// empty → PermissionModeBypass (backward-compat fallback when an operator leaves
+// config.worker.default_permission_mode unset). Valid tiers pass through unchanged.
+// Called by NewBridge/UpdateDefaultPermissionMode to normalize the bridge default;
+// resolveWorkspacePermissionMode consumes the result via Load (not by calling this).
 func NormalizePermissionMode(mode string) string {
 	if mode == "" {
 		return PermissionModeBypass

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -17,22 +17,24 @@ const WORKER_OPTIONS: { value: string; label: string }[] = [
   { value: 'acp', label: 'ACP (Any ACP-compatible Agent)' },
 ];
 
-// Workspace permission tier → worker native mapping (issue #789). An empty
-// server value means "worker default" (CC/OCS apply bypass; the select exposes
-// the 4 tiers directly so the chosen blast radius is explicit, not inherited).
+// Workspace permission tier → worker native mapping (#789, r3 #804). An empty
+// server value means "no explicit override" — the bridge injects its global
+// default (workspace) for workspace sessions. The select exposes the 4 tiers
+// directly so the chosen blast radius is explicit, not inherited.
 const PERMISSION_MODE_OPTIONS: { value: string; label: string }[] = [
-  { value: 'bypass', label: 'Bypass — Full access (default)' },
+  { value: 'workspace', label: 'Workspace — Edits within workspace (default)' },
   { value: 'auto-edit', label: 'Auto Edit — Auto-approve edits' },
-  { value: 'workspace', label: 'Workspace — Edits within workspace' },
+  { value: 'bypass', label: 'Bypass — Full access' },
   { value: 'read-only', label: 'Read Only — Plan only' },
 ];
 
 interface GeneralTabProps {
   workspace: Workspace;
+  isAdmin: boolean;
   onUpdated?: (ws: Workspace) => void;
 }
 
-export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
+export function GeneralTab({ workspace, isAdmin, onUpdated }: GeneralTabProps) {
   // Anchor the sandbox by owner_id rather than a hard-coded ~/ prefix: backend
   // ExpandAndAbs stores work_dir as an absolute $HOME path, so the on-disk form
   // differs from the ~/ form used by the create flow. resolveSandboxAnchor reads
@@ -44,7 +46,7 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
 
   const [name, setName] = useState(workspace.name);
   const [worker, setWorker] = useState(workspace.worker_preference || '');
-  const [permMode, setPermMode] = useState(workspace.permission_mode || 'bypass');
+  const [permMode, setPermMode] = useState(workspace.permission_mode || 'workspace');
   const [seg, setSeg] = useState(segBaseline);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,7 +59,7 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
   useEffect(() => {
     setName(workspace.name);
     setWorker(workspace.worker_preference || '');
-    setPermMode(workspace.permission_mode || 'bypass');
+    setPermMode(workspace.permission_mode || 'workspace');
     const a = resolveSandboxAnchor(workspace.work_dir, workspace.owner_user_id);
     setSeg(a?.seg ?? workspace.work_dir);
     setError(null);
@@ -71,7 +73,7 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
   const dirty =
     (name.trim() !== workspace.name && name.trim().length > 0) ||
     worker !== (workspace.worker_preference || '') ||
-    permMode !== (workspace.permission_mode || 'bypass') ||
+    permMode !== (workspace.permission_mode || 'workspace') ||
     (segEditable && seg.trim() !== segBaseline);
 
   const previewSeg = segEditable ? sanitizeWorkspaceDir(seg) : '';
@@ -93,7 +95,10 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
       const updated = await updateWorkspace(workspace.id, {
         name: name.trim(),
         workerPreference: worker,
-        permissionMode: permMode,
+        // r3 (#804): permission_mode is admin-only — non-admins omit the field so the
+        // backend leaves the stored value untouched (sending it would 403). The control
+        // is hidden when !isAdmin.
+        ...(isAdmin ? { permissionMode: permMode } : {}),
         workDir,
       });
       onUpdated?.(updated);
@@ -165,33 +170,37 @@ export function GeneralTab({ workspace, onUpdated }: GeneralTabProps) {
         </p>
       </div>
 
-      {/* Permission Mode Selection (issue #789) */}
-      <div>
-        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
-          Permission Mode
-        </label>
-        <div className="relative">
-          <select
-            value={permMode}
-            onChange={(e) => setPermMode(e.target.value)}
-            className="w-full pl-3.5 pr-10 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-default)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] focus:ring-1 focus:ring-[var(--accent-gold)]/20 transition-all appearance-none cursor-pointer"
-          >
-            {PERMISSION_MODE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3.5 text-[var(--text-faint)]">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
+      {/* Permission Mode Selection — admin-only (r3 #804): non-admins cannot
+          configure workspace permission mode; the control is hidden and the field
+          is omitted from the PATCH body so the stored value is preserved. */}
+      {isAdmin && (
+        <div>
+          <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+            Permission Mode
+          </label>
+          <div className="relative">
+            <select
+              value={permMode}
+              onChange={(e) => setPermMode(e.target.value)}
+              className="w-full pl-3.5 pr-10 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-default)] text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] focus:ring-1 focus:ring-[var(--accent-gold)]/20 transition-all appearance-none cursor-pointer"
+            >
+              {PERMISSION_MODE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3.5 text-[var(--text-faint)]">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
           </div>
+          <p className="text-[10px] text-[var(--text-muted)] mt-1.5 leading-relaxed">
+            Controls the blast radius for new sessions: how aggressively the agent may edit files or run commands. Applies to new sessions only; existing sessions keep their current mode.
+          </p>
         </div>
-        <p className="text-[10px] text-[var(--text-muted)] mt-1.5 leading-relaxed">
-          Controls the blast radius for new sessions: how aggressively the agent may edit files or run commands. Applies to new sessions only; existing sessions keep their current mode.
-        </p>
-      </div>
+      )}
 
       {/* Working Directory: sandbox prefix (read-only) + editable segment */}
       <div>

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -97,8 +97,11 @@ export function GeneralTab({ workspace, isAdmin, onUpdated }: GeneralTabProps) {
         workerPreference: worker,
         // r3 (#804): permission_mode is admin-only — non-admins omit the field so the
         // backend leaves the stored value untouched (sending it would 403). The control
-        // is hidden when !isAdmin.
-        ...(isAdmin ? { permissionMode: permMode } : {}),
+        // is hidden when !isAdmin. Admins send it only when actually changed, so a
+        // name-only save doesn't touch the admin-gated field (audit noise / coupling).
+        ...(isAdmin && permMode !== (workspace.permission_mode || 'workspace')
+          ? { permissionMode: permMode }
+          : {}),
         workDir,
       });
       onUpdated?.(updated);

--- a/webchat/app/settings/page.tsx
+++ b/webchat/app/settings/page.tsx
@@ -272,6 +272,7 @@ export default function SettingsPage() {
                   {activeTab === 'general' && workspace && currentUser && (
                     <GeneralTab
                       workspace={workspace}
+                      isAdmin={currentUser.role === 'admin'}
                       onUpdated={handleWorkspaceUpdated}
                     />
                   )}


### PR DESCRIPTION
## Summary

实施 r3 修订（跟踪 issue #804，关联原 #789）：

| | r2 | r3 |
|---|---|---|
| **A. 默认值** | `bypass`（no-op，bridge 不注入） | `workspace`（bridge 真正消费 config 默认） |
| **B. 配置权限** | owner 自己可设/改 | admin-only；非 admin 传字段 → 403 fail-closed |
| **C. 生效范围** | — | 仅 workspace session；cron/平台 channel 保持注入 `""` |

**关键安全洞察**：因默认值同档下调（bypass→workspace），"注入全局默认"在 CC/OCS/Codex/ACP 上全部是收紧而非提权，化解 r2 §8 的核心担忧（详见 spec §2 权衡表）。

## 改动（commit f3816d77）

**后端**
- `config_defaults.go`：`DefaultPermissionMode` `bypass` → `workspace`
- `bridge_worker.go`：`resolveWorkspacePermissionMode` 无覆盖分支返回 `b.defaultPermissionMode.Load()`
- `workspace_handlers.go`：Create + Update 增 admin-only 门（403 PERMISSION_DENIED）
- `bridge.go` / `deps.go` / `config_types.go` / `worker.go`：去 no-op 注释 + doc 更新

**前端**
- `general-tab.tsx`：`isAdmin` prop + 非 admin 隐藏控件 + 默认 workspace + options 标签
- `settings/page.tsx`：传 `isAdmin`

**测试**（TDD：3 cycle 均先 RED 后 GREEN）
- bridge 三分支（无覆盖/覆盖/无 workspace）+ 热重载默认
- handler admin-only 四象限（非 admin 传/不传 × Create/Update）
- config 默认值断言

**文档**
- 新增 `Workspace-Permission-Mode-Admin-Only-Revision-Spec.md`（r3 设计，commit 91a43727）
- 原 `Workspace-Permission-Mode-Spec.md` 顶部加 r3 横幅

## Test plan

- [x] `go test ./... -race` 全量通过（gateway 18s / session 13s / security 11s）
- [x] golangci-lint 0 issues
- [x] pre-push 全量门禁（vet / mod verify / lint / build / tests）
- [x] webchat `tsc --noEmit` 通过
- [ ] 代码审查
- [ ] 手动验证：非 admin 在 webchat settings 看不到 Permission Mode 控件；admin 默认见 workspace 档

Resolves #804
关联原 issue：#789
设计文档：`docs/specs/Workspace-Permission-Mode-Admin-Only-Revision-Spec.md`