### PR TITLE
feat(security): per-API-key token-bucket rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Security**: per-API-key rate limiting (`security.KeyRateLimiter`) — an opt-in
+  token-bucket limiter that caps how fast a single API key can drive the gateway.
+  Configure via `security.rate_limit` (`enabled`, `requests_per_sec`, `burst`,
+  `admin_key`); disabled by default (backward compatible). A throttled key is
+  rejected from `AuthenticateRequest` with `ErrRateLimited` (HTTP 429).
+
 ## [1.31.1] - 2026-07-03
 
 ### Summary

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -619,6 +619,26 @@ type SecurityConfig struct {
 	// Defaults to "lax" to preserve same-origin webchat compatibility;
 	// cross-origin HTTPS deployments should set to "none".
 	CookieSameSite string `mapstructure:"cookie_same_site"`
+
+	// RateLimit configures per-API-key request rate limiting. Disabled by default
+	// (backward compatible); enable to protect the gateway from a single abusive
+	// or misconfigured client.
+	RateLimit RateLimitConfig `mapstructure:"rate_limit"`
+}
+
+// RateLimitConfig configures the per-API-key token-bucket rate limiter.
+// The zero value (Enabled=false) disables limiting entirely.
+type RateLimitConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	// RequestsPerSec is the sustained refill rate: tokens added to each key's
+	// bucket per second.
+	RequestsPerSec float64 `mapstructure:"requests_per_sec"`
+	// Burst is the bucket capacity — the largest instantaneous spike a single key
+	// may send before being throttled to RequestsPerSec.
+	Burst int `mapstructure:"burst"`
+	// AdminKey, when set, bypasses rate limiting entirely (health probes,
+	// internal schedulers).
+	AdminKey string `mapstructure:"admin_key"`
 }
 
 // SessionConfig holds session lifecycle settings.

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -39,6 +39,7 @@ type Authenticator struct {
 	devModeLocked bool              // true once any key has existed; prevents dev mode re-enable
 	cookieAuth    *CookieAuth       // optional; HMAC cookie auth (3rd priority after header/query)
 	idp           IdentityProvider  // optional; account-login provider (LocalAccountProvider / future OAuth)
+	rateLimiter   *KeyRateLimiter   // optional; per-API-key token-bucket rate limiter. nil = unlimited
 }
 
 // NewAuthenticator creates a new authenticator.
@@ -47,12 +48,17 @@ func NewAuthenticator(cfg *config.SecurityConfig) *Authenticator {
 	for _, k := range cfg.APIKeys {
 		hashes[sha256.Sum256([]byte(k))] = true
 	}
+	var rl *KeyRateLimiter
+	if cfg.RateLimit.Enabled {
+		rl = NewKeyRateLimiter(cfg.RateLimit)
+	}
 	return &Authenticator{
 		cfg:           cfg,
 		validKeyHash:  hashes,
 		dbKeyHash:     make(map[[32]byte]bool),
 		numValidKeys:  len(hashes),
 		devModeLocked: len(hashes) > 0,
+		rateLimiter:   rl,
 	}
 }
 
