### PR TITLE
feat(admin): /admin/workspaces 控制台 — 全局 workspace 列表 + inline permission_mode 管理 (#807)

### DIFF
--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -84,6 +84,7 @@ func setupRoutes(
 		Cron:             cronProvider,
 		BotLister:        &botListerAdapter{registry: messaging.DefaultBotRegistry()},
 		BotConfig:        newBotConfigAdapter(deps.ConfigStore, cfg.AgentConfig.ConfigDir, ""),
+		WorkspaceStore:   deps.WorkspaceStore,
 		Version:          versionString,
 		NewSessionID:     newSessionID,
 		AllowedOriginsFn: corsOriginsFn,
@@ -183,6 +184,13 @@ func setupRoutes(
 	adminMux.HandleFunc("GET /admin/api-keys/{id}", adminAPI.HandleAPIKeyUserGet)
 	adminMux.HandleFunc("PATCH /admin/api-keys/{id}", adminAPI.HandleAPIKeyUserUpdate)
 	adminMux.HandleFunc("DELETE /admin/api-keys/{id}", adminAPI.HandleAPIKeyUserDelete)
+
+	// Workspace admin console (issue #807): global list (with owner identity) +
+	// inline permission_mode edit. Admin-only via AdminAPI.Middleware; the user
+	// self-service /api/workspaces/* endpoints stay separate (registered below at
+	// /api/workspaces with Authenticator + CSRF, not admin scope).
+	adminMux.HandleFunc("GET /admin/workspaces", adminAPI.HandleListAdminWorkspaces)
+	adminMux.HandleFunc("PATCH /admin/workspaces/{id}", adminAPI.HandleUpdateAdminWorkspacePermissionMode)
 
 	// Documentation
 	if resolved := security.ResolveCSP(security.DefaultDocsCSP, cfg.Security.CSP); security.IsPermissiveCSP(resolved) {

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -277,7 +277,7 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 
 > 🛡️ **审计**：PATCH 写操作由 middleware 级 `admin_audit` 统一记录，action = `workspace.permission_mode.update`，actor = uid（Cookie 通道）或 `admin-token`（Bearer），target = `/admin/workspaces/{id}`。
 
-PATCH 错误码：`400 INVALID_PERMISSION_MODE`（档位非法）/ `400 BAD_REQUEST`（body 缺 `permission_mode`）/ `404 WORKSPACE_NOT_FOUND`（id 不存在）/ `409 WORKSPACE_VERSION_MISMATCH`（`updated_at` CAS 冲突，提示重新拉取）。
+PATCH 错误码：`400 INVALID_PERMISSION_MODE`（档位非法）/ `400 BAD_REQUEST`（body 缺 `permission_mode`）/ `404 WORKSPACE_NOT_FOUND`（id 不存在）/ `409 WORKSPACE_VERSION_MISMATCH`（`updated_at` CAS 冲突；或并发更新下 workspace 恰有活跃会话时的 CAS heuristic 误判——本端点只改 `permission_mode`、不动 `work_dir`，活跃会话不真正阻塞，故两种成因都应重新 GET 最新 `updated_at` 后重试，新值仅对新会话生效）。
 
 ## Gateway API 端点
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -260,6 +260,25 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 
 **DELETE /admin/api-keys/{id}** — 物理删除映射，同时清除缓存的 resolver 条目。
 
+### Workspace 管理（admin 控制台）
+
+> 🆕 **issue #807** — admin 控制台的 workspace 全局视图。区别于用户自助的 `/api/workspaces/*`（见下文 Gateway API 段）：这两个端点走 admin 双通道鉴权（Bearer + Cookie fallback，强制 `role==admin && status==active`），列出全平台 workspace 并支持 inline 修改 `permission_mode`。
+
+| 方法 | 路径 | Scope | 说明 |
+|------|------|-------|------|
+| GET | `/admin/workspaces` | `admin:read` | 列出所有 workspace（带 owner 可读标识） |
+| PATCH | `/admin/workspaces/{id}` | `admin:write` | 修改单个 workspace 的 `permission_mode` |
+
+**GET /admin/workspaces** — 返回所有 active workspace，`LEFT JOIN users` 带上 owner 可读标识（`owner_display_name` + `owner_username`），admin 无需面对裸 UUID。owner 行缺失时（并发删除窗口）owner 字段回落为空串、workspace 仍返回。响应：`{"workspaces":[{id, owner_user_id, owner_display_name, owner_username, name, work_dir, permission_mode, status, created_at, updated_at, agent_config_overrides, worker_preference}]}`。读操作不审计。
+
+**PATCH /admin/workspaces/{id}** — **仅**接受 `permission_mode` 字段（admin 控制台范围最小化：不暴露 `work_dir`/`name` 修改，避免 admin 误改用户工作目录；这些仍走用户自助 `/api/workspaces/{id}`）。JSON body：`{"permission_mode":"<tier>"}`，`permission_mode` 必须显式提供（缺失返回 `400 BAD_REQUEST`）；值为 4 档之一（`bypass`/`auto-edit`/`workspace`/`read-only`）或空串（清除覆盖，回落 `config.worker.default_permission_mode`，缺省 `workspace`）。返回更新后的 workspace 裸行。
+
+> ⏱️ **生效语义**：写库后**运行中 session 不受影响**（worker 进程已注入权限参数）；新 session（新对话 / `/reset`）初始化时 `resolveWorkspacePermissionMode` 读到新值。UI 标注「对新会话生效」。
+
+> 🛡️ **审计**：PATCH 写操作由 middleware 级 `admin_audit` 统一记录，action = `workspace.permission_mode.update`，actor = uid（Cookie 通道）或 `admin-token`（Bearer），target = `/admin/workspaces/{id}`。
+
+PATCH 错误码：`400 INVALID_PERMISSION_MODE`（档位非法）/ `400 BAD_REQUEST`（body 缺 `permission_mode`）/ `404 WORKSPACE_NOT_FOUND`（id 不存在）/ `409 WORKSPACE_VERSION_MISMATCH`（`updated_at` CAS 冲突，提示重新拉取）。
+
 ## Gateway API 端点
 
 Gateway API（`/api/sessions`）监听在网关主端口（`8888`），面向客户端 SDK 和 WebSocket 连接，使用 API Key 认证（非 Bearer Token）。

--- a/docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md
+++ b/docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md
@@ -1,6 +1,6 @@
 # Admin 控制台 — Workspace Permission Mode 管理
 
-**状态**: Draft · **日期**: 2026-06-29 · **关联**: [Workspace-Permission-Mode-Spec.md](./Workspace-Permission-Mode-Spec.md)、[Workspace-Permission-Mode-Admin-Only-Revision-Spec.md](./Workspace-Permission-Mode-Admin-Only-Revision-Spec.md)（r3）· **版本目标**: v1.31.x
+**状态**: Implemented · **日期**: 2026-06-29 · **关联 issue**: #807 · **关联**: [Workspace-Permission-Mode-Spec.md](./Workspace-Permission-Mode-Spec.md)、[Workspace-Permission-Mode-Admin-Only-Revision-Spec.md](./Workspace-Permission-Mode-Admin-Only-Revision-Spec.md)（r3）· **版本目标**: v1.31.x
 
 ---
 

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1895,6 +1895,101 @@
                 }
             }
         },
+        "/admin/workspaces": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns every workspace across owners with owner display identity. Requires admin:read.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List all workspaces (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.WorkspaceListResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/workspaces/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Change a workspace's permission_mode. Admin-only. Affects new sessions only.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Update workspace permission mode (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "permission_mode to set",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.updateAdminWorkspaceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.WorkspaceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "INVALID_PERMISSION_MODE / missing permission_mode",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "WORKSPACE_NOT_FOUND",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "WORKSPACE_VERSION_MISMATCH",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/sessions": {
             "get": {
                 "security": [
@@ -3561,12 +3656,69 @@
                 }
             }
         },
+        "admin.WorkspaceListResponse": {
+            "type": "object",
+            "properties": {
+                "workspaces": {
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "admin.WorkspaceResponse": {
+            "type": "object",
+            "properties": {
+                "agent_config_overrides": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "ws-uuid"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "my-project"
+                },
+                "owner_user_id": {
+                    "type": "string"
+                },
+                "permission_mode": {
+                    "type": "string",
+                    "example": "workspace"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "active"
+                },
+                "updated_at": {
+                    "type": "integer"
+                },
+                "work_dir": {
+                    "type": "string",
+                    "example": "/home/u/.hotplex/workspaces/uid/my-project"
+                },
+                "worker_preference": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.WriteAgentConfigRequest": {
             "type": "object",
             "properties": {
                 "content": {
                     "type": "string",
                     "example": "You are a helpful assistant."
+                }
+            }
+        },
+        "admin.updateAdminWorkspaceRequest": {
+            "type": "object",
+            "properties": {
+                "permission_mode": {
+                    "type": "string"
                 }
             }
         }

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/security"
+	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/web"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -111,6 +112,7 @@ type AdminAPI struct {
 	cron             CronSchedulerProvider
 	botLister        BotListerProvider
 	botConfig        BotConfigProvider
+	wsStore          session.UserWorkspaceStore // Optional: enables /admin/workspaces console (issue #807); nil when multitenancy/webchat disabled
 	logCollector     LogCollector
 	akStore          APIKeyUserStorer // nil when DB resolver not enabled
 	keyValidator     KeyValidator     // nil when not injected
@@ -136,6 +138,7 @@ type Deps struct {
 	Cron             CronSchedulerProvider
 	BotLister        BotListerProvider
 	BotConfig        BotConfigProvider
+	WorkspaceStore   session.UserWorkspaceStore // Optional: enables /admin/workspaces console (issue #807)
 	LogCollector     LogCollector
 	Version          func() string
 	NewSessionID     func() string
@@ -164,6 +167,7 @@ func New(deps Deps) *AdminAPI {
 		cron:          deps.Cron,
 		botLister:     deps.BotLister,
 		botConfig:     deps.BotConfig,
+		wsStore:       deps.WorkspaceStore,
 		logCollector:  lc,
 		keyValidator:  deps.KeyValidator,
 		akStore: func() APIKeyUserStorer {

--- a/internal/admin/audit.go
+++ b/internal/admin/audit.go
@@ -10,27 +10,28 @@ import (
 // admin_audit slog records. Stable strings — never rename without a consumer
 // audit, log dashboards filter on these.
 const (
-	AuditGatewayRestart     = "gateway.restart"
-	AuditBotCreate          = "bot.create"
-	AuditBotUpdate          = "bot.update"
-	AuditBotDelete          = "bot.delete"
-	AuditAPIKeyCreate       = "apikey.create"
-	AuditAPIKeyUpdate       = "apikey.update"
-	AuditAPIKeyDelete       = "apikey.delete"
-	AuditCronCreate         = "cron.create"
-	AuditCronUpdate         = "cron.update"
-	AuditCronDelete         = "cron.delete"
-	AuditCronTrigger        = "cron.trigger"
-	AuditSessionDelete      = "session.delete"
-	AuditSessionTerminate   = "session.terminate"
-	AuditSessionPatch       = "session.patch"
-	AuditSessionPut         = "session.put"
-	AuditConfigRollback     = "config.rollback"
-	AuditConfigValidate     = "config.validate"
-	AuditMemberStatusUpdate = "member.status.update"
-	AuditInvitationCreate   = "invitation.create"
-	AuditInvitationDelete   = "invitation.delete"
-	AuditAuthDenied         = "auth.denied"
+	AuditGatewayRestart                = "gateway.restart"
+	AuditBotCreate                     = "bot.create"
+	AuditBotUpdate                     = "bot.update"
+	AuditBotDelete                     = "bot.delete"
+	AuditAPIKeyCreate                  = "apikey.create"
+	AuditAPIKeyUpdate                  = "apikey.update"
+	AuditAPIKeyDelete                  = "apikey.delete"
+	AuditCronCreate                    = "cron.create"
+	AuditCronUpdate                    = "cron.update"
+	AuditCronDelete                    = "cron.delete"
+	AuditCronTrigger                   = "cron.trigger"
+	AuditSessionDelete                 = "session.delete"
+	AuditSessionTerminate              = "session.terminate"
+	AuditSessionPatch                  = "session.patch"
+	AuditSessionPut                    = "session.put"
+	AuditConfigRollback                = "config.rollback"
+	AuditConfigValidate                = "config.validate"
+	AuditMemberStatusUpdate            = "member.status.update"
+	AuditInvitationCreate              = "invitation.create"
+	AuditInvitationDelete              = "invitation.delete"
+	AuditWorkspacePermissionModeUpdate = "workspace.permission_mode.update" // issue #807 admin console
+	AuditAuthDenied                    = "auth.denied"
 
 	// AuditResult* — stable "result" field values. Reuse instead of literals so
 	// dashboard filters stay correct (issue #788 review P3).
@@ -97,8 +98,23 @@ func adminActionFor(method, path string) string {
 		return botAction(method)
 	case strings.Contains(path, "/sessions"):
 		return sessionAction(method)
+	case strings.Contains(path, "/workspaces"):
+		return workspaceAction(method)
 	}
 	return method + " " + path
+}
+
+// workspaceAction covers PATCH /admin/workspaces/{id} (issue #807) — the only
+// admin workspace write. GET /admin/workspaces (list) isn't audited
+// (isWriteMethod is false). The /workspaces branch sits last in adminActionFor
+// so it can't shadow the /sessions, /bots, /cron, /api-keys branches above
+// (none of those paths contain "/workspaces" as a substring).
+func workspaceAction(method string) string {
+	switch method {
+	case http.MethodPatch, http.MethodPut:
+		return AuditWorkspacePermissionModeUpdate
+	}
+	return "workspace." + strings.ToLower(method)
 }
 
 func botAction(method string) string {

--- a/internal/admin/models.go
+++ b/internal/admin/models.go
@@ -29,6 +29,30 @@ type SessionListResponse struct {
 	Offset   int   `json:"offset" example:"0"`
 }
 
+// WorkspaceListResponse is returned by GET /admin/workspaces (issue #807). Each
+// entry is a session.AdminWorkspaceView (workspace row + owner_display_name +
+// owner_username). Schema-only — handlers respond via respondJSON(map[string]any).
+type WorkspaceListResponse struct {
+	Workspaces []any `json:"workspaces"`
+}
+
+// WorkspaceResponse mirrors session.Workspace for the PATCH /admin/workspaces/{id}
+// success schema (issue #807). Defined locally because swaggo indexes types only
+// within the admin package — it cannot resolve cross-package session.Workspace.
+// Runtime serialization is unaffected (handlers return the real *session.Workspace).
+type WorkspaceResponse struct {
+	ID                   string `json:"id" example:"ws-uuid"`
+	OwnerUserID          string `json:"owner_user_id"`
+	Name                 string `json:"name" example:"my-project"`
+	WorkDir              string `json:"work_dir" example:"/home/u/.hotplex/workspaces/uid/my-project"`
+	AgentConfigOverrides string `json:"agent_config_overrides"`
+	WorkerPreference     string `json:"worker_preference"`
+	PermissionMode       string `json:"permission_mode" example:"workspace"`
+	Status               string `json:"status" example:"active"`
+	CreatedAt            int64  `json:"created_at"`
+	UpdatedAt            int64  `json:"updated_at"`
+}
+
 // CreateSessionResponse is returned by POST /admin/sessions.
 type CreateSessionResponse struct {
 	SessionID string `json:"session_id" example:"550e8400-e29b-41d4-a716-446655440000"`

--- a/internal/admin/workspace_handlers.go
+++ b/internal/admin/workspace_handlers.go
@@ -133,13 +133,11 @@ func (a *AdminAPI) HandleUpdateAdminWorkspacePermissionMode(w http.ResponseWrite
 			web.WriteAppError(w, http.StatusConflict, "WORKSPACE_VERSION_MISMATCH", "workspace concurrently modified, please re-fetch and retry")
 			return
 		}
-		// permission_mode changes don't trip the work_dir CAS guard (work_dir is
-		// unchanged), so ErrWorkspaceNotEmpty shouldn't occur here — mapped
-		// defensively rather than leaking a 500.
-		if errors.Is(err, session.ErrWorkspaceNotEmpty) {
-			web.WriteAppError(w, http.StatusConflict, "WORKSPACE_NOT_EMPTY", "workspace has active sessions blocking the update")
-			return
-		}
+		// ErrWorkspaceNotEmpty is intentionally not mapped: the store only raises
+		// it when a work_dir change is blocked by an active session, but this
+		// endpoint only changes permission_mode (never work_dir), so it's
+		// unreachable for this path. A concurrent edit that loses the updated_at
+		// CAS is caught above as ErrWorkspaceConflict; any other failure is a 500.
 		a.log.Error("admin: update workspace permission_mode", "id", id, "err", err)
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "update failed")
 		return

--- a/internal/admin/workspace_handlers.go
+++ b/internal/admin/workspace_handlers.go
@@ -1,0 +1,148 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/web"
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+// updateAdminWorkspaceRequest is the body for PATCH /admin/workspaces/{id} (issue
+// #807). Only permission_mode is accepted — the admin console scope is minimal
+// (list + inline permission_mode change); name/work_dir edits stay on the user
+// self-service /api/workspaces/{id} endpoint so an admin can't accidentally
+// rewrite a user's work_dir. PermissionMode is a pointer so "field absent" (nil,
+// → 400) is distinct from "clear override" ("").
+type updateAdminWorkspaceRequest struct {
+	PermissionMode *string `json:"permission_mode"`
+}
+
+// HandleListAdminWorkspaces returns every workspace across owners with readable
+// owner identity for the admin console global view (spec §3.1, issue #807).
+// Distinct from GET /api/workspaces (user self-service, own workspaces only):
+// this lists all workspaces joined with users.display_name + users.username so an
+// admin scanning the table can identify ownership instead of raw owner_user_id
+// UUIDs.
+//
+// Auth: AdminAPI.Middleware has already enforced admin (role==admin && status==
+// active) before this handler runs; requireScope narrows to admin:read. GET is not
+// audited (admin read endpoints aren't — audit.go isWriteMethod).
+//
+// @Summary      List all workspaces (admin)
+// @Description  Returns every workspace across owners with owner display identity. Requires admin:read.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  WorkspaceListResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Router       /admin/workspaces [get]
+func (a *AdminAPI) HandleListAdminWorkspaces(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminRead) {
+		return
+	}
+	if a.wsStore == nil {
+		// Webchat/multitenancy disabled — return an empty list rather than 503 so
+		// the console renders cleanly in single-tenant deployments.
+		respondJSON(w, map[string]any{"workspaces": []any{}})
+		return
+	}
+	views, err := a.wsStore.ListAllWorkspacesWithOwner(r.Context())
+	if err != nil {
+		a.log.Error("admin: list workspaces with owner", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "list workspaces failed")
+		return
+	}
+	respondJSON(w, map[string]any{"workspaces": views})
+}
+
+// HandleUpdateAdminWorkspacePermissionMode changes a single workspace's
+// permission_mode (spec §3.2, issue #807). Admin-only by middleware; only the
+// permission_mode field is accepted.
+//
+// Effect semantics: UpdateWorkspace writes the row; running sessions are
+// unaffected (the worker process already has its permission params injected).
+// New sessions (new conversation / /reset) pick up the new value via
+// resolveWorkspacePermissionMode at init — the UI surfaces this as "takes effect
+// for new sessions".
+//
+// The PATCH write is auto-audited by AdminAPI.Middleware's defer (audit.go) as
+// AuditWorkspacePermissionModeUpdate via adminActionFor; this handler does not
+// call AdminAudit itself (the middleware covers both ok and failed results).
+//
+// @Summary      Update workspace permission mode (admin)
+// @Description  Change a workspace's permission_mode. Admin-only. Affects new sessions only.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id    path      string  true  "Workspace ID"
+// @Param        body  body      updateAdminWorkspaceRequest  true  "permission_mode to set"
+// @Success      200   {object}  WorkspaceResponse
+// @Failure      400   {object}  ErrorResponse  "INVALID_PERMISSION_MODE / missing permission_mode"
+// @Failure      404   {object}  ErrorResponse  "WORKSPACE_NOT_FOUND"
+// @Failure      409   {object}  ErrorResponse  "WORKSPACE_VERSION_MISMATCH"
+// @Router       /admin/workspaces/{id} [patch]
+func (a *AdminAPI) HandleUpdateAdminWorkspacePermissionMode(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminWrite) {
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "missing workspace id")
+		return
+	}
+	if a.wsStore == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "workspace store not configured")
+		return
+	}
+	var req updateAdminWorkspaceRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid request body")
+		return
+	}
+	// permission_mode must be explicitly present (nil = field omitted). This
+	// endpoint's only job is changing that one field, so an absent field is a
+	// client bug, not a no-op. "" is valid (clears the override → config default),
+	// mirroring the user self-service PATCH semantics (workspace_handlers.go:286).
+	if req.PermissionMode == nil {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "permission_mode field is required")
+		return
+	}
+	if err := worker.ValidatePermissionMode(*req.PermissionMode); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "INVALID_PERMISSION_MODE", err.Error())
+		return
+	}
+	ws, err := a.wsStore.GetWorkspaceByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, session.ErrWorkspaceNotFound) {
+			web.WriteAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "workspace not found")
+			return
+		}
+		a.log.Error("admin: get workspace", "id", id, "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "get workspace failed")
+		return
+	}
+	ws.PermissionMode = *req.PermissionMode
+	if err := a.wsStore.UpdateWorkspace(r.Context(), ws, time.Now().Unix()); err != nil {
+		if errors.Is(err, session.ErrWorkspaceConflict) {
+			web.WriteAppError(w, http.StatusConflict, "WORKSPACE_VERSION_MISMATCH", "workspace concurrently modified, please re-fetch and retry")
+			return
+		}
+		// permission_mode changes don't trip the work_dir CAS guard (work_dir is
+		// unchanged), so ErrWorkspaceNotEmpty shouldn't occur here — mapped
+		// defensively rather than leaking a 500.
+		if errors.Is(err, session.ErrWorkspaceNotEmpty) {
+			web.WriteAppError(w, http.StatusConflict, "WORKSPACE_NOT_EMPTY", "workspace has active sessions blocking the update")
+			return
+		}
+		a.log.Error("admin: update workspace permission_mode", "id", id, "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "update failed")
+		return
+	}
+	respondJSON(w, ws)
+}

