### PR TITLE
fix(webchat): unblock pnpm 11 build via trustLockfile

### DIFF
--- a/.github/actions/setup-go-webchat/action.yml
+++ b/.github/actions/setup-go-webchat/action.yml
@@ -13,7 +13,7 @@ inputs:
   pnpm-version:
     description: 'pnpm version'
     required: false
-    default: '10'
+    default: '11.4.0'
   build-webchat:
     description: 'Whether to build webchat SPA (if false, still restores from cache)'
     required: false

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -295,6 +295,7 @@ LLM Provider 返回临时错误（429、529、400 等）时的自动重试配置
 | `ready_timeout` | duration | `10s` | `HOTPLEX_WORKER_OPENCODE_SERVER_READY_TIMEOUT` | 进程就绪等待超时 |
 | `ready_poll_interval` | duration | `200ms` | `HOTPLEX_WORKER_OPENCODE_SERVER_READY_POLL_INTERVAL` | 就绪状态轮询间隔 |
 | `http_timeout` | duration | `30s` | `HOTPLEX_WORKER_OPENCODE_SERVER_HTTP_TIMEOUT` | HTTP 请求超时 |
+| `context_window` | int | `200000` | `HOTPLEX_WORKER_OPENCODE_SERVER_CONTEXT_WINDOW` | OCS fallback context window（token 数）。OCS HTTP API 不暴露真实模型 context window，此可配置值喂给 `context_pct`；设 `0` 则不设置 `context_pct`（spec §5 O1，turn summary parity #776） |
 
 #### 3.7.5 codex_cli — Codex CLI Worker
 
@@ -790,6 +791,7 @@ HOTPLEX_SECURITY_API_KEY_1, HOTPLEX_SECURITY_API_KEY_2, ...
 | `HOTPLEX_WORKER_OPENCODE_SERVER_READY_TIMEOUT` | `worker.opencode_server.ready_timeout` | `10s` |
 | `HOTPLEX_WORKER_OPENCODE_SERVER_READY_POLL_INTERVAL` | `worker.opencode_server.ready_poll_interval` | `200ms` |
 | `HOTPLEX_WORKER_OPENCODE_SERVER_HTTP_TIMEOUT` | `worker.opencode_server.http_timeout` | `30s` |
+| `HOTPLEX_WORKER_OPENCODE_SERVER_CONTEXT_WINDOW` | `worker.opencode_server.context_window` | `200000` |
 | `HOTPLEX_WORKER_AUTO_RETRY_ENABLED` | `worker.auto_retry.enabled` | `true` |
 | `HOTPLEX_WORKER_AUTO_RETRY_MAX_RETRIES` | `worker.auto_retry.max_retries` | `9` |
 | `HOTPLEX_WORKER_CODEX_CLI_COMMAND` | `worker.codex_cli.command` | `codex` |

--- a/webchat/package.json
+++ b/webchat/package.json
@@ -2,6 +2,7 @@
   "name": "hotplex-webchat",
   "version": "1.30.2",
   "private": true,
+  "packageManager": "pnpm@11.4.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/webchat/pnpm-workspace.yaml
+++ b/webchat/pnpm-workspace.yaml
@@ -1,2 +1,16 @@
+# Build-script approvals (pnpm v11 strictDepBuilds default).
+# sharp: required by Next.js for image optimization — allow.
+# unrs-resolver: optional native (Rust) eslint import resolver; the JS fallback
+#   works fine for `next build`, so skip its postinstall.
 allowBuilds:
   sharp: true
+  unrs-resolver: false
+
+# pnpm 11 enables minimumReleaseAge=1440 (24h) by default. Under --frozen-lockfile
+# the lockfile pins exact versions, so a freshly-published transitive dep (e.g.
+# typescript-eslint@8.62.1) cannot fall back to an older version and fails the
+# supply-chain verification pass (ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION),
+# blocking install/build for ~24h after every such release. trustLockfile=true
+# skips that re-verification of the loaded lockfile, which is reviewed on
+# origin/main (trusted base). See https://pnpm.io/settings#trustLockfile
+trustLockfile: true

--- a/webchat/pnpm-workspace.yaml
+++ b/webchat/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ allowBuilds:
 # typescript-eslint@8.62.1) cannot fall back to an older version and fails the
 # supply-chain verification pass (ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION),
 # blocking install/build for ~24h after every such release. trustLockfile=true
-# skips that re-verification of the loaded lockfile, which is reviewed on
-# origin/main (trusted base). See https://pnpm.io/settings#trustLockfile
+# (requires pnpm >= 11.3) skips that re-verification of the loaded lockfile,
+# which is reviewed on origin/main (trusted base). See
+# https://pnpm.io/settings#trustLockfile
 trustLockfile: true


### PR DESCRIPTION
Fixes #823

## 问题
`make build` 在 pnpm 11 环境下因供应链策略失败，每次有传递依赖发布新版本后会阻塞约 24h。

## 根因
**pnpm 11 "hardened defaults"**：`minimumReleaseAge` 默认 **1440 分钟（24h）**，v11 起内置开启（无需任何配置即生效，[文档](https://pnpm.io/settings#minimumReleaseAge)）。它是内置默认（非显式配置），故 `pnpm config get` 显示 undefined 但策略引擎用默认值。

致命交互链：
- 内置默认是非严格（`minimumReleaseAgeStrict: false`），本应 fallback 到旧版本
- 但 `webchat-embed` Makefile 用 `--frozen-lockfile`，lockfile pin 死版本无法 fallback → `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
- 本次中招：`typescript-eslint@8.62.1`（发布 ~20h）+ 10 个 `@typescript-eslint/*` 包
- 旁证：`pnpm build` 内部 `runDepsStatusCheck` spawn 的 install 子进程**不继承** CLI flag/env，故 `--config.minimumReleaseAge=0` 仅对直接 `install` 有效、对 `build` 无效 —— 必须改持久配置

## 修复
在 `webchat/pnpm-workspace.yaml` 增加：

- **`trustLockfile: true`**（pnpm ≥ 11.3）：让 `pnpm install` 跳过对已加载 lockfile 的 supply-chain 重检（minimumReleaseAge/trustPolicy）。[文档](https://pnpm.io/settings#trustLockfile)原文："Useful in environments where the lockfile is effectively part of the trusted base"。webchat lockfile 在 origin/main 上评审，属可信基座。
- **`unrs-resolver: false`**：明确 pnpm 自动追加的 build-script 审批占位符，消除 `ERR_PNPM_IGNORED_BUILDS`（next build 的 JS fallback 已验证可用）。

## 消除 CI/本地版本割裂（review P2）
`trustLockfile`/`allowBuilds` 仅 pnpm 11+ 认识，原 CI 默认 pnpm 10 会静默忽略 → CI 从不验证此修复。本 PR：
- `.github/actions/setup-go-webchat/action.yml`：`pnpm-version` 默认 `10` → `11.4.0`
- `webchat/package.json`：加 `"packageManager": "pnpm@11.4.0"` 固定版本（之前无 packageManager/engines，版本由各机器决定，正是割裂根源）

CI 现也用 pnpm 11.4.0，真正守护此修复。

## 权衡
`trustLockfile` 跳过对 lockfile 的 supply-chain 重检。文档建议 "leave false whenever outside collaborators can edit the lockfile"。HotPlex webchat lockfile 由维护者在 origin/main 评审，CI 走 frozenLockfile，符合 "trusted base" 语义；`pnpm add` 新增依赖仍受 minimumReleaseAge 约束（trustLockfile 只跳过对已加载 lockfile 的重检，不影响新解析）。

## 验证
完整 `make build`（删 `internal/webchat/out` 强制 webchat 完整重建，无任何 bypass flag/env）：
```
✓ Webchat built
✓ bin/hotplex-linux-amd64
EXIT=0
```
全程无 `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)