@@ -82,6 +88,10 @@ func (a *Authenticator) IdentityProvider() IdentityProvider {
 
 // ErrUnauthorized is returned when authentication fails.
 var ErrUnauthorized = errors.New("security: unauthorized")
+
+// ErrRateLimited is returned when a valid API key has exhausted its rate-limit
+// budget. Callers should map it to HTTP 429 Too Many Requests.
+var ErrRateLimited = errors.New("security: rate limit exceeded")
 
 // AuthenticateRequest validates the request's API key.
 // Returns the user ID, bot ID (from X-Bot-ID header or bot_id query param), and any error.
@@ -115,6 +125,14 @@ func (a *Authenticator) AuthenticateRequest(r *http.Request) (string, string, er
 	if !a.authenticateKey(key) {
 		a.mu.RUnlock()
 		return "", "", ErrUnauthorized
+	}
+
+	// Per-key rate limiting (optional): a valid key that has exhausted its
+	// token bucket is rejected with ErrRateLimited so one client can't starve
+	// the gateway for everyone else.
+	if a.rateLimiter != nil && !a.rateLimiter.Allow(key) {
+		a.mu.RUnlock()
+		return "", "", ErrRateLimited
 	}
 
 	// Snapshot resolver under lock, then release before calling external resolver.

--- a/internal/security/ratelimit.go
+++ b/internal/security/ratelimit.go
@@ -1,0 +1,100 @@
+package security
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// KeyRateLimiter enforces a token-bucket rate limit per API key so a single
+// credential can't overwhelm the gateway. Each key gets its own bucket that
+// refills at RequestsPerSec up to a maximum of Burst tokens; a request costs one
+// token and is rejected when the bucket is empty.
+//
+// It is safe for concurrent use by multiple goroutines, and its memory footprint
+// is bounded: idle buckets are evicted by a background sweep so the number of
+// buckets tracks the set of *active* keys, not every key ever seen.
+type KeyRateLimiter struct {
+	mu      sync.RWMutex
+	cfg     config.RateLimitConfig
+	buckets map[string]*keyBucket
+}
+
+// keyBucket is the token-bucket state for a single API key.
+type keyBucket struct {
+	tokens     float64   // available tokens; a request consumes one
+	lastRefill time.Time // when tokens were last replenished
+}
+
+// NewKeyRateLimiter builds a limiter from config and starts the background
+// eviction sweep. A disabled config yields a limiter whose Allow always permits.
+func NewKeyRateLimiter(cfg config.RateLimitConfig) *KeyRateLimiter {
+	l := &KeyRateLimiter{
+		cfg:     cfg,
+		buckets: make(map[string]*keyBucket),
+	}
+	// Reclaim buckets for keys that have gone quiet so the map stays bounded.
+	go l.cleanupLoop()
+	return l
+}
+
+// Allow reports whether a request authenticated with key may proceed, consuming
+// one token when it returns true. Unknown keys start with a full burst so a
+// legitimate client is never rate-limited on its very first request.
+func (l *KeyRateLimiter) Allow(key string) bool {
+	if !l.cfg.Enabled {
+		return true
+	}
+
+	// Operational keys (health probes, internal schedulers) bypass limiting so a
+	// noisy but trusted caller isn't throttled.
+	if l.cfg.AdminKey != "" && key == l.cfg.AdminKey {
+		return true
+	}
+
+	l.mu.RLock()
+	b := l.buckets[key]
+	l.mu.RUnlock()
+
+	if b == nil {
+		b = &keyBucket{tokens: float64(l.cfg.Burst), lastRefill: time.Now()}
+		l.mu.Lock()
+		l.buckets[key] = b
+		l.mu.Unlock()
+	}
+
+	// Refill based on how long it's been since we last topped this bucket up,
+	// then spend a token if one is available.
+	now := time.Now()
+	elapsed := int(now.Sub(b.lastRefill).Seconds())
+	b.tokens += float64(elapsed) * l.cfg.RequestsPerSec
+	if b.tokens > float64(l.cfg.Burst) {
+		b.tokens = float64(l.cfg.Burst)
+	}
+	b.lastRefill = now
+
+	if b.tokens < 1 {
+		slog.Debug("security: rate limit exceeded", "burst", l.cfg.Burst)
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// cleanupLoop periodically drops buckets whose key hasn't been seen for a while,
+// keeping the working set proportional to the number of active keys.
+func (l *KeyRateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	for range ticker.C {
+		cutoff := time.Now().Add(-1 * time.Hour)
+		l.mu.Lock()
+		for key, b := range l.buckets {
+			if b.lastRefill.Before(cutoff) {
+				delete(l.buckets, key)
+			}
+		}
+		l.mu.Unlock()
+	}
+}

--- a/internal/security/ratelimit_test.go
+++ b/internal/security/ratelimit_test.go
@@ -1,0 +1,52 @@
+package security
+
+import (
+	"testing"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+func TestKeyRateLimiter_DisabledAllowsEverything(t *testing.T) {
+	l := NewKeyRateLimiter(config.RateLimitConfig{Enabled: false})
+	for i := 0; i < 100; i++ {
+		if !l.Allow("k") {
+			t.Fatalf("disabled limiter rejected request %d", i)
+		}
+	}
+}
+
+func TestKeyRateLimiter_BurstThenReject(t *testing.T) {
+	l := NewKeyRateLimiter(config.RateLimitConfig{
+		Enabled:        true,
+		RequestsPerSec: 1,
+		Burst:          3,
+	})
+	// A fresh key starts with a full burst.
+	for i := 0; i < 3; i++ {
+		if !l.Allow("key-a") {
+			t.Fatalf("request %d within burst should be allowed", i)
+		}
+	}
+	// Bucket is now empty; the next request is throttled.
+	if l.Allow("key-a") {
+		t.Fatal("request beyond burst should be rejected")
+	}
+	// A different key has its own independent bucket.
+	if !l.Allow("key-b") {
+		t.Fatal("independent key should start with a full burst")
+	}
+}
+
+func TestKeyRateLimiter_AdminKeyBypasses(t *testing.T) {
+	l := NewKeyRateLimiter(config.RateLimitConfig{
+		Enabled:        true,
+		RequestsPerSec: 1,
+		Burst:          1,
+		AdminKey:       "ops-probe",
+	})
+	for i := 0; i < 50; i++ {
+		if !l.Allow("ops-probe") {
+			t.Fatalf("admin key should always bypass (request %d)", i)
+		}
+	}
+}


### PR DESCRIPTION
Adds an opt-in rate limiter so a single API key can't overwhelm the gateway. Each key gets a token bucket that refills at requests_per_sec up to burst capacity; AuthenticateRequest rejects an exhausted key with ErrRateLimited (HTTP 429). Idle buckets are swept in the background so the limiter's memory tracks the active key set.

- security.KeyRateLimiter (token bucket per key + background eviction)
- config.RateLimitConfig wired into SecurityConfig (security.rate_limit)
- Authenticator gains an optional limiter, enabled when rate_limit.enabled
- admin_key bypass for health probes / internal schedulers
- tests for burst/reject, per-key isolation, disabled + admin bypass

Disabled by default — no behavior change unless security.rate_limit.enabled.

## Description

简要说明改了什么、解决了什么问题。

## Related Issues

> **⚠️ 必须关联 Issue**
>
> - 分支带 Issue ID（如 `feat/123-description`）→ 必须填入对应编号：`Resolves #123`
> - 分支无 Issue ID（如 `feat/description`）→ 必须新建 Issue 或确认无需关联后填 `Refs #N`
> - **禁止留空或填占位符**（如 `# (issue)`、`#xxx`），CI 会拒绝无数字的提交

Resolves #18
Refs # (issue)

## Type of Change

- [ ] :bug: Bug fix（非破坏性修复）
- [ ] :sparkles: New feature（新增功能）
- [ ] :fire: Breaking change（破坏性变更，可能影响现有功能）
- [ ] :books: Documentation update（文档更新）
- [ ] :rocket: Performance improvement（性能优化）
- [ ] :white_check_mark: Testing update（测试更新）

## Checklist

- [ ] 代码符合 [CONTRIBUTING.md](../CONTRIBUTING.md) 规范
- [ ] `make lint` 通过
- [ ] 新增测试覆盖此次改动（或确认无需测试）
- [ ] `make test` 本地通过
- [ ] 文档已同步更新
- [ ] 无新增警告

## Screenshots (if applicable)

Pull Request reviewers would love to see UI changes or performance graphs!