--- a/internal/admin/workspace_handlers.go
+++ b/internal/admin/workspace_handlers.go
@@ -129,15 +129,17 @@ func (a *AdminAPI) HandleUpdateAdminWorkspacePermissionMode(w http.ResponseWrite
 	}
 	ws.PermissionMode = *req.PermissionMode
 	if err := a.wsStore.UpdateWorkspace(r.Context(), ws, time.Now().Unix()); err != nil {
-		if errors.Is(err, session.ErrWorkspaceConflict) {
+		// Both ErrWorkspaceConflict (updated_at CAS loss) and ErrWorkspaceNotEmpty
+		// are version mismatches for the caller: this endpoint only changes
+		// permission_mode (never work_dir), so the store's work_dir-blocking
+		// NotEmpty signal can only surface here as a CAS-loss heuristic misjudgment
+		// (RowsAffected==0 + a concurrent active session), not a real work_dir
+		// conflict. Map both to a retryable WORKSPACE_VERSION_MISMATCH so the client
+		// re-fetches instead of hitting an unretryable 500.
+		if errors.Is(err, session.ErrWorkspaceConflict) || errors.Is(err, session.ErrWorkspaceNotEmpty) {
 			web.WriteAppError(w, http.StatusConflict, "WORKSPACE_VERSION_MISMATCH", "workspace concurrently modified, please re-fetch and retry")
 			return
 		}
-		// ErrWorkspaceNotEmpty is intentionally not mapped: the store only raises
-		// it when a work_dir change is blocked by an active session, but this
-		// endpoint only changes permission_mode (never work_dir), so it's
-		// unreachable for this path. A concurrent edit that loses the updated_at
-		// CAS is caught above as ErrWorkspaceConflict; any other failure is a 500.
 		a.log.Error("admin: update workspace permission_mode", "id", id, "err", err)
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "update failed")
 		return

--- a/internal/admin/workspace_handlers_test.go
+++ b/internal/admin/workspace_handlers_test.go
@@ -1,0 +1,183 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/security"
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/sqlutil"
+)
+
+// setupWorkspaceTestStore builds a real SQLiteStore (migrated) for /admin/workspaces
+// handler tests. Mirrors session.helperDB but lives in the admin package so the
+// handlers exercise the actual store rather than a hand-rolled mock.
+func setupWorkspaceTestStore(t *testing.T) *session.SQLiteStore {
+	t.Helper()
+	cfg := config.Default()
+	cfg.DB.Path = filepath.Join(t.TempDir(), "test.db")
+	cfg.DB.SQLite.Path = cfg.DB.Path
+	cfg.DB.WALMode = true
+	store, err := session.NewSQLiteStore(context.Background(), cfg, sqlutil.NewWriteMu(sqlutil.DialectSQLite))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// setupWorkspaceAPI seeds one owner (Alice/u-1) + one workspace (ws-1, mode
+// "workspace") and wires the store into a fresh AdminAPI.
+func setupWorkspaceAPI(t *testing.T) *AdminAPI {
+	t.Helper()
+	store := setupWorkspaceTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-1", Username: "alice", DisplayName: "Alice", Role: "user", Status: "active"}, 1700000000))
+	require.NoError(t, store.CreateWorkspace(ctx, &session.Workspace{ID: "ws-1", OwnerUserID: "u-1", Name: "proj", WorkDir: "/tmp/p", PermissionMode: "workspace"}, 1700000000))
+	return newTestAPI(func(d *Deps) { d.WorkspaceStore = store })
+}
+
+// --- GET /admin/workspaces ---
+
+func TestHandleListAdminWorkspaces(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	r := httptest.NewRequest(http.MethodGet, "/admin/workspaces", nil)
+	r = withScope(r, ScopeAdminRead)
+	w := httptest.NewRecorder()
+	api.HandleListAdminWorkspaces(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Workspaces []session.AdminWorkspaceView `json:"workspaces"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Workspaces, 1)
+	require.Equal(t, "ws-1", resp.Workspaces[0].ID)
+	require.Equal(t, "Alice", resp.Workspaces[0].OwnerDisplayName)
+	require.Equal(t, "alice", resp.Workspaces[0].OwnerUsername)
+	require.Equal(t, "workspace", resp.Workspaces[0].PermissionMode)
+}
+
+func TestHandleListAdminWorkspaces_NilStore(t *testing.T) {
+	api := newTestAPI() // no WorkspaceStore → multitenancy disabled
+	r := httptest.NewRequest(http.MethodGet, "/admin/workspaces", nil)
+	r = withScope(r, ScopeAdminRead)
+	w := httptest.NewRecorder()
+	api.HandleListAdminWorkspaces(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, "nil store returns empty list, not 503")
+	var resp map[string][]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Empty(t, resp["workspaces"])
+}
+
+func TestHandleListAdminWorkspaces_Forbidden(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	r := httptest.NewRequest(http.MethodGet, "/admin/workspaces", nil)
+	r = withScope(r, ScopeSessionRead) // not admin:read
+	w := httptest.NewRecorder()
+	api.HandleListAdminWorkspaces(w, r)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// --- PATCH /admin/workspaces/{id} ---
+
+func TestHandleUpdateAdminWorkspacePermissionMode_LegalValues(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	// All four tiers + "" (clear override) must round-trip (spec §3.2, issue #789).
+	for _, mode := range []string{"read-only", "workspace", "auto-edit", "bypass", ""} {
+		r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/{id}",
+			strings.NewReader(fmt.Sprintf(`{"permission_mode":%q}`, mode)))
+		r.SetPathValue("id", "ws-1")
+		r = withScope(r, ScopeAdminWrite)
+		w := httptest.NewRecorder()
+		api.HandleUpdateAdminWorkspacePermissionMode(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code, "mode %q should be accepted", mode)
+		var ws session.Workspace
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&ws))
+		require.Equal(t, mode, ws.PermissionMode, "mode %q should persist", mode)
+	}
+}
+
+func TestHandleUpdateAdminWorkspacePermissionMode_InvalidMode(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/{id}",
+		strings.NewReader(`{"permission_mode":"god-mode"}`))
+	r.SetPathValue("id", "ws-1")
+	r = withScope(r, ScopeAdminWrite)
+	w := httptest.NewRecorder()
+	api.HandleUpdateAdminWorkspacePermissionMode(w, r)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleUpdateAdminWorkspacePermissionMode_MissingField(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	// Body without permission_mode → 400 (the field is this endpoint's sole job).
+	r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/{id}", strings.NewReader(`{}`))
+	r.SetPathValue("id", "ws-1")
+	r = withScope(r, ScopeAdminWrite)
+	w := httptest.NewRecorder()
+	api.HandleUpdateAdminWorkspacePermissionMode(w, r)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleUpdateAdminWorkspacePermissionMode_NotFound(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/{id}",
+		strings.NewReader(`{"permission_mode":"read-only"}`))
+	r.SetPathValue("id", "ws-ghost")
+	r = withScope(r, ScopeAdminWrite)
+	w := httptest.NewRecorder()
+	api.HandleUpdateAdminWorkspacePermissionMode(w, r)
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleUpdateAdminWorkspacePermissionMode_Forbidden(t *testing.T) {
+	api := setupWorkspaceAPI(t)
+	r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/{id}",
+		strings.NewReader(`{"permission_mode":"read-only"}`))
+	r.SetPathValue("id", "ws-1")
+	r = withScope(r, ScopeAdminRead) // not admin:write
+	w := httptest.NewRecorder()
+	api.HandleUpdateAdminWorkspacePermissionMode(w, r)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestAdminWorkspaceUpdate_AuditTrail locks in the middleware-level audit: a
+// successful PATCH /admin/workspaces/{id} must emit an admin_audit record tagged
+// workspace.permission_mode.update (spec §3.3, issue #807). Drives the full
+// AdminAPI.Middleware so the audit defer fires (handler-direct calls bypass it).
+// NOT parallel: SetAuditLogger swaps a process-global logger.
+func TestAdminWorkspaceUpdate_AuditTrail(t *testing.T) {
+	var buf bytes.Buffer
+	SetAuditLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { SetAuditLogger(slog.Default()) })
+
+	api := setupWorkspaceAPI(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /admin/workspaces/{id}", api.HandleUpdateAdminWorkspacePermissionMode)
+	handler := api.Middleware(mux)
+
+	r := httptest.NewRequest(http.MethodPatch, "/admin/workspaces/ws-1",
+		strings.NewReader(`{"permission_mode":"read-only"}`))
+	r.Header.Set("Authorization", "Bearer test-token") // mockConfig token → DefaultScopes (has admin:write)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	out := buf.String()
+	require.Contains(t, out, "admin_audit", "PATCH must leave an audit trail")
+	require.Contains(t, out, "workspace.permission_mode.update", "audit action must be the workspace enum")
+	require.Contains(t, out, "admin-token", "Bearer channel actor is admin-token")
+	require.Contains(t, out, "/admin/workspaces/ws-1", "audit target must carry the workspace id")
+}

--- a/internal/session/multitenancy_admin_view_test.go
+++ b/internal/session/multitenancy_admin_view_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/security"
+)
+
+// TestWorkspacesStore_ListAllWithOwner verifies the admin console projection
+// (spec §3.1, issue #807): every active workspace returns with its owner's
+// readable identity (display_name + username) joined in, ordered by owner
+// display_name then workspace name, and the permission_mode override passes
+// through ("" = no explicit override).
+func TestWorkspacesStore_ListAllWithOwner(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-1", Username: "alice", DisplayName: "Alice", Role: "user", Status: "active"}, 1700000000))
+	require.NoError(t, store.CreateUser(ctx, &security.User{ID: "u-2", Username: "bob", DisplayName: "Bob", Role: "user", Status: "active"}, 1700000000))
+	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-1", OwnerUserID: "u-1", Name: "proj-a", WorkDir: "/tmp/a", PermissionMode: "workspace"}, 1700000000))
+	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-2", OwnerUserID: "u-1", Name: "proj-b", WorkDir: "/tmp/b"}, 1700000000)) // no override
+	require.NoError(t, store.CreateWorkspace(ctx, &Workspace{ID: "ws-3", OwnerUserID: "u-2", Name: "proj-c", WorkDir: "/tmp/c", PermissionMode: "read-only"}, 1700000000))
+
+	views, err := store.ListAllWorkspacesWithOwner(ctx)
+	require.NoError(t, err)
+	require.Len(t, views, 3)
+
+	// ORDER BY u.display_name, w.name → Alice/proj-a, Alice/proj-b, Bob/proj-c.
+	require.Equal(t, "ws-1", views[0].ID)
+	require.Equal(t, "Alice", views[0].OwnerDisplayName, "owner display_name must join in")
+	require.Equal(t, "alice", views[0].OwnerUsername, "owner username must join in")
+	require.Equal(t, "workspace", views[0].PermissionMode)
+
+	require.Equal(t, "ws-2", views[1].ID)
+	require.Equal(t, "Alice", views[1].OwnerDisplayName)
+	require.Equal(t, "", views[1].PermissionMode, "no explicit override scans as empty")
+
+	require.Equal(t, "ws-3", views[2].ID)
+	require.Equal(t, "Bob", views[2].OwnerDisplayName)
+	require.Equal(t, "read-only", views[2].PermissionMode)
+}
+
+func TestWorkspacesStore_ListAllWithOwner_Empty(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	views, err := store.ListAllWorkspacesWithOwner(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, views)
+}

--- a/internal/session/multitenancy_pg_store.go
+++ b/internal/session/multitenancy_pg_store.go
@@ -129,6 +129,26 @@ func (s *pgStore) ListAllWorkspaces(ctx context.Context) ([]*Workspace, error) {
 	return out, rows.Err()
 }
 
+// ListAllWorkspacesWithOwner mirrors SQLiteStore.ListAllWorkspacesWithOwner for PG
+// (spec §3.1, issue #807). The query has no bind params, so the rebound text is
+// dialect-identical to the SQLite form; only the store handle differs.
+func (s *pgStore) ListAllWorkspacesWithOwner(ctx context.Context) ([]*AdminWorkspaceView, error) {
+	rows, err := s.db.QueryContext(ctx, s.queries["workspaces.list_with_owner"])
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []*AdminWorkspaceView
+	for rows.Next() {
+		v, err := scanAdminWorkspace(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
 func (s *pgStore) GetWorkspaceByOwnerAndWorkDir(ctx context.Context, ownerUserID, workDir string) (*Workspace, error) {
 	w, err := scanWorkspace(s.db.QueryRowContext(ctx, s.queries["workspaces.get_by_owner_and_workdir"], ownerUserID, workDir))
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/session/multitenancy_store.go
+++ b/internal/session/multitenancy_store.go
@@ -26,6 +26,17 @@ type Workspace struct {
 	UpdatedAt            int64  `json:"updated_at"`
 }
 
+// AdminWorkspaceView is the admin console projection of a workspace with the
+// owner's readable identity joined in (spec §3.1, issue #807). It embeds Workspace
+// so the full row (id/owner/name/work_dir/permission_mode/...) serializes as-is,
+// plus OwnerDisplayName/OwnerUsername so an admin scanning the global list can
+// identify ownership instead of staring at a raw owner_user_id UUID.
+type AdminWorkspaceView struct {
+	Workspace
+	OwnerDisplayName string `json:"owner_display_name"`
+	OwnerUsername    string `json:"owner_username"`
+}
+
 // Invitation is a one-time invite code (spec §6.3).
 // json tags are required: AdminListInvitations responds with the struct
 // directly, so without them the field names serialize as PascalCase and the
@@ -82,6 +93,10 @@ type UserWorkspaceStore interface {
 	GetWorkspaceByID(ctx context.Context, id string) (*Workspace, error)
 	ListWorkspacesByOwner(ctx context.Context, ownerUserID string, limit, offset int) ([]*Workspace, error)
 	ListAllWorkspaces(ctx context.Context) ([]*Workspace, error)
+	// ListAllWorkspacesWithOwner returns all active workspaces joined with owner
+	// identity (display_name + username) for the admin console global view (issue
+	// #807). Distinct from ListAllWorkspaces (bare rows for the startup scan).
+	ListAllWorkspacesWithOwner(ctx context.Context) ([]*AdminWorkspaceView, error)
 	GetWorkspaceByOwnerAndWorkDir(ctx context.Context, ownerUserID, workDir string) (*Workspace, error)
 	UpdateWorkspace(ctx context.Context, w *Workspace, now int64) error
 	DeleteWorkspace(ctx context.Context, id string) error
@@ -155,6 +170,27 @@ func scanWorkspace(sc rowScanner) (*Workspace, error) {
 	w.CreatedAt = createdAt.Int64
 	w.UpdatedAt = updatedAt.Int64
 	return &w, nil
+}
+
+// scanAdminWorkspace scans the workspaces.list_with_owner projection: the 10
+// Workspace columns followed by the two LEFT-JOIN'd owner columns (COALESCE'd to
+// ” in SQL, so plain string — no NullString). Mirrors scanWorkspace's column
+// order for the embedded fields (see workspaces.list_with_owner.sql).
+func scanAdminWorkspace(sc rowScanner) (*AdminWorkspaceView, error) {
+	var v AdminWorkspaceView
+	var overrides, pref, perm sql.NullString
+	var createdAt, updatedAt sql.NullInt64
+	err := sc.Scan(&v.ID, &v.OwnerUserID, &v.Name, &v.WorkDir, &overrides, &pref, &v.Status,
+		&createdAt, &updatedAt, &perm, &v.OwnerDisplayName, &v.OwnerUsername)
+	if err != nil {
+		return nil, err
+	}
+	v.AgentConfigOverrides = overrides.String
+	v.WorkerPreference = pref.String
+	v.PermissionMode = perm.String
+	v.CreatedAt = createdAt.Int64
+	v.UpdatedAt = updatedAt.Int64
+	return &v, nil
 }
 
 func scanInvitation(sc rowScanner) (*Invitation, error) {
@@ -298,6 +334,28 @@ func (s *SQLiteStore) ListAllWorkspaces(ctx context.Context) ([]*Workspace, erro
 			return nil, err
 		}
 		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// ListAllWorkspacesWithOwner returns all active workspaces joined with the owner's
+// readable identity (display_name + username) for the admin console global view
+// (spec §3.1, issue #807). Distinct from ListAllWorkspaces: that returns bare rows
+// for the gateway startup stale-override scan; this carries owner identity so an
+// admin doesn't face raw UUIDs.
+func (s *SQLiteStore) ListAllWorkspacesWithOwner(ctx context.Context) ([]*AdminWorkspaceView, error) {
+	rows, err := s.db.QueryContext(ctx, queries["workspaces.list_with_owner"])
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []*AdminWorkspaceView
+	for rows.Next() {
+		v, err := scanAdminWorkspace(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
 	}
 	return out, rows.Err()
 }

--- a/internal/session/sql/queries/workspaces.list_with_owner.sql
+++ b/internal/session/sql/queries/workspaces.list_with_owner.sql
@@ -1,0 +1,14 @@
+-- workspaces.list_with_owner: admin console global view (spec §3.1, issue #807).
+-- Joins users for readable owner identity (display_name + username) so admins
+-- scanning the global list don't face raw UUIDs. LEFT JOIN tolerates a raced
+-- owner-user deletion window (workspace stays visible, owner fields → '');
+-- the FK normally guarantees the owner row exists. COALESCE keeps scan types as
+-- plain string (no NullString needed). Shared by SQLiteStore and pgStore (no
+-- bind params, so dialect-identical).
+SELECT w.id, w.owner_user_id, w.name, w.work_dir, w.agent_config_overrides,
+       w.worker_preference, w.status, w.created_at, w.updated_at, w.permission_mode,
+       COALESCE(u.display_name, ''), COALESCE(u.username, '')
+FROM workspaces w
+LEFT JOIN users u ON u.id = w.owner_user_id
+WHERE w.status = 'active'
+ORDER BY u.display_name, w.name

--- a/webchat/app/admin/workspaces/page.tsx
+++ b/webchat/app/admin/workspaces/page.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  listAdminWorkspaces,
+  updateAdminWorkspacePermissionMode,
+} from '@/lib/api/admin-workspaces';
+import type { AdminWorkspace } from '@/lib/types/admin';
+import { useResource } from '@/hooks/use-resource';
+import {
+  LoadingState,
+  ErrorState,
+  EmptyState,
+} from '@/components/admin/resource-states';
+import { useAdminUI } from '@/context/admin-ui-context';
+
+// 4 tiers + "" (clear override → config global default, which r3 made "workspace").
+// Mirrors GeneralTab's set with an explicit "" entry for the admin console.
+const PERMISSION_MODE_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: 'Default (workspace)' },
+  { value: 'workspace', label: 'Workspace' },
+  { value: 'auto-edit', label: 'Auto Edit' },
+  { value: 'read-only', label: 'Read Only' },
+  { value: 'bypass', label: 'Bypass' },
+];
+
+const selectClass =
+  'w-full rounded-[var(--radius-sm)] bg-[var(--bg-surface)] border border-[var(--border-subtle)] px-3 py-1.5 text-xs text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] appearance-none cursor-pointer';
+
+// WorkspaceRow renders one workspace with an inline permission_mode editor.
+// Effect semantics (spec §3.2): the write only changes the stored row; running
+// sessions keep their injected mode, new sessions pick up the new value —
+// surfaced in the toast so the admin isn't surprised a live chat didn't change.
+function WorkspaceRow({
+  ws,
+  onUpdated,
+}: {
+  ws: AdminWorkspace;
+  onUpdated: () => void;
+}) {
+  const { showToast } = useAdminUI();
+  const [mode, setMode] = useState(ws.permission_mode || '');
+  const [saving, setSaving] = useState(false);
+
+  // Resync when the row data changes after a list reload (PR #779 pattern).
+  useEffect(() => {
+    setMode(ws.permission_mode || '');
+  }, [ws.permission_mode, ws.updated_at]);
+
+  const dirty = mode !== (ws.permission_mode || '');
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateAdminWorkspacePermissionMode(ws.id, mode);
+      showToast('Updated — takes effect for new sessions.', 'success');
+      onUpdated(); // refetch so updated_at + any reordering propagate
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Update failed.', 'error');
+      setMode(ws.permission_mode || ''); // revert local selection
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const owner =
+    ws.owner_display_name || ws.owner_username
+      ? `${ws.owner_display_name}${ws.owner_username ? ` (${ws.owner_username})` : ''}`
+      : ws.owner_user_id; // orphaned owner fallback (LEFT JOIN collapsed to '')
+
+  return (
+    <div className="grid grid-cols-[1.4fr_1fr_1.6fr_1.3fr_auto] items-center gap-3 px-4 py-3 border-t border-[var(--border-subtle)] hover:bg-[var(--bg-hover)]/40 transition-colors">
+      {/* Owner — primary identity, not the raw UUID */}
+      <div className="min-w-0">
+        <div className="text-sm text-[var(--text-primary)] truncate">{owner}</div>
+        <div className="text-[10px] font-mono text-[var(--text-faint)] truncate">
+          {ws.owner_user_id}
+        </div>
+      </div>
+
+      {/* Workspace name */}
+      <div className="text-sm text-[var(--text-secondary)] truncate" title={ws.name}>
+        {ws.name}
+      </div>
+
+      {/* Work dir — truncated, full path on hover */}
+      <div
+        className="text-[11px] font-mono text-[var(--text-faint)] truncate"
+        title={ws.work_dir}
+      >
+        {ws.work_dir}
+      </div>
+
+      {/* Permission mode inline editor */}
+      <div className="relative">
+        <select
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+          className={selectClass}
+          disabled={saving}
+        >
+          {PERMISSION_MODE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-[var(--text-faint)]">
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </div>
+
+      {/* Save */}
+      <button
+        onClick={handleSave}
+        disabled={!dirty || saving}
+        className="px-3 py-1.5 rounded-[var(--radius-sm)] text-[11px] font-bold bg-[var(--accent-gold)] text-black hover:bg-[var(--accent-gold-bright)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed whitespace-nowrap"
+      >
+        {saving ? 'Saving…' : 'Save'}
+      </button>
+    </div>
+  );
+}
+
+export default function AdminWorkspacesPage() {
+  const { data, loading, error, reload } = useResource<AdminWorkspace[]>(
+    () => listAdminWorkspaces(),
+    [],
+  );
+  const list = data ?? [];
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-base)] p-6">
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-display font-bold text-[var(--text-primary)]">
+              Workspaces
+            </h1>
+            {!loading && !error && (
+              <span className="text-[11px] font-mono text-[var(--text-faint)] px-2 py-0.5 rounded-full bg-[var(--bg-hover)]">
+                {list.length}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={reload}
+            disabled={loading}
+            className="inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] transition-colors disabled:opacity-50"
+            title="Refresh"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={loading ? 'animate-spin' : ''}
+            >
+              <path d="M21 2v6h-6" />
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+              <path d="M3 22v-6h6" />
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Effect-semantics banner (spec §3.4) */}
+        <div className="mb-5 flex items-start gap-2 px-4 py-3 rounded-[var(--radius-md)] bg-[rgba(245,158,11,0.06)] border border-[rgba(245,158,11,0.15)] text-xs text-[var(--text-secondary)]">
+          <svg className="w-4 h-4 shrink-0 mt-0.5 text-[var(--accent-gold)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+          </svg>
+          <span>
+            Permission mode changes apply to <strong>new sessions only</strong>; running
+            conversations keep their current mode. The user self-service endpoints
+            (<code className="font-mono">/api/workspaces</code>) remain admin-gated for this
+            field.
+          </span>
+        </div>
+
+        {loading && <LoadingState label="Loading workspaces..." />}
+        {error && <ErrorState message={error} onRetry={reload} />}
+
+        {!loading && !error && list.length === 0 && (
+          <EmptyState
+            title="No workspaces"
+            description="Workspaces appear here once users create them via the chat client."
+          />
+        )}
+
+        {/* Table */}
+        {!loading && !error && list.length > 0 && (
+          <div className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+            {/* Header row */}
+            <div className="grid grid-cols-[1.4fr_1fr_1.6fr_1.3fr_auto] items-center gap-3 px-4 py-2.5 bg-[var(--bg-hover)]/60 border-b border-[var(--border-subtle)]">
+              {['Owner', 'Workspace', 'Work Dir', 'Permission Mode', ''].map((h, i) => (
+                <div
+                  key={i}
+                  className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest"
+                >
+                  {h}
+                </div>
+              ))}
+            </div>
+            {list.map((ws) => (
+              <WorkspaceRow key={ws.id} ws={ws} onUpdated={reload} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webchat/app/components/chat/settings-modal/general-tab.tsx
+++ b/webchat/app/components/chat/settings-modal/general-tab.tsx
@@ -173,14 +173,15 @@ export function GeneralTab({ workspace, isAdmin, onUpdated }: GeneralTabProps) {
         </p>
       </div>
 
-      {/* Permission Mode Selection — admin-only (r3 #804): non-admins cannot
-          configure workspace permission mode; the control is hidden and the field
-          is omitted from the PATCH body so the stored value is preserved. */}
-      {isAdmin && (
-        <div>
-          <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
-            Permission Mode
-          </label>
+      {/* Permission Mode — admin-editable select (r3 #804); non-admins see a
+          read-only badge of the current mode (issue #807 §3.6). The field is
+          omitted from the PATCH body when unchanged, so a non-admin save never
+          touches the admin-gated column (r3 would 403 if it did). */}
+      <div>
+        <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
+          Permission Mode
+        </label>
+        {isAdmin ? (
           <div className="relative">
             <select
               value={permMode}
@@ -199,11 +200,18 @@ export function GeneralTab({ workspace, isAdmin, onUpdated }: GeneralTabProps) {
               </svg>
             </div>
           </div>
-          <p className="text-[10px] text-[var(--text-muted)] mt-1.5 leading-relaxed">
-            Controls the blast radius for new sessions: how aggressively the agent may edit files or run commands. Applies to new sessions only; existing sessions keep their current mode.
-          </p>
-        </div>
-      )}
+        ) : (
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-xs font-medium text-[var(--text-secondary)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent-gold)]" />
+            {workspace.permission_mode === ''
+              ? 'Default (workspace)'
+              : (PERMISSION_MODE_OPTIONS.find((o) => o.value === workspace.permission_mode)?.label ?? workspace.permission_mode)}
+          </div>
+        )}
+        <p className="text-[10px] text-[var(--text-muted)] mt-1.5 leading-relaxed">
+          Controls the blast radius for new sessions: how aggressively the agent may edit files or run commands. Applies to new sessions only; existing sessions keep their current mode.
+        </p>
+      </div>
 
       {/* Working Directory: sandbox prefix (read-only) + editable segment */}
       <div>

--- a/webchat/components/admin/admin-nav.tsx
+++ b/webchat/components/admin/admin-nav.tsx
@@ -39,6 +39,16 @@ const NAV_ITEMS = [
     exact: false,
   },
   {
+    label: 'Workspaces',
+    href: '/admin/workspaces',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+      </svg>
+    ),
+    exact: false,
+  },
+  {
     label: 'Cron',
     href: '/admin/cron',
     icon: (

--- a/webchat/lib/api/admin-workspaces.ts
+++ b/webchat/lib/api/admin-workspaces.ts
@@ -1,0 +1,34 @@
+/**
+ * Admin Workspaces API (issue #807).
+ *
+ * /admin/workspaces is the admin console global view: list every workspace across
+ * owners (with readable owner identity) + inline permission_mode edit. Distinct
+ * from /api/workspaces (user self-service, own workspaces only) — these endpoints
+ * ride the admin dual-channel (adminFetch: Bearer or cookie-session admin).
+ */
+
+import { adminFetch } from './admin-client';
+import type { AdminWorkspace } from '@/lib/types/admin';
+import type { Workspace } from './workspaces';
+
+interface AdminWorkspaceListResponse {
+  workspaces: AdminWorkspace[];
+}
+
+export async function listAdminWorkspaces(): Promise<AdminWorkspace[]> {
+  const r = await adminFetch<AdminWorkspaceListResponse>('/admin/workspaces');
+  return r.workspaces;
+}
+
+// updateAdminWorkspacePermissionMode changes a single workspace's permission_mode.
+// permissionMode "" clears the override (falls back to the config global default).
+// The PATCH write is admin-audited server-side (workspace.permission_mode.update).
+export function updateAdminWorkspacePermissionMode(
+  id: string,
+  permissionMode: string,
+): Promise<Workspace> {
+  return adminFetch<Workspace>(`/admin/workspaces/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ permission_mode: permissionMode }),
+  });
+}

