### PR TITLE
feat(admin): 补齐 webchat 通道 platform-base agent config 编辑入口 (#796)

### DIFF
--- a/cmd/hotplex/bot_config_adapter.go
+++ b/cmd/hotplex/bot_config_adapter.go
@@ -276,6 +276,49 @@ func (a *botConfigAdapter) WriteAgentConfigFile(ctx context.Context, botName str
 	return nil
 }
 
+// GetPlatformAgentConfigFile reads a single platform-level (channel team
+// default) agent config file. Unlike GetAgentConfigFile it addresses the
+// dir/{platform}/ layer directly with an empty botName, so platforms without a
+// bot instance (e.g. webchat) are reachable without consulting the messaging
+// registry. The platform must be a recognized identifier.
+func (a *botConfigAdapter) GetPlatformAgentConfigFile(ctx context.Context, platform string, file admin.AgentConfigFileName) (*admin.AgentConfigFile, error) {
+	if !agentconfig.IsValidPlatform(platform) {
+		return nil, fmt.Errorf("unknown platform %q", platform)
+	}
+
+	// Empty botName: resolveFile skips the bot level and resolves platform →
+	// global, matching LoadForWorkspace's team-default semantics for webchat.
+	excl := resolveInjectExcludeForAdmin(a.cfgStore.Load(), platform, "")
+	configs, err := agentconfig.Load(a.agentConfigDir, platform, "", excl...)
+	if err != nil {
+		return nil, fmt.Errorf("load platform agent config: %w", err)
+	}
+
+	content := getConfigField(configs, file)
+	source := agentconfig.ResolvedSource(a.agentConfigDir, platform, "", string(file))
+
+	return &admin.AgentConfigFile{
+		Content: content,
+		Source:  source,
+		Size:    len(content),
+		File:    string(file),
+	}, nil
+}
+
+// WritePlatformAgentConfigFile writes content to a single platform-level
+// agent config file (channel team default). An empty platform-level file lets
+// resolution fall through to the global layer, matching the read semantics.
+func (a *botConfigAdapter) WritePlatformAgentConfigFile(ctx context.Context, platform string, file admin.AgentConfigFileName, content string) error {
+	if !agentconfig.IsValidPlatform(platform) {
+		return fmt.Errorf("unknown platform %q", platform)
+	}
+
+	if err := agentconfig.WriteFile(a.agentConfigDir, platform, "", string(file), content, agentconfig.MaxFileChars); err != nil {
+		return fmt.Errorf("write platform agent config file: %w", err)
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------

--- a/cmd/hotplex/bot_config_adapter_test.go
+++ b/cmd/hotplex/bot_config_adapter_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/admin"
+	"github.com/hrygo/hotplex/internal/agentconfig"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// newTestBotConfigAdapter builds a botConfigAdapter over a temp agent-config
+// directory backed by an empty config store. Used to exercise platform-level
+// (channel team-default) agent config read/write without the messaging
+// registry — the webchat path has no bot instance.
+func newTestBotConfigAdapter(t *testing.T) (*botConfigAdapter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgStore := config.NewConfigStore(&config.Config{}, slog.Default())
+	return newBotConfigAdapter(cfgStore, dir, filepath.Join(dir, "config.yaml")), dir
+}
+
+// Write then read a webchat platform-level file; verify it lands at
+// dir/webchat/<file> and reports source "platform".
+func TestBotConfigAdapter_PlatformAgentConfigFile_WriteRead(t *testing.T) {
+	t.Parallel()
+	a, dir := newTestBotConfigAdapter(t)
+
+	content := "# WebChat Soul\nYou are a webchat channel agent.\n"
+	require.NoError(t, a.WritePlatformAgentConfigFile(
+		context.Background(), "webchat", admin.AgentConfigSoul, content))
+
+	got, err := a.GetPlatformAgentConfigFile(context.Background(), "webchat", admin.AgentConfigSoul)
+	require.NoError(t, err)
+	require.Equal(t, content, got.Content)
+	require.Equal(t, "platform", got.Source) // platform-level team default
+	require.Equal(t, "SOUL.md", got.File)
+	require.Equal(t, len(content), got.Size)
+
+	// Verify on-disk location: dir/webchat/SOUL.md.
+	data, err := os.ReadFile(filepath.Join(dir, "webchat", "SOUL.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "WebChat Soul")
+}
+
+// The written platform-level file must serve as the webchat channel team
+// default via LoadForWorkspace, and be overridden per-workspace following the
+// existing precedence (issue #796 acceptance ②).
+func TestBotConfigAdapter_PlatformAgentConfigFile_TeamDefaultEffective(t *testing.T) {
+	t.Parallel()
+	a, dir := newTestBotConfigAdapter(t)
+
+	content := "# WebChat Rules\n- Be concise.\n"
+	require.NoError(t, a.WritePlatformAgentConfigFile(
+		context.Background(), "webchat", admin.AgentConfigAgents, content))
+
+	// No override → platform-level team default resolves.
+	cfg, err := agentconfig.LoadForWorkspace(dir, "webchat", nil)
+	require.NoError(t, err)
+	require.Equal(t, content, cfg.Agents)
+
+	// Non-empty override replaces the team default.
+	override := map[string]string{"AGENTS.md": "# Override\nWorkspace-specific rules."}
+	cfg2, err := agentconfig.LoadForWorkspace(dir, "webchat", override)
+	require.NoError(t, err)
+	require.Equal(t, "# Override\nWorkspace-specific rules.", cfg2.Agents)
+
+	// Empty override value inherits the team default.
+	cfg3, err := agentconfig.LoadForWorkspace(dir, "webchat", map[string]string{"AGENTS.md": ""})
+	require.NoError(t, err)
+	require.Equal(t, content, cfg3.Agents)
+}
+
+// Unknown platforms are rejected before any path resolution (defense-in-depth
+// against arbitrary directory creation).
+func TestBotConfigAdapter_PlatformAgentConfigFile_UnknownPlatformRejected(t *testing.T) {
+	t.Parallel()
+	a, dir := newTestBotConfigAdapter(t)
+
+	_, err := a.GetPlatformAgentConfigFile(context.Background(), "telegram", admin.AgentConfigSoul)
+	require.Error(t, err)
+
+	err = a.WritePlatformAgentConfigFile(context.Background(), "telegram", admin.AgentConfigSoul, "x")
+	require.Error(t, err)
+
+	// No directory created for the rejected platform.
+	_, statErr := os.Stat(filepath.Join(dir, "telegram"))
+	require.Error(t, statErr) // not exist
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// Without a platform-level file, reads fall through to the global layer.
+func TestBotConfigAdapter_PlatformAgentConfigFile_GlobalFallback(t *testing.T) {
+	t.Parallel()
+	a, dir := newTestBotConfigAdapter(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "MEMORY.md"), []byte("global memory"), 0o644))
+	got, err := a.GetPlatformAgentConfigFile(context.Background(), "webchat", admin.AgentConfigMemory)
+	require.NoError(t, err)
+	require.Equal(t, "global memory", got.Content)
+	require.Equal(t, "global", got.Source)
+}
+
+// Each recognized platform gets its own team-default namespace.
+func TestBotConfigAdapter_PlatformAgentConfigFile_PerPlatformIsolation(t *testing.T) {
+	t.Parallel()
+	a, _ := newTestBotConfigAdapter(t)
+
+	require.NoError(t, a.WritePlatformAgentConfigFile(
+		context.Background(), "webchat", admin.AgentConfigUser, "webchat user"))
+	require.NoError(t, a.WritePlatformAgentConfigFile(
+		context.Background(), "feishu", admin.AgentConfigUser, "feishu user"))
+
+	wc, err := a.GetPlatformAgentConfigFile(context.Background(), "webchat", admin.AgentConfigUser)
+	require.NoError(t, err)
+	require.Equal(t, "webchat user", wc.Content)
+
+	fc, err := a.GetPlatformAgentConfigFile(context.Background(), "feishu", admin.AgentConfigUser)
+	require.NoError(t, err)
+	require.Equal(t, "feishu user", fc.Content)
+}

--- a/cmd/hotplex/bot_config_routes_test.go
+++ b/cmd/hotplex/bot_config_routes_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlatformConfigRoute_Isolation guards the route design from issue #796:
+// the literal "platform" segment coexists with the {name} wildcard without a
+// ServeMux registration panic, and channel-default requests dispatch to the
+// platform handlers rather than the bot-level handlers. Cases run sequentially
+// (subtests share a dispatch marker).
+func TestPlatformConfigRoute_Isolation(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+
+	hit := ""
+	botHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { hit = "bot" })
+	platformHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { hit = "platform" })
+
+	// Mirror the admin bot config routes from routes.go.
+	mux.HandleFunc("GET /admin/bots/config", botHandler)
+	mux.HandleFunc("GET /admin/bots/{name}", botHandler)
+	mux.HandleFunc("GET /admin/bots/{name}/config", botHandler)
+	mux.HandleFunc("GET /admin/bots/{name}/config/{file}", botHandler)
+	mux.HandleFunc("GET /admin/bots/{name}/preview", botHandler)
+	mux.HandleFunc("PUT /admin/bots/{name}/config/{file}", botHandler)
+	// New channel-default (platform-level) routes.
+	mux.HandleFunc("GET /admin/bots/platform/{platform}/config/{file}", platformHandler)
+	mux.HandleFunc("PUT /admin/bots/platform/{platform}/config/{file}", platformHandler)
+
+	cases := []struct {
+		method, target, want string
+	}{
+		{http.MethodGet, "/admin/bots/platform/webchat/config/SOUL.md", "platform"},
+		{http.MethodPut, "/admin/bots/platform/webchat/config/SOUL.md", "platform"},
+		{http.MethodGet, "/admin/bots/my-bot/config/SOUL.md", "bot"},
+		{http.MethodGet, "/admin/bots/my-bot/preview", "bot"},
+		{http.MethodGet, "/admin/bots/my-bot", "bot"},
+		{http.MethodGet, "/admin/bots/config", "bot"},
+	}
+	for _, tc := range cases {
+		hit = ""
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(tc.method, tc.target, nil))
+		require.Equal(t, http.StatusOK, w.Code, "target %s %s", tc.method, tc.target)
+		require.Equal(t, tc.want, hit, "%s %s dispatched to wrong handler", tc.method, tc.target)
+	}
+}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hrygo/hotplex/internal/admin"
+	"github.com/hrygo/hotplex/internal/agentconfig"
 	"github.com/hrygo/hotplex/internal/assets"
 	"github.com/hrygo/hotplex/internal/brain"
 	"github.com/hrygo/hotplex/internal/config"
@@ -1094,7 +1095,7 @@ func warnDeprecatedSuffixFiles(dir string, log *slog.Logger) {
 	if dir == "" {
 		return
 	}
-	platforms := []string{"slack", "feishu", "webchat"}
+	platforms := agentconfig.KnownPlatforms()
 	bases := []string{"SOUL", "AGENTS", "SKILLS", "USER", "MEMORY"}
 	for _, p := range platforms {
 		for _, b := range bases {

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -168,6 +168,15 @@ func setupRoutes(
 	adminMux.HandleFunc("DELETE /admin/bots/{name}", adminAPI.HandleDeleteBot)
 	adminMux.HandleFunc("PUT /admin/bots/{name}/config/{file}", adminAPI.HandleWriteAgentConfigFile)
 
+	// Channel default config API (platform-level team defaults). Platforms
+	// without a bot instance — webchat owns dir/webchat/ team defaults but
+	// never appears in the bot registry — need a dedicated entry point that
+	// addresses the dir/{platform}/ layer directly. The literal "platform"
+	// segment is more specific than the {name} wildcard above, so these routes
+	// never collide with the bot-level routes (different segment counts). #796
+	adminMux.HandleFunc("GET /admin/bots/platform/{platform}/config/{file}", adminAPI.HandleGetPlatformAgentConfigFile)
+	adminMux.HandleFunc("PUT /admin/bots/platform/{platform}/config/{file}", adminAPI.HandleWritePlatformAgentConfigFile)
+
 	// API key user management
 	adminMux.HandleFunc("GET /admin/api-keys", adminAPI.HandleAPIKeyUserList)
 	adminMux.HandleFunc("POST /admin/api-keys", adminAPI.HandleAPIKeyUserCreate)

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -416,6 +416,140 @@
                 }
             }
         },
+        "/admin/bots/platform/{platform}/config/{file}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the content of a single platform-level agent config file (channel team default). Used for platforms without a bot instance, e.g. webchat. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get channel default agent config file",
+                "parameters": [
+                    {
+                        "enum": [
+                            "webchat",
+                            "slack",
+                            "feishu"
+                        ],
+                        "type": "string",
+                        "description": "Platform identifier",
+                        "name": "platform",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "SOUL.md",
+                            "AGENTS.md",
+                            "SKILLS.md",
+                            "USER.md",
+                            "MEMORY.md"
+                        ],
+                        "type": "string",
+                        "description": "Config file name",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.AgentConfigFile"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid platform or config file name",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Writes content to a single platform-level agent config file (channel team default). Used for platforms without a bot instance, e.g. webchat. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Write channel default agent config file",
+                "parameters": [
+                    {
+                        "enum": [
+                            "webchat",
+                            "slack",
+                            "feishu"
+                        ],
+                        "type": "string",
+                        "description": "Platform identifier",
+                        "name": "platform",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "SOUL.md",
+                            "AGENTS.md",
+                            "SKILLS.md",
+                            "USER.md",
+                            "MEMORY.md"
+                        ],
+                        "type": "string",
+                        "description": "Config file name",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "File content",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.WriteAgentConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "File written"
+                    },
+                    "400": {
+                        "description": "Invalid platform/config file or write failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/bots/{name}": {
             "get": {
                 "security": [

--- a/internal/admin/bot_config_handlers.go
+++ b/internal/admin/bot_config_handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/hrygo/hotplex/internal/agentconfig"
 	"github.com/hrygo/hotplex/internal/web"
 )
 
@@ -319,6 +320,101 @@ func (a *AdminAPI) HandleWriteAgentConfigFile(w http.ResponseWriter, r *http.Req
 		return
 	}
 	a.log.Info("admin: agent config file written", "bot", name, "file", fileStr, "admin", adminKeyPrefix(r))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleGetPlatformAgentConfigFile reads a single platform-level (channel team
+// default) agent config file, identified by platform rather than a bot name.
+//
+// @Summary      Get channel default agent config file
+// @Description  Returns the content of a single platform-level agent config file (channel team default). Used for platforms without a bot instance, e.g. webchat. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        platform  path  string  true  "Platform identifier"  Enums(webchat,slack,feishu)
+// @Param        file      path  string  true  "Config file name"     Enums(SOUL.md,AGENTS.md,SKILLS.md,USER.md,MEMORY.md)
+// @Success      200  {object}  AgentConfigFile
+// @Failure      400  {object}  ErrorResponse  "Invalid platform or config file name"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Router       /admin/bots/platform/{platform}/config/{file} [get]
+// GET /admin/bots/platform/{platform}/config/{file}
+func (a *AdminAPI) HandleGetPlatformAgentConfigFile(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminRead) {
+		return
+	}
+	if a.botConfig == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "bot config provider not available")
+		return
+	}
+	platform := r.PathValue("platform")
+	if !agentconfig.IsValidPlatform(platform) {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", fmt.Sprintf("invalid platform %q", platform))
+		return
+	}
+	fileStr := r.PathValue("file")
+	fileName := AgentConfigFileName(fileStr)
+	if !ValidConfigFiles[fileName] {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", fmt.Sprintf("invalid config file %q", fileStr))
+		return
+	}
+	result, err := a.botConfig.GetPlatformAgentConfigFile(r.Context(), platform, fileName)
+	if err != nil {
+		respondStoreError(w, a.log, "admin: get platform agent config file", err)
+		return
+	}
+	respondJSON(w, result)
+}
+
+// HandleWritePlatformAgentConfigFile writes content to a single platform-level
+// (channel team default) agent config file.
+//
+// @Summary      Write channel default agent config file
+// @Description  Writes content to a single platform-level agent config file (channel team default). Used for platforms without a bot instance, e.g. webchat. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        platform  path  string                   true  "Platform identifier"  Enums(webchat,slack,feishu)
+// @Param        file      path  string                   true  "Config file name"     Enums(SOUL.md,AGENTS.md,SKILLS.md,USER.md,MEMORY.md)
+// @Param        body      body  WriteAgentConfigRequest  true  "File content"
+// @Success      204  "File written"
+// @Failure      400  {object}  ErrorResponse  "Invalid platform/config file or write failed"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Router       /admin/bots/platform/{platform}/config/{file} [put]
+// PUT /admin/bots/platform/{platform}/config/{file}
+func (a *AdminAPI) HandleWritePlatformAgentConfigFile(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminWrite) {
+		return
+	}
+	if a.botConfig == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "bot config provider not available")
+		return
+	}
+	platform := r.PathValue("platform")
+	if !agentconfig.IsValidPlatform(platform) {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", fmt.Sprintf("invalid platform %q", platform))
+		return
+	}
+	fileStr := r.PathValue("file")
+	fileName := AgentConfigFileName(fileStr)
+	if !ValidConfigFiles[fileName] {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", fmt.Sprintf("invalid config file %q", fileStr))
+		return
+	}
+
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid JSON")
+		return
+	}
+
+	if err := a.botConfig.WritePlatformAgentConfigFile(r.Context(), platform, fileName, body.Content); err != nil {
+		a.log.Error("admin: write platform agent config file", "err", err)
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "write failed")
+		return
+	}
+	a.log.Info("admin: platform agent config file written", "platform", platform, "file", fileStr, "admin", adminKeyPrefix(r))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/admin/bot_config_handlers_test.go
+++ b/internal/admin/bot_config_handlers_test.go
@@ -1,0 +1,203 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockBotConfigProvider implements BotConfigProvider for handler tests. Only
+// the platform-level (channel team-default) methods carry configurable
+// behavior; the bot CRUD methods return zero values — they are out of scope
+// for the channel-default endpoint tests.
+type mockBotConfigProvider struct {
+	getFn   func(ctx context.Context, platform string, file AgentConfigFileName) (*AgentConfigFile, error)
+	writeFn func(ctx context.Context, platform string, file AgentConfigFileName, content string) error
+
+	// Recorded call args for assertion.
+	gotPlatform string
+	gotFile     AgentConfigFileName
+	gotContent  string
+}
+
+func (m *mockBotConfigProvider) GetBotConfig(context.Context, string) (*BotConfigEntry, error) {
+	return nil, nil
+}
+func (m *mockBotConfigProvider) ListBotConfigs(context.Context) ([]BotConfigEntry, error) {
+	return nil, nil
+}
+func (m *mockBotConfigProvider) GetAgentConfigFile(context.Context, string, AgentConfigFileName) (*AgentConfigFile, error) {
+	return nil, nil
+}
+func (m *mockBotConfigProvider) GetSystemPromptPreview(context.Context, string) (string, error) {
+	return "", nil
+}
+func (m *mockBotConfigProvider) UpdateBotConfig(context.Context, string, *BotConfigAttrs) error {
+	return nil
+}
+func (m *mockBotConfigProvider) CreateBot(context.Context, string, *BotConfigAttrs) error {
+	return nil
+}
+func (m *mockBotConfigProvider) DeleteBot(context.Context, string) error { return nil }
+func (m *mockBotConfigProvider) WriteAgentConfigFile(context.Context, string, AgentConfigFileName, string) error {
+	return nil
+}
+
+func (m *mockBotConfigProvider) GetPlatformAgentConfigFile(ctx context.Context, platform string, file AgentConfigFileName) (*AgentConfigFile, error) {
+	m.gotPlatform = platform
+	m.gotFile = file
+	if m.getFn != nil {
+		return m.getFn(ctx, platform, file)
+	}
+	return &AgentConfigFile{Content: "channel default", Source: "platform", Size: 15, File: string(file)}, nil
+}
+
+func (m *mockBotConfigProvider) WritePlatformAgentConfigFile(ctx context.Context, platform string, file AgentConfigFileName, content string) error {
+	m.gotPlatform = platform
+	m.gotFile = file
+	m.gotContent = content
+	if m.writeFn != nil {
+		return m.writeFn(ctx, platform, file, content)
+	}
+	return nil
+}
+
+// newPlatformRequest builds a request preloaded with platform/file path values
+// and an optional scope, mirroring how ServeMux would populate PathValue.
+func newPlatformRequest(t *testing.T, method, platform, file, scope string, body []byte) (*httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	var rdr *bytes.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	var r *http.Request
+	if rdr != nil {
+		r = httptest.NewRequest(method, "/admin/bots/platform/"+platform+"/config/"+file, rdr)
+	} else {
+		r = httptest.NewRequest(method, "/admin/bots/platform/"+platform+"/config/"+file, nil)
+	}
+	if scope != "" {
+		r = withScope(r, scope)
+	}
+	r.SetPathValue("platform", platform)
+	r.SetPathValue("file", file)
+	return httptest.NewRecorder(), r
+}
+
+func TestHandleGetPlatformAgentConfigFile_Success(t *testing.T) {
+	t.Parallel()
+	prov := &mockBotConfigProvider{}
+	api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+	w, r := newPlatformRequest(t, http.MethodGet, "webchat", "SOUL.md", ScopeAdminRead, nil)
+	api.HandleGetPlatformAgentConfigFile(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "webchat", prov.gotPlatform)
+	require.Equal(t, AgentConfigSoul, prov.gotFile)
+
+	var got AgentConfigFile
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, "channel default", got.Content)
+	require.Equal(t, "platform", got.Source)
+	require.Equal(t, "SOUL.md", got.File)
+}
+
+func TestHandleWritePlatformAgentConfigFile_Success(t *testing.T) {
+	t.Parallel()
+	prov := &mockBotConfigProvider{}
+	api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+	body, err := json.Marshal(map[string]string{"content": "new webchat soul"})
+	require.NoError(t, err)
+	w, r := newPlatformRequest(t, http.MethodPut, "webchat", "SOUL.md", ScopeAdminWrite, body)
+	api.HandleWritePlatformAgentConfigFile(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Equal(t, "new webchat soul", prov.gotContent)
+	require.Equal(t, "webchat", prov.gotPlatform)
+	require.Equal(t, AgentConfigSoul, prov.gotFile)
+}
+
+// TestHandlePlatformAgentConfigFile_Rejections covers input validation and
+// authorization boundaries that must hold before the provider is consulted.
+func TestHandlePlatformAgentConfigFile_Rejections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		method   string
+		scope    string
+		platform string
+		file     string
+		want     int
+	}{
+		{"get invalid platform", http.MethodGet, ScopeAdminRead, "telegram", "SOUL.md", http.StatusBadRequest},
+		{"get invalid file traversal", http.MethodGet, ScopeAdminRead, "webchat", "../../etc/passwd", http.StatusBadRequest},
+		{"get unknown file", http.MethodGet, ScopeAdminRead, "webchat", "META-COGNITION.md", http.StatusBadRequest},
+		{"get no scope", http.MethodGet, "", "webchat", "SOUL.md", http.StatusForbidden},
+		{"put invalid platform", http.MethodPut, ScopeAdminWrite, "telegram", "SOUL.md", http.StatusBadRequest},
+		{"put invalid file", http.MethodPut, ScopeAdminWrite, "webchat", "README.md", http.StatusBadRequest},
+		{"put no scope", http.MethodPut, "", "webchat", "SOUL.md", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			prov := &mockBotConfigProvider{}
+			api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+			var body []byte
+			if tc.method == http.MethodPut {
+				body = []byte(`{"content":"x"}`)
+			}
+			w, r := newPlatformRequest(t, tc.method, tc.platform, tc.file, tc.scope, body)
+
+			if tc.method == http.MethodGet {
+				api.HandleGetPlatformAgentConfigFile(w, r)
+			} else {
+				api.HandleWritePlatformAgentConfigFile(w, r)
+			}
+
+			require.Equal(t, tc.want, w.Code, "body=%q", w.Body.String())
+			// Provider must not be reached on rejection.
+			require.Empty(t, prov.gotPlatform, "provider should not be consulted on %d", tc.want)
+		})
+	}
+}
+
+// A nil provider surfaces as 503, consistent with the bot-level endpoints.
+func TestHandlePlatformAgentConfigFile_NilProvider(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI() // BotConfig left nil
+
+	wGet, rGet := newPlatformRequest(t, http.MethodGet, "webchat", "SOUL.md", ScopeAdminRead, nil)
+	api.HandleGetPlatformAgentConfigFile(wGet, rGet)
+	require.Equal(t, http.StatusServiceUnavailable, wGet.Code)
+
+	wPut, rPut := newPlatformRequest(t, http.MethodPut, "webchat", "SOUL.md", ScopeAdminWrite, []byte(`{"content":"x"}`))
+	api.HandleWritePlatformAgentConfigFile(wPut, rPut)
+	require.Equal(t, http.StatusServiceUnavailable, wPut.Code)
+}
+
+// A provider error on write surfaces as 400 (write failed), matching the
+// bot-level write handler's contract.
+func TestHandleWritePlatformAgentConfigFile_ProviderError(t *testing.T) {
+	t.Parallel()
+	prov := &mockBotConfigProvider{
+		writeFn: func(context.Context, string, AgentConfigFileName, string) error {
+			return errors.New("write failed")
+		},
+	}
+	api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+	w, r := newPlatformRequest(t, http.MethodPut, "webchat", "SOUL.md", ScopeAdminWrite, []byte(`{"content":"x"}`))
+	api.HandleWritePlatformAgentConfigFile(w, r)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/admin/bot_config_handlers_test.go
+++ b/internal/admin/bot_config_handlers_test.go
@@ -201,3 +201,42 @@ func TestHandleWritePlatformAgentConfigFile_ProviderError(t *testing.T) {
 	api.HandleWritePlatformAgentConfigFile(w, r)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// TestHandlePlatformAgentConfigFile_AllPlatforms asserts the endpoint serves
+// every recognized platform — not only webchat — making the multi-platform
+// contract explicit rather than implicit. The IsValidPlatform whitelist accepts
+// webchat/slack/feishu; each must round-trip through both verbs. See #796.
+func TestHandlePlatformAgentConfigFile_AllPlatforms(t *testing.T) {
+	t.Parallel()
+
+	platforms := []string{"webchat", "slack", "feishu"}
+	for _, p := range platforms {
+		t.Run(p+"_read", func(t *testing.T) {
+			t.Parallel()
+			prov := &mockBotConfigProvider{}
+			api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+			w, r := newPlatformRequest(t, http.MethodGet, p, "AGENTS.md", ScopeAdminRead, nil)
+			api.HandleGetPlatformAgentConfigFile(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, p, prov.gotPlatform)
+			require.Equal(t, AgentConfigAgents, prov.gotFile)
+		})
+		t.Run(p+"_write", func(t *testing.T) {
+			t.Parallel()
+			prov := &mockBotConfigProvider{}
+			api := newTestAPI(func(d *Deps) { d.BotConfig = prov })
+
+			body, err := json.Marshal(map[string]string{"content": "team default for " + p})
+			require.NoError(t, err)
+			w, r := newPlatformRequest(t, http.MethodPut, p, "AGENTS.md", ScopeAdminWrite, body)
+			api.HandleWritePlatformAgentConfigFile(w, r)
+
+			require.Equal(t, http.StatusNoContent, w.Code)
+			require.Equal(t, p, prov.gotPlatform)
+			require.Equal(t, AgentConfigAgents, prov.gotFile)
+			require.Equal(t, "team default for "+p, prov.gotContent)
+		})
+	}
+}

--- a/internal/admin/bot_config_provider.go
+++ b/internal/admin/bot_config_provider.go
@@ -136,4 +136,18 @@ type BotConfigProvider interface {
 	// WriteAgentConfigFile writes content to a single agent config file
 	// for the named bot. The file name must appear in ValidConfigFiles.
 	WriteAgentConfigFile(ctx context.Context, botName string, file AgentConfigFileName, content string) error
+
+	// GetPlatformAgentConfigFile reads a single platform-level (channel team
+	// default) agent config file, identified by platform rather than a bot
+	// name. This addresses the dir/{platform}/ layer directly and does not
+	// require a registered bot — webchat, for example, owns dir/webchat/ team
+	// defaults but has no bot instance in the messaging registry. The platform
+	// must be a recognized identifier (see agentconfig.IsValidPlatform).
+	GetPlatformAgentConfigFile(ctx context.Context, platform string, file AgentConfigFileName) (*AgentConfigFile, error)
+
+	// WritePlatformAgentConfigFile writes content to a single platform-level
+	// agent config file. The platform must be recognized and the file name
+	// must appear in ValidConfigFiles. Writes serve as channel team defaults,
+	// overridden per-workspace by LoadForWorkspace's existing precedence.
+	WritePlatformAgentConfigFile(ctx context.Context, platform string, file AgentConfigFileName, content string) error
 }

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -125,6 +125,26 @@ func KnownFiles() []string {
 	return slices.Clone(configFiles)
 }
 
+// knownPlatforms lists platform identifiers that own a platform-level agent
+// config directory (dir/<platform>/). These are first-class platforms whose
+// team-default files resolve through Load/LoadForWorkspace. Order is stable so
+// diagnostics render deterministically.
+var knownPlatforms = []string{"slack", "feishu", "webchat"}
+
+// KnownPlatforms returns the list of recognized platform identifiers for
+// validation and diagnostics. The returned slice is a copy and may be mutated
+// by callers without affecting the package state.
+func KnownPlatforms() []string {
+	return slices.Clone(knownPlatforms)
+}
+
+// IsValidPlatform reports whether platform is a recognized identifier that may
+// own platform-level team-default files (dir/<platform>/). Used by admin
+// channel-config endpoints to reject unknown platforms before path resolution.
+func IsValidPlatform(platform string) bool {
+	return slices.Contains(knownPlatforms, platform)
+}
+
 // shouldExclude reports whether a config file should be skipped from injection.
 // baseName is matched case-insensitively against the exclude list.
 // META-COGNITION.md is never excluded (it is go:embed, always injected outside Load).

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -129,6 +129,11 @@ func KnownFiles() []string {
 // config directory (dir/<platform>/). These are first-class platforms whose
 // team-default files resolve through Load/LoadForWorkspace. Order is stable so
 // diagnostics render deterministically.
+//
+// Single source of truth for valid platforms: when adding one here, also
+// update the duplicated enum in docs/swagger/swagger.json and the @Param
+// Enums(...) annotations in bot_config_handlers.go (OpenAPI can't reference
+// Go vars, so the list is mirrored in three places).
 var knownPlatforms = []string{"slack", "feishu", "webchat"}
 
 // KnownPlatforms returns the list of recognized platform identifiers for

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hrygo/hotplex/internal/agentconfig"
 	"github.com/hrygo/hotplex/internal/cli"
 	"github.com/hrygo/hotplex/internal/config"
 )
@@ -50,7 +51,7 @@ func (c agentConfigSuffixChecker) Check(_ context.Context) cli.Diagnostic {
 		}
 	}
 
-	platforms := []string{"slack", "feishu", "webchat"}
+	platforms := agentconfig.KnownPlatforms()
 	var deprecated []string
 	for _, e := range entries {
 		if e.IsDir() {

--- a/webchat/app/admin/bots/page.tsx
+++ b/webchat/app/admin/bots/page.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 import { listBots } from '@/lib/api/admin-bots';
 import type { BotConfigEntry } from '@/lib/types/admin';
 import { BotCard } from '@/components/admin/bot-card';
+import { ChannelConfigEditor } from '@/components/admin/channel-config-editor';
 import { useResource } from '@/hooks/use-resource';
 import { LoadingState, ErrorState, EmptyState } from '@/components/admin/resource-states';
 
 export default function BotsPage() {
   const [query, setQuery] = useState('');
+  const [showChannelDefaults, setShowChannelDefaults] = useState(false);
 
   const { data: bots, loading, error, reload } = useResource<BotConfigEntry[]>(
     () => listBots(),
@@ -81,6 +83,45 @@ export default function BotsPage() {
               + New Bot
             </Link>
           </div>
+        </div>
+
+        {/* Channel defaults — platform-level team configs for channels without
+            a bot instance (webchat owns dir/webchat/ but is never a bot). #796 */}
+        <div className="mb-6 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+          <button
+            onClick={() => setShowChannelDefaults((v) => !v)}
+            className="w-full flex items-center justify-between px-4 py-3 hover:bg-[var(--bg-hover)] transition-colors"
+          >
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-semibold text-[var(--text-primary)]">
+                Channel Defaults
+              </span>
+              <span className="text-[11px] font-mono text-[var(--text-faint)] px-2 py-0.5 rounded-full bg-[var(--bg-hover)]">
+                WebChat
+              </span>
+              <span className="text-[11px] text-[var(--text-faint)]">
+                Team defaults for channels without a bot instance
+              </span>
+            </div>
+            <svg
+              className={`flex-shrink-0 text-[var(--text-faint)] transition-transform ${showChannelDefaults ? 'rotate-180' : ''}`}
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+          {showChannelDefaults && (
+            <div className="px-4 pb-4 pt-3 border-t border-[var(--border-subtle)]">
+              <ChannelConfigEditor platform="webchat" />
+            </div>
+          )}
         </div>
 
         {/* Search */}

--- a/webchat/components/admin/channel-config-editor.tsx
+++ b/webchat/components/admin/channel-config-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { getChannelConfigFile, writeChannelConfigFile } from '@/lib/api/admin-bots';
 import type { AgentConfigFile } from '@/lib/types/admin';
 import { CONFIG_FILES } from './agent-config-file-list';
@@ -21,24 +21,31 @@ export function ChannelConfigEditor({ platform }: { platform: string }) {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const dirty = content !== savedContent;
 
+  // Request-sequence guard: when the user switches files quickly, a stale
+  // in-flight load must not overwrite the newer file's state.
+  const loadIdRef = useRef(0);
+
   const loadFile = useCallback(async (fileKey: string) => {
     const def = CONFIG_FILES.find((f) => f.key === fileKey);
     if (!def) return;
 
+    const reqId = ++loadIdRef.current;
     setLoading(true);
     setMessage(null);
     try {
       const data = await getChannelConfigFile(platform, def.file);
+      if (reqId !== loadIdRef.current) return; // superseded by a newer switch
       setFileData(data);
       setContent(data.content);
       setSavedContent(data.content);
     } catch (err) {
+      if (reqId !== loadIdRef.current) return;
       setMessage({ type: 'error', text: String(err) });
       setFileData(null);
       setContent('');
       setSavedContent('');
     } finally {
-      setLoading(false);
+      if (reqId === loadIdRef.current) setLoading(false);
     }
   }, [platform]);
 

--- a/webchat/components/admin/channel-config-editor.tsx
+++ b/webchat/components/admin/channel-config-editor.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { getChannelConfigFile, writeChannelConfigFile } from '@/lib/api/admin-bots';
+import type { AgentConfigFile } from '@/lib/types/admin';
+import { CONFIG_FILES } from './agent-config-file-list';
+
+/**
+ * ChannelConfigEditor edits platform-level (channel team-default) agent config
+ * files for a channel that has no bot instance — webchat owns dir/webchat/
+ * defaults but never appears in the bot registry. Mirrors BotConfigEditor's UX
+ * but addresses the dir/<platform>/ layer directly. See issue #796.
+ */
+export function ChannelConfigEditor({ platform }: { platform: string }) {
+  const [activeFile, setActiveFile] = useState<string>('soul');
+  const [fileData, setFileData] = useState<AgentConfigFile | null>(null);
+  const [content, setContent] = useState('');
+  const [savedContent, setSavedContent] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const dirty = content !== savedContent;
+
+  const loadFile = useCallback(async (fileKey: string) => {
+    const def = CONFIG_FILES.find((f) => f.key === fileKey);
+    if (!def) return;
+
+    setLoading(true);
+    setMessage(null);
+    try {
+      const data = await getChannelConfigFile(platform, def.file);
+      setFileData(data);
+      setContent(data.content);
+      setSavedContent(data.content);
+    } catch (err) {
+      setMessage({ type: 'error', text: String(err) });
+      setFileData(null);
+      setContent('');
+      setSavedContent('');
+    } finally {
+      setLoading(false);
+    }
+  }, [platform]);
+
+  useEffect(() => {
+    loadFile(activeFile);
+  }, [activeFile, loadFile]);
+
+  // Warn before navigating away with unsaved changes
+  useEffect(() => {
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      if (dirty) {
+        e.preventDefault();
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [dirty]);
+
+  const handleSwitchFile = (key: string) => {
+    if (key === activeFile) return;
+
+    if (dirty) {
+      if (!window.confirm('You have unsaved changes. Discard them and switch file?')) {
+        return;
+      }
+    }
+    setActiveFile(key);
+  };
+
+  const handleSave = async () => {
+    const def = CONFIG_FILES.find((f) => f.key === activeFile);
+    if (!def) return;
+
+    setSaving(true);
+    setMessage(null);
+    try {
+      await writeChannelConfigFile(platform, def.file, content);
+      setSavedContent(content);
+      setMessage({ type: 'success', text: 'Saved successfully' });
+      const data = await getChannelConfigFile(platform, def.file);
+      setFileData(data);
+      setTimeout(() => setMessage(null), 3000);
+    } catch (err) {
+      setMessage({ type: 'error', text: String(err) });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Keyboard shortcut: Ctrl/Cmd+S to save
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        if (dirty && !saving && !loading) {
+          handleSave();
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  });
+
+  const currentDef = CONFIG_FILES.find((f) => f.key === activeFile);
+  const charCount = content.length;
+  const charWarning = charCount > 8000;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Channel-default banner */}
+      <div className="px-3 py-2 rounded-lg bg-[var(--bg-hover)] border border-[var(--border-subtle)] text-[11px] text-[var(--text-muted)]">
+        Editing <span className="font-mono text-[var(--text-secondary)]">{platform}/</span> channel
+        team defaults. These apply to every {platform} workspace unless overridden per-workspace in
+        Settings &rarr; AI.
+      </div>
+
+      <div className="flex gap-4">
+        {/* Left sidebar */}
+        <div className="w-48 flex-shrink-0 space-y-1">
+          {CONFIG_FILES.map((def) => {
+            const isActive = activeFile === def.key;
+            return (
+              <button
+                key={def.key}
+                onClick={() => handleSwitchFile(def.key)}
+                className={`w-full text-left px-3 py-2.5 rounded-xl transition-all text-sm ${
+                  isActive
+                    ? 'bg-[var(--bg-active)] border border-[var(--border-active)] text-[var(--accent-gold)]'
+                    : 'hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] border border-transparent'
+                }`}
+              >
+                <span className="font-semibold block">{def.label}</span>
+                <span className="text-[10px] text-[var(--text-faint)] block mt-0.5">
+                  {def.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Right side */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {/* Header */}
+          {currentDef && fileData && (
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-semibold text-[var(--text-primary)]">
+                  {currentDef.file}
+                </span>
+                <span className="px-2 py-0.5 rounded-full text-[10px] font-mono bg-[var(--bg-elevated)] text-[var(--text-faint)] border border-[var(--border-subtle)]">
+                  {fileData.source}
+                </span>
+                <span
+                  className={`text-[10px] font-mono ${
+                    charWarning ? 'text-[var(--accent-coral)]' : 'text-[var(--text-faint)]'
+                  }`}
+                >
+                  {charCount.toLocaleString()} chars
+                  {charWarning && ' (> 8000)'}
+                </span>
+                {dirty && (
+                  <span className="px-1.5 py-0.5 rounded text-[9px] font-bold bg-[var(--accent-gold)]/15 text-[var(--accent-gold)]">
+                    unsaved
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={handleSave}
+                disabled={saving || loading || !dirty}
+                className="px-4 py-1.5 rounded-lg text-xs font-semibold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-[var(--accent-gold)] text-[var(--text-contrast)] hover:bg-[var(--accent-gold-bright)]"
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          )}
+
+          {/* Status message */}
+          {message && (
+            <div
+              className={`mb-3 px-4 py-3 rounded-[var(--radius-md)] text-xs ${
+                message.type === 'success'
+                  ? 'bg-[var(--accent-emerald-glow)] text-[var(--accent-emerald)]'
+                  : 'bg-[rgba(244,63,94,0.08)] border border-[rgba(244,63,94,0.15)] text-[var(--accent-coral)]'
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+
+          {/* Textarea */}
+          {loading ? (
+            <div className="flex-1 flex items-center justify-center rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] min-h-[600px]">
+              <div className="w-5 h-5 border-2 border-[var(--accent-gold)] border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : (
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="flex-1 w-full min-h-[600px] p-4 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] text-[var(--text-primary)] font-mono text-sm leading-relaxed resize-none focus:outline-none focus:border-[var(--border-active)] transition-colors placeholder:text-[var(--text-faint)]"
+              placeholder={currentDef ? `Edit ${currentDef.file}...` : ''}
+              spellCheck={false}
+            />
+          )}
+
+          {/* Footer hint */}
+          <div className="mt-2 flex items-center justify-between text-[10px] text-[var(--text-faint)]">
+            <span>Ctrl+S to save</span>
+            {dirty && <span>Changes not saved</span>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webchat/components/admin/channel-config-editor.tsx
+++ b/webchat/components/admin/channel-config-editor.tsx
@@ -68,7 +68,7 @@ export function ChannelConfigEditor({ platform }: { platform: string }) {
     setActiveFile(key);
   };
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     const def = CONFIG_FILES.find((f) => f.key === activeFile);
     if (!def) return;
 
@@ -86,9 +86,10 @@ export function ChannelConfigEditor({ platform }: { platform: string }) {
     } finally {
       setSaving(false);
     }
-  };
+  }, [platform, activeFile, content]);
 
-  // Keyboard shortcut: Ctrl/Cmd+S to save
+  // Keyboard shortcut: Ctrl/Cmd+S to save. Depends on the save handler and
+  // editor state so the listener never closes over stale values.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
@@ -100,7 +101,7 @@ export function ChannelConfigEditor({ platform }: { platform: string }) {
     }
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  });
+  }, [handleSave, dirty, saving, loading]);
 
   const currentDef = CONFIG_FILES.find((f) => f.key === activeFile);
   const charCount = content.length;

--- a/webchat/lib/api/admin-bots.ts
+++ b/webchat/lib/api/admin-bots.ts
@@ -65,6 +65,35 @@ export function writeAgentFile(
 }
 
 // ---------------------------------------------------------------------------
+// Channel Default Config (platform-level team defaults)
+//
+// Platforms without a bot instance (e.g. webchat) own dir/<platform>/ team
+// defaults but never appear in the bot registry. These endpoints address that
+// layer directly, serving as channel-wide defaults overridden per-workspace
+// by LoadForWorkspace. See issue #796.
+// ---------------------------------------------------------------------------
+
+export function getChannelConfigFile(platform: string, file: string): Promise<AgentConfigFile> {
+  return adminFetch<AgentConfigFile>(
+    `/admin/bots/platform/${encodeURIComponent(platform)}/config/${encodeURIComponent(file)}`,
+  );
+}
+
+export function writeChannelConfigFile(
+  platform: string,
+  file: string,
+  content: string,
+): Promise<AgentConfigFile> {
+  return adminFetch<AgentConfigFile>(
+    `/admin/bots/platform/${encodeURIComponent(platform)}/config/${encodeURIComponent(file)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ content }),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
 // System Prompt Preview
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 背景

Issue #796：webchat 与消息平台是接入同一 workspace 的两条平行通道。webchat 拥有 `dir/webchat/` platform-base（team-default）agent config 文件，但 adapter 的 `resolvePlatformForBot` 把 webchat 挡在 messaging registry 之外（webchat 无 bot 实例），导致这层文件**没有任何 admin UI 编辑入口**——只能手动改文件系统。

## 方案

补一条**按 platform 寻址的旁路**：绕过 registry、用空 botName 直接读写 `dir/{platform}/` platform 层。loader/writer 零改动（`Load(dir,"webchat","")` 早已支持并测试，loader_test.go:517-527）。

### 后端
- `agentconfig`: 新增 `KnownPlatforms()`/`IsValidPlatform()` 单一来源，替换 checkers + gateway_run 两处硬编码
- `BotConfigProvider` 接口 + adapter: 新增 `GetPlatformAgentConfigFile`/`WritePlatformAgentConfigFile`（`Load`/`WriteFile` 传空 botName）
- handlers: 新增 2 handler，platform 白名单 + file 白名单双防（traversal）
- routes: `GET/PUT /admin/bots/platform/{platform}/config/{file}`（字面段 `platform` 与 `{name}` 通配零冲突，段数不同）
- 写操作复用 `/admin/*` middleware（Bearer/cookie 鉴权 + sameOrigin CSRF + admin_audit，无需新接线）

### 前端
- `admin-bots` API: 新增 `getChannelConfigFile`/`writeChannelConfigFile`
- `ChannelConfigEditor`: 复用 `BotConfigEditor` 文件读写模式（props `{platform}`）
- `/admin/bots` 列表页: 加 "Channel Defaults" 可折叠入口（webchat）

> issue 写"复用 AgentConfigEditor"，但代码实证它是 workspace override 编辑器（写 `updateWorkspace`），不适用；真正复用的是 `BotConfigEditor` 的文件读写模式。

## 验收对齐
- [x] UI 可编辑 webchat platform-base（SOUL/AGENTS/SKILLS/USER/MEMORY）写入 `~/.hotplex/agent-configs/webchat/`
- [x] 写入即作为 webchat 通道 team-default 生效（LoadForWorkspace 既有优先级：workspace override > platform base > global）
- [x] 写操作经 admin 鉴权 + audit + CSRF
- [x] 现有 `/admin/bots/{name}/config/{file}` 行为不变（独立路由段，零交集）

## 测试
- adapter 集成测试：落盘 `dir/webchat/`、LoadForWorkspace team-default 生效、override 优先级、未知 platform 拒绝、global fallback、per-platform 隔离
- handler 测试：scope 校验、platform/file 白名单、nil-provider 503、provider-error 400
- 路由隔离测试：ServeMux 注册无 panic + webchat 请求命中 platform handler 不误入 bot handler（bot config 此前零测试覆盖）

## 验证
- `make quality`（fmt + lint + test -race）全绿
- pre-push 完整门禁（fmt + lint + vet + checksums + build + tests）通过
- `tsc --noEmit` 通过

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)