### PR TITLE
docs(patrol): 2026-06-30 文档维护（#806 platform config 端点 + #805 default_permission_mode）

### DIFF
--- a/docs/guides/developer/security-model.md
+++ b/docs/guides/developer/security-model.md
@@ -44,7 +44,7 @@ HotPlex Gateway 采用纵深防御（Defense in Depth）策略，通过七层安
 
 ### 权限模式
 
-Workspace 级 4 档统一权限模式（#789），跨 Claude Code / Codex / OpenCode Server / ACP 四类 Worker 统一映射。空值（默认）= "Worker 默认"：CC/OCS 应用 `bypass`，Codex/ACP 沿用各自 operator 配置。
+Workspace 级 4 档统一权限模式（#789），跨 Claude Code / Codex / OpenCode Server / ACP 四类 Worker 统一映射。空值（默认）= "Worker 默认"：bridge 注入全局 `worker.default_permission_mode`（r3 起缺省 `workspace`），再按各 Worker 映射生效。
 
 | 模式 | 行为 | 适用场景 |
 |------|------|---------|

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -220,6 +220,8 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 | GET | `/admin/bots/{name}/config` | `admin:read` | 单个 bot 完整配置 |
 | GET | `/admin/bots/{name}/config/{file}` | `admin:read` | 读取 Agent 配置文件（如 SOUL.md、AGENTS.md） |
 | PUT | `/admin/bots/{name}/config/{file}` | `admin:write` | 写入 Agent 配置文件 |
+| GET | `/admin/bots/platform/{platform}/config/{file}` | `admin:read` | 读取**平台级 channel 默认**配置文件（webchat 等，绕过 registry 寻址 `dir/{platform}/` 层） |
+| PUT | `/admin/bots/platform/{platform}/config/{file}` | `admin:write` | 写入平台级 channel 默认配置文件 |
 | GET | `/admin/bots/{name}/preview` | `admin:read` | 预览组装后的系统提示（B+C 通道完整输出） |
 
 **GET /admin/bots** — 返回所有活跃 bot 列表，含 name、platform、worker_type、状态等信息。
@@ -231,6 +233,8 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 **GET /admin/bots/{name}/preview** — 返回该 bot 组装后的完整系统提示，包含 B 通道（directives）和 C 通道（context）内容，便于调试 Agent 人格配置。
 
 **PUT /admin/bots/{name}/config/{file}`** — 写入指定 Agent 配置文件（如 `SOUL.md`、`AGENTS.md`、`USER.md`）。请求体为文件内容，Content-Type 为 `text/plain`。
+
+**GET/PUT /admin/bots/platform/{platform}/config/{file}** — 读写**平台级 channel 默认** Agent 配置文件。`{platform}` 为平台标识（如 `webchat`），绕过 messaging registry 直接寻址 `dir/{platform}/` 层，让无 bot 实例的平台（webchat team-default）获得与消息平台 bot 对等的配置编辑能力。文件白名单与 bot 级端点一致（`SOUL.md`/`AGENTS.md`/`SKILLS.md`/`USER.md`/`MEMORY.md`），复用 `/admin/*` 中间件鉴权（`admin:read`/`admin:write`）与审计。
 
 ### 网关重启
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -253,6 +253,7 @@ Worker 进程生命周期和环境配置。
 | `pid_dir` | string | `~/.hotplex/.pids` | — | PID 文件存储目录 |
 | `env_blocklist` | []string | `[]` | — | 需要从 Worker 环境中屏蔽的变量前缀列表（带尾部 `_`） |
 | `environment` | []string | 见下方 | — | 注入到所有 Worker 进程的额外环境变量。支持 `${VAR}` 展开，未设置且无默认值的条目被排除 |
+| `default_permission_mode` | string | `workspace` | — | workspace 无显式 override 时 bridge 注入的默认权限模式（r3 #804）。合法值 `read-only`/`workspace`/`auto-edit`/`bypass`/空，空与缺省均归一化为 `workspace`；非法值在启动与热重载时拒绝（防 typo fail-open）。仅 config.yaml 可配置，无 env 绑定 |
 
 **默认 environment**：
 


### PR DESCRIPTION
## Summary

变更窗口 `82e208af`(#789) → `e5a9a58b`(#805) 三提交的文档影响映射，3 处精准维护：

- **`admin-api.md`**：Bot 管理表补 `GET/PUT /admin/bots/platform/{platform}/config/{file}` — #806 webchat channel defaults 端点（swagger.json 已生成，人类参考未记录）
- **`configuration.md`**：worker 表补 `default_permission_mode` — #805 r3 全局配置项（缺省 `workspace`，无 env 绑定故标 `—`）
- **`security-model.md`**：「空值=Worker 默认」语义从 r2「CC/OCS `bypass`」更新为 r3「注入 `default_permission_mode`（缺省 `workspace`）」

#805 自带的 403 契约与注入描述已准确，跳过。`make docs-build` 通过（55 篇文档，无断链）。

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)