--- a/webchat/lib/types/admin.ts
+++ b/webchat/lib/types/admin.ts
@@ -120,3 +120,23 @@ export interface APIKeyUser {
   created_at?: string;
   updated_at?: string;
 }
+
+// --- Workspace (admin console, issue #807) ---
+
+// AdminWorkspace is the admin console projection of a workspace: the full row
+// plus the owner's readable identity (display_name + username) joined server-side
+// (GET /admin/workspaces). permission_mode "" = no explicit override (config default).
+export interface AdminWorkspace {
+  id: string;
+  owner_user_id: string;
+  owner_display_name: string;
+  owner_username: string;
+  name: string;
+  work_dir: string;
+  agent_config_overrides: string;
+  worker_preference: string;
+  permission_mode: string;
+  status: string;
+  created_at: number;
+  updated_at: number;
+}


### PR DESCRIPTION
## 背景

Closes #807 · 依赖 r3（PR #805，已合并）。

r3 把 workspace `permission_mode` 收紧为 admin-only，但 admin 缺少操作面：没有 admin 入口、没有全局视图、owner 仅显示 UUID。本 PR 补齐 admin 控制台的工作区权限管理。

## 改动

**后端**
- `internal/session`：`AdminWorkspaceView` + `ListAllWorkspacesWithOwner`（SQLiteStore + pgStore，LEFT JOIN users 带 owner 可读标识）
- `internal/admin`：`HandleListAdminWorkspaces` + `HandleUpdateAdminWorkspacePermissionMode`（middleware 强制 admin，handler requireScope）
- `internal/admin`：`WorkspaceStore` 注入 `AdminAPI`/`Deps` + `AuditWorkspacePermissionModeUpdate` + `adminActionFor /workspaces` 分支（middleware 级审计，GET 不审计）
- `cmd/hotplex/routes.go`：注册 `GET /admin/workspaces` + `PATCH /admin/workspaces/{id}`
- `internal/admin/models.go`：`WorkspaceListResponse` + `WorkspaceResponse`（swagger，swaggo 跨包类型本地镜像）

**前端**
- `webchat/app/admin/workspaces/page.tsx`：表格 + inline 下拉修改（useResource + ResourceStates + useAdminUI toast），顶部"仅对新会话生效"提示条
- `webchat/components/admin/admin-nav.tsx`：加 Workspaces 入口（Sessions 之后）
- `webchat/app/components/chat/settings-modal/general-tab.tsx`：非 admin 由 r3 完全隐藏 → 只读 badge（spec §3.6 用户知情权）
- `webchat/lib/types/admin.ts` + `lib/api/admin-workspaces.ts`：`AdminWorkspace` 类型 + list/patch API（adminFetch 双通道）

**文档**
- `docs/reference/admin-api.md`：补 `GET` / `PATCH /admin/workspaces` 契约
- `docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md`：Draft → Implemented

## 生效语义

`UpdateWorkspace` 写库后**运行中 session 不受影响**（worker 进程已注入权限参数）。新 session（新对话 / `/reset`）初始化时 `resolveWorkspacePermissionMode` 读到新值。UI 标注"对新会话生效"。

## 安全

- admin-only：`AdminAPI.Middleware` 强制 `role==admin && status==active`
- 最小化：PATCH `/admin/workspaces/{id}` 只接受 `permission_mode`，work_dir/name 忽略（防 admin 误改用户工作目录）
- owner 隔离：permission_mode 是 worker 行为参数，非文件系统权限，无越权风险

## 验证

- `make check` 全通过（quality + build + webchat 重建 + swagger + 二进制）
- `cd webchat && npx tsc --noEmit` 通过
- 后端测试：store `ListAllWorkspacesWithOwner` 一致性、admin handler List/Update/Audit

## Spec

[Admin-Workspace-PermissionMode-Management-Spec.md](docs/specs/Admin-Workspace-PermissionMode-Management-Spec.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)