### PR TITLE
fix(messaging/feishu): proactive TTL rotation (#839) + bridge 空 done 兜底

### DIFF
--- a/docs/specs/Feishu-Streaming-Card-TTL-Rotation-Spec.md
+++ b/docs/specs/Feishu-Streaming-Card-TTL-Rotation-Spec.md
@@ -47,9 +47,9 @@ worker 在 delta 间隙（tool 思考、长计算）时 `writeContent` 不被调
 **`conn.go` — FeishuConn**：
 - 新增 `rotateMu sync.Mutex` —— 串行化轮转（timer vs writeContent 并发请求）
 - 抽离 `rotateStreamingCard(ctx) (newCtrl, rotated)` —— 从 `writeContent:515-548` 提取，复用
-- 新增 `onCardExpired()` —— timer 回调入口，`go rotateStreamingCard` 独立 goroutine 避免阻塞
+- 新增 `onCardExpired()` —— timer 回调入口，同步调用 `rotateStreamingCard`（`time.AfterFunc` 已在独立 goroutine，10s ctx 限时避免阻塞 timer）
 - `writeContent` 替换内联轮转逻辑为 `rotateStreamingCard` 调用
-- 3 个 controller 创建点（`handler.go:227`、`conn.go:122 resetStreamCtrl`、`conn.go:539`）
+- 3 个 controller 创建点（`handler.go:227`、`conn.go:122 resetStreamCtrl`、`conn.go:185 rotateStreamingCard`）
   在 `EnableStreaming` / 创建后 `SetOnExpired(c.onCardExpired)` 注入回调
 
 ### 3.3 并发安全（重点 — 见观察 #8465 历史 data race）
@@ -57,7 +57,7 @@ worker 在 delta 间隙（tool 思考、长计算）时 `writeContent` 不被调
 | 风险 | 缓解 |
 |------|------|
 | timer 与 writeContent 同时触发轮转 | `rotateMu` 串行化 + 进入后 `Expired()` 复检 |
-| Close 持锁阻塞 writeContent | Close 在 `rotateMu` 下但**不持 `c.mu`**；仅替换 ctrl 时短暂持 `c.mu` |
+| Close 持锁阻塞 writeContent | 轮转路径的 `cur.Close`（在 `rotateStreamingCard` 内）于 `rotateMu` 下调用，不持 `FeishuConn.mu`；仅 ctrl 替换时短暂持 `FeishuConn.mu`。注：`FeishuConn.Close()` 是另一路径（持 `FeishuConn.mu`，不涉及轮转） |
 | 旧 ctrl 已被并发替换 | 替换前校验 `c.streamCtrl == cur`，否则放弃 |
 | timer 在 Close 后触发 | `Close()` Stop timer；`triggerRotation` 检查 phase ≥ Completed 直接返回 |
 

--- a/docs/specs/Feishu-Streaming-Card-TTL-Rotation-Spec.md
+++ b/docs/specs/Feishu-Streaming-Card-TTL-Rotation-Spec.md
@@ -1,0 +1,82 @@
+# Feishu Streaming Card TTL Rotation — Spec
+
+**Issue**: [#839](https://github.com/hrygo/hotplex/issues/839)
+**Status**: Implementing
+**Owner**: 黄飞虹
+
+---
+
+## 1. 背景
+
+飞书 CardKit streaming 有 **10 分钟服务端硬限制**：超时后服务端强制关闭 streaming mode
+（错误 `200850: card streaming timeout` / `300309: streaming mode is closed`）。
+
+HotPlex 的 `StreamTTL = 500s`（8.3min）设计为"到期前主动轮转新卡"。
+但当前轮转检查在 `writeContent()` 开头（`conn.go:517`），**只在 worker 产出 delta 时触发**。
+
+## 2. 根因（运行日志证据，2026-07-04 17:00–19:06，v1.30.2）
+
+| 指标 | 值 | 含义 |
+|------|----|------|
+| session created | 9 | 9 个独立 turn |
+| card_id 总数 | 13 | 多出 4 张轮转卡 |
+| `streaming card rotated` | 5 | TTL 轮转触发 5 次 |
+| 飞书 200850/300309 | 2 | 服务端强制关闭 2 次 |
+
+worker 在 delta 间隙（tool 思考、长计算）时 `writeContent` 不被调用 → 轮转错过 ~100s 窗口
+→ 飞书 10min 先关闭 streaming → 卡片卡在"生成中"、final flush 降级/失败。
+
+铁证：卡1 存活 `17:00:52 → 17:11:06` = **10min14s**，撞飞书硬限制。
+
+## 3. 设计
+
+### 3.1 核心方案：主动 timer 触发轮转
+
+`StreamingCardController` 进入 `PhaseStreaming` 时启动 `time.AfterFunc(StreamTTL)` 定时器。
+到期主动触发 conn 层轮转回调，**不再依赖 delta 到达**。
+
+### 3.2 改动点
+
+**`streaming.go` — StreamingCardController**：
+- 新增字段：`onExpired func()`、`rotateTimer *time.Timer`
+- 新增 `SetOnExpired(fn)` —— conn 在创建 controller 后注入回调
+- `createAndEnable()` transition(PhaseStreaming) 成功后启动 `rotateTimer = AfterFunc(StreamTTL, c.triggerRotation)`
+- `triggerRotation()`：`recover` 包裹 + 调 `onExpired`（不阻塞 timer 线程）
+- `Close()` / `Abort()` 中 `Stop()` rotateTimer（与 stopFlushLoop 一致的清理时机）
+
+**`conn.go` — FeishuConn**：
+- 新增 `rotateMu sync.Mutex` —— 串行化轮转（timer vs writeContent 并发请求）
+- 抽离 `rotateStreamingCard(ctx) (newCtrl, rotated)` —— 从 `writeContent:515-548` 提取，复用
+- 新增 `onCardExpired()` —— timer 回调入口，`go rotateStreamingCard` 独立 goroutine 避免阻塞
+- `writeContent` 替换内联轮转逻辑为 `rotateStreamingCard` 调用
+- 3 个 controller 创建点（`handler.go:227`、`conn.go:122 resetStreamCtrl`、`conn.go:539`）
+  在 `EnableStreaming` / 创建后 `SetOnExpired(c.onCardExpired)` 注入回调
+
+### 3.3 并发安全（重点 — 见观察 #8465 历史 data race）
+
+| 风险 | 缓解 |
+|------|------|
+| timer 与 writeContent 同时触发轮转 | `rotateMu` 串行化 + 进入后 `Expired()` 复检 |
+| Close 持锁阻塞 writeContent | Close 在 `rotateMu` 下但**不持 `c.mu`**；仅替换 ctrl 时短暂持 `c.mu` |
+| 旧 ctrl 已被并发替换 | 替换前校验 `c.streamCtrl == cur`，否则放弃 |
+| timer 在 Close 后触发 | `Close()` Stop timer；`triggerRotation` 检查 phase ≥ Completed 直接返回 |
+
+### 3.4 不变式
+
+- 每 controller 至多触发一次主动轮转（Close 后 timer Stop）
+- 轮转后新 controller 自动注入 onExpired，形成链式主动轮转
+- 短任务（<StreamTTL）行为完全不变（timer 被 Close 提前 Stop）
+
+## 4. 实施
+
+1. `streaming.go`：加 timer + onExpired + triggerRotation + Stop 时机
+2. `conn.go`：抽离 `rotateStreamingCard` + `onCardExpired` + 注入回调
+3. 测试：`TestStreamingCard_ProactiveRotation` — 模拟 TTL 到期无 delta，验证主动轮转
+4. `make check` + PR
+
+## 5. 验收
+
+- ✅ 长任务（>8.3min）delta 间隙时 ~500s 主动轮转，不再出现 200850/300309
+- ✅ 短任务行为不变（单卡 seq 递增）
+- ✅ timer 回调与 writeContent 不重复轮转（rotateMu + 复检）
+- ✅ `-race` 通过

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/observability"
 	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -395,6 +396,7 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 		b.injectSessionStats(env, acc)
 		b.captureAssistantTurn(sessionID, env.Seq, acc, fc.turnText.String(),
 			fc.sessOwner, fc.sessPlatform, env.Timestamp)
+		b.maybeSendDoneFallback(sessionID, acc, fc)
 		acc.resetPerTurn()
 		if b.log.Enabled(context.Background(), slog.LevelDebug) {
 			b.log.Debug("bridge: turn completed",
@@ -402,6 +404,34 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 				"duration", time.Since(fc.turnStartTime).Round(time.Millisecond),
 				"text_len", fc.turnText.Len(), "tools", acc.ToolCallCount.Load())
 		}
+	}
+}
+
+// maybeSendDoneFallback synthesizes a user-facing Message event when a turn
+// did tool work but produced no assistant text — so feishu/slack don't show an
+// empty reply for tool-only turns (e.g. "build and deploy" tasks where the
+// worker only calls tools and never writes a reply). Mirrors sendCommandFeedback
+// (worker_cmds.go). Skipped for webchat (its UI renders the tool_call list
+// independently), and when the turn already produced text or made no tool calls.
+func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator, fc *forwardContext) {
+	if fc.turnText.Len() != 0 || acc.ToolCallCount.Load() == 0 {
+		return
+	}
+	if fc.sessPlatform == platformWebChat {
+		return
+	}
+	d := messaging.TurnSummaryData{
+		ToolCallCount:  int(acc.ToolCallCount.Load()),
+		ToolNames:      acc.ToolNames,
+		TurnDurationMs: acc.TurnDurationMs,
+	}
+	env := events.NewEnvelope(
+		aep.NewID(), sessionID, b.hub.NextSeq(sessionID),
+		events.Message,
+		events.MessageData{Role: "assistant", Content: messaging.FormatDoneFallback(d)},
+	)
+	if err := b.hub.SendToSession(context.Background(), env); err != nil {
+		b.log.Warn("bridge: done fallback send failed", "session_id", sessionID, "err", err)
 	}
 }
 

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -394,9 +394,9 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 		}
 
 		b.injectSessionStats(env, acc)
+		b.maybeSendDoneFallback(sessionID, acc, fc)
 		b.captureAssistantTurn(sessionID, env.Seq, acc, fc.turnText.String(),
 			fc.sessOwner, fc.sessPlatform, env.Timestamp)
-		b.maybeSendDoneFallback(sessionID, acc, fc)
 		acc.resetPerTurn()
 		if b.log.Enabled(context.Background(), slog.LevelDebug) {
 			b.log.Debug("bridge: turn completed",
@@ -413,6 +413,11 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 // worker only calls tools and never writes a reply). Mirrors sendCommandFeedback
 // (worker_cmds.go). Skipped for webchat (its UI renders the tool_call list
 // independently), and when the turn already produced text or made no tool calls.
+//
+// Must run BEFORE captureAssistantTurn: it backfills fc.turnText with the
+// fallback text so the turns table records it (history/replay shows the
+// fallback instead of an empty assistant turn). Also persists to the events
+// table via captureEvent so WS event replay surfaces it too.
 func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator, fc *forwardContext) {
 	if fc.turnText.Len() != 0 || acc.ToolCallCount.Load() == 0 {
 		return
@@ -425,14 +430,21 @@ func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator
 		ToolNames:      acc.ToolNames,
 		TurnDurationMs: acc.TurnDurationMs,
 	}
+	text := messaging.FormatDoneFallback(d)
+	// Backfill turnText so captureAssistantTurn records the fallback to the
+	// turns table (history/replay shows it, not an empty assistant turn).
+	fc.turnText.WriteString(text)
+
 	env := events.NewEnvelope(
 		aep.NewID(), sessionID, b.hub.NextSeq(sessionID),
 		events.Message,
-		events.MessageData{Role: "assistant", Content: messaging.FormatDoneFallback(d)},
+		events.MessageData{Content: text},
 	)
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {
 		b.log.Warn("bridge: done fallback send failed", "session_id", sessionID, "err", err)
 	}
+	// Persist to the events table so WS event replay also surfaces the fallback.
+	b.captureEvent(sessionID, env.Seq, events.Message, env.Event.Data)
 }
 
 // maybeTransitionIdleAfterDone transitions a messaging session to IDLE after

--- a/internal/gateway/bridge_forward_fallback_test.go
+++ b/internal/gateway/bridge_forward_fallback_test.go
@@ -1,0 +1,110 @@
+package gateway
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// tryReadEnvelope reads one envelope from the WS conn with a short deadline.
+// Returns nil if nothing arrived (used to assert "no message was sent").
+func tryReadEnvelope(t *testing.T, server interface {
+	ReadMessage() (int, []byte, error)
+	SetReadDeadline(time.Time) error
+}) *events.Envelope {
+	t.Helper()
+	require.NoError(t, server.SetReadDeadline(time.Now().Add(300*time.Millisecond)))
+	defer func() { _ = server.SetReadDeadline(time.Time{}) }()
+	_, data, err := server.ReadMessage()
+	if err != nil {
+		return nil
+	}
+	var env events.Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return &env
+}
+
+// TestMaybeSendDoneFallback verifies a synthetic Message is injected when a
+// turn did tool work but produced no assistant text, so feishu/slack don't
+// show an empty reply. Mirrors maybeTransitionIdleAfterDone test pattern.
+func TestMaybeSendDoneFallback(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T, platform string) (*Bridge, *sessionAccumulator, *forwardContext, interface {
+		ReadMessage() (int, []byte, error)
+		SetReadDeadline(time.Time) error
+	}) {
+		t.Helper()
+		h := newTestHub(t)
+		conn, server := newTestWSConnPair(t)
+		t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+		c := newConn(h, conn, "s1", nil)
+		h.JoinSession("s1", c)
+		b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+		acc := &sessionAccumulator{}
+		fc := &forwardContext{
+			sessionID:     "s1",
+			sessPlatform:  platform,
+			turnStartTime: time.Now().Add(-5 * time.Second),
+		}
+		acc.TurnDurationMs = 5000
+		return b, acc, fc, server
+	}
+
+	t.Run("triggers_when_no_text_with_tools", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, "feishu")
+		acc.ToolCallCount.Store(3)
+		acc.ToolNames = map[string]int{"Bash": 2, "Read": 1}
+
+		b.maybeSendDoneFallback("s1", acc, fc)
+
+		env := tryReadEnvelope(t, server)
+		require.NotNil(t, env, "expected a fallback Message envelope")
+		require.Equal(t, events.Message, env.Event.Type)
+		data, ok := env.Event.Data.(map[string]any)
+		require.True(t, ok, "event data should deserialize to map")
+		content, _ := data["content"].(string)
+		require.Contains(t, content, "3")
+		require.Contains(t, content, "Bash×2")
+		require.Contains(t, content, "Read×1")
+	})
+
+	t.Run("skipped_when_text_present", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, "feishu")
+		acc.ToolCallCount.Store(3)
+		fc.turnText.WriteString("real reply text")
+
+		b.maybeSendDoneFallback("s1", acc, fc)
+
+		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected when turn has text")
+	})
+
+	t.Run("skipped_when_no_tools", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, "feishu")
+		// ToolCallCount stays 0
+
+		b.maybeSendDoneFallback("s1", acc, fc)
+
+		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected when no tool calls")
+	})
+
+	t.Run("skipped_for_webchat", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, platformWebChat)
+		acc.ToolCallCount.Store(3)
+
+		b.maybeSendDoneFallback("s1", acc, fc)
+
+		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected for webchat")
+	})
+}

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -39,6 +39,11 @@ type FeishuConn struct {
 	lastSummarySentMs atomic.Int64
 	voiceTriggered    atomic.Bool
 	paraBreaker       textutil.ParagraphBreaker
+
+	// rotateMu serializes proactive TTL rotation between the controller's
+	// timer callback and the lazy check inside writeContent, so concurrent
+	// triggers never double-rotate. See #839.
+	rotateMu sync.Mutex
 }
 
 func NewFeishuConn(adapter *Adapter, chatID, threadKey, workDir string) *FeishuConn {
@@ -124,9 +129,75 @@ func (c *FeishuConn) resetStreamCtrl() {
 		c.adapter.resolveDisplayName(), tc, m, br, wd,
 		c.adapter.phrases,
 	)
+	newCtrl.SetOnExpired(c.onCardExpired)
 	c.mu.Lock()
 	c.streamCtrl = newCtrl
 	c.mu.Unlock()
+}
+
+// onCardExpired is the proactive TTL-rotation callback wired into each
+// StreamingCardController via SetOnExpired. Invoked on the timer goroutine;
+// rotation runs under a bounded-time context so it never blocks the timer.
+func (c *FeishuConn) onCardExpired() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, rotated := c.rotateStreamingCard(ctx); rotated {
+		c.adapter.Log.Info("feishu: streaming card rotated (TTL timer)")
+	}
+}
+
+// rotateStreamingCard closes the expired streaming card and replaces it with
+// a fresh controller, so the next delta streams into a new card well before
+// Feishu's 10-min server hard limit. Serialized by rotateMu so concurrent
+// triggers (timer + lazy writeContent check) don't double-rotate. Returns the
+// controller the caller should use next and whether this call rotated.
+func (c *FeishuConn) rotateStreamingCard(ctx context.Context) (*StreamingCardController, bool) {
+	c.rotateMu.Lock()
+	defer c.rotateMu.Unlock()
+
+	c.mu.RLock()
+	cur := c.streamCtrl
+	c.mu.RUnlock()
+	// Re-check: a concurrent rotation may have just completed, or the card
+	// already closed.
+	if cur == nil || !cur.IsCreated() || !cur.Expired() {
+		return cur, false
+	}
+
+	// Close old card. Held under rotateMu (NOT c.mu) so a slow Close doesn't
+	// block other conn operations.
+	cur.MarkAllToolsDone()
+	oldMsgID := cur.MsgID()
+	closeCtx, closeCancel := context.WithTimeout(ctx, 5*time.Second)
+	if err := cur.Close(closeCtx); err != nil {
+		c.adapter.Log.Warn("feishu: failed to close rotated card",
+			"old_msg_id", oldMsgID, "err", err)
+		observability.StreamingCardRotationFailures().Add(ctx, 1, metric.WithAttributes(attribute.String("phase", "close_old")))
+	}
+	closeCancel()
+
+	observability.StreamingCardRotations().Add(ctx, 1)
+	c.adapter.Log.Info("feishu: streaming card rotated", "old_msg_id", oldMsgID)
+
+	c.mu.RLock()
+	tc, m, br, wd := c.turnCount, c.lastModel, c.lastBranch, c.workDir
+	c.mu.RUnlock()
+	newCtrl := NewStreamingCardController(c.adapter.larkClient, c.adapter.rateLimiter, c.adapter.Log, c.adapter.resolveDisplayName(), tc+1, m, br, wd, c.adapter.phrases)
+	newCtrl.SetOnExpired(c.onCardExpired)
+
+	c.mu.Lock()
+	// Only swap if cur is still current; a concurrent turn reset may have
+	// already replaced it.
+	swapped := c.streamCtrl == cur
+	if swapped {
+		c.streamCtrl = newCtrl
+		if oldMsgID != "" {
+			c.replyToMsgID = oldMsgID
+		}
+	}
+	ctrl := c.streamCtrl
+	c.mu.Unlock()
+	return ctrl, swapped
 }
 
 func (c *FeishuConn) SetTypingReactionID(rid string) {
@@ -513,38 +584,11 @@ func (c *FeishuConn) writeContent(ctx context.Context, env *events.Envelope, tex
 	)
 
 	// TTL rotation: proactively replace expired streaming cards before
-	// Feishu's 10-minute server limit kicks in.
+	// Feishu's 10-minute server limit kicks in. Triggered lazily here on
+	// delta arrival AND proactively by the controller's TTL timer (see #839);
+	// rotateMu serializes both so they never double-rotate.
 	if streamCtrl != nil && streamCtrl.IsCreated() && streamCtrl.Expired() {
-		// Mark all tools done so Close can flush done markers to the old card.
-		streamCtrl.MarkAllToolsDone()
-		oldMsgID := streamCtrl.MsgID()
-
-		// Synchronous close: ensures old card is fully finalized before
-		// creating the new one, avoiding API rate-limit collisions.
-		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := streamCtrl.Close(closeCtx); err != nil {
-			c.adapter.Log.Warn("feishu: failed to close rotated card",
-				"old_msg_id", oldMsgID, "err", err)
-			observability.StreamingCardRotationFailures().Add(ctx, 1, metric.WithAttributes(attribute.String("phase", "close_old")))
-		}
-		closeCancel()
-
-		observability.StreamingCardRotations().Add(ctx, 1)
-		c.adapter.Log.Info("feishu: streaming card rotated",
-			"old_msg_id", oldMsgID)
-
-		c.mu.RLock()
-		tc, m, br, wd := c.turnCount, c.lastModel, c.lastBranch, c.workDir
-		c.mu.RUnlock()
-		newCtrl := NewStreamingCardController(c.adapter.larkClient, c.adapter.rateLimiter, c.adapter.Log, c.adapter.resolveDisplayName(), tc+1, m, br, wd, c.adapter.phrases)
-		c.mu.Lock()
-		c.streamCtrl = newCtrl
-		if oldMsgID != "" {
-			c.replyToMsgID = oldMsgID
-			replyToMsgID = oldMsgID
-		}
-		streamCtrl = newCtrl
-		c.mu.Unlock()
+		streamCtrl, _ = c.rotateStreamingCard(ctx)
 	}
 
 	if streamCtrl != nil {

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -169,11 +169,10 @@ func (c *FeishuConn) rotateStreamingCard(ctx context.Context) (*StreamingCardCon
 	cur.MarkAllToolsDone()
 	oldMsgID := cur.MsgID()
 	closeCtx, closeCancel := context.WithTimeout(ctx, 5*time.Second)
-	if err := cur.Close(closeCtx); err != nil {
-		c.adapter.Log.Warn("feishu: failed to close rotated card",
-			"old_msg_id", oldMsgID, "err", err)
-		observability.StreamingCardRotationFailures().Add(ctx, 1, metric.WithAttributes(attribute.String("phase", "close_old")))
-	}
+	// cur.Close currently always returns nil (streaming.go Close returns nil
+	// on all paths); the call is best-effort. If Close gains real error
+	// reporting, restore error handling + close_old metric here.
+	_ = cur.Close(closeCtx)
 	closeCancel()
 
 	observability.StreamingCardRotations().Add(ctx, 1)

--- a/internal/messaging/feishu/handler.go
+++ b/internal/messaging/feishu/handler.go
@@ -225,6 +225,7 @@ func (a *Adapter) handleTextMessage(ctx context.Context, platformMsgID, channelI
 		} else {
 			turnNum, model, branch, workDir := conn.turnHeaderMeta()
 			ctrl := NewStreamingCardController(a.larkClient, a.rateLimiter, a.Log, a.resolveDisplayName(), turnNum+1, model, branch, workDir, a.phrases)
+			ctrl.SetOnExpired(conn.onCardExpired)
 			conn.EnableStreaming(ctrl)
 
 			// Send placeholder card immediately — same streaming card structure as real messages.

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -176,6 +176,12 @@ func (c *StreamingCardController) SetCloseMeta(d messaging.TurnSummaryData) {
 // SetOnExpired wires the conn-layer callback invoked when the proactive TTL
 // timer fires. Must be set before the controller enters PhaseStreaming to
 // enable proactive rotation; if unset, rotation stays lazy (delta-driven).
+//
+// Happens-before: all current callers (conn.go resetStreamCtrl/rotateStreamingCard,
+// handler.go) inject the callback before createAndEnable → startRotationTimer arms
+// time.AfterFunc. AfterFunc guarantees writes preceding its return are visible to
+// the timer's callback goroutine, so onExpired is safely published to triggerRotation
+// without explicit synchronization.
 func (c *StreamingCardController) SetOnExpired(fn func()) {
 	c.onExpired = fn
 }

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -126,6 +126,13 @@ type StreamingCardController struct {
 	flushStart   sync.Once
 	flushWg      sync.WaitGroup
 	flushTrigger chan struct{} // buffered 1: coalesces rapid signals
+
+	// Proactive TTL rotation — fires at StreamTTL to trigger conn-layer
+	// rotation even without a delta arrival (worker thinking / long compute).
+	// Without it, streaming hits Feishu's 10-min server hard limit while the
+	// controller waits idle for the next writeContent(). See #839.
+	onExpired   func()
+	rotateTimer *time.Timer // guarded by mu
 }
 
 const streamingElementID = "streaming_content"
@@ -164,6 +171,52 @@ func NewStreamingCardController(client *lark.Client, limiter *FeishuRateLimiter,
 // SetCloseMeta injects turn summary data before Close() for header enrichment.
 func (c *StreamingCardController) SetCloseMeta(d messaging.TurnSummaryData) {
 	c.closeMeta.Store(&d)
+}
+
+// SetOnExpired wires the conn-layer callback invoked when the proactive TTL
+// timer fires. Must be set before the controller enters PhaseStreaming to
+// enable proactive rotation; if unset, rotation stays lazy (delta-driven).
+func (c *StreamingCardController) SetOnExpired(fn func()) {
+	c.onExpired = fn
+}
+
+// startRotationTimer arms the proactive TTL timer. Called once after the
+// transition to PhaseStreaming. No-op if onExpired is unset (tests / legacy).
+func (c *StreamingCardController) startRotationTimer() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.onExpired == nil {
+		return
+	}
+	c.rotateTimer = time.AfterFunc(StreamTTL, c.triggerRotation)
+}
+
+// stopRotationTimer stops the proactive timer; idempotent. Called on Close/Abort.
+func (c *StreamingCardController) stopRotationTimer() {
+	c.mu.Lock()
+	if c.rotateTimer != nil {
+		c.rotateTimer.Stop()
+		c.rotateTimer = nil
+	}
+	c.mu.Unlock()
+}
+
+// triggerRotation is the timer callback. It re-checks phase — Close may have
+// stopped the timer while this callback was already inflight — before invoking
+// the conn-layer rotation. Panics are recovered so a timer failure can never
+// crash the process.
+func (c *StreamingCardController) triggerRotation() {
+	defer func() {
+		if r := recover(); r != nil {
+			c.log.Error("feishu: panic in rotation timer", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	if c.getPhase() >= PhaseCompleted {
+		return
+	}
+	if c.onExpired != nil {
+		c.onExpired()
+	}
 }
 
 const maxToolEntries = 2
@@ -387,6 +440,7 @@ func (c *StreamingCardController) createAndEnable(ctx context.Context, msgID str
 		return fmt.Errorf("feishu: cannot transition to streaming")
 	}
 	c.startFlushLoop()
+	c.startRotationTimer()
 	return nil
 }
 
@@ -624,6 +678,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	// This can happen when SendPlaceholder fails but the goroutine was already started.
 	if phase == PhaseCreationFailed {
 		c.stopFlushLoop()
+		c.stopRotationTimer()
 		return nil
 	}
 
@@ -632,6 +687,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	}
 
 	c.stopFlushLoop()
+	c.stopRotationTimer()
 	c.MarkAllToolsDone()
 
 	// Flush tool activity with done markers before the final card rebuild.
@@ -733,6 +789,7 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 	}
 
 	c.stopFlushLoop()
+	c.stopRotationTimer()
 	c.MarkAllToolsDone()
 
 	c.mu.Lock()

--- a/internal/messaging/feishu/streaming_test.go
+++ b/internal/messaging/feishu/streaming_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -386,4 +387,71 @@ func TestStreamingCardController_IntegrityCheck(t *testing.T) {
 	// Close should not panic with zero bytes.
 	err := c.Close(context.Background())
 	require.NoError(t, err)
+}
+
+// ─── Proactive TTL Rotation (#839) ──────────────────────────────────────────
+
+// TestStreamingCard_ProactiveRotation_TriggersCallback verifies that the TTL
+// timer's callback (triggerRotation) invokes the conn-layer onExpired hook
+// while the card is still streaming — this is what lets us proactively rotate
+// even when no worker delta arrives. See issue #839.
+func TestStreamingCard_ProactiveRotation_TriggersCallback(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctrl := NewStreamingCardController(nil, nil, log, "agent", 1, "m", "b", "w", nil)
+
+	called := make(chan struct{}, 1)
+	ctrl.SetOnExpired(func() { called <- struct{}{} })
+
+	ctrl.phase.Store(int32(PhaseStreaming)) // simulate active streaming
+	ctrl.triggerRotation()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case <-called:
+		// success: onExpired invoked by triggerRotation
+	case <-ctx.Done():
+		t.Fatal("triggerRotation did not invoke onExpired")
+	}
+}
+
+// TestStreamingCard_ProactiveRotation_SkipsAfterClose verifies the race where
+// Close() stops the timer but the callback was already inflight: phase has
+// advanced to Completed, so triggerRotation must NOT invoke onExpired (which
+// would rotate a card that no longer exists).
+func TestStreamingCard_ProactiveRotation_SkipsAfterClose(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctrl := NewStreamingCardController(nil, nil, log, "agent", 1, "m", "b", "w", nil)
+
+	called := make(chan struct{}, 1)
+	ctrl.SetOnExpired(func() { called <- struct{}{} })
+
+	ctrl.phase.Store(int32(PhaseCompleted)) // Close won the race
+	ctrl.triggerRotation()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	select {
+	case <-called:
+		t.Fatal("triggerRotation must not invoke onExpired after Close")
+	case <-ctx.Done():
+		// success: callback skipped
+	}
+}
+
+// TestStreamingCard_ProactiveRotation_NoopWithoutCallback verifies the legacy
+// / test path: if SetOnExpired was never called, startRotationTimer is a no-op
+// (no timer leaks) and triggerRotation is a safe no-op.
+func TestStreamingCard_ProactiveRotation_NoopWithoutCallback(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctrl := NewStreamingCardController(nil, nil, log, "agent", 1, "m", "b", "w", nil)
+
+	require.NotPanics(t, func() {
+		ctrl.startRotationTimer() // no-op: onExpired is nil
+		ctrl.triggerRotation()
+		ctrl.stopRotationTimer()
+	})
 }

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -212,6 +212,16 @@ func FormatDuration(ms int64) string {
 	}
 }
 
+// FormatDoneFallback synthesizes a user-facing message when a turn completes
+// with tool calls but no assistant text — the worker did work (tool calls) but
+// produced no reply. Used by the bridge to avoid empty replies on feishu/slack
+// for tool-only turns. Reuses FormatToolNames + FormatDuration.
+func FormatDoneFallback(d TurnSummaryData) string {
+	tools := FormatToolNames(d.ToolNames, d.ToolCallCount)
+	dur := FormatDuration(d.TurnDurationMs)
+	return fmt.Sprintf("✅ 已完成 · 🔧 %s · ⏱ %s", tools, dur)
+}
+
 // FormatSessionDuration formats session elapsed seconds to human-readable string.
 func FormatSessionDuration(secs float64) string {
 	if secs <= 0 {

--- a/internal/messaging/turn_summary_test.go
+++ b/internal/messaging/turn_summary_test.go
@@ -58,6 +58,42 @@ func TestExtractTurnSummary_Full(t *testing.T) {
 	require.InDelta(t, 750.0, d.SessionDuration, 0.01)
 }
 
+func TestFormatDoneFallback(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		d    TurnSummaryData
+		want []string // substrings that must appear
+	}{
+		{
+			name: "tools and duration",
+			d: TurnSummaryData{
+				ToolCallCount:  6,
+				ToolNames:      map[string]int{"Bash": 3, "Read": 2, "Edit": 1},
+				TurnDurationMs: 90_000, // 1m30s
+			},
+			want: []string{"✅", "6", "Bash×3", "Read×2", "Edit×1", "1m30s"},
+		},
+		{
+			name: "no tool names only count",
+			d: TurnSummaryData{
+				ToolCallCount:  3,
+				TurnDurationMs: 5_000, // 5s
+			},
+			want: []string{"✅", "3", "5s"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatDoneFallback(tc.d)
+			for _, s := range tc.want {
+				require.Contains(t, got, s)
+			}
+		})
+	}
+}
+
 func TestExtractTurnSummary_NilSession(t *testing.T) {
 	t.Parallel()
 	env := &events.Envelope{


### PR DESCRIPTION
## Summary

两个相关修复，解决飞书消息"响应不符合预期"的不同层面（根因来自同一次运行时诊断）。

### 1. 流式卡片 proactive TTL 轮转（Closes #839）

**问题**：TTL 轮转检查原在 `writeContent()` 顶部，仅在 worker delta 到达时触发。长 delta 间隔（工具思考/长计算）下错过窗口，命中飞书服务端 10min 硬限制，最终 flush 降级（error 200850/300309），卡片卡在 "generating"。

**修复**：进入 PhaseStreaming 时 arm `time.AfterFunc(StreamTTL=500s)`，timer 触发 conn 层 `onExpired` 回调执行 `rotateStreamingCard`，与 delta 到达无关。

**并发**：`rotateMu` 串行化 timer vs lazy writeContent；Close 跑在 rotateMu 下（非 c.mu）避免阻塞；`swapped = (c.streamCtrl == cur)` guard 丢弃 lost race。

### 2. 空 done 兜底消息

**问题**：Worker 执行纯工具型长任务时（如建 issue + 写代码，单 turn 45 次工具调用、27 分钟），全程只调工具不产出 message，飞书卡片/Slack 收到空回复（`summary_len:0`），用户体验为"长时间无响应 + 空卡片"。

**修复**：turn done 时若 `turnText.Len()==0 && tool_call>0`（非 webchat），bridge 合成一条含工具调用摘要的 Message 投递，复用 `sendCommandFeedback` (worker_cmds.go) 先例。

**输出**：`✅ 已完成 · 🔧 45 (Bash×13, Edit×12...) · ⏱ 27m5s`

**时序安全**：accumulateStats(254) 先于 SendToSession(269)，兜底 message 在 done 投递前发送，seq 正确（message < done）；events.Message 不在 isDroppable，保证投递。

## 根因诊断证据（eventstore + journal）

- turn 13 单轮 27min / 45 tool_calls / **0 次 message.delta** / 10 次 silence timeout
- 卡片活 10min 被服务端强制关闭（200850→300309）
- input_tok 9.4M 是**递增队列求和**（累计 token 消耗），非上下文规模

## 改动文件

- `internal/messaging/feishu/{streaming,conn,handler}.go`：proactive TTL rotation timer
- `internal/messaging/turn_summary.go`：`FormatDoneFallback` 纯函数
- `internal/gateway/bridge_forward.go`：`maybeSendDoneFallback` 注入

## 验证

- 单元测试 `-race -count=1` 全过（gateway 27.8s + messaging 全包）
- 已部署运行实例验证

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)