### PR TITLE
fix(admin): admin create --config 默认值与 gateway start 对齐

### DIFF
--- a/cmd/hotplex/admin_cmd.go
+++ b/cmd/hotplex/admin_cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/dbutil"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
@@ -22,7 +23,7 @@ func newAdminCmd() *cobra.Command {
 		Use:   "admin",
 		Short: "用户与账号管理（bootstrap admin 等）",
 	}
-	cmd.PersistentFlags().String("config", "", "配置文件路径（默认 ~/.hotplex/config.yaml）")
+	cmd.PersistentFlags().String("config", config.DefaultConfigPath, "配置文件路径（默认 ~/.hotplex/config.yaml）")
 
 	create := &cobra.Command{
 		Use:   "create",


### PR DESCRIPTION
## 问题\n\n 的  标志默认值为空字符串，而  的默认值是 。\n\n这导致如果用户运行  时不显式传入 ，它会加载编译时默认配置（而非用户主目录下的 ），可能将 admin 用户写入与运行中网关不同的 SQLite 数据库，登录时出现 401 INVALID_CREDENTIALS。\n\n## 修复\n\n将  命令的  默认值改为 ，与  保持一致。\n\n## 变更\n\n- \n  - 导入 \n  -  默认值从  改为 \n\n## 验证\n\n-  ✅\n- ok  	github.com/hrygo/hotplex/cmd/hotplex	0.298s ✅\n- 0 issues. ✅