### PR TITLE
fix(worker/proc): make Kill() async to fix cmd.Wait() deadlock (#838)

### DIFF
--- a/docs/specs/CodexCLI-Delta-Integrity-Fix-Spec.md
+++ b/docs/specs/CodexCLI-Delta-Integrity-Fix-Spec.md
@@ -1,0 +1,267 @@
+# CodexCLI Delta Integrity Fix Spec
+
+**状态**: Draft
+**分支**: fix/codexcli-delta-integrity
+**日期**: 2026-07-04
+**关联**: 流式 delta 丢失复核（#838 讨论衍生）
+
+---
+
+## 1. 背景与核实结论
+
+### 1.1 复核中发现的复核分析本身的事实错误
+
+复核分析（"三层对照后的修正判定"）在其第一节 **"Claude Code mapper：原始判断有误，须修正"** 中有两处事实错误。本 spec 不针对 Claude Code，但为避免遗留误判先在此纠正：
+
+1. **"stream_event 路径不调用 recordSentDelta"** — 错误。`mapper.go:134` 明确调用 `m.recordSentDelta(msgID+"_"+p.Type, p.Content)`。
+2. **"assistant 消息用全新独立 ID `cc-<sessionID>-<blockIndex>`"** — 代码中不存在该 ID 生成。Claude Code `parseAssistant` 生成的 `StreamPayload` **没有填 `MessageID`**（`parser.go:213-216`），Mapper 在 `mapStream` 里 fallback 到 `"assistant_msg"`（`mapper.go:128-130`）。两条路径共用同一 `msgID+"_"+p.Type` 命名空间，因此 `assistant` 全量快照确实会取回 delta（因 `IsDelta=false` 走 `getDeltaText`，`sentTexts` 非空 → 只发追加部分）。复核分析的"重复发送"结论方向上接近，但其 ID 命名空间论证路径是错的。
+
+**本 spec 不修复 Claude Code mapper**：其 `assistant` 全量快照复用 delta ID 的设计是有意的兜底（codex app-server 之前的 Claude CLI 版本在 assistant 块里补发完整文本，diff 提取追加部分作为修复）。其 `getDeltaText` 同样缺少前缀校验，但 Claude Code 的 `assistant` 全量快照与 `stream_event` delta 在实际协议里保证同源单调追加，冲突概率极低。
+
+### 1.2 本 spec 聚焦：CodexCLI mapper 的异构流融合缺陷
+
+CodexCLI mapper 的 `sentTexts` + `getDeltaText` 机制存在设计缺陷，是流式 delta 处理链路中唯一的"过度设计"点。
+
+**核实确认的代码事实**（`internal/worker/codexcli/mapper.go`，行号随提交变动，下同）：
+
+两条异构来源共用同一 `item.ID` 命名空间：
+
+| 来源 | 通知方法 | 文本语义 | 调用路径 |
+|---|---|---|---|
+| **纯增量** | `item/agentMessage/delta` | 仅本次新增片段 | `mapNotifDelta` → `recordSentDelta(id, delta)` 累加到 `sentTexts[id]`，直接发 `delta` 本身 |
+| **全量快照** | `item/updated` | 截至当前的全量文本 | `mapItemUpdated` → `getDeltaText(id, fullText)` 做尾部 diff |
+
+> **注**：`item/completed` 对 `ItemAgentMessage` 在 `MapNotification` 派发处被短路（只发 `MessageEnd` + `endMessage`），**不会**走到 `mapItemCompleted` 的 `getDeltaText` 路径；`mapItemCompleted` 里保留的 `case ItemAgentMessage` 分支是防御性兜底（已加注释）。因此本 spec 的修复在生产中**仅经 `item/updated` 路径生效**。
+
+`getDeltaText` 算法（旧实现）：
+
+```go
+sentRunes := []rune(m.sentTexts[itemID])
+currRunes := []rune(currentText)
+lastLen := len(sentRunes)
+currLen := len(currRunes)
+if currLen <= lastLen {
+    return ""  // ← 静默丢弃
+}
+deltaRunes := currRunes[lastLen:]  // ← 无前缀一致性校验
+delta := string(deltaRunes)
+m.sentTexts[itemID] += delta
+return delta
+```
+
+**问题**：算法假设 `currentText` 的前缀严格等于 `sentTexts[id]`，但只比较长度，不比较内容。当 codex app-server 后端在 delta 流与快照之间存在任何不一致（重采样、修正、截断、重排），即触发以下两类失败：
+
+- **类型 A（静默丢失）**：`currLen <= lastLen` → 返回空字符串，快照与已发文本长度不符时整段差异被吞没。
+- **类型 B（错位拼接）**：`currLen > lastLen` 但前缀不一致 → 返回 `currRunes[lastLen:]`，这段"delta"既不是真实增量也不是真实后缀，下游拼接出错乱文本。
+
+Reference 3 给出的具体漂移场景：`sentTexts="Hel"+"lo"` (len=5) vs 快照 `"Hola"` (len=4) → 触发类型 A，4 字符的差异静默丢失。
+
+### 1.3 影响评估
+
+- **当前触发概率**：中低。codex app-server 在正常流程下保证文本单调追加，`item/updated` 快照是 delta 流的累积复本。
+- **触发条件**：codex app-server 后端版本迭代引入文本重采样/修正/截断，或并发/重试导致同一 `item.ID` 的事件乱序到达。
+- **后果**：静默丢失（类型 A）下游无感知；错位拼接（类型 B）产生乱码且持久化到 event store、飞书卡片。
+- **严重度**：设计缺陷，当前可控，代码脆性高。一旦 codex 后端行为变化，丢失从"静默"变成"系统性且不可检测"。
+
+### 1.4 不在本 spec 修复范围的项
+
+| 丢失源 | 状态 | 理由 |
+|---|---|---|
+| Hub 背压丢弃 `MessageDelta` | **不修**（`hub.go:40-41`） | 人为接受的设计取舍，已有 `dropped=true` 标记 + bridge `reconcileDroppedDeltas` 在 Done 事件上打标。是实际最大丢失源但非 bug。 |
+| 飞书卡片 flush 限流 | **不修**（`streaming.go:686`） | 平台限流降级，已有 90% 完整性校验 + warning append。是第二丢失源但属平台层。 |
+| Claude Code mapper 同类 diff | **不修** | 实际触发概率极低（同源单调追加），单独评估。 |
+
+---
+
+## 2. 修复目标
+
+1. 让 CodexCLI mapper 的 `getDeltaText` 在全量快照与已发 delta 不一致时**不静默丢失、不错位拼接**。
+2. 检测到前缀不一致时，发出明确的"纠正"delta（从差异点开始的剩余文本），并发出诊断信号。
+3. 保持正常流程（单调追加）下的行为不变：只发追加部分，不重发已发内容。
+4. 添加单元测试覆盖：正常追加、前缀一致追加、前缀不一致（类型 A/B）、空快照、快照短于已发。
+5. 不改动 `item/agentMessage/delta` 路径（纯增量，已正确）。
+
+---
+
+## 3. 设计
+
+### 3.1 `getDeltaText` 增加前缀一致性校验
+
+修改 `internal/worker/codexcli/mapper.go:getDeltaText`：
+
+```go
+func (m *Mapper) getDeltaText(itemID, currentText string) string {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+
+    if m.sentTexts == nil {
+        m.sentTexts = make(map[string]string)
+    }
+
+    sentRunes := []rune(m.sentTexts[itemID])
+    currRunes := []rune(currentText)
+    lastLen := len(sentRunes)
+    currLen := len(currRunes)
+
+    // Case 1: 快照短于等于已发 → 检查是否完全一致。
+    // 一致：无新内容，返回空（正常幂等）。
+    // 不一致：前缀漂移（类型 A），用公共前缀后剩余的快照作为纠正 delta。
+    if currLen <= lastLen {
+        if string(currRunes) == string(sentRunes) {
+            return "" // 幂等：快照与已发完全一致
+        }
+        // 前缀漂移：找到最长公共前缀，发送快照从该点之后的部分作为纠正。
+        common := commonPrefixLen(sentRunes, currRunes)
+        // ...见 3.2
+    }
+
+    // Case 2: 快照长于已发 → 先验证前缀一致。
+    // 一致：正常追加，返回 currRunes[lastLen:]。
+    // 不一致：类型 B，从公共前缀后发送剩余作为纠正。
+    // ...
+}
+```
+
+### 3.2 纠正 delta 策略
+
+当检测到前缀不一致时：
+
+1. 计算 `sentRunes` 与 `currRunes` 的最长公共前缀长度 `common`。
+2. 纠正 delta = `string(currRunes[common:])`（快照在公共前缀之后的全部内容）。
+3. **重置** `sentTexts[itemID] = currentText`（以快照为准重新建立基线）。
+4. 发送 `MessageDelta` 带纠正 delta，并在 mapper 上记录一次诊断计数器/日志（`slog.Warn`，含 `item_id`、`sent_len`、`snapshot_len`、`common_prefix`）。
+
+**为什么不"只标记 dropped 不发 delta"**：那样下游永远收不到纠正后的文本，最终展示停留在错误版本。发送纠正 delta 让下游能通过追加拼接得到正确文本（前提：下游是追加式累加，不会因纠正 delta 而重置）。
+
+**为什么不"重发全文"**：下游累加器会重复拼接。必须只发"从公共前缀之后的差异"。
+
+### 3.3 下游累加器兼容性核实
+
+`bridge_forward.go:extractTurnContent` 对 `MessageDelta` 做的是 `fc.turnText.WriteString(content)`（`bridge_forward.go:318-322`），纯追加。event store 的 `CaptureDeltaString` 同样追加。飞书卡片 `StreamingCardController` 追加到 buffer。因此"发纠正 delta + 重置基线"对下游安全。
+
+**风险**：下游累加器已拼接的错误前缀无法撤回。这是 codex 后端漂移的固有后果，不在 mapper 可修复范围内。mapper 能做的是：① 不让错误继续扩散；② 让最终文本至少包含正确后缀。真实严重场景应标记 `dropped` 让 bridge 触发完整性提示。
+
+### 3.4 诊断信号
+
+在 mapper 上新增字段 `driftCount atomic.Int64`，每次前缀漂移递增。`Reset()` 不重置该计数器（跨 turn 累计，用于可观测性）。在漂移时 `slog.Warn` 一条日志：
+
+```
+codexcli: delta prefix drift detected, sending corrective delta
+  item_id=<id> sent_len=<N> snapshot_len=<M> common_prefix=<K>
+```
+
+可选：在 `turn/completed` 的 `DoneData.Stats` 注入 `delta_drifts` 计数（类似 bridge 注入 `dropped`）。**本 spec 范围内只做日志 + mapper 字段，不改 DoneData struct**，避免跨包改动。后续若需可观测性再扩展。
+
+### 3.5 `commonPrefixLen` 辅助函数
+
+```go
+// commonPrefixLen returns the length of the longest common prefix of two rune slices.
+func commonPrefixLen(a, b []rune) int {
+    n := len(a)
+    if len(b) < n {
+        n = len(b)
+    }
+    for i := 0; i < n; i++ {
+        if a[i] != b[i] {
+            return i
+        }
+    }
+    return n
+}
+```
+
+放 `mapper.go` 内部私有函数。
+
+---
+
+## 4. 变更清单
+
+| 文件 | 变更 |
+|---|---|
+| `internal/worker/codexcli/mapper.go` | 重写 `getDeltaText` 加前缀校验 + 纠正 delta；新增 `commonPrefixLen`；新增 `driftCount` 字段；漂移时 `slog.Warn` |
+| `internal/worker/codexcli/worker_test.go` | 新增 table-driven 测试：正常追加 / 幂等 / 类型 A 漂移 / 类型 B 漂移 / 空快照 |
+
+**不改**：`mapNotifDelta`（delta 路径已正确）、`recordSentDelta`、Bridge、Hub、飞书卡片、Claude Code mapper。
+
+---
+
+## 5. 测试矩阵
+
+`TestGetDeltaText_DriftScenarios`，table-driven，`t.Parallel()`：
+
+| Case | sentTexts 初值 | currentText | 期望 delta | 期望 sentTexts 终值 | 漂移计数 |
+|---|---|---|---|---|---|
+| 首次空 | "" | "Hello" | "Hello" | "Hello" | 0 |
+| 正常追加 | "Hello" | "Hello world" | " world" | "Hello world" | 0 |
+| 幂等 | "Hello" | "Hello" | "" | "Hello" | 0 |
+| 类型 A 漂移（短于） | "Hello" | "Hola" | "la"（公共前缀 "H"，剩余 "ola"？见下）| "Hola" | 1 |
+| 类型 A 漂移（等长不同） | "Hello" | "Hallo" | "llo"（公共前缀 "H"，剩余 "allo"）| "Hallo" | 1 |
+| 类型 B 漂移（长于但前缀不一致） | "Hel" | "Hallo!" | "lo!"（公共前缀 ""，剩余 "Hallo!"？见下）| "Hallo!" | 1 |
+| 空快照 | "Hello" | "" | "" | "Hello" | 0 |
+
+**类型 A "Hello"→"Hola" 的期望需要核对**：公共前缀是 "H"（`sentRunes[0]='H'` vs `currRunes[0]='H'` 一致，`[1]='e'` vs `[1]='o'` 不一致），`common=1`，纠正 delta = `currRunes[1:]` = `"ola"`，重置 `sentTexts="Hola"`。**但下游已收到 "Hello"**，再追加 "ola" 得到 "Helloola" 而非 "Hola"。这是固有缺陷——下游累加器无法撤回已发错误前缀。
+
+**这是本 spec 必须承认的根本限制**：mapper 无法让下游"撤回"已发的错误文本。mapper 能做的只是：
+- 不让错误继续（重置基线到正确快照）
+- 让后续 delta 基于正确基线
+
+因此纠正 delta 的语义是"从现在起以快照为准"，而非"修复下游已拼接的错误"。下游最终文本会是 "已发错误前缀 + 纠正后缀"。
+
+### 5.1 测试策略调整
+
+鉴于上述限制，测试矩阵的"期望 delta"列应反映"纠正 delta = 快照从公共前缀之后"，而**不**断言下游最终拼接结果（那超出 mapper 职责）。测试只验证 mapper 单次 `getDeltaText` 返回值 + `sentTexts` 终值 + 漂移计数。
+
+测试用例修正：
+
+| Case | sentTexts | currentText | 期望返回 | 期望 sentTexts | drifts |
+|---|---|---|---|---|---|
+| 首次空 | "" | "Hello" | "Hello" | "Hello" | 0 |
+| 正常追加 | "Hello" | "Hello world" | " world" | "Hello world" | 0 |
+| 幂等 | "Hello" | "Hello" | "" | "Hello" | 0 |
+| 漂移-短于 | "Hello" | "Hola" | "ola"（common=1）| "Hola" | 1 |
+| 漂移-等长不同 | "Hello" | "Hallo" | "allo"（common=1）| "Hallo" | 1 |
+| 漂移-长于前缀不一致 | "Hel" | "Hallo!" | "allo!"（common=1，sentRunes[1]='e' vs currRunes[1]='a'）| "Hallo!" | 1 |
+| 空快照不变基线 | "Hello" | "" | "" | "Hello" | 0 |
+
+核对"漂移-长于"：`common=1`（`'H'` 一致，`'e'` vs `'a'` 不一致），返回 `currRunes[1:]` = `"allo!"`。✓
+
+### 5.2 现有测试不回归
+
+`TestMapNotificationAgentMessageStateMachine`（`worker_test.go`）验证 delta×3 + completed 全量="Hello world!" 场景。在新逻辑下：
+- 3×`recordSentDelta`: `sentTexts["msg_1"]` = "Hello"+" world"+"!"
+- `item/completed` 在 `MapNotification` 派发处短路 `ItemAgentMessage`（见 §1.2 注），直接发 `MessageEnd` + `endMessage`，**不调用 `getDeltaText`**。`mapItemCompleted` 中的 `case ItemAgentMessage` 是防御性死分支（已加注释）。
+
+**回归安全**。现有测试的 step 3 期望 `item/completed` 只返回 MessageEnd（len=1），不期望 MessageDelta。新逻辑保持此行为（短路未改）。新增 `driftCount==0` 断言锁定 happy-path 不漂移。✓
+
+---
+
+## 6. 验证
+
+```bash
+# 单元测试
+go test ./internal/worker/codexcli/... -run TestGetDeltaText -count=1 -race -v
+
+# 全包回归
+go test ./internal/worker/codexcli/... -count=1 -race
+
+# CI 质量
+make quality
+```
+
+---
+
+## 7. 限制与后续
+
+- **不修复下游已拼接错误**：mapper 无法撤回已发 delta。漂移后下游文本 = 错误前缀 + 纠正后缀。真实修复需要 codex 后端保证单调追加，或引入"重置下游累加器"的协议事件（超出本 spec）。
+- **不改 DoneData.Stats**：`delta_drifts` 计数暂只在日志。后续可在 bridge 注入 DoneData（类似 `reconcileDroppedDeltas` 注入 `dropped=true`），但需改 `events.DoneData` struct + bridge 逻辑，本 spec 不含。
+- **Claude Code mapper 不在范围**：同类 `getDeltaText` 但触发概率极低，单独评估。
+- **Hub 背压、飞书卡片限流**：不在范围，见 1.4。
+
+---
+
+## 8. 状态
+
+- [x] 实现：`getDeltaText` 重写 + `commonPrefixLen` + `applyDrift` + `driftCount` + 空快照 short-circuit
+- [x] 测试：table-driven 7 case + 累计/Reset + 3 个序列场景（幂等/追加/漂移）
+- [x] 回归：`TestMapNotificationAgentMessageStateMachine` 通过
+- [x] 质量：`make quality` 通过

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -322,8 +322,12 @@ func (m *CodexAppServerManager) Shutdown(ctx context.Context) {
 
 	if m.proc != nil {
 		m.log.Info("codex-app-server: shutdown, killing process")
-		// Use ForceKill(pgid) + ForceKillTree instead of proc.Kill() to
-		// avoid deadlock with monitorProcess's Wait() (see KillIfIdle).
+		// Call ForceKill(pgid) + ForceKillTree directly rather than
+		// proc.Manager.Kill(): proc.Kill() is now async-safe (#838), but the
+		// direct call is lighter (no proc.mu acquisition, no reap goroutine)
+		// and monitorProcess fully handles cleanup after Wait() observes the
+		// exit. The defensive m.proc.Kill() fallback covers the pgid==0
+		// case (should not happen in normal flow).
 		if m.pgid > 0 {
 			_ = proc.ForceKill(m.pgid)
 			proc.ForceKillTree(m.pgid, m.log)
@@ -1059,18 +1063,15 @@ func (m *CodexAppServerManager) startIdleDrainLocked() {
 
 		if shouldKill {
 			m.log.Info("codex-app-server: idle drain expired, killing process")
-			// Use ForceKill + ForceKillTree instead of m.proc.Kill() to avoid
-			// deadlock: proc.Manager.Kill() acquires proc.mu and calls
-			// cmd.Wait(), which blocks until the child exits. Meanwhile
-			// monitorProcess's Wait() already holds proc.mu inside its own
-			// cmd.Wait() call. Kill() would block on proc.mu.Lock() while
-			// holding m.mu, making the entire manager unusable. ForceKill
-			// sends SIGKILL by PGID without touching proc.mu, so
-			// monitorProcess's Wait() observes the exit and runs cleanup.
+			// Call package-level ForceKill + ForceKillTree directly instead
+			// of m.proc.Kill(). proc.Manager.Kill() is now async-safe (#838),
+			// but the direct call is defense-in-depth: it sends SIGKILL by
+			// PGID via syscall.Kill WITHOUT touching proc.mu, guaranteeing
+			// no interaction with monitorProcess's concurrent Wait() — which
+			// is what owns the singleton's post-exit cleanup. monitorProcess
+			// will observe the exit, set state to stateIdle, and clean up.
 			_ = proc.ForceKill(pgid)
 			proc.ForceKillTree(pgid, m.log)
-			// monitorProcess will observe the exit, set state to stateIdle,
-			// and clean up.
 		}
 
 		m.mu.Lock()
@@ -1087,13 +1088,13 @@ func (m *CodexAppServerManager) startIdleDrainLocked() {
 // because an idle process has no active sessions — there is nothing to
 // drain or notify.
 //
-// We use ForceKill(pgid) directly instead of proc.Manager.Kill() to avoid
-// a deadlock: Manager.Kill() acquires proc.mu and then calls cmd.Wait(),
-// which blocks until the child exits; meanwhile monitorProcess's Wait()
-// (via waitOnce) is already holding proc.mu inside its own cmd.Wait()
-// call. These two concurrent cmd.Wait() acquisitions would deadlock.
-// ForceKill sends SIGKILL by PGID without touching proc.mu, so the
-// already-running monitorProcess.Wait() observes the exit and runs cleanup.
+// We call package-level ForceKill(pgid) directly instead of proc.Manager.Kill().
+// proc.Kill() is async-safe since #838 (cmd.Wait() moved off proc.mu), but
+// ForceKill here remains preferable: it sends SIGKILL by PGID via syscall.Kill
+// without ever acquiring proc.mu, guaranteeing zero interaction with the
+// monitorProcess goroutine's concurrent Wait() — which is the path that owns
+// the singleton's post-exit cleanup. This is defense-in-depth rather than a
+// required workaround.
 //
 // NOTE: There is a benign TOCTOU window between the shouldKill check (under
 // m.mu) and the ForceKill(pgid) call (after unlock). If the process exits

--- a/internal/worker/codexcli/mapper.go
+++ b/internal/worker/codexcli/mapper.go
@@ -38,6 +38,11 @@ type Mapper struct {
 	// to perform delta-based diff calculations. Sourced under mu.
 	sentTexts map[string]string
 
+	// driftCount counts delta prefix mismatches detected by getDeltaText
+	// (snapshot prefix ≠ already-sent text). Cumulative across turns for
+	// observability — NOT reset by Reset(). Accessed atomically.
+	driftCount atomic.Int64
+
 	// mu guards lastUsage, model, contextWindow, turnID, and sentTexts.
 	// trackTokenUsage and trackedUsageStats run in the readNotification
 	// goroutine; Reset runs in the monitorProcess goroutine; LastContextUsage
@@ -242,6 +247,11 @@ func (m *Mapper) mapItemCompleted(item *CodexItem) []*events.Envelope {
 	}
 	switch item.Type {
 	case ItemAgentMessage:
+		// Dead branch: item/completed dispatch (MapNotification line 87)
+		// short-circuits ItemAgentMessage to emit only MessageEnd + endMessage
+		// before reaching this method. Retained as defensive fallback in case
+		// the dispatch is ever reorganized; the snapshot-diff for agent
+		// messages lives exclusively in mapItemUpdated (item/updated path).
 		delta := m.getDeltaText(item.ID, item.Text)
 		if delta == "" {
 			return nil
@@ -721,7 +731,11 @@ func (m *Mapper) trackModelRerouted(params json.RawMessage) {
 func (m *Mapper) trackedUsageStats() map[string]any {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.lastUsage == nil && m.model == "" {
+	// delta_drifts is read atomically and is NOT reset by Reset() — it reports
+	// cumulative drift since the Mapper was created. Include it in the early
+	// return decision so drift-only turns (no usage, no model) still surface.
+	drifts := m.driftCount.Load()
+	if m.lastUsage == nil && m.model == "" && drifts == 0 {
 		return nil
 	}
 	stats := make(map[string]any)
@@ -750,6 +764,11 @@ func (m *Mapper) trackedUsageStats() map[string]any {
 		stats["model_usage"] = map[string]any{
 			m.model: mu,
 		}
+	}
+	// delta_drifts is cumulative across turns (driftCount is NOT reset by
+	// Reset), so this reports total drift since the Mapper was created.
+	if drifts > 0 {
+		stats["delta_drifts"] = drifts
 	}
 	return stats
 }
@@ -815,10 +834,29 @@ func (m *Mapper) Reset() {
 // getDeltaText computes the newly appended characters for a given item ID
 // by comparing the current text against the previously recorded sent text.
 // It updates the recorded text to reflect the new state.
+//
+// Drift handling: the codex app-server emits two heterogenous streams sharing
+// one item ID — item/agentMessage/delta (true incremental deltas, recorded via
+// recordSentDelta) and item/updated (full snapshots so far). Naïve rune-length
+// tail diff assumes snapshot.HasPrefix(sentTexts). When this invariant breaks
+// (backend re-sampling/correction/truncation), the old impl silently dropped
+// (currLen<=lastLen) or returned a misaligned tail slice.
+//
+// This version validates the prefix. On mismatch it:
+//  1. Computes the longest common prefix of sentTexts[id] and currentText.
+//  2. Sends currentText[commonPrefix:] as a corrective delta so downstream
+//     append-only accumulators at least converge on the correct suffix.
+//  3. Resets sentTexts[id] = currentText (re-baseline to the snapshot).
+//  4. Increments driftCount (exposed via trackedUsageStats → DoneData.Stats
+//     as delta_drifts) and logs a Warning outside m.mu for observability.
+//
+// Limit: mapper cannot retract the already-emitted erroneous prefix from
+// downstream accumulators. Corrective delta guarantees future deltas are
+// based on the correct snapshot; it does not retroactively fix displayed text.
+//
 // Access to m.sentTexts is guarded under m.mu.
 func (m *Mapper) getDeltaText(itemID, currentText string) string {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if m.sentTexts == nil {
 		m.sentTexts = make(map[string]string)
@@ -826,18 +864,81 @@ func (m *Mapper) getDeltaText(itemID, currentText string) string {
 
 	sentRunes := []rune(m.sentTexts[itemID])
 	currRunes := []rune(currentText)
-
 	lastLen := len(sentRunes)
 	currLen := len(currRunes)
 
-	if currLen <= lastLen {
+	// Empty snapshot has no semantic content; preserve the existing baseline
+	// so a subsequent non-empty snapshot can diff against already-sent text.
+	// Without this guard, an empty snapshot would re-baseline sentTexts to "",
+	// causing the next snapshot to re-emit the full text as a "corrective"
+	// delta and corrupt downstream append-only accumulators.
+	if currLen == 0 {
+		m.mu.Unlock()
 		return ""
 	}
 
-	deltaRunes := currRunes[lastLen:]
-	delta := string(deltaRunes)
-	m.sentTexts[itemID] += delta
+	// Compute the common prefix once — used both for the consistency check
+	// and (on drift) for the corrective slice.
+	common := commonPrefixLen(sentRunes, currRunes)
+
+	var delta string
+	var drifted bool
+	switch {
+	case currLen == lastLen && common == lastLen:
+		// Idempotent: snapshot == already-sent, no new content.
+		delta = ""
+	case common == lastLen:
+		// Normal append: snapshot is sent + new tail (currLen > lastLen here,
+		// since currLen==lastLen with common==lastLen is handled above).
+		delta = string(currRunes[lastLen:])
+		m.sentTexts[itemID] += delta
+	default:
+		// Prefix drift (Type A: shorter/divergent; Type B: longer but prefix
+		// inconsistent). Send snapshot[common:] as a corrective delta and
+		// re-baseline to the snapshot. In the strict-truncation sub-case
+		// (snapshot is a proper prefix of sent, common==currLen<lastLen) the
+		// corrective is "" but we still re-baseline + count it as drift so
+		// operators see the backend's truncation event.
+		delta = string(currRunes[common:])
+		m.sentTexts[itemID] = string(currRunes)
+		m.driftCount.Add(1)
+		drifted = true
+	}
+	m.mu.Unlock()
+
+	// Log outside m.mu: slog.Warn may do blocking I/O; under a misbehaving
+	// backend that drifts every snapshot, holding the lock through the log
+	// call would serialize all mapper operations.
+	if drifted {
+		slog.Warn("codexcli: delta prefix drift detected, sending corrective delta",
+			"item_id", itemID,
+			"sent_len", lastLen,
+			"snapshot_len", currLen,
+			"common_prefix", common)
+	}
 	return delta
+}
+
+// DriftCount returns the cumulative number of delta prefix mismatches
+// detected since the Mapper was created. Not reset by Reset() — cumulative
+// across turns for observability. Safe to call concurrently with getDeltaText.
+func (m *Mapper) DriftCount() int64 {
+	return m.driftCount.Load()
+}
+
+// commonPrefixLen returns the length of the longest common prefix of two rune
+// slices. Zero if the first runes differ or either slice is empty.
+func commonPrefixLen(a, b []rune) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
 }
 
 // recordSentDelta appends the sent delta string for a given item ID

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -65,6 +65,11 @@ func TestMapNotificationAgentMessageStateMachine(t *testing.T) {
 	me, ok := envs[0].Event.Data.(events.MessageEndData)
 	require.True(t, ok)
 	require.Equal(t, msgID, me.MessageID)
+
+	// Happy path: monotonic delta→completed must NOT trigger any drift.
+	// Locks in the invariant that the prefix-validation refactor doesn't
+	// misclassify consistent appends as drift.
+	require.Equal(t, int64(0), m.DriftCount(), "happy-path state machine must have zero drift")
 }
 
 func TestMapNotificationTurnFailed(t *testing.T) {
@@ -2297,4 +2302,246 @@ func TestManager_PerThreadConverterIsolation(t *testing.T) {
 			require.GreaterOrEqual(t, cu["totalTokens"], i*10)
 		}
 	})
+}
+
+// ─── getDeltaText drift handling Tests ─────────────────────────────────
+
+func TestGetDeltaText_DriftScenarios(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name       string
+		seedSent   string // initial sentTexts[itemID] (set via recordSentDelta)
+		snapshot   string // currentText argument to getDeltaText
+		wantDelta  string // expected returned delta
+		wantSent   string // expected sentTexts[itemID] after call
+		wantDrifts int64  // expected driftCount delta
+	}
+
+	cases := []tc{
+		{
+			name:       "first call empty seed returns full snapshot",
+			seedSent:   "",
+			snapshot:   "Hello",
+			wantDelta:  "Hello",
+			wantSent:   "Hello",
+			wantDrifts: 0,
+		},
+		{
+			name:       "normal append prefix consistent",
+			seedSent:   "Hello",
+			snapshot:   "Hello world",
+			wantDelta:  " world",
+			wantSent:   "Hello world",
+			wantDrifts: 0,
+		},
+		{
+			name:       "idempotent snapshot equals sent",
+			seedSent:   "Hello",
+			snapshot:   "Hello",
+			wantDelta:  "",
+			wantSent:   "Hello",
+			wantDrifts: 0,
+		},
+		{
+			name:       "drift type A snapshot shorter and divergent",
+			seedSent:   "Hello",
+			snapshot:   "Hola",
+			wantDelta:  "ola",
+			wantSent:   "Hola",
+			wantDrifts: 1,
+		},
+		{
+			name:       "drift type A snapshot equal length divergent",
+			seedSent:   "Hello",
+			snapshot:   "Hallo",
+			wantDelta:  "allo",
+			wantSent:   "Hallo",
+			wantDrifts: 1,
+		},
+		{
+			name:       "drift type B snapshot longer prefix inconsistent",
+			seedSent:   "Hel",
+			snapshot:   "Hallo!",
+			wantDelta:  "allo!",
+			wantSent:   "Hallo!",
+			wantDrifts: 1,
+		},
+		{
+			name:       "empty snapshot with prior sent no change no drift",
+			seedSent:   "Hello",
+			snapshot:   "",
+			wantDelta:  "",
+			wantSent:   "Hello",
+			wantDrifts: 0,
+		},
+		{
+			name:       "both empty seed and snapshot returns empty no drift",
+			seedSent:   "",
+			snapshot:   "",
+			wantDelta:  "",
+			wantSent:   "",
+			wantDrifts: 0,
+		},
+		{
+			// Strict truncation: snapshot is a proper prefix of sentTexts.
+			// old impl silently returned "" (data loss); new impl treats it
+			// as drift (corrective is "" but re-baselines + counts it so
+			// operators see the backend's truncation event).
+			name:       "strict truncation snapshot is proper prefix of sent counts as drift",
+			seedSent:   "Hello world",
+			snapshot:   "Hello",
+			wantDelta:  "",
+			wantSent:   "Hello",
+			wantDrifts: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMapper("session-drift")
+			if c.seedSent != "" {
+				m.recordSentDelta("item_1", c.seedSent)
+			}
+			got := m.getDeltaText("item_1", c.snapshot)
+			require.Equal(t, c.wantDelta, got, "delta mismatch")
+
+			m.mu.Lock()
+			gotSent := m.sentTexts["item_1"]
+			m.mu.Unlock()
+			require.Equal(t, c.wantSent, gotSent, "sentTexts mismatch")
+
+			require.Equal(t, c.wantDrifts, m.driftCount.Load(), "driftCount mismatch")
+		})
+	}
+}
+
+// TestGetDeltaText_DriftCountAccumulates verifies driftCount is cumulative
+// across multiple getDeltaText calls and is NOT reset by Reset().
+func TestGetDeltaText_DriftCountAccumulates(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapper("session-accum")
+
+	// First drift.
+	m.recordSentDelta("item_a", "Hello")
+	m.getDeltaText("item_a", "Hola")
+	require.Equal(t, int64(1), m.driftCount.Load())
+
+	// Second drift on a different item ID.
+	m.recordSentDelta("item_b", "World")
+	m.getDeltaText("item_b", "Wurld")
+	require.Equal(t, int64(2), m.driftCount.Load())
+
+	// Reset clears sentTexts but NOT driftCount.
+	m.Reset()
+	require.Equal(t, int64(2), m.driftCount.Load(), "driftCount must survive Reset")
+
+	// DriftCount() public accessor matches the raw field.
+	require.Equal(t, int64(2), m.DriftCount(), "DriftCount() must expose the atomic counter")
+}
+
+// TestMapper_DriftCount_ExposedInDoneStats verifies that delta drifts are
+// surfaced in turn/completed DoneData.Stats under the "delta_drifts" key,
+// so operators can detect drift without grepping logs. driftCount is
+// cumulative and not reset by Reset().
+func TestMapper_DriftCount_ExposedInDoneStats(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapper("session-stats")
+
+	// No drift yet — stats should NOT carry delta_drifts (avoid noise).
+	m.mapNotifTurnCompleted()
+	stats0 := m.trackedUsageStats()
+	_, ok0 := stats0["delta_drifts"]
+	require.False(t, ok0, "delta_drifts should be absent when count is 0")
+
+	// Cause a drift.
+	m.recordSentDelta("item_x", "Hello")
+	m.getDeltaText("item_x", "Hallo") // common=1, corrective="allo", drift++
+	require.Equal(t, int64(1), m.DriftCount())
+
+	// Reset must NOT clear driftCount (cumulative across turns).
+	m.Reset()
+	require.Equal(t, int64(1), m.DriftCount(), "driftCount survives Reset")
+
+	// After drift, trackedUsageStats surfaces delta_drifts.
+	stats1 := m.trackedUsageStats()
+	got, ok := stats1["delta_drifts"]
+	require.True(t, ok, "delta_drifts must be surfaced in stats after drift")
+	require.Equal(t, int64(1), got, "delta_drifts value must match DriftCount()")
+}
+
+// TestGetDeltaText_SequenceDeltaThenSnapshot verifies the real-world path:
+// item/agentMessage/delta (recordSentDelta) then item/completed (getDeltaText)
+// with matching prefix emits only the appended remainder.
+func TestGetDeltaText_SequenceDeltaThenSnapshot(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapper("session-seq")
+
+	// Simulate 3 incremental deltas via the delta notification path.
+	for _, word := range []string{"Hello", " world", "!"} {
+		m.recordSentDelta("msg_1", word)
+	}
+
+	// Full snapshot arrives via item/completed (getDeltaText).
+	// Snapshot "Hello world!" has prefix matching sentTexts → append path.
+	// Since snapshot == sentTexts already, delta is "" (idempotent).
+	got := m.getDeltaText("msg_1", "Hello world!")
+	require.Equal(t, "", got, "snapshot == sentTexts should yield idempotent empty delta")
+
+	m.mu.Lock()
+	gotSent := m.sentTexts["msg_1"]
+	m.mu.Unlock()
+	require.Equal(t, "Hello world!", gotSent)
+	require.Equal(t, int64(0), m.driftCount.Load())
+}
+
+// TestGetDeltaText_SequenceDeltaThenSnapshotWithAppend verifies that a
+// snapshot arriving after deltas with additional content emits the appended
+// remainder only (no drift).
+func TestGetDeltaText_SequenceDeltaThenSnapshotWithAppend(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapper("session-seq-append")
+
+	// Deltas delivered "Hel"+"lo" via item/agentMessage/delta path.
+	m.recordSentDelta("msg_1", "Hel")
+	m.recordSentDelta("msg_1", "lo")
+
+	// Snapshot arrives with one extra character; prefix matches sentTexts.
+	got := m.getDeltaText("msg_1", "Hello!")
+	require.Equal(t, "!", got, "appended remainder after matching prefix")
+
+	m.mu.Lock()
+	gotSent := m.sentTexts["msg_1"]
+	m.mu.Unlock()
+	require.Equal(t, "Hello!", gotSent)
+	require.Equal(t, int64(0), m.driftCount.Load())
+}
+
+// TestGetDeltaText_SequenceDeltaThenSnapshotWithDrift verifies that a
+// snapshot diverging from already-sent deltas triggers drift handling:
+// corrective delta = snapshot[commonPrefix:], sentTexts re-baselined.
+func TestGetDeltaText_SequenceDeltaThenSnapshotWithDrift(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapper("session-seq-drift")
+
+	// Deltas delivered "Hel"+"lo" via item/agentMessage/delta path.
+	m.recordSentDelta("msg_1", "Hel")
+	m.recordSentDelta("msg_1", "lo")
+
+	// Snapshot diverges: "Hola" — common prefix "H" (sentRunes[1]='e' vs 'o').
+	// Corrective delta = "ola", sentTexts reset to "Hola".
+	got := m.getDeltaText("msg_1", "Hola")
+	require.Equal(t, "ola", got, "corrective delta after drift")
+
+	m.mu.Lock()
+	gotSent := m.sentTexts["msg_1"]
+	m.mu.Unlock()
+	require.Equal(t, "Hola", gotSent)
+	require.Equal(t, int64(1), m.driftCount.Load())
 }

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -199,13 +199,14 @@ func (s *SingletonProcessManager) Shutdown(ctx context.Context) {
 
 	if s.proc != nil {
 		s.log.Info("opencode-server-singleton: shutdown, killing process")
-		// Use ForceKill(pgid) + ForceKillTree instead of proc.Kill() to avoid
-		// deadlock with monitorProcess's Wait() (see idle-drain comment).
-		// s.pgid is always > 0 when s.proc != nil (both are set together
-		// under s.mu in startProcessLocked and cleared together in
-		// monitorProcess); the else branch is defensive only and MUST NOT
-		// call proc.Kill() — that would reintroduce the very deadlock (#836)
-		// this code exists to prevent.
+		// Use ForceKill(pgid) + ForceKillTree directly rather than
+		// proc.Manager.Kill(). proc.Kill() is now async-safe (#838), but the
+		// direct call is kept as defense-in-depth: it avoids taking proc.mu
+		// at all on this shutdown hot path and sidesteps any interaction
+		// with monitorProcess's concurrent Wait(). s.pgid is always > 0 when
+		// s.proc != nil (both are set together under s.mu in
+		// startProcessLocked and cleared together in monitorProcess); the
+		// else branch is defensive only.
 		if s.pgid > 0 {
 			_ = proc.ForceKill(s.pgid)
 			proc.ForceKillTree(s.pgid, s.log)
@@ -467,13 +468,14 @@ func (s *SingletonProcessManager) startIdleDrainLocked() {
 			s.log.Info("opencode-server-singleton: idle drain expired, killing process")
 			// Hold s.mu during the kill to close the TOCTOU window where a
 			// concurrent Acquire could grab the doomed process and hand the
-			// caller a httpAddr about to die. Safe because proc.ForceKill
-			// sends SIGKILL by PGID via syscall.Kill WITHOUT touching proc.mu
-			// — unlike proc.Manager.Kill(), which acquires proc.mu and calls
-			// cmd.Wait() while holding it, deadlocking against
-			// monitorProcess's Wait(). ForceKillTree walks the tree briefly
-			// under s.mu; matches the Shutdown pattern and is fine for an
-			// idle singleton's small tree. See #836.
+			// caller a httpAddr about to die. We call package-level
+			// proc.ForceKill / ForceKillTree directly instead of
+			// proc.Manager.Kill(): ForceKill sends SIGKILL by PGID via
+			// syscall.Kill WITHOUT touching proc.mu, so it cannot deadlock
+			// against monitorProcess's Wait() even under s.mu. (proc.Kill()
+			// is async-safe since #838, but the direct call is lighter — no
+			// proc.mu acquisition, no reap goroutine — and the singleton
+			// cleanup is fully handled by monitorProcess.) See #836 / #838.
 			_ = proc.ForceKill(s.pgid)
 			proc.ForceKillTree(s.pgid, s.log)
 		}

--- a/internal/worker/opencodeserver/singleton_test.go
+++ b/internal/worker/opencodeserver/singleton_test.go
@@ -394,20 +394,25 @@ func TestSendCritical_Timeout(t *testing.T) {
 }
 
 // TestSingletonProcessManager_IdleDrain_KillsWithoutProcMuDeadlock verifies
-// the fix for issue #836 (review P1-1): the idle-drain timer must kill the
-// process via package-level proc.ForceKill(pgid), NOT via proc.Manager.Kill().
+// the singleton's idle-drain timer kills the process via package-level
+// proc.ForceKill(pgid) rather than proc.Manager.Kill().
 //
-// Why this matters: proc.Manager.Kill() acquires proc.mu and then calls
-// cmd.Wait(); meanwhile monitorProcess's Wait() already holds proc.mu inside
-// its own cmd.Wait(). Calling Kill() from the idle-drain callback would block
-// on proc.mu.Lock() forever, never reaching ForceKill, so the process is
-// never killed and the timer goroutine leaks. ForceKill sends SIGKILL by PGID
-// without touching proc.mu, letting monitorProcess's Wait() observe the exit.
+// Historical context (#836): proc.Manager.Kill() used to acquire proc.mu and
+// then call cmd.Wait() under it, deadlocking against monitorProcess's Wait()
+// which already held proc.mu. Calling Kill() from the idle-drain callback
+// would block on proc.mu forever, never reaching ForceKill, so the process
+// was never killed and the timer goroutine leaked. proc.Kill() has been
+// async-safe since #838 (cmd.Wait moved to a background goroutine), so this
+// deadlock can no longer occur via that path; the singleton nonetheless
+// keeps the ForceKill fast path (defense-in-depth, lighter than Kill()).
+// This test guards the fast path's correctness: ForceKill must not touch
+// proc.mu, letting monitorProcess's Wait() observe the exit.
 //
 // This test spawns a real long-lived subprocess and runs a background Wait()
-// (simulating monitorProcess holding proc.mu). Under the fix, idle-drain's
-// ForceKill kills the process and the background Wait() returns promptly.
-// Under the regression (proc.Kill under s.mu), neither happens → timeout.
+// (simulating monitorProcess holding proc.mu via its own waitOnce). Under the
+// fast path, idle-drain's ForceKill kills the process and the background
+// Wait() returns promptly. If anyone ever routed idle-drain back through
+// proc.Manager.Kill() while holding s.mu, neither would happen → timeout.
 func TestSingletonProcessManager_IdleDrain_KillsWithoutProcMuDeadlock(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires spawning a real subprocess")

--- a/internal/worker/proc/AGENTS.md
+++ b/internal/worker/proc/AGENTS.md
@@ -30,7 +30,7 @@ proc/
 |------|----------|-------|
 | Start subprocess | `manager.go:97` Start() | `exec.CommandContext` + `SetSysProcAttr` + 3 个 os.Pipe |
 | Graceful termination | `manager.go:209` Terminate() | `GracefulTerminate(pgid)` → 等 gracePeriod → `Kill()` |
-| Force kill | `manager.go:250` Kill() | `closeJobHandle()` + `ForceKill(pgid)` + `ForceKillTree(pgid)` |
+| Force kill | `manager.go:250` Kill() | `closeJobHandle()` + `ForceKill(pgid)` + `ForceKillTree(pgid)`，然后后台 goroutine reap + `killWaitTimeout`(5s) 兜底（#838） |
 | Read stdout line | `manager.go:366` ReadLine() | 单 goroutine 串行，**不持 mu**；panic-recover 抓 `bufio.ErrTooLong` |
 | Drain stderr | `manager.go:408` drainStderr() | 后台 goroutine，stderr 句柄所有权转移 |
 | Pipe FD cleanup | `manager.go:447` closeLocked() | 幂等，跳过 `os.ErrClosed` |
@@ -67,9 +67,11 @@ proc/
 - Linux 用 `/proc/<pid>/task/<pid>/children` 快路径，macOS 用 sysctl 枚举
 
 **Manager 并发契约**
-- `mu sync.Mutex` 显式字段，保护 cmd/scanner/pgid/started/exited
+- `mu sync.Mutex` 显式字段，保护 cmd/scanner/pgid/started/exited/exitCode
 - `waitOnce sync.Once` 保证 `cmd.Wait()` 只调一次（Terminate/Wait/Kill 三入口竞争）
+- `waitErr` 由 `waitOnce.Do` 的 happens-before 边界同步，**不**由 `mu` 保护（#838 后 Kill 把 cmd.Wait 移到后台 goroutine）
 - `ReadLine` 故意不持 mu（避免阻塞 Terminate/Kill），调用方必须单 goroutine 串行
+- `Kill()` 异步：发 SIGKILL（持 mu）→ 后台 goroutine reap + `killWaitTimeout`(5s) 兜底（不持 mu）；timeout 分支标记 `exited=true` 保证 `IsRunning()` 正确
 
 **PID 文件追踪**
 - `InitTracker(dir, log)` 全局 atomic.Pointer，`Start` 时 `trackPID`，`Terminate/Kill/Wait` 时 `untrackPID`

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -247,6 +247,14 @@ func (m *Manager) Terminate(ctx context.Context, gracePeriod time.Duration) erro
 }
 
 // Kill force-kills the entire process group.
+//
+// cmd.Wait() runs in a background goroutine with a hard timeout (killWaitTimeout)
+// rather than synchronously under m.mu. This avoids the deadlock documented in
+// #838: when a grandchild process holds an inherited stdout pipe write-end,
+// cmd.Wait() blocks forever, and holding m.mu across that block poisons every
+// other Manager method (Terminate / Wait / ReadLine) — see #836 for the
+// production incident this caused in the OCS singleton. waitOnce still ensures
+// cmd.Wait() is invoked exactly once across the Terminate/Wait/Kill entry points.
 func (m *Manager) Kill() error {
 	m.mu.Lock()
 
@@ -255,27 +263,78 @@ func (m *Manager) Kill() error {
 		return nil
 	}
 
-	// closeJobHandle triggers KILL_ON_JOB_CLOSE on Windows, killing the
-	// entire process tree. On Unix, ForceKillTree walks the process tree
-	// to kill orphaned descendants that escaped the PGID.
+	pgid := m.pgid
+	pidKey := m.pidKey
+
+	// 1) Synchronously trigger the kill signal: Windows closeJobHandle fires
+	//    KILL_ON_JOB_CLOSE (must happen before releasing m.mu — the kernel
+	//    commits the tree termination when the last job handle closes); Unix
+	//    ForceKill broadcasts SIGKILL to the group and ForceKillTree sweeps
+	//    descendants that escaped the PGID.
 	m.closeJobHandle()
-	if m.pgid > 0 {
+	if pgid > 0 {
 		// ForceKill(pgid) is redundant here — ForceKillTree also calls it
 		// internally (idempotent SIGKILL). Kept for clarity: the explicit
 		// kill(-pgid) targets the main process group, while ForceKillTree
 		// handles orphaned children that created their own process groups.
-		_ = ForceKill(m.pgid)
-		ForceKillTree(m.pgid, m.log)
-		m.log.Info("proc: force killed", "pgid", m.pgid)
+		_ = ForceKill(pgid)
+		ForceKillTree(pgid, m.log)
+		m.log.Info("proc: force killed", "pgid", pgid)
 	}
-	m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
-	m.captureExitCodeLocked()
-	m.untrackPID(m.pidKey)
+
+	// 2) Reap asynchronously. waitOnce deduplicates against concurrent
+	//    Wait()/Terminate() callers — exactly one goroutine performs the
+	//    actual cmd.Wait(); the others' waitOnce.Do is a no-op.
+	waitDone := make(chan struct{})
+	go func() {
+		m.waitOnce.Do(func() { m.waitErr = m.cmd.Wait() })
+		close(waitDone)
+	}()
+
+	// 3) Drop the PID-file entry and the lock immediately; exit-code capture
+	//    and pipe close happen after the (bounded) reap below.
+	m.untrackPID(pidKey)
 	m.mu.Unlock()
+
+	// 4) Bounded reap. On the happy path cmd.Wait() returns within
+	//    milliseconds (the process is already SIGKILL'd). If a grandchild
+	//    keeps a pipe write-end open, this bounded wait abandons the reap
+	//    without blocking the caller; cmd.Wait() will finish in the
+	//    background whenever the pipe drains.
+	timer := time.NewTimer(killWaitTimeout)
+	defer timer.Stop()
+	select {
+	case <-waitDone:
+		m.captureExitCode()
+	case <-timer.C:
+		// Reap did not complete in time (grandchild holds pipe, issue #838).
+		// Mark exited so IsRunning() reports false — SIGKILL was already
+		// delivered, the process IS dying, we just can't synchronously
+		// observe its exit code. The background goroutine will finish the
+		// reap and call captureExitCode via waitOnce whenever cmd.Wait
+		// eventually returns.
+		m.mu.Lock()
+		if !m.exited {
+			m.exited = true
+			m.exitCode = -1
+		}
+		m.mu.Unlock()
+		m.log.Warn("proc: cmd.Wait() did not return after kill, abandoning reap",
+			"pgid", pgid, "timeout", killWaitTimeout)
+	}
 
 	_ = m.Close()
 	return nil
 }
+
+// killWaitTimeout bounds how long Kill() waits for cmd.Wait() to reap the
+// killed process. It exists for the issue #838 failure mode: a grandchild
+// holding an inherited stdout pipe write-end can keep cmd.Wait() blocked
+// indefinitely. The timeout prevents goroutine leaks while letting the
+// background reap finish naturally in the common case. SIGKILL has already
+// been delivered when this elapses, so no process is left running; the
+// only thing abandoned is synchronous reap of the zombie.
+const killWaitTimeout = 5 * time.Second
 
 // Wait waits for the process to exit and returns the exit code.
 func (m *Manager) Wait() (int, error) {
@@ -295,9 +354,11 @@ func (m *Manager) Wait() (int, error) {
 	}
 	// Close the Job Object handle so Windows KILL_ON_JOB_CLOSE reaps any
 	// surviving children. Required when a caller bypasses Kill() — e.g. the
-	// OCS singleton uses package-level ForceKill to avoid a proc.mu deadlock,
-	// leaving Wait() as the only cleanup path. No-op on Unix; idempotent
-	// (CloseJobHandle(0) returns immediately, and m.jobHandle is zeroed).
+	// OCS / Codex singletons call package-level ForceKill directly as
+	// defense-in-depth (historically to dodge the #836 proc.mu deadlock,
+	// now fixed at #838), leaving Wait() as their only cleanup path. No-op
+	// on Unix; idempotent (CloseJobHandle(0) returns immediately, and
+	// m.jobHandle is zeroed).
 	m.closeJobHandle()
 	return m.exitCode, m.waitErr
 }

--- a/internal/worker/proc/manager_test.go
+++ b/internal/worker/proc/manager_test.go
@@ -560,6 +560,122 @@ func TestManager_WaitOnce_KillThenWait(t *testing.T) {
 	})
 }
 
+// --- TestManager_Kill_AsyncWait (#838) ---------------------------------------
+// Verify Kill() no longer synchronously blocks on cmd.Wait(). See issue #838:
+// a grandchild holding an inherited stdout pipe write-end can keep cmd.Wait()
+// blocked indefinitely; the old Kill() held m.mu across that block, poisoning
+// every other Manager method (production incident #836 in the OCS singleton).
+// The fix moves cmd.Wait() to a background goroutine with killWaitTimeout.
+
+// TestManager_Kill_ReturnsDespiteStuckCmdWait is the core regression guard
+// for #838. It DETERMINISTICALLY reproduces the bug condition by pre-acquiring
+// waitOnce with a goroutine that blocks indefinitely (simulating a
+// cmd.Wait() that never returns because a grandchild holds the stdout pipe).
+//
+// Under the old (buggy) Kill(): the call to waitOnce.Do(cmd.Wait) ran
+// synchronously under m.mu and would block forever, deadlocking the Manager.
+// Under the fix: Kill()'s waitOnce.Do runs in a background goroutine and the
+// bounded select abandons it after killWaitTimeout, so Kill() returns.
+//
+// This test uses NO real subprocess — it constructs a Manager with a minimal
+// cmd stub and pre-arms waitOnce — so it runs under -race on all platforms.
+func TestManager_Kill_ReturnsDespiteStuckCmdWait(t *testing.T) {
+	t.Parallel()
+
+	log := slog.Default()
+	m := &Manager{
+		log:     log,
+		cmd:     &exec.Cmd{},
+		pgid:    0, // pgid==0 skips ForceKill/ForceKillTree in Kill()
+		started: true,
+		exited:  false,
+	}
+
+	// Pre-acquire waitOnce with a goroutine that NEVER returns until the test
+	// ends. This simulates the #838 condition: cmd.Wait() is stuck because a
+	// grandchild holds the inherited stdout pipe write-end.
+	release := make(chan struct{})
+	waitOnceAcquired := make(chan struct{})
+	go func() {
+		m.waitOnce.Do(func() {
+			close(waitOnceAcquired)
+			<-release // block forever (until test closes release in Cleanup)
+		})
+	}()
+	<-waitOnceAcquired
+	t.Cleanup(func() { close(release) })
+
+	// Kill must return within killWaitTimeout + margin despite the stuck
+	// waitOnce. Under the regression (synchronous cmd.Wait under m.mu) this
+	// would block forever.
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- m.Kill() }()
+
+	margin := 2 * time.Second
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.Greater(t, elapsed, killWaitTimeout-200*time.Millisecond,
+			"Kill returned too fast (%v) — did it take the timeout branch?", elapsed)
+		require.Less(t, elapsed, killWaitTimeout+margin,
+			"Kill blocked longer than killWaitTimeout+margin (%v) — issue #838 regression", elapsed)
+		// IsRunning must report false even though we abandoned the reap.
+		require.False(t, m.IsRunning(),
+			"IsRunning() must be false after Kill's timeout branch (m.exited should be set)")
+	case <-time.After(killWaitTimeout + margin):
+		t.Fatalf("Kill() blocked for >%v — issue #838 regression (synchronous cmd.Wait under m.mu)",
+			killWaitTimeout+margin)
+	}
+}
+
+// TestManager_Kill_ReturnsPromptlyWhenProcessDies verifies the fast path:
+// when cmd.Wait() actually completes (process dies on SIGKILL), Kill() must
+// return quickly WITHOUT waiting for the full killWaitTimeout. This guards
+// against an overcorrection where Kill always sleeps for the timeout.
+//
+// This needs a real subprocess and skips under -race (TSAN OOM). The
+// deterministic test above covers the timeout branch.
+func TestManager_Kill_ReturnsPromptlyWhenProcessDies(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("skipping: real process tests cause TSAN OOM under -race")
+	}
+	t.Parallel()
+
+	m := New(Opts{Logger: slog.Default()})
+	ctx := context.Background()
+
+	_, _, _, err := m.Start(ctx, "sleep", []string{"30"}, nil, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if pgid := m.PGID(); pgid > 0 {
+			_ = ForceKill(pgid)
+			ForceKillTree(pgid, slog.Default())
+		}
+		_ = m.Close()
+	})
+
+	// Background Wait mirrors monitorProcess: joins waitOnce before Kill.
+	monitorDone := make(chan struct{})
+	go func() {
+		defer close(monitorDone)
+		_, _ = m.Wait()
+	}()
+
+	start := time.Now()
+	require.NoError(t, m.Kill())
+	elapsed := time.Since(start)
+	require.Less(t, elapsed, killWaitTimeout,
+		"Kill() should return fast on the happy path, took %v", elapsed)
+
+	select {
+	case <-monitorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background Wait() never returned after Kill")
+	}
+}
+
 // --- TestManager_drainStderr -------------------------------------------------
 
 type mockReadCloser struct {


### PR DESCRIPTION
## Summary

Fixes the proc-layer root cause behind the OCS singleton deadlock that took down Slack→OpenCode in production (#836). #837 papered over it at the OCS layer; this PR fixes the underlying `proc.Manager.Kill()` so all worker adapters (claudecode / codex / ocs / acp) are immune.

Also bundles an independent CodexCLI mapper fix (delta drift on prefix mismatch) that was living in the same worktree.

Closes #838.

---

## Change 1 — `proc.Manager.Kill()` async reap (#838)

### Root cause
`proc.Manager.Kill()` called `cmd.Wait()` while holding `m.mu`. When a grandchild process held an inherited stdout pipe write-end, `cmd.Wait()` blocked forever, poisoning every other Manager method (Terminate / Wait / ReadLine). This is the proc-layer root cause #837 worked around at the OCS layer.

### Fix (B1 approach — minimal change)
Move `cmd.Wait()` to a background goroutine and bound `Kill()`'s wait with `killWaitTimeout` (5s) via `time.NewTimer`:
- `waitOnce sync.Once` still deduplicates `cmd.Wait()` across the Terminate/Wait/Kill entry points.
- SIGKILL is delivered before the bounded wait elapses → no process left running; only synchronous reap of the zombie is abandoned.
- Timeout branch sets `m.exited=true` so `IsRunning()` reports `false`.
- The #836/#837 ForceKill fast paths in the OCS/Codex singletons remain as defense-in-depth (comments updated — they no longer claim `proc.Kill()` deadlocks, since #838 makes it async-safe).

### Out of scope (follow-ups)
- **B2** — `ForceKillTree` deep-tree-cleanup enhancement / Darwin `maxScanPID` increase. Separate issue.
- **B3** — kill-before-close-pipes. Subagent analysis proved ineffective (parent holds the read-end; closing the read-end doesn't affect the grandchild's write-end).
- **B4 (flagged by reviewer)** — `proc.Manager.Wait()` still holds `m.mu` across `cmd.Wait()`. Symmetric to this fix; same pattern could be applied. Pre-existing, explicitly out of scope here.

### Tests
- `TestManager_Kill_ReturnsDespiteStuckCmdWait` — **deterministic** regression guard. Pre-acquires `waitOnce` with a never-returning goroutine (simulates stuck `cmd.Wait()`), asserts `Kill()` returns within `killWaitTimeout+margin` and `IsRunning()=false`. **Runs under `-race`** (no subprocess) on all platforms — covers the highest-risk field-access pattern that real-subprocess tests skip under `-race`.
- `TestManager_Kill_ReturnsPromptlyWhenProcessDies` — fast-path guard; asserts `Kill()` returns quickly (`< killWaitTimeout`) when the process actually dies on SIGKILL.
- Existing `TestManager_WaitOnce_*` unchanged and still pass.

---

## Change 2 — CodexCLI `getDeltaText` prefix drift (independent)

CodexCLI mapper's `getDeltaText` assumed `snapshot.HasPrefix(sentTexts)` when fusing the `item/agentMessage/delta` (pure incremental) stream with the `item/updated` (full snapshot) stream. When the backend re-samples/corrects/truncates, that invariant breaks and the naive rune-length tail diff **silently drops** or **emits a misaligned tail slice**.

### Fix
- Validates the prefix on every snapshot.
- On mismatch: computes longest common prefix, emits `snapshot[commonPrefix:]` as a corrective delta, re-baselines `sentTexts[id] = snapshot`, increments `driftCount` (atomic), logs a Warning **outside** `m.mu`.
- Empty-snapshot guard: an empty snapshot no longer re-baselines `sentTexts[id]` to `""`.
- Strict-truncation sub-case (snapshot is a proper prefix of sent) now counts as drift (old behavior was silent drop).
- `driftCount` is now exposed via `DriftCount()` accessor and surfaced in `turn/completed` `DoneData.Stats["delta_drifts"]` (cumulative across turns, not reset by `Reset()`). Previously write-only dead code.

### Tests
- `TestGetDeltaText_DriftScenarios` — table-driven, 9 cases (incl. new both-empty + strict-truncation).
- `TestGetDeltaText_DriftCountAccumulates` — cumulative + `DriftCount()` accessor.
- `TestMapper_DriftCount_ExposedInDoneStats` — verifies `delta_drifts` surfaces in stats and survives `Reset()`.
- `TestMapNotificationAgentMessageStateMachine` — added `driftCount==0` happy-path assertion.

Spec: `docs/specs/CodexCLI-Delta-Integrity-Fix-Spec.md` (§1.2/§5.2 corrected to reflect `item/completed` short-circuit).

---

## Verification

```
make check — ✓ CI check passed (fmt + lint + test -race + build + docs + webchat)
pre-push hook — ✓ All quality gates passed (6 passed, 0 failed)
```

Affected worker packages (ocs/codex/claude/acp/base) green under `-race`. Code review issues all addressed (see commit history).

Refs #836, #837. Closes #838.