### PR TITLE
feat(audit): close user activity follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ gh api repos/hrygo/hotplex/pulls/{N}/reviews --jq 'max_by(.id) | {state, commit_
 - **`inject_exclude` 边界**（`internal/agentconfig/loader.go:106`）：5 个可排除文件 `SOUL.md` / `AGENTS.md` / `SKILLS.md` / `USER.md` / `MEMORY.md`；`META-COGNITION.md` 是 `go:embed` **强制注入首位，无法被排除**（Worker 身份边界）。3 级 fallback：bot > platform > global；nil 继承父级，`[]string{}` 显式清空。
 - **dev YAML vs home YAML**: `configs/config-dev.yaml` 通过 `inherits: config.yaml` 覆盖基础，是 dev-only 覆盖层；`~/.hotplex/config.yaml` 是运行实例配置（影响服务安装路径）。两者**独立**，不互通。
 - **Admin 后台双通道鉴权**（issue #788）：`/admin/*`（Bearer+scope，`AdminAPI.Middleware`）与 `/api/admin/*`（cookie session，`UserAdminHandlers.requireAdmin`）是**两套独立 handler**，不是同一端点的两种认证。`/admin/*` 的 `Middleware` 支持 cookie fallback——无 Bearer 时回落 chat session cookie（校验 `role==admin && status==active`，注入全 scope），使内嵌 webchat admin 免另填 admin token；远程运维仍走 Bearer。SetCookieFallback 在 `routes.go` lap 创建后注入，nil 时回 Bearer-only。Admin 写操作（POST/PUT/PATCH/DELETE）由 middleware 级 `admin_audit` slog 统一记录（动作枚举 `internal/admin/audit.go`，actor=uid 或 `admin-token`）；`/api/admin/*` 写操作在各 handler 成功路径显式调用 `AdminAudit`。
+- **`log.file` 文件日志 + 轮转**（`cmd/hotplex/gateway_run.go:buildLogWriter`）：`log.file.enabled` **默认 false**（仅写 stderr，行为不变）。启用后日志经 lumberjack 轮转写入文件（默认 `~/.hotplex/logs/gateway.log`，可 `log.file.path` 覆盖）。前台/TTY 模式同时 tee 到 stderr 便于调试；**daemon/service 模式 stderr 非 TTY 时自动抑制**，避免 daemon 已把 stderr 重定向到同名文件导致双写。`log.file.*` 全部为 **static**（改路径/轮转参数需重启，运行时重建 lumberjack writer 不安全）。`HOTPLEX_HOME` 环境变量覆盖 `config.HotplexHome()` 解析的默认根目录（主要供测试与非标准安装路径）。
 
 ---
 

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/hrygo/hotplex/internal/admin"
 	"github.com/hrygo/hotplex/internal/agentconfig"
@@ -871,10 +873,11 @@ func initLogging(cfg *config.Config) (*slog.Logger, *config.ConfigStore, *slog.L
 	}
 
 	var logHandler slog.Handler
+	writer := buildLogWriter(cfg)
 	if cfg.Log.Format == "text" {
-		logHandler = slog.NewTextHandler(os.Stderr, opts)
+		logHandler = slog.NewTextHandler(writer, opts)
 	} else {
-		logHandler = slog.NewJSONHandler(os.Stderr, opts)
+		logHandler = slog.NewJSONHandler(writer, opts)
 	}
 
 	log := slog.New(logHandler).With(
@@ -884,6 +887,64 @@ func initLogging(cfg *config.Config) (*slog.Logger, *config.ConfigStore, *slog.L
 	slog.SetDefault(log)
 
 	return log, cfgStore, levelVar
+}
+
+// stderrIsTTY reports whether stderr is connected to a terminal.
+// Used to decide whether to tee logs to stderr when file logging is enabled:
+// in daemon mode stderr is redirected to a file (not a TTY), so tee-ing would
+// duplicate every line into the same file lumberjack manages.
+func stderrIsTTY() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// buildLogWriter constructs the slog writer based on LogConfig.
+//
+// When log.file is disabled (default), it returns os.Stderr unchanged,
+// preserving historical behavior in both foreground and daemon modes.
+//
+// When log.file is enabled, logs are written to the file (rotated via
+// lumberjack). In a foreground TTY, logs are also teed to stderr for live
+// debugging; in daemon/service mode (stderr already redirected to a file),
+// stderr is suppressed to avoid duplicating lines into the same file.
+func buildLogWriter(cfg *config.Config) io.Writer {
+	fc := cfg.Log.File
+	if !fc.Enabled {
+		return os.Stderr
+	}
+
+	path := fc.Path
+	if path == "" {
+		// Default path mirrors daemon mode: ~/.hotplex/logs/gateway.log.
+		logDir := filepath.Join(config.HotplexHome(), "logs")
+		path = filepath.Join(logDir, "gateway.log")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		// Cannot create log dir — fall back to stderr rather than aborting startup.
+		fmt.Fprintf(os.Stderr, "log: failed to create log dir %q: %v; falling back to stderr\n", filepath.Dir(path), err)
+		return os.Stderr
+	}
+
+	lw := &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    fc.MaxSize,
+		MaxAge:     fc.MaxAge,
+		MaxBackups: fc.MaxBackups,
+		Compress:   fc.Compress,
+		LocalTime:  fc.LocalTime,
+	}
+
+	// Tee to stderr only in foreground (TTY) mode. In daemon/service mode
+	// stderr is already redirected to a log file; writing there too would
+	// duplicate every line when path coincides with the daemon's redirect target.
+	if stderrIsTTY() {
+		return io.MultiWriter(os.Stderr, lw)
+	}
+	return lw
 }
 
 // cleanupStaleTempFiles removes orphaned temp files from previous gateway runs.

--- a/cmd/hotplex/gateway_run_logfile_test.go
+++ b/cmd/hotplex/gateway_run_logfile_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// TestBuildLogWriter_DisabledReturnsStderr verifies the default (file logging
+// off) keeps the historical stderr-only writer, preserving daemon-mode
+// stderr redirection behavior.
+func TestBuildLogWriter_DisabledReturnsStderr(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Log.File.Enabled = false
+
+	w := buildLogWriter(cfg)
+	require.Same(t, os.Stderr, w, "disabled file logging must return os.Stderr unchanged")
+}
+
+// TestBuildLogWriter_EnabledWritesToFile verifies that enabling file logging
+// produces a writer that actually persists to the configured path. It does not
+// assert on the MultiWriter-vs-lumberjack distinction (which depends on whether
+// the test runner's stderr is a TTY); it only asserts the file receives data.
+func TestBuildLogWriter_EnabledWritesToFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "sub", "gateway.log") // nested dir to exercise MkdirAll
+
+	cfg := config.Default()
+	cfg.Log.File.Enabled = true
+	cfg.Log.File.Path = logPath
+	cfg.Log.File.MaxSize = 1
+	cfg.Log.File.MaxBackups = 1
+
+	w := buildLogWriter(cfg)
+
+	// Should not be plain stderr once file logging is enabled.
+	require.NotSame(t, os.Stderr, w)
+
+	// Write through the writer and verify the bytes land on disk. slog handlers
+	// write whole lines, so emulate that.
+	_, err := io.WriteString(w, `{"level":"INFO","msg":"boot"}`+"\n")
+	require.NoError(t, err)
+
+	// lumberjack buffers via its own Write which calls the underlying file
+	// directly (no user-facing buffer to flush); reading after Write is safe.
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "boot")
+}
+
+// TestBuildLogWriter_EnabledEmptyPathResolvesDefault verifies that an empty
+// path is resolved to the default under the configured HotPlex home, and that
+// the parent directory is created. We point HOTPLEX_HOME at a temp dir to keep
+// the test hermetic. Not parallel: t.Setenv mutates process env.
+func TestBuildLogWriter_EnabledEmptyPathResolvesDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOTPLEX_HOME", home)
+
+	cfg := config.Default()
+	cfg.Log.File.Enabled = true
+	cfg.Log.File.Path = "" // expect default under $HOTPLEX_HOME/logs/gateway.log
+
+	w := buildLogWriter(cfg)
+	require.NotSame(t, os.Stderr, w)
+
+	_, err := io.WriteString(w, `{"level":"INFO","msg":"hi"}`+"\n")
+	require.NoError(t, err)
+
+	defaultPath := filepath.Join(home, "logs", "gateway.log")
+	data, err := os.ReadFile(defaultPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "hi")
+}
+
+// TestBuildLogWriter_UncreatableDirFallsBackToStderr verifies that if the log
+// directory cannot be created, buildLogWriter falls back to stderr rather than
+// aborting (startup resilience).
+func TestBuildLogWriter_UncreatableDirFallsBackToStderr(t *testing.T) {
+	// Not parallel: relies on a path under a file (a POSIX trick to force
+	// MkdirAll failure). Some platforms may allow this, so skip gracefully.
+
+	// Create a regular file and try to use a path *inside* it as a directory.
+	base := t.TempDir()
+	blocker := filepath.Join(base, "blocker")
+	require.NoError(t, os.WriteFile(blocker, nil, 0o644))
+
+	cfg := config.Default()
+	cfg.Log.File.Enabled = true
+	cfg.Log.File.Path = filepath.Join(blocker, "nested", "gateway.log")
+
+	w := buildLogWriter(cfg)
+	require.Same(t, os.Stderr, w, "uncreatable log dir must fall back to stderr")
+}
+
+// TestStderrIsTTY is a smoke test; it only asserts the helper does not panic
+// and returns a bool. The actual value depends on the test runner environment.
+func TestStderrIsTTY(t *testing.T) {
+	t.Parallel()
+	_ = stderrIsTTY() // must not panic; result is environment-dependent
+}

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -166,6 +166,9 @@ func setupRoutes(
 	adminMux.HandleFunc("GET /admin/users/{id}/activity/export", adminAPI.HandleUserActivityExport)
 	adminMux.HandleFunc("GET /admin/activity", adminAPI.HandleAdminActivity)
 	adminMux.HandleFunc("GET /admin/activity/export", adminAPI.HandleAdminActivityExport)
+	adminMux.HandleFunc("GET /admin/audit/identity-links", adminAPI.HandleAuditIdentityLinks)
+	adminMux.HandleFunc("POST /admin/audit/identity-links", adminAPI.HandleCreateAuditIdentityLink)
+	adminMux.HandleFunc("DELETE /admin/audit/identity-links/{id}", adminAPI.HandleDeleteAuditIdentityLink)
 
 	// Cron API
 	adminMux.HandleFunc("GET /admin/cron/jobs", adminAPI.HandleCronList)

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -165,6 +165,7 @@ func setupRoutes(
 	adminMux.HandleFunc("GET /admin/users/{id}/activity", adminAPI.HandleUserActivity)
 	adminMux.HandleFunc("GET /admin/users/{id}/activity/export", adminAPI.HandleUserActivityExport)
 	adminMux.HandleFunc("GET /admin/activity", adminAPI.HandleAdminActivity)
+	adminMux.HandleFunc("GET /admin/activity/stats", adminAPI.HandleActivityStats)
 	adminMux.HandleFunc("GET /admin/activity/export", adminAPI.HandleAdminActivityExport)
 	adminMux.HandleFunc("GET /admin/audit/identity-links", adminAPI.HandleAuditIdentityLinks)
 	adminMux.HandleFunc("POST /admin/audit/identity-links", adminAPI.HandleCreateAuditIdentityLink)
@@ -283,6 +284,17 @@ func setupRoutes(
 		mux.Handle("GET /api/admin/users", corsMw(http.HandlerFunc(userAdmin.ListUsers)))
 		mux.Handle("PATCH /api/admin/users/{id}", corsMw(userAdmin.AuditWrite(admin.AuditMemberStatusUpdate, csrfMw(http.HandlerFunc(userAdmin.UpdateUserStatus)))))
 
+		// Embedded admin activity console. The standalone admin server exposes
+		// the same handlers at /admin/* for Bearer-token clients; the webchat UI
+		// needs same-origin cookie-authenticated routes that do not collide with
+		// the SPA /admin/activity page.
+		mux.Handle("GET /api/admin/activity", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleAdminActivity))))
+		mux.Handle("GET /api/admin/activity/stats", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleActivityStats))))
+		mux.Handle("GET /api/admin/activity/export", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleAdminActivityExport))))
+		mux.Handle("GET /api/admin/audit/identity-links", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleAuditIdentityLinks))))
+		mux.Handle("POST /api/admin/audit/identity-links", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleCreateAuditIdentityLink))))
+		mux.Handle("DELETE /api/admin/audit/identity-links/{id}", corsMw(adminAPI.Middleware(http.HandlerFunc(adminAPI.HandleDeleteAuditIdentityLink))))
+
 		// OPTIONS preflight handlers for Auth & Admin APIs
 		mux.Handle("OPTIONS /api/auth/login", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 		mux.Handle("OPTIONS /api/auth/logout", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
@@ -294,6 +306,11 @@ func setupRoutes(
 		mux.Handle("OPTIONS /api/admin/users", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 		mux.Handle("OPTIONS /api/admin/users/", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 		mux.Handle("OPTIONS /api/admin/users/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/admin/activity", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/admin/activity/stats", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/admin/activity/export", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/admin/audit/identity-links", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/admin/audit/identity-links/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
 		// Workspaces CRUD endpoints. Write routes (POST/PATCH/DELETE) mount
 		// csrfMw for the same reason /api/admin/* does (issue #794 P2-1):

--- a/configs/config-dev.yaml
+++ b/configs/config-dev.yaml
@@ -55,6 +55,15 @@ worker:
 log:
   level: "debug"
   format: "text"
+  # File logging is disabled in dev (logs go to stderr for live debugging).
+  # file:
+  #   enabled: false
+  #   path: ""
+  #   max_size: 10
+  #   max_age: 30
+  #   max_backups: 100
+  #   compress: true
+  #   local_time: true
 
 messaging:
   turn_summary_enabled: true

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -300,6 +300,17 @@ skills:
 log:
   level: "info"
   format: "json" # "json" or "text"
+  # File logging + rotation. Disabled by default (logs go to stderr only,
+  # matching daemon-mode stderr redirection). Enable to tee logs to a rotated
+  # file; in foreground/TTY mode logs still appear on stderr too.
+  file:
+    enabled: false
+    path: "" # empty → ~/.hotplex/logs/gateway.log
+    max_size: 10 # MB per file before rotation
+    max_age: 30 # days to retain rotated logs
+    max_backups: 100 # number of rotated backups to keep
+    compress: true # gzip rotated backups
+    local_time: true # use local time in rotation filenames
 
 webchat:
   addr: ""      # informational: banner display only

--- a/configs/env.example
+++ b/configs/env.example
@@ -49,6 +49,18 @@ ADMIN_TOKEN=
 # Log format: json, text (default: json)
 # HOTPLEX_LOG_FORMAT=text
 
+# File logging + rotation (default: disabled, stderr-only).
+# When enabled, logs are teed to a rotated file (lumberjack). In foreground/TTY
+# mode they also appear on stderr; in daemon/service mode stderr is suppressed to
+# avoid duplication. All log.file.* fields require a restart to take effect.
+# HOTPLEX_LOG_FILE_ENABLED=false
+# HOTPLEX_LOG_FILE_PATH=                   # empty → ~/.hotplex/logs/gateway.log
+# HOTPLEX_LOG_FILE_MAX_SIZE=10             # MB per file
+# HOTPLEX_LOG_FILE_MAX_AGE=30              # days
+# HOTPLEX_LOG_FILE_MAX_BACKUPS=100
+# HOTPLEX_LOG_FILE_COMPRESS=true
+# HOTPLEX_LOG_FILE_LOCAL_TIME=true
+
 # Database path (default: data/hotplex.db)
 # HOTPLEX_DB_PATH=data/hotplex.db
 

--- a/docs/guides/user/troubleshooting-cross-origin.md
+++ b/docs/guides/user/troubleshooting-cross-origin.md
@@ -1,0 +1,826 @@
+---
+title: 常见问题排查手册
+weight: 5
+description: 用服务器 IP 访问时页面卡住、创建会话报错、工作区创建失败？本手册手把手教你解决。
+---
+
+# 常见问题排查手册
+
+> 本手册面向普通用户，用一步一步的操作指引帮你解决部署和使用中遇到的问题。
+> 不需要编程基础，只需要会编辑配置文件和重启服务。
+
+---
+
+## 你将学到什么
+
+读完本手册，你能解决以下 4 类问题：
+
+| 问题 | 你会遇到的情况 |
+|------|--------------|
+| **问题一** | 用服务器 IP 访问 WebChat，登录后页面一直转圈，无法创建会话 |
+| **问题二** | 创建会话时选择 opencode_server 报错，但选 claude_code 正常 |
+| **问题三** | 把 localhost 改成服务器 IP 后，新建工作区报错 |
+| **问题四** | 不清楚 API Key 还有没有用，不知道该怎么认证 |
+
+---
+
+## 开始之前：确认你的环境
+
+在开始排查之前，请先回答以下问题，帮助你判断该看哪个章节：
+
+**问题 1：你是怎么访问 HotPlex 的？**
+
+- A. 在安装了 HotPlex 的那台电脑上，打开浏览器访问 `http://localhost:8888` → **你不太会遇到本手册的问题**，但如果遇到了，直接看问题一
+- B. 在另一台电脑/手机/平板上，通过服务器 IP 访问，例如 `http://192.168.1.100:8888` → **看问题一和问题三**
+- C. 通过域名访问，例如 `https://hotplex.example.com` → **看问题一**
+
+**问题 2：你创建会话时选择的是什么 Worker 类型？**
+
+- A. claude_code（默认） → 如果报错，看问题一
+- B. opencode_server → 如果报错，看问题二
+- C. 不确定 → 看问题四了解认证方式
+
+---
+
+## 问题一：用服务器 IP 访问时，页面一直转圈
+
+### 你会看到什么
+
+1. 你在浏览器地址栏输入 `http://192.168.1.100:8888`（你的服务器 IP）
+2. 页面正常加载，你看到了登录界面
+3. 输入用户名和密码，点击登录
+4. 登录成功，但页面卡在"创建中"或一直转圈
+5. 打开浏览器开发者工具（按 F12），在 Console（控制台）里看到红色错误：
+
+```
+POST /api/workspaces → 403
+{"error":{"code":"FORBIDDEN","message":"cross-origin write blocked"}}
+```
+
+或者在 Admin 管理后台看到：
+
+```
+Unexpected token '<', "<!DOCTYPE "... is not valid JSON
+```
+
+### 为什么会这样
+
+HotPlex 默认配置允许所有来源的访问（`allowed_origins: ["*"]`），这在 localhost 下工作正常。但当你用服务器 IP 访问时，浏览器出于安全考虑，会检查"这个请求是不是来自被允许的地址"。默认的通配符配置在写操作（比如创建会话、创建工作区）时会被拦截。
+
+**简单来说**：你需要告诉 HotPlex"我允许从哪个地址访问"。
+
+### 解决方法（3 选 1）
+
+#### 方法 A：修改配置文件（推荐，最简单）
+
+**第 1 步：找到配置文件**
+
+打开终端（Terminal），输入以下命令查看配置文件位置：
+
+```bash
+echo ~/.hotplex/config.yaml
+```
+
+你会看到类似 `/Users/你的用户名/.hotplex/config.yaml` 的路径。记住这个路径。
+
+**第 2 步：打开配置文件**
+
+用任何文本编辑器打开这个文件：
+
+```bash
+# macOS
+open -e ~/.hotplex/config.yaml
+
+# Linux（使用 nano）
+nano ~/.hotplex/config.yaml
+
+# Windows（使用记事本）
+notepad %USERPROFILE%\.hotplex\config.yaml
+```
+
+**第 3 步：找到 allowed_origins 配置**
+
+在文件中搜索 `allowed_origins`，你会看到类似这样的内容：
+
+```yaml
+security:
+  # ... 其他配置 ...
+  allowed_origins:
+    - "*"
+```
+
+**第 4 步：修改配置**
+
+把 `- "*"` 改成你的实际访问地址。格式是：`协议://IP地址:端口号`。
+
+**举例**：
+
+如果你通过 `http://192.168.1.100:8888` 访问，改成：
+
+```yaml
+security:
+  allowed_origins:
+    - "http://192.168.1.100:8888"
+    - "http://localhost:8888"
+```
+
+**注意**：
+- 必须包含 `http://` 或 `https://`
+- 必须包含端口号（默认是 8888）
+- 不要有多余的斜杠（`http://192.168.1.100:8888/` 是错的）
+- 建议同时保留 `localhost` 那一行，方便本机访问
+
+**如果你同时从多个地址访问**（比如电脑和手机），把所有地址都列出来：
+
+```yaml
+security:
+  allowed_origins:
+    - "http://192.168.1.100:8888"    # 电脑访问
+    - "http://192.168.1.101:8888"    # 手机访问
+    - "http://localhost:8888"         # 本机访问
+```
+
+**第 5 步：保存文件**
+
+- macOS/记事本：按 `Cmd + S` 或 `Ctrl + S`
+- nano：按 `Ctrl + O`，然后按 `Enter` 确认，再按 `Ctrl + X` 退出
+
+**第 6 步：重启 HotPlex**
+
+```bash
+hotplex gateway restart
+```
+
+你应该看到：
+
+```
+Gateway restarted successfully
+```
+
+如果提示 `hotplex: command not found`，试试：
+
+```bash
+# macOS/Linux
+~/.hotplex/bin/hotplex gateway restart
+
+# 或者重新安装后重试
+export PATH="$HOME/.hotplex/bin:$PATH"
+hotplex gateway restart
+```
+
+**第 7 步：验证修复**
+
+1. **清除浏览器缓存**：按 `Ctrl + Shift + Delete`（Windows）或 `Cmd + Shift + Delete`（Mac），选择"缓存的图片和文件"，点击清除
+2. **关闭浏览器**，重新打开
+3. 再次访问 `http://192.168.1.100:8888`
+4. 登录，观察页面是否正常加载，不再转圈
+
+**如果还是转圈**，按 F12 打开开发者工具，切换到 Network（网络）面板，刷新页面，找到 `workspaces` 这个请求，看它的状态码：
+
+- **200** → 成功了！问题已解决
+- **403** → 配置没生效，检查第 4 步的地址是否写对了
+- **401** → 登录失效了，重新登录试试
+- **其他** → 看问题四
+
+---
+
+#### 方法 B：使用反向代理（适合有域名的场景）
+
+如果你有域名（比如 `hotplex.example.com`），可以通过 Nginx 反向代理让浏览器认为"WebChat 和 API 是同一个地址"，从而避免跨域问题。
+
+**第 1 步：安装 Nginx**
+
+```bash
+# Ubuntu/Debian
+sudo apt update && sudo apt install nginx
+
+# CentOS/RHEL
+sudo yum install nginx
+
+# macOS
+brew install nginx
+```
+
+**第 2 步：配置 Nginx**
+
+创建配置文件：
+
+```bash
+sudo nano /etc/nginx/sites-available/hotplex
+```
+
+粘贴以下内容（把 `hotplex.example.com` 改成你的域名）：
+
+```nginx
+server {
+    listen 80;
+    server_name hotplex.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8888;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+保存并启用：
+
+```bash
+sudo ln -s /etc/nginx/sites-available/hotplex /etc/nginx/sites-enabled/
+sudo nginx -t          # 测试配置是否正确
+sudo systemctl reload nginx   # 重载 Nginx
+```
+
+**第 3 步：修改 HotPlex 配置**
+
+编辑 `~/.hotplex/config.yaml`：
+
+```yaml
+security:
+  allowed_origins:
+    - "http://hotplex.example.com"   # 你的域名
+```
+
+**第 4 步：重启 HotPlex**
+
+```bash
+hotplex gateway restart
+```
+
+**第 5 步：验证**
+
+访问 `http://hotplex.example.com`，登录，检查是否正常。
+
+---
+
+#### 方法 C：只在本机使用（最简单）
+
+如果你只需要在安装 HotPlex 的那台电脑上使用，不需要从其他设备访问，那么：
+
+1. **不要修改任何配置**
+2. 始终通过 `http://localhost:8888` 访问
+3. 不要改成 `127.0.0.1` 或服务器 IP
+
+localhost 访问时，浏览器会自动认为是"同源"，不会触发跨域检查。
+
+---
+
+### 问题一的完整检查清单
+
+完成上述步骤后，逐项检查：
+
+- [ ] 配置文件中的 `allowed_origins` 包含你的访问地址（含协议和端口）
+- [ ] 地址格式正确：`http://192.168.1.100:8888`（不是 `192.168.1.100:8888`，不是 `http://192.168.1.100:8888/`）
+- [ ] 已执行 `hotplex gateway restart` 重启服务
+- [ ] 已清除浏览器缓存
+- [ ] 浏览器地址栏显示的地址与配置中的地址完全一致
+
+如果全部打勾还是不行，看下面的"还是不行？"部分。
+
+---
+
+## 问题二：opencode_server 创建会话失败
+
+### 你会看到什么
+
+1. 在 WebChat 中创建新会话
+2. 选择 Worker 类型为 `opencode_server`
+3. 点击创建，页面提示"failed"或"创建失败"
+4. 如果选择 `claude_code`，则创建成功
+
+### 为什么会这样
+
+`opencode_server` 和 `claude_code` 是两种不同的 AI Worker：
+
+- **claude_code**：每次创建会话时启动一个独立的 Claude 进程，简单直接
+- **opencode_server**：使用一个共享的 OpenCode 服务进程，所有会话共用
+
+`opencode_server` 的启动过程更复杂，需要：
+1. `opencode` 程序已安装
+2. 启动一个后台服务进程
+3. 等待服务就绪
+4. 通过 HTTP 创建会话
+
+任何一个环节出问题，都会导致创建失败。
+
+### 解决方法
+
+#### 第 1 步：确认 opencode 已安装
+
+打开终端，输入：
+
+```bash
+which opencode
+```
+
+**你应该看到**：一个路径，比如 `/usr/local/bin/opencode` 或 `/home/你的用户名/.local/bin/opencode`
+
+**如果看到**：`opencode not found` 或没有输出
+
+→ **opencode 没有安装**，请先安装：
+
+```bash
+# 方法 1：使用官方安装脚本
+curl -fsSL https://opencode.ai/install | bash
+
+# 方法 2：如果你用 npm
+npm install -g opencode
+
+# 方法 3：从源码编译（需要 Go 1.26+）
+git clone https://github.com/opencode-ai/opencode.git
+cd opencode
+go build -o opencode ./cmd/opencode
+sudo mv opencode /usr/local/bin/
+```
+
+安装完成后，验证：
+
+```bash
+opencode --version
+```
+
+应该输出版本号，比如 `opencode version 1.2.3`。
+
+#### 第 2 步：检查 HotPlex 配置
+
+编辑 `~/.hotplex/config.yaml`，找到 `worker` 部分：
+
+```yaml
+worker:
+  opencode_server:
+    command: "opencode"       # 确保这里与 which opencode 的输出一致
+    ready_timeout: 15s        # 如果网络慢，可以改成 30s
+```
+
+**如果 `which opencode` 输出的是完整路径**（比如 `/usr/local/bin/opencode`），建议把 `command` 也改成完整路径：
+
+```yaml
+worker:
+  opencode_server:
+    command: "/usr/local/bin/opencode"
+```
+
+保存后重启：
+
+```bash
+hotplex gateway restart
+```
+
+#### 第 3 步：查看日志定位问题
+
+```bash
+hotplex gateway logs -f
+```
+
+这个命令会实时显示日志。**保持这个窗口打开**，然后在另一个终端或浏览器中尝试创建 opencode_server 会话。
+
+**观察日志中出现的错误信息**，对照下表：
+
+| 你看到的日志 | 问题是什么 | 怎么解决 |
+|-------------|-----------|---------|
+| `executable file not found in path` | opencode 没安装或不在 PATH 中 | 回到第 1 步安装，或在配置中写完整路径 |
+| `timeout discovering port` | opencode 启动了但没输出端口信息 | 可能是 opencode 版本不兼容，尝试更新到最新版 |
+| `timeout waiting for server health` | opencode 服务启动了但不响应 | 检查 opencode 是否正常运行：`ps aux \| grep opencode` |
+| `create session failed: status 500` | opencode 内部错误 | 查看 opencode 自身的日志 |
+| `singleton not initialized` | HotPlex 配置问题 | 检查 config.yaml 中 `worker.opencode_server` 配置是否正确 |
+| `connection refused` | opencode 服务已停止 | 重启 HotPlex：`hotplex gateway restart` |
+
+#### 第 4 步：手动测试 opencode 服务
+
+如果日志没有明确错误，可以手动测试 opencode 是否能正常启动：
+
+```bash
+# 启动 opencode 服务（按 Ctrl+C 停止）
+opencode serve --port 0
+```
+
+**你应该看到**类似这样的输出：
+
+```
+Starting OpenCode server...
+listening on http://127.0.0.1:12345
+```
+
+**如果没有看到 `listening on` 这一行**，或者输出格式不同，说明 opencode 版本与 HotPlex 不兼容。请：
+
+1. 更新 opencode 到最新版
+2. 或暂时使用 `claude_code` Worker
+
+#### 第 5 步：暂时使用 claude_code
+
+如果 opencode_server 持续无法工作，你可以先用 claude_code 代替：
+
+**方法 1：在 WebChat 中创建会话时选择 claude_code**
+
+创建会话的界面中，Worker 类型选择 `claude_code`（通常是默认选项）。
+
+**方法 2：修改默认 Worker 类型**
+
+编辑 `~/.hotplex/config.yaml`：
+
+```yaml
+messaging:
+  worker_type: claude_code   # 改成 claude_code
+```
+
+保存后重启：
+
+```bash
+hotplex gateway restart
+```
+
+#### 第 6 步：验证修复
+
+完成上述步骤后，在 WebChat 中创建新会话：
+
+1. 点击"新建会话"
+2. 选择 Worker 类型（opencode_server 或 claude_code）
+3. 输入会话标题
+4. 点击创建
+
+**你应该看到**：会话创建成功，进入对话界面，可以开始输入消息。
+
+---
+
+### 问题二的完整检查清单
+
+- [ ] `which opencode` 有输出，且 `opencode --version` 显示版本号
+- [ ] `~/.hotplex/config.yaml` 中 `worker.opencode_server.command` 与 `which opencode` 输出一致
+- [ ] 已执行 `hotplex gateway restart`
+- [ ] 日志中没有 `executable file not found` 错误
+- [ ] 手动运行 `opencode serve --port 0` 能看到 `listening on` 输出
+
+---
+
+## 问题三：把 localhost 改成服务器 IP 后，新建工作区报错
+
+### 你会看到什么
+
+1. 你修改了 `~/.hotplex/config.yaml` 中的 `gateway.addr`，从 `localhost:8888` 改成 `192.168.1.100:8888`
+2. 重启 HotPlex 后，访问 WebChat
+3. 登录后，点击"新建工作区"或系统自动创建工作区时报错
+4. 把 `gateway.addr` 改回 `localhost:8888`，错误消失
+
+### 为什么会这样
+
+这个问题和**问题一**是同一个原因。`gateway.addr` 控制的是 HotPlex 监听哪个地址，但真正影响跨域访问的是 `security.allowed_origins` 配置。
+
+当你把 `gateway.addr` 改成服务器 IP 后，浏览器从服务器 IP 访问，但 `allowed_origins` 还是默认的 `["*"]`，导致写操作被拦截。
+
+### 解决方法
+
+**你不需要改 `gateway.addr`**。正确的做法是：
+
+1. **保持 `gateway.addr` 为 `0.0.0.0:8888`**（监听所有网卡，允许外部访问）或 `localhost:8888`（仅本机访问）
+2. **修改 `security.allowed_origins`**，添加你的访问地址
+
+编辑 `~/.hotplex/config.yaml`：
+
+```yaml
+gateway:
+  addr: "0.0.0.0:8888"   # 监听所有网卡，允许从任何 IP 访问
+
+security:
+  allowed_origins:
+    - "http://192.168.1.100:8888"   # 你的服务器 IP
+    - "http://localhost:8888"        # 本机访问
+```
+
+保存后重启：
+
+```bash
+hotplex gateway restart
+```
+
+然后按照**问题一的方法 A**中的"第 7 步：验证修复"操作。
+
+### 常见误区
+
+| 误区 | 正确做法 |
+|------|---------|
+| "把 `gateway.addr` 改成服务器 IP 就能从外部访问" | `gateway.addr` 应该改成 `0.0.0.0:8888`（监听所有网卡），而不是具体 IP |
+| "改了 `gateway.addr` 就不需要改 `allowed_origins`" | 两者是独立的配置，都需要正确设置 |
+| "用 `127.0.0.1:8888` 和 `localhost:8888` 是一样的" | 对浏览器来说不一样，`127.0.0.1` 可能触发跨域问题，建议统一用 `localhost` |
+
+---
+
+## 问题四：API Key 还有用吗？该怎么认证？
+
+### 你的疑问
+
+你可能注意到了：
+
+- 以前的教程说"在 Admin 后台创建 API Key，然后用 API Key 访问"
+- 现在的 WebChat 是"先登录账号，然后自动创建会话"
+- 你不确定 API Key 还有没有用，或者该怎么用
+
+### 答案：API Key 仍然完全有效
+
+HotPlex 支持两种认证方式，**它们同时工作，互不影响**：
+
+| 认证方式 | 适合谁用 | 怎么用 |
+|---------|---------|--------|
+| **API Key** | 开发者、脚本、自动化工具、SDK | 在请求中带上 API Key |
+| **账号登录（Cookie）** | 普通用户、WebChat 界面 | 在网页上输入用户名密码登录 |
+
+**简单来说**：
+- 如果你用 WebChat 网页界面 → 用账号登录（你已经在用了）
+- 如果你用代码/脚本/SDK 连接 HotPlex → 用 API Key
+
+### API Key 怎么用
+
+#### 第 1 步：在 Admin 后台创建 API Key
+
+1. 访问 `http://localhost:8888/admin`（或你的服务器地址）
+2. 登录 Admin 后台
+3. 找到"API Keys"或"API 密钥"菜单
+4. 点击"创建新的 API Key"
+5. 给 Key 起个名字（比如"我的脚本"），选择对应的用户
+6. 点击创建，**复制生成的 API Key**（只显示一次，务必保存好）
+
+#### 第 2 步：使用 API Key 访问
+
+**方式 1：通过 HTTP Header（推荐）**
+
+```bash
+curl -H "X-API-Key: 你的API密钥" \
+  http://localhost:8888/api/sessions
+```
+
+**方式 2：通过 URL 参数**
+
+```bash
+curl "http://localhost:8888/api/sessions?api_key=你的API密钥"
+```
+
+**方式 3：在代码中使用**
+
+```python
+# Python 示例
+import requests
+
+headers = {"X-API-Key": "你的API密钥"}
+response = requests.get("http://localhost:8888/api/sessions", headers=headers)
+print(response.json())
+```
+
+```javascript
+// JavaScript 示例
+const response = await fetch("http://localhost:8888/api/sessions", {
+  headers: { "X-API-Key": "你的API密钥" }
+});
+const data = await response.json();
+console.log(data);
+```
+
+#### 第 3 步：验证 API Key 有效
+
+```bash
+# 测试 API Key 是否能正常获取会话列表
+curl -H "X-API-Key: 你的API密钥" http://localhost:8888/api/sessions
+```
+
+**你应该看到**：一个 JSON 数组，包含你的会话列表，类似：
+
+```json
+{
+  "sessions": [
+    {
+      "id": "abc123...",
+      "title": "测试会话",
+      "status": "active",
+      ...
+    }
+  ],
+  "total": 1
+}
+```
+
+**如果看到**：`{"error":{"code":"UNAUTHORIZED","message":"..."}}`
+
+→ API Key 无效或已过期，回到 Admin 后台重新创建一个。
+
+### API Key 的常见用途
+
+| 用途 | 示例 |
+|------|------|
+| **SDK 连接** | Go/Python/TypeScript/Java SDK 使用 API Key 认证 |
+| **自动化脚本** | 定时任务、CI/CD 流水线中触发 AI 会话 |
+| **消息平台** | Slack/飞书 Bot 的后端认证 |
+| **多用户管理** | 为不同用户分配不同 Key，隔离会话和数据 |
+
+### 两种认证方式的对比
+
+| | API Key | 账号登录（Cookie） |
+|---|---|---|
+| **谁用** | 开发者、脚本、自动化工具 | 普通用户 |
+| **怎么用** | 在请求头或 URL 中带上 Key | 在网页上输入用户名密码 |
+| **需要 Admin 后台吗** | 需要（创建 Key） | 不需要 |
+| **适合什么场景** | 代码集成、自动化、SDK | 日常使用 WebChat |
+| **安全性** | Key 要保密，不要泄露 | 密码要保密，登录后浏览器自动管理 |
+| **是否仍然有效** | ✅ 完全支持 | ✅ 完全支持 |
+
+---
+
+## 还是不行？完整的排查流程
+
+如果按照上述步骤操作后问题仍然存在，按以下顺序逐项检查：
+
+### 检查 1：HotPlex 是否在运行
+
+```bash
+hotplex gateway status
+```
+
+**你应该看到**：`Gateway is running (PID: 12345)`
+
+**如果看到**：`Gateway is not running`
+
+→ 启动 HotPlex：
+
+```bash
+hotplex gateway start
+```
+
+### 检查 2：端口是否在监听
+
+```bash
+# macOS/Linux
+lsof -i :8888
+
+# Windows
+netstat -ano | findstr :8888
+```
+
+**你应该看到**：一行输出，显示 `hotplex` 进程在监听 8888 端口
+
+**如果没有输出**：HotPlex 没有正常启动，查看日志：
+
+```bash
+hotplex gateway logs -n 50   # 查看最近 50 行日志
+```
+
+### 检查 3：配置文件是否正确
+
+```bash
+# 查看当前生效的 allowed_origins
+grep -A 5 "allowed_origins" ~/.hotplex/config.yaml
+```
+
+**你应该看到**：
+
+```yaml
+allowed_origins:
+  - "http://192.168.1.100:8888"
+  - "http://localhost:8888"
+```
+
+**如果看到**：
+
+```yaml
+allowed_origins:
+  - "*"
+```
+
+→ 回到问题一的方法 A，修改配置。
+
+### 检查 4：浏览器缓存是否清除
+
+1. 按 `Ctrl + Shift + Delete`（Windows）或 `Cmd + Shift + Delete`（Mac）
+2. 选择"缓存的图片和文件"
+3. 时间范围选"全部时间"
+4. 点击"清除数据"
+5. 关闭浏览器，重新打开
+
+### 检查 5：用无痕模式测试
+
+无痕模式不使用缓存和 Cookie，可以排除缓存问题：
+
+- **Chrome**：`Ctrl + Shift + N`（Windows）或 `Cmd + Shift + N`（Mac）
+- **Firefox**：`Ctrl + Shift + P`（Windows）或 `Cmd + Shift + P`（Mac）
+- **Safari**：`Cmd + Shift + N`
+
+在无痕窗口中访问 HotPlex，登录，检查是否正常。
+
+### 检查 6：查看浏览器网络请求
+
+1. 按 F12 打开开发者工具
+2. 切换到 **Network**（网络）面板
+3. 刷新页面
+4. 找到失败的请求（红色），点击查看
+
+**你应该关注**：
+
+| 字段 | 期望值 | 如果不对 |
+|------|--------|---------|
+| **Status Code** | 200 | 403 → 跨域问题，看问题一；401 → 认证问题，看问题四 |
+| **Request URL** | 你的服务器地址 | 如果地址不对，检查配置 |
+| **Response Headers** 中的 `Access-Control-Allow-Origin` | 你的服务器地址 | 如果是 `*` 或缺失，说明配置没生效 |
+
+### 检查 7：查看 HotPlex 日志
+
+```bash
+hotplex gateway logs -f
+```
+
+在另一个窗口中操作 WebChat，观察日志输出。
+
+**你应该看到**：正常的请求日志，没有 `ERROR` 或 `WARN`。
+
+**如果看到**：
+
+- `WARN: wildcard "*" in allowed_origins` → 配置还是通配符，需要改成具体地址
+- `ERROR: cross-origin write blocked` → CSRF 拦截，看问题一
+- `ERROR: executable file not found` → opencode 没安装，看问题二
+
+---
+
+## 快速参考卡片
+
+### 配置文件位置
+
+| 系统 | 路径 |
+|------|------|
+| macOS/Linux | `~/.hotplex/config.yaml` |
+| Windows | `%USERPROFILE%\.hotplex\config.yaml` |
+
+### 常用命令
+
+```bash
+# 查看状态
+hotplex gateway status
+
+# 启动/停止/重启
+hotplex gateway start
+hotplex gateway stop
+hotplex gateway restart
+
+# 查看日志
+hotplex gateway logs -f        # 实时跟踪
+hotplex gateway logs -n 100    # 最近 100 行
+
+# 诊断检查
+hotplex doctor                 # 运行 25 项诊断检查
+```
+
+### 配置修改后的操作
+
+**每次修改 `~/.hotplex/config.yaml` 后，都要重启 HotPlex**：
+
+```bash
+hotplex gateway restart
+```
+
+然后**清除浏览器缓存**或**用无痕模式测试**。
+
+### 关键配置项
+
+```yaml
+# 监听地址（允许外部访问用 0.0.0.0，仅本机用 localhost）
+gateway:
+  addr: "0.0.0.0:8888"
+
+# 允许的来源（必须包含你的访问地址）
+security:
+  allowed_origins:
+    - "http://192.168.1.100:8888"   # 你的服务器 IP
+    - "http://localhost:8888"        # 本机
+
+# Worker 类型（默认 claude_code）
+messaging:
+  worker_type: claude_code
+
+# opencode_server 配置（如果用 opencode_server）
+worker:
+  opencode_server:
+    command: "opencode"       # opencode 二进制路径
+    ready_timeout: 15s        # 启动超时
+```
+
+---
+
+## 获取帮助
+
+如果本手册没有解决你的问题：
+
+1. **运行诊断**：`hotplex doctor`，它会检查 25 项常见问题并给出建议
+2. **查看日志**：`hotplex gateway logs -n 200`，把日志内容发给支持者
+3. **提交 Issue**：在 [GitHub](https://github.com/hrygo/hotplex/issues) 提交问题，附上：
+   - 你的 HotPlex 版本：`hotplex version`
+   - 你的操作系统：`uname -a`（Mac/Linux）或 `ver`（Windows）
+   - 你的配置文件：`cat ~/.hotplex/config.yaml`（注意删除敏感信息）
+   - 错误日志：`hotplex gateway logs -n 100`
+   - 浏览器控制台的错误信息（F12 → Console）
+
+---
+
+## 相关文档
+
+- [配置完整参考](../../reference/configuration.md) — 所有配置项的详细说明
+- [CLI 命令参考](../../reference/cli.md) — 所有 hotplex 命令的用法
+- [认证与授权](../../security/Security-Authentication.md) — API Key 和 Cookie 认证的技术细节
+- [安全策略](../../reference/security-policies.md) — CSRF、CORS 等安全机制说明

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -73,7 +73,7 @@ Rate Limit 和 IP Whitelist 支持配置热重载，无需重启生效。
 
 ## 操作审计
 
-所有 admin 写操作（`POST`/`PUT`/`PATCH`/`DELETE`）均通过 `slog` 记录结构化审计事件（`admin_audit`，issue #788 A5），用于合规追溯与事故取证。审计复用网关现有 JSON 日志管道，无独立存储——直接流向标准日志输出，可由日志聚合系统按字段过滤检索，无需额外配置。
+所有 admin 写操作（`POST`/`PUT`/`PATCH`/`DELETE`）均进入 `user_activity` 防篡改审计表（issue #833），并在兼容期继续输出结构化 `slog` 事件（`admin_audit`，issue #788 A5）。`user_activity` 是权威审计载体；`admin_audit` 仅保留给既有日志看板迁移使用。
 
 **覆盖范围**：
 
@@ -98,6 +98,7 @@ Rate Limit 和 IP Whitelist 支持配置热重载，无需重启生效。
 | API Key | `apikey.create` / `apikey.update` / `apikey.delete` |
 | Cron | `cron.create` / `cron.update` / `cron.delete` / `cron.trigger` |
 | Session | `session.delete` / `session.terminate` / `session.patch` / `session.put` |
+| Audit | `audit.identity_link.create` / `audit.identity_link.delete` |
 | Config | `config.rollback` / `config.validate` |
 | 多租户成员/邀请 | `member.status.update` / `invitation.create` / `invitation.delete` |
 | 认证拒绝 | `auth.denied` |
@@ -243,6 +244,47 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 | POST | `/admin/restart` | `admin:write` | 触发网关重启 |
 
 **POST /admin/restart** — 异步触发网关重启。Gateway 在 500ms 延迟后执行重启，立即返回 `{ "status": "restarting" }`。使用 `restart helper`（独立 PGID）确保安全隔离。未配置 restart handler 时返回 `503`。
+
+### 用户行为审计
+
+`/admin/activity` 系列端点查询 issue #833 的 `user_activity` 表。所有读端点需要 `admin:read`；导出默认脱敏，`include_pii=true` 需要 `admin:write`。每次导出都会写入 `system.audit_export` meta-audit。
+
+| 方法 | 路径 | Scope | 说明 |
+|------|------|-------|------|
+| GET | `/admin/activity` | `admin:read` | 查询全局活动时间线 |
+| GET | `/admin/activity/export` | `admin:read` | 导出全局活动时间线（`format=json|csv`） |
+| GET | `/admin/users/{id}/activity` | `admin:read` | 查询单个原生 user_id 的活动 |
+| GET | `/admin/users/{id}/activity/export` | `admin:read` | 导出单个原生 user_id 的活动 |
+| GET | `/admin/audit/identity-links` | `admin:read` | 列出跨通道身份链接 |
+| POST | `/admin/audit/identity-links` | `admin:write` | 创建或更新身份链接 |
+| DELETE | `/admin/audit/identity-links/{id}` | `admin:write` | 删除身份链接 |
+
+查询参数：
+
+| 参数 | 说明 |
+|------|------|
+| `user_id` | 按审计行原始 `user_id` 查询 |
+| `principal_user_id` | 按本地 canonical 用户查询；会展开 `audit_identity_links` 中的所有平台原生 subject |
+| `action` | 精确匹配 action，如 `tool.call` / `admin.bot.create` |
+| `outcome` | `success` / `failure` / `denied` |
+| `from` / `to` | RFC3339 时间范围 |
+| `limit` / `offset` | 分页 |
+| `format` | 导出格式：`json` 或 `csv` |
+
+**POST /admin/audit/identity-links** — JSON body：
+
+```json
+{
+  "principal_user_id": "local-user-uuid",
+  "provider": "feishu",
+  "subject": "ou_xxx",
+  "subject_type": "platform",
+  "display_name": "Alice",
+  "email": "alice@example.com"
+}
+```
+
+`principal_user_id`、`provider`、`subject` 必填；`subject_type` 默认为 `platform`，允许 `registered` / `platform` / `system` / `anonymous`。`UNIQUE(provider, subject)` 保证一个平台原生 ID 只归属一个 principal。写操作通过 middleware 审计为 `admin.audit.identity_link.create` / `admin.audit.identity_link.delete`。
 
 ### API Key 用户管理
 

--- a/docs/specs/User-Behavior-Audit-Final-Followups-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Final-Followups-Spec.md
@@ -1,0 +1,110 @@
+# User Behavior Audit Final Follow-ups Spec
+
+| Item | Value |
+|---|---|
+| Status | Implementing |
+| Date | 2026-07-07 |
+| Issue | #833 |
+| Base | main after PR #845 |
+
+## 1. Goal
+
+Issue #833 has delivered the audit core through P1 and P2. This PR closes the remaining operational gaps in one reviewable package:
+
+- admin UI timeline for `user_activity`
+- cross-channel user activity lookup through explicit identity links
+- SIEM/export posture using the built-in sink/export surfaces
+- cold archive posture through downloadable JSON/CSV activity exports
+- PostgreSQL follow-up note for monthly partitioning
+- legacy `admin_audit` slog retirement plan
+
+The PR must not expand #833 into a full alerting rules engine. Rules, deduplication, alert lifecycle, and channel-specific alert delivery remain a separate subsystem behind the existing `AlertSink` contract.
+
+## 2. Current State
+
+Already complete on main:
+
+- append-only `user_activity` table with hash chain and checkpoint GC
+- zero-loss collector with spill WAL
+- auth/session/message/tool/admin write points
+- `NoopSink`, `LogSink`, `WebhookSink`, and sink registry
+- `/admin/activity`, `/admin/users/{id}/activity`, and JSON/CSV export endpoints
+- admin workspace console from issue #807
+- `audit.full_content_retention`
+- `system.audit_config_changed` meta-audit
+
+Remaining work is mostly operational access and identity resolution.
+
+## 3. Design
+
+### 3.1 Admin Activity Timeline
+
+Add `/admin/activity` to the embedded webchat admin console.
+
+The page is a dense operational timeline, not a marketing page:
+
+- filter by user ID, principal user ID, action, outcome, and time range
+- list activity rows with timestamp, user, platform, action, resource, outcome, and detail summary
+- provide JSON/CSV export links for the current filter
+- keep all strings in `webchat/locales/{zh-CN,en}/admin.json`
+
+The page consumes existing admin endpoints. It does not add write behavior.
+
+### 3.2 Cross-channel Identity Links
+
+Platform native IDs remain the stored audit subject. Cross-channel lookup is an explicit admin-managed mapping, not automatic email/name matching.
+
+Add `audit_identity_links`:
+
+- `principal_user_id`: canonical local user ID
+- `provider`: `webchat`, `feishu`, `slack`, `api`, `cron`, or another stable provider key
+- `subject`: platform native user ID
+- `subject_type`: `registered`, `platform`, `system`, or `anonymous`
+- optional display fields for admin readability
+
+`GET /admin/activity?principal_user_id=<id>` expands to:
+
+- the principal ID itself
+- all linked `subject` values for that principal
+
+This preserves hash-chain rows unchanged while allowing an investigator to search one person across channels.
+
+### 3.3 Identity Link Admin API
+
+Add small admin endpoints:
+
+- `GET /admin/audit/identity-links?principal_user_id=...`
+- `POST /admin/audit/identity-links`
+- `DELETE /admin/audit/identity-links/{id}`
+
+Writes go through existing admin middleware and therefore produce `admin.*` audit rows.
+
+### 3.4 SIEM And Cold Archive
+
+No new alert rules are added. SIEM export is satisfied by the existing `WebhookSink`, which posts signed audit events to an external collector. Cold archive is satisfied by JSON/CSV activity export for selected filters; this PR documents that route and exposes it in the UI.
+
+### 3.5 PostgreSQL Partitioning
+
+The current table already exists as a normal table. A safe partition migration requires a table replacement plan and staging smoke test. This PR records that decision instead of attempting an unsafe in-place conversion on unknown production data.
+
+### 3.6 Legacy `admin_audit` Slog
+
+The old slog path remains as a compatibility stream until dashboards migrate to `user_activity`. This PR updates the issue spec to stop describing slog-only audit as a future task. Full removal is a breaking observability change and should be versioned separately.
+
+## 4. Acceptance Criteria
+
+- Admin can open `/admin/activity` and inspect audit rows.
+- Filters include user ID, principal user ID, action, outcome, and time range.
+- Export buttons preserve the active filters.
+- Admin can create, list, and delete identity links via API.
+- `principal_user_id` queries return activity for the principal plus linked subjects.
+- SQLite and PostgreSQL migrations both create/drop `audit_identity_links`.
+- Existing activity endpoints keep backward-compatible responses.
+- Tests cover identity link persistence and principal expansion.
+
+## 5. Non-goals
+
+- Automatic identity matching.
+- Full alert rule engine.
+- Backfilling historical orphaned events.
+- Unsafe conversion of the existing PostgreSQL `user_activity` table into a partitioned table.

--- a/docs/specs/User-Behavior-Audit-Final-Followups-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Final-Followups-Spec.md
@@ -2,10 +2,11 @@
 
 | Item | Value |
 |---|---|
-| Status | Implementing |
+| Status | Implemented in PR #854 |
 | Date | 2026-07-07 |
 | Issue | #833 |
 | Base | main after PR #845 |
+| PR | https://github.com/hrygo/hotplex/pull/854 |
 
 ## 1. Goal
 
@@ -33,7 +34,7 @@ Already complete on main:
 - `audit.full_content_retention`
 - `system.audit_config_changed` meta-audit
 
-Remaining work is mostly operational access and identity resolution.
+This spec covers the final operational access and identity resolution layer.
 
 ## 3. Design
 
@@ -93,16 +94,45 @@ The old slog path remains as a compatibility stream until dashboards migrate to 
 
 ## 4. Acceptance Criteria
 
-- Admin can open `/admin/activity` and inspect audit rows.
-- Filters include user ID, principal user ID, action, outcome, and time range.
-- Export buttons preserve the active filters.
-- Admin can create, list, and delete identity links via API.
-- `principal_user_id` queries return activity for the principal plus linked subjects.
-- SQLite and PostgreSQL migrations both create/drop `audit_identity_links`.
-- Existing activity endpoints keep backward-compatible responses.
-- Tests cover identity link persistence and principal expansion.
+- ✅ Admin can open `/admin/activity` and inspect audit rows.
+- ✅ Filters include user ID, principal user ID, action, outcome, and time range.
+- ✅ Export buttons preserve the active filters.
+- ✅ Admin can create, list, and delete identity links via API.
+- ✅ `principal_user_id` queries return activity for the principal plus linked subjects.
+- ✅ SQLite and PostgreSQL migrations both create/drop `audit_identity_links`.
+- ✅ Existing activity endpoints keep backward-compatible responses.
+- ✅ Tests cover identity link persistence and principal expansion.
 
-## 5. Non-goals
+## 5. Implementation Status
+
+| Area | Status | Landing |
+|---|---|---|
+| Spec update | ✅ | `docs/specs/User-Behavior-Audit-Final-Followups-Spec.md`, `docs/specs/User-Behavior-Audit-Spec.md` |
+| Identity link schema | ✅ | `internal/session/sql/migrations/024_audit_identity_links.sql`, `internal/session/sql/migrations-postgres/024_audit_identity_links.pg.sql` |
+| Store/API support | ✅ | `internal/audit/store.go`, `internal/admin/activity_handlers.go`, `internal/admin/audit_service.go` |
+| Principal expansion | ✅ | `/admin/activity?principal_user_id=...` |
+| Admin write audit labels | ✅ | `audit.identity_link.create`, `audit.identity_link.delete` in `internal/admin/audit.go` |
+| Admin activity UI | ✅ | `webchat/app/admin/activity/page.tsx` |
+| i18n | ✅ | `webchat/locales/en/admin.json`, `webchat/locales/zh-CN/admin.json` |
+| API docs | ✅ | `docs/reference/admin-api.md` |
+
+## 6. Validation
+
+- ✅ `go test -count=1 ./...`
+- ✅ `go test -race -count=1 ./internal/audit ./internal/admin ./internal/security ./cmd/hotplex`
+- ✅ `cd webchat && npx tsc --noEmit`
+- ✅ `cd webchat && npx eslint app/admin/activity/page.tsx lib/api/admin-activity.ts lib/types/admin.ts components/admin/admin-nav.tsx`
+- ✅ `make check`
+- ✅ pre-push hook: formatting, vet, `go mod verify`, lint, build, tests
+- ✅ GitHub PR checks on #854: Branch Naming, Issue Link, Large File Guard, Build, Test
+
+## 7. Deferred Boundaries
+
+- Full alert rule engine remains out of #833 and should be specified separately.
+- PostgreSQL monthly partition conversion remains deferred because safe conversion of an existing `user_activity` table requires a staged table replacement plan and staging smoke test.
+- Full removal of legacy `admin_audit` slog remains deferred as a versioned observability compatibility change.
+
+## 8. Non-goals
 
 - Automatic identity matching.
 - Full alert rule engine.

--- a/docs/specs/User-Behavior-Audit-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Spec.md
@@ -2,7 +2,7 @@
 
 | 项 | 值 |
 |---|---|
-| 状态 | Draft — 待 review |
+| 状态 | Implemented — P1/P2 complete; final follow-ups in `User-Behavior-Audit-Final-Followups-Spec.md` |
 | 日期 | 2026-07-03 |
 | 适用版本 | hotplex ≥ v1.31 |
 | 关联调研 | events/sessions/turns 数据模型 · admin_audit · observability · 用户身份模型 |

--- a/docs/specs/User-Behavior-Audit-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Spec.md
@@ -290,6 +290,7 @@ audit:
 
 - **Phase 1(核心)**:表 + migration + hash chain(checkpoint)+ 独立 collector(spill)+ 写入点(认证/会话/消息)+ retention(3 年)+ by-user 端点 + chain verify + **`AlertSink` 接口 + `NoopSink`(collector 预留 sink fan-out 钩子)**
 - **Phase 2(覆盖 + 告警 + UI)**:工具调用审计 + admin 操作迁移 + **`LogSink` + `RegisterSink` 注册机制 + 告警配置** + admin UI 时间线 + 导出
+- **Final follow-ups(PR #854)**:admin 活动时间线 UI + `audit_identity_links` 显式跨通道身份链接 + `principal_user_id` 查询展开 + identity-link admin API + 文档化 SIEM/冷归档边界
 
 > 具体告警能力(规则引擎 / 多通道投递 / 去噪 / 告警状态机)**另立 spec**,不在本 spec 范围。本 spec 仅提供 `AlertSink` 扩展点与数据契约,保证审计核心稳定、告警子系统可独立演进。
 
@@ -297,7 +298,7 @@ audit:
 
 ## 11. 实施状态(Implementation Status)
 
-> **当前状态**:Phase 1 已完成,PR [#844](https://github.com/hrygo/hotplex/pull/844) 待 review & merge。
+> **当前状态**:Phase 1 PR [#844](https://github.com/hrygo/hotplex/pull/844) 已合并,Phase 2 PR [#845](https://github.com/hrygo/hotplex/pull/845) 已合并,final follow-ups PR [#854](https://github.com/hrygo/hotplex/pull/854) 已创建并通过质量门禁。
 
 ### P1 已完成 ✅
 
@@ -330,21 +331,31 @@ audit:
 | `GatewayDeps.AuditCollector` 集成 + 关闭顺序 (在 EventCollector 之后、SessionMgr 之前) | ✅ | `cmd/hotplex/gateway_run.go` |
 | Hot-reload 接线 (retention 立即生效,`batch_interval` 需重启) | ✅ | spec §8 |
 
-### P2 仍未开始 ⏳
+### P2 已完成 ✅
 
 - `tool.call` 工具调用审计(spec §5.2)
-- 现有 `internal/admin/audit.go` AdminAudit slog 路径迁移为双写 user_activity
-- 外部 `RegisterSink` 机制 (P1 仅内嵌 noop/log)
-- admin UI 用户活动时间线(issue #807 集成)
-- `full_content_retention` 延长 events/turns TTL(目前 30 天)
-- `requested-code-review` skill 用于 P2 PR review
+- 现有 `internal/admin/audit.go` AdminAudit slog 路径迁移为双写 `user_activity`
+- 外部 `RegisterSink` 机制 + `WebhookSink`
+- `full_content_retention` 延长 events/turns TTL(默认 90 天)
+- `system.audit_config_changed` meta-audit
+- sinks↔audit 单向导入清理
 
-### P3 仍未开始 ⏳
+### Final follow-ups 已完成 / PR #854 ✅
 
-- 跨通道归一 v2 (`user_identities` 扩展 vs 新建 `platform_user_map`)
-- SIEM / OTLP 导出
-- 冷归档到外部存储
-- PG 按月分区(性能)
+- `docs/specs/User-Behavior-Audit-Final-Followups-Spec.md` 收尾 spec
+- `audit_identity_links` 显式身份链接表(SQLite + PostgreSQL migration 024)
+- `GET /admin/activity?principal_user_id=...` 展开 principal + linked subjects
+- `GET/POST/DELETE /admin/audit/identity-links`
+- `/admin/activity` webchat admin 时间线(过滤 + JSON/CSV 导出)
+- `docs/reference/admin-api.md` 更新活动查询、身份链接、`admin_audit` 兼容期说明
+
+### P3 / 独立子系统仍未开始 ⏳
+
+- 自动身份匹配 / 跨通道归一 v2(当前只做 admin 显式链接,不做 email/name fuzzy matching)
+- 告警规则引擎 / 多通道投递 / 去噪 / 告警状态机
+- 冷归档到外部存储(当前通过 JSON/CSV 导出作为人工归档面)
+- PG 按月分区(需要 staged table replacement + staging smoke,不做未知生产表的 unsafe in-place conversion)
+- `admin_audit` slog 完全退役(当前是兼容流,权威审计载体为 `user_activity`)
 
 ### 已发现 + 已修复的 Bug (P1 review 期间)
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/term v0.44.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.81.1
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.51.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,8 @@ gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/internal/admin/activity_handlers.go
+++ b/internal/admin/activity_handlers.go
@@ -32,11 +32,19 @@ func (api *AdminAPI) HandleUserActivity(w http.ResponseWriter, r *http.Request) 
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to query activity")
 		return
 	}
+	links, _ := api.activityService.ListAllIdentityLinks(r.Context())
+	linksMap := make(map[string]audit.IdentityLink)
+	for _, link := range links {
+		if link.Subject != "" {
+			linksMap[link.Subject] = link
+		}
+	}
 	respondJSON(w, map[string]any{
-		"user_id": userID,
-		"rows":    rows,
-		"limit":   q.Limit,
-		"offset":  q.Offset,
+		"user_id":        userID,
+		"rows":           rows,
+		"identity_links": linksMap,
+		"limit":          q.Limit,
+		"offset":         q.Offset,
 	})
 }
 
@@ -51,7 +59,19 @@ func (api *AdminAPI) HandleAdminActivity(w http.ResponseWriter, r *http.Request)
 	if !api.ensureActivityService(w) {
 		return
 	}
+	if hasConflictingActivityUserFilters(r, r.URL.Query().Get("user_id")) {
+		writeActivityFilterConflict(w)
+		return
+	}
 	q := parseActivityQuery(r)
+	links, _ := api.activityService.ListAllIdentityLinks(r.Context())
+	linksMap := make(map[string]audit.IdentityLink)
+	for _, link := range links {
+		if link.Subject != "" {
+			linksMap[link.Subject] = link
+		}
+	}
+
 	if principalUserID := r.URL.Query().Get("principal_user_id"); principalUserID != "" {
 		rows, resolved, err := api.activityService.QueryPrincipal(r.Context(), principalUserID, q)
 		if err != nil {
@@ -63,6 +83,7 @@ func (api *AdminAPI) HandleAdminActivity(w http.ResponseWriter, r *http.Request)
 			"principal_user_id": principalUserID,
 			"resolved_user_ids": resolved,
 			"rows":              rows,
+			"identity_links":    linksMap,
 			"limit":             q.Limit,
 			"offset":            q.Offset,
 		})
@@ -78,10 +99,45 @@ func (api *AdminAPI) HandleAdminActivity(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	respondJSON(w, map[string]any{
-		"rows":   rows,
-		"limit":  q.Limit,
-		"offset": q.Offset,
+		"rows":           rows,
+		"identity_links": linksMap,
+		"limit":          q.Limit,
+		"offset":         q.Offset,
 	})
+}
+
+// HandleActivityStats is GET /admin/activity/stats and GET /api/admin/activity/stats.
+// Returns aggregate counts (total / per-outcome / per-platform) scoped by the
+// same query filters as the list endpoint. Powers the timeline overview cards.
+// Requires admin:read scope.
+func (api *AdminAPI) HandleActivityStats(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminRead) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:read")
+		return
+	}
+	if !api.ensureActivityService(w) {
+		return
+	}
+	q := parseActivityQuery(r)
+	if principalUserID := r.URL.Query().Get("principal_user_id"); principalUserID != "" {
+		resolved, err := api.activityService.ResolvePrincipalUserIDs(r.Context(), principalUserID)
+		if err != nil {
+			api.log.Error("admin: activity stats principal resolve", "err", err, "principal_user_id", principalUserID)
+			web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to compute stats")
+			return
+		}
+		q.UserID = ""
+		q.UserIDs = resolved
+	} else if uid := r.URL.Query().Get("user_id"); uid != "" {
+		q.UserID = uid
+	}
+	stats, err := api.activityService.Stats(r.Context(), q)
+	if err != nil {
+		api.log.Error("admin: activity stats", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to compute stats")
+		return
+	}
+	respondJSON(w, stats)
 }
 
 // HandleUserActivityExport is GET /admin/users/{id}/activity?format=json|csv
@@ -104,6 +160,10 @@ func (api *AdminAPI) handleActivityExport(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if !api.ensureActivityService(w) {
+		return
+	}
+	if hasConflictingActivityUserFilters(r, userID) {
+		writeActivityFilterConflict(w)
 		return
 	}
 	// include_pii=true requires admin:write (spec section 5.9)
@@ -266,6 +326,14 @@ func (api *AdminAPI) ensureActivityService(w http.ResponseWriter) bool {
 	return false
 }
 
+func hasConflictingActivityUserFilters(r *http.Request, userID string) bool {
+	return strings.TrimSpace(userID) != "" && strings.TrimSpace(r.URL.Query().Get("principal_user_id")) != ""
+}
+
+func writeActivityFilterConflict(w http.ResponseWriter) {
+	web.WriteAppError(w, http.StatusBadRequest, "INVALID_REQUEST", "user_id and principal_user_id are mutually exclusive")
+}
+
 func identityLinkFromRequest(req identityLinkRequest) (audit.IdentityLink, error) {
 	principal := strings.TrimSpace(req.PrincipalUserID)
 	provider := strings.TrimSpace(req.Provider)
@@ -309,7 +377,11 @@ func parseActivityQuery(r *http.Request) audit.Query {
 		}
 	}
 	q.Action = r.URL.Query().Get("action")
+	q.ActionPrefix = r.URL.Query().Get("action_prefix")
 	q.Outcome = r.URL.Query().Get("outcome")
+	q.Platform = r.URL.Query().Get("platform")
+	q.SessionID = r.URL.Query().Get("session_id")
+	q.ResourceType = r.URL.Query().Get("resource_type")
 	if v := r.URL.Query().Get("include_pii"); v == "true" {
 		q.IncludePII = true
 	}

--- a/internal/admin/activity_handlers.go
+++ b/internal/admin/activity_handlers.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/hrygo/hotplex/internal/audit"
 	"github.com/hrygo/hotplex/internal/web"
@@ -16,6 +19,9 @@ import (
 func (api *AdminAPI) HandleUserActivity(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeAdminRead) {
 		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:read")
+		return
+	}
+	if !api.ensureActivityService(w) {
 		return
 	}
 	userID := r.PathValue("id")
@@ -42,7 +48,26 @@ func (api *AdminAPI) HandleAdminActivity(w http.ResponseWriter, r *http.Request)
 		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:read")
 		return
 	}
+	if !api.ensureActivityService(w) {
+		return
+	}
 	q := parseActivityQuery(r)
+	if principalUserID := r.URL.Query().Get("principal_user_id"); principalUserID != "" {
+		rows, resolved, err := api.activityService.QueryPrincipal(r.Context(), principalUserID, q)
+		if err != nil {
+			api.log.Error("admin: principal activity query", "err", err, "principal_user_id", principalUserID)
+			web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to query activity")
+			return
+		}
+		respondJSON(w, map[string]any{
+			"principal_user_id": principalUserID,
+			"resolved_user_ids": resolved,
+			"rows":              rows,
+			"limit":             q.Limit,
+			"offset":            q.Offset,
+		})
+		return
+	}
 	if uid := r.URL.Query().Get("user_id"); uid != "" {
 		q.UserID = uid
 	}
@@ -78,6 +103,9 @@ func (api *AdminAPI) handleActivityExport(w http.ResponseWriter, r *http.Request
 		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:read")
 		return
 	}
+	if !api.ensureActivityService(w) {
+		return
+	}
 	// include_pii=true requires admin:write (spec section 5.9)
 	if r.URL.Query().Get("include_pii") == "true" && !hasScope(r, ScopeAdminWrite) {
 		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "include_pii=true requires admin:write scope")
@@ -86,6 +114,17 @@ func (api *AdminAPI) handleActivityExport(w http.ResponseWriter, r *http.Request
 	q := parseActivityQuery(r)
 	if userID != "" {
 		q.UserID = userID
+	}
+	if principalUserID := r.URL.Query().Get("principal_user_id"); principalUserID != "" {
+		resolved, resolveErr := api.activityService.ResolvePrincipalUserIDs(r.Context(), principalUserID)
+		if resolveErr != nil {
+			api.log.Error("admin: activity export principal resolve", "err", resolveErr, "principal_user_id", principalUserID)
+			web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "export failed")
+			return
+		}
+		q.UserID = ""
+		q.UserIDs = resolved
+		userID = principalUserID
 	}
 	format := r.URL.Query().Get("format")
 	if format == "" {
@@ -140,6 +179,121 @@ func (api *AdminAPI) handleActivityExport(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="activity-%s.%s"`, time.Now().UTC().Format("20060102-150405"), format))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
+}
+
+type identityLinkRequest struct {
+	PrincipalUserID string `json:"principal_user_id"`
+	Provider        string `json:"provider"`
+	Subject         string `json:"subject"`
+	SubjectType     string `json:"subject_type"`
+	DisplayName     string `json:"display_name"`
+	Email           string `json:"email"`
+}
+
+// HandleAuditIdentityLinks is GET /admin/audit/identity-links.
+// It lists explicit cross-channel mappings used by principal activity queries.
+func (api *AdminAPI) HandleAuditIdentityLinks(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminRead) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:read")
+		return
+	}
+	if !api.ensureActivityService(w) {
+		return
+	}
+	links, err := api.activityService.ListIdentityLinks(r.Context(), r.URL.Query().Get("principal_user_id"))
+	if err != nil {
+		api.log.Error("admin: audit identity links list", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to list identity links")
+		return
+	}
+	respondJSON(w, map[string]any{"links": links})
+}
+
+// HandleCreateAuditIdentityLink is POST /admin/audit/identity-links.
+func (api *AdminAPI) HandleCreateAuditIdentityLink(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:write")
+		return
+	}
+	if !api.ensureActivityService(w) {
+		return
+	}
+	var req identityLinkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body")
+		return
+	}
+	link, err := identityLinkFromRequest(req)
+	if err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+		return
+	}
+	if err := api.activityService.UpsertIdentityLink(r.Context(), link); err != nil {
+		api.log.Error("admin: audit identity link upsert", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to save identity link")
+		return
+	}
+	respondJSON(w, map[string]any{"link": link})
+}
+
+// HandleDeleteAuditIdentityLink is DELETE /admin/audit/identity-links/{id}.
+func (api *AdminAPI) HandleDeleteAuditIdentityLink(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeAdminWrite) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need admin:write")
+		return
+	}
+	if !api.ensureActivityService(w) {
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		web.WriteAppError(w, http.StatusBadRequest, "INVALID_REQUEST", "id is required")
+		return
+	}
+	if err := api.activityService.DeleteIdentityLink(r.Context(), id); err != nil {
+		api.log.Error("admin: audit identity link delete", "err", err, "id", id)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete identity link")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (api *AdminAPI) ensureActivityService(w http.ResponseWriter) bool {
+	if api.activityService != nil {
+		return true
+	}
+	web.WriteAppError(w, http.StatusServiceUnavailable, "AUDIT_DISABLED", "audit activity service is not available")
+	return false
+}
+
+func identityLinkFromRequest(req identityLinkRequest) (audit.IdentityLink, error) {
+	principal := strings.TrimSpace(req.PrincipalUserID)
+	provider := strings.TrimSpace(req.Provider)
+	subject := strings.TrimSpace(req.Subject)
+	if principal == "" || provider == "" || subject == "" {
+		return audit.IdentityLink{}, fmt.Errorf("principal_user_id, provider, and subject are required")
+	}
+	subjectType := strings.TrimSpace(req.SubjectType)
+	if subjectType == "" {
+		subjectType = audit.UserIDTypePlatform
+	}
+	switch subjectType {
+	case audit.UserIDTypeRegistered, audit.UserIDTypePlatform, audit.UserIDTypeSystem, audit.UserIDTypeAnonymous:
+	default:
+		return audit.IdentityLink{}, fmt.Errorf("subject_type must be registered, platform, system, or anonymous")
+	}
+	now := time.Now().UnixMilli()
+	return audit.IdentityLink{
+		ID:              uuid.NewString(),
+		PrincipalUserID: principal,
+		Provider:        provider,
+		Subject:         subject,
+		SubjectType:     subjectType,
+		DisplayName:     strings.TrimSpace(req.DisplayName),
+		Email:           strings.TrimSpace(req.Email),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}, nil
 }
 
 func parseActivityQuery(r *http.Request) audit.Query {

--- a/internal/admin/activity_handlers_test.go
+++ b/internal/admin/activity_handlers_test.go
@@ -21,6 +21,7 @@ import (
 // mockAuditStoreForHandler implements audit.Store for handler tests.
 type mockAuditStoreForHandler struct {
 	queryFn       func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	statsFn       func(ctx context.Context, q audit.Query) (audit.ActivityStats, error)
 	identityLinks []audit.IdentityLink
 }
 
@@ -32,6 +33,12 @@ func (m *mockAuditStoreForHandler) Query(ctx context.Context, q audit.Query) ([]
 		return m.queryFn(ctx, q)
 	}
 	return nil, nil
+}
+func (m *mockAuditStoreForHandler) Stats(ctx context.Context, q audit.Query) (audit.ActivityStats, error) {
+	if m.statsFn != nil {
+		return m.statsFn(ctx, q)
+	}
+	return audit.ActivityStats{ByOutcome: map[string]int64{}, ByPlatform: map[string]int64{}}, nil
 }
 func (m *mockAuditStoreForHandler) QueryAsc(ctx context.Context, fromID int64, limit int) ([]audit.UserActivity, error) {
 	return nil, nil // handler tests don't exercise the verifier path
@@ -535,6 +542,127 @@ func TestHandleActivityExport_CSVFormat(t *testing.T) {
 	require.True(t, strings.Contains(body, "id,ts,user_id"))
 }
 
+func TestHandleActivityExport_DefaultMasksPII(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	store := &mockAuditStoreForHandler{
+		queryFn: func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error) {
+			require.False(t, q.IncludePII)
+			return []audit.UserActivity{
+				{
+					ID:        1,
+					UserID:    "u1",
+					IP:        "192.168.1.100",
+					UserAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+				},
+			}, nil
+		},
+	}
+	api.SetActivityService(NewActivityService(store, slog.Default()))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/admin/activity/export?format=json", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleAdminActivityExport(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var rows []audit.UserActivity
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, "192.168.1.0", rows[0].IP)
+	require.True(t, strings.HasSuffix(rows[0].UserAgent, "..."))
+}
+
+func TestHandleAdminActivity_RejectsUserAndPrincipalFilters(t *testing.T) {
+	t.Parallel()
+	api := newTestAPIWithActivity()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/admin/activity?user_id=u1&principal_user_id=u-local", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleAdminActivity(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "mutually exclusive")
+}
+
+func TestHandleAdminActivityExport_RejectsUserAndPrincipalFilters(t *testing.T) {
+	t.Parallel()
+	api := newTestAPIWithActivity()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/admin/activity/export?user_id=u1&principal_user_id=u-local", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleAdminActivityExport(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "mutually exclusive")
+}
+
+func TestHandleCreateAuditIdentityLink_Success(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	store := &mockAuditStoreForHandler{}
+	api.SetActivityService(NewActivityService(store, slog.Default()))
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"principal_user_id":"u-local","provider":"feishu","subject":"ou_feishu","subject_type":"platform","display_name":"Feishu User"}`)
+	r := httptest.NewRequest(http.MethodPost, "/admin/audit/identity-links", body)
+	r = withScope(r, ScopeAdminWrite)
+
+	api.HandleCreateAuditIdentityLink(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Link audit.IdentityLink `json:"link"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.NotEmpty(t, resp.Link.ID)
+	require.Equal(t, "u-local", resp.Link.PrincipalUserID)
+	require.Equal(t, "ou_feishu", resp.Link.Subject)
+	require.Len(t, store.identityLinks, 1)
+}
+
+func TestHandleAuditIdentityLinks_Success(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	store := &mockAuditStoreForHandler{
+		identityLinks: []audit.IdentityLink{
+			{ID: "link-1", PrincipalUserID: "u-local", Provider: "feishu", Subject: "ou_feishu"},
+			{ID: "link-2", PrincipalUserID: "other", Provider: "slack", Subject: "U_other"},
+		},
+	}
+	api.SetActivityService(NewActivityService(store, slog.Default()))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/admin/audit/identity-links?principal_user_id=u-local", nil)
+	r = withScope(r, ScopeAdminRead)
+
+	api.HandleAuditIdentityLinks(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Links []audit.IdentityLink `json:"links"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Links, 1)
+	require.Equal(t, "link-1", resp.Links[0].ID)
+}
+
+func TestHandleDeleteAuditIdentityLink_Success(t *testing.T) {
+	t.Parallel()
+	api := newTestAPIWithActivity()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/admin/audit/identity-links/link-1", nil)
+	r = withScope(r, ScopeAdminWrite)
+	r.SetPathValue("id", "link-1")
+
+	api.HandleDeleteAuditIdentityLink(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+}
+
 // ─── I1: meta-audit must fire on export failure (spec §5.8) ───────────────────
 
 // capturingAuditStore is an audit.Store whose BeginTx returns a capturing Tx
@@ -550,6 +678,9 @@ func (s *capturingAuditStore) BeginTx(context.Context) (audit.Tx, error) {
 }
 func (s *capturingAuditStore) Query(context.Context, audit.Query) ([]audit.UserActivity, error) {
 	return nil, nil
+}
+func (s *capturingAuditStore) Stats(context.Context, audit.Query) (audit.ActivityStats, error) {
+	return audit.ActivityStats{ByOutcome: map[string]int64{}, ByPlatform: map[string]int64{}}, nil
 }
 func (s *capturingAuditStore) QueryAsc(context.Context, int64, int) ([]audit.UserActivity, error) {
 	return nil, nil

--- a/internal/admin/activity_handlers_test.go
+++ b/internal/admin/activity_handlers_test.go
@@ -20,7 +20,8 @@ import (
 
 // mockAuditStoreForHandler implements audit.Store for handler tests.
 type mockAuditStoreForHandler struct {
-	queryFn func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	queryFn       func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	identityLinks []audit.IdentityLink
 }
 
 func (m *mockAuditStoreForHandler) BeginTx(ctx context.Context) (audit.Tx, error) {
@@ -43,6 +44,25 @@ func (m *mockAuditStoreForHandler) SaveCheckpoint(ctx context.Context, c audit.C
 }
 func (m *mockAuditStoreForHandler) LatestCheckpoint(ctx context.Context) (*audit.Checkpoint, error) {
 	return nil, nil
+}
+func (m *mockAuditStoreForHandler) ListIdentityLinks(ctx context.Context, principalUserID string) ([]audit.IdentityLink, error) {
+	if principalUserID == "" {
+		return m.identityLinks, nil
+	}
+	var out []audit.IdentityLink
+	for _, link := range m.identityLinks {
+		if link.PrincipalUserID == principalUserID {
+			out = append(out, link)
+		}
+	}
+	return out, nil
+}
+func (m *mockAuditStoreForHandler) UpsertIdentityLink(ctx context.Context, link audit.IdentityLink) error {
+	m.identityLinks = append(m.identityLinks, link)
+	return nil
+}
+func (m *mockAuditStoreForHandler) DeleteIdentityLink(ctx context.Context, id string) error {
+	return nil
 }
 func (m *mockAuditStoreForHandler) Close() error { return nil }
 func (m *mockAuditStoreForHandler) Dialect() dbutil.Dialect {
@@ -541,8 +561,15 @@ func (s *capturingAuditStore) SaveCheckpoint(context.Context, audit.Checkpoint) 
 func (s *capturingAuditStore) LatestCheckpoint(context.Context) (*audit.Checkpoint, error) {
 	return nil, nil
 }
-func (s *capturingAuditStore) Close() error            { return nil }
-func (s *capturingAuditStore) Dialect() dbutil.Dialect { return dbutil.DialectSQLite }
+func (s *capturingAuditStore) ListIdentityLinks(context.Context, string) ([]audit.IdentityLink, error) {
+	return nil, nil
+}
+func (s *capturingAuditStore) UpsertIdentityLink(context.Context, audit.IdentityLink) error {
+	return nil
+}
+func (s *capturingAuditStore) DeleteIdentityLink(context.Context, string) error { return nil }
+func (s *capturingAuditStore) Close() error                                     { return nil }
+func (s *capturingAuditStore) Dialect() dbutil.Dialect                          { return dbutil.DialectSQLite }
 func (s *capturingAuditStore) snapshot() []audit.UserActivity {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/admin/audit.go
+++ b/internal/admin/audit.go
@@ -36,6 +36,8 @@ const (
 	AuditInvitationCreate              = "invitation.create"
 	AuditInvitationDelete              = "invitation.delete"
 	AuditWorkspacePermissionModeUpdate = "workspace.permission_mode.update" // issue #807 admin console
+	AuditIdentityLinkCreate            = "audit.identity_link.create"
+	AuditIdentityLinkDelete            = "audit.identity_link.delete"
 	AuditAuthDenied                    = "auth.denied"
 
 	// AuditResult* — stable "result" field values. Reuse instead of literals so
@@ -95,6 +97,8 @@ func adminActionFor(method, path string) string {
 		return AuditConfigRollback
 	case strings.Contains(path, "/config/validate"):
 		return AuditConfigValidate
+	case strings.Contains(path, "/audit/identity-links"):
+		return auditIdentityLinkAction(method)
 	case strings.Contains(path, "/api-keys"):
 		return apiKeyAction(method)
 	case strings.Contains(path, "/cron/jobs"):
@@ -107,6 +111,16 @@ func adminActionFor(method, path string) string {
 		return workspaceAction(method)
 	}
 	return method + " " + path
+}
+
+func auditIdentityLinkAction(method string) string {
+	switch method {
+	case http.MethodPost:
+		return AuditIdentityLinkCreate
+	case http.MethodDelete:
+		return AuditIdentityLinkDelete
+	}
+	return "audit.identity_link." + strings.ToLower(method)
 }
 
 // workspaceAction covers PATCH /admin/workspaces/{id} (issue #807) — the only

--- a/internal/admin/audit_service.go
+++ b/internal/admin/audit_service.go
@@ -50,6 +50,58 @@ func (s *ActivityService) QueryByUser(ctx context.Context, userID string, q audi
 	return s.Query(ctx, q)
 }
 
+// QueryPrincipal expands a canonical principal user ID into all explicitly
+// linked platform-native audit subjects, then queries the unified timeline.
+func (s *ActivityService) QueryPrincipal(ctx context.Context, principalUserID string, q audit.Query) ([]audit.UserActivity, []string, error) {
+	userIDs, err := s.ResolvePrincipalUserIDs(ctx, principalUserID)
+	if err != nil {
+		return nil, nil, err
+	}
+	q.UserID = ""
+	q.UserIDs = userIDs
+	rows, err := s.Query(ctx, q)
+	return rows, userIDs, err
+}
+
+// ResolvePrincipalUserIDs returns the principal itself plus linked subjects.
+// This is intentionally explicit: no email/name fuzzy matching is performed.
+func (s *ActivityService) ResolvePrincipalUserIDs(ctx context.Context, principalUserID string) ([]string, error) {
+	principalUserID = strings.TrimSpace(principalUserID)
+	if principalUserID == "" {
+		return nil, fmt.Errorf("principal_user_id is required")
+	}
+	links, err := s.store.ListIdentityLinks(ctx, principalUserID)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{principalUserID: {}}
+	out := []string{principalUserID}
+	for _, link := range links {
+		subject := strings.TrimSpace(link.Subject)
+		if subject == "" {
+			continue
+		}
+		if _, ok := seen[subject]; ok {
+			continue
+		}
+		seen[subject] = struct{}{}
+		out = append(out, subject)
+	}
+	return out, nil
+}
+
+func (s *ActivityService) ListIdentityLinks(ctx context.Context, principalUserID string) ([]audit.IdentityLink, error) {
+	return s.store.ListIdentityLinks(ctx, principalUserID)
+}
+
+func (s *ActivityService) UpsertIdentityLink(ctx context.Context, link audit.IdentityLink) error {
+	return s.store.UpsertIdentityLink(ctx, link)
+}
+
+func (s *ActivityService) DeleteIdentityLink(ctx context.Context, id string) error {
+	return s.store.DeleteIdentityLink(ctx, id)
+}
+
 // Export returns the audit rows in the requested format ("json" or "csv").
 // An empty format defaults to JSON. Always includes PII — the HTTP layer
 // gates ?include_pii=true on admin:write scope. The caller (HTTP handler)

--- a/internal/admin/audit_service.go
+++ b/internal/admin/audit_service.go
@@ -50,6 +50,16 @@ func (s *ActivityService) QueryByUser(ctx context.Context, userID string, q audi
 	return s.Query(ctx, q)
 }
 
+// Stats returns aggregate counts (total / by-outcome / by-platform) scoped by
+// the query filters. Aggregates contain no PII, so no masking is applied.
+func (s *ActivityService) Stats(ctx context.Context, q audit.Query) (audit.ActivityStats, error) {
+	stats, err := s.store.Stats(ctx, q)
+	if err != nil {
+		return stats, fmt.Errorf("audit stats: %w", err)
+	}
+	return stats, nil
+}
+
 // QueryPrincipal expands a canonical principal user ID into all explicitly
 // linked platform-native audit subjects, then queries the unified timeline.
 func (s *ActivityService) QueryPrincipal(ctx context.Context, principalUserID string, q audit.Query) ([]audit.UserActivity, []string, error) {
@@ -94,6 +104,10 @@ func (s *ActivityService) ListIdentityLinks(ctx context.Context, principalUserID
 	return s.store.ListIdentityLinks(ctx, principalUserID)
 }
 
+func (s *ActivityService) ListAllIdentityLinks(ctx context.Context) ([]audit.IdentityLink, error) {
+	return s.store.ListIdentityLinks(ctx, "")
+}
+
 func (s *ActivityService) UpsertIdentityLink(ctx context.Context, link audit.IdentityLink) error {
 	return s.store.UpsertIdentityLink(ctx, link)
 }
@@ -103,16 +117,14 @@ func (s *ActivityService) DeleteIdentityLink(ctx context.Context, id string) err
 }
 
 // Export returns the audit rows in the requested format ("json" or "csv").
-// An empty format defaults to JSON. Always includes PII — the HTTP layer
-// gates ?include_pii=true on admin:write scope. The caller (HTTP handler)
-// is responsible for emitting the system.audit_export meta-audit row.
+// An empty format defaults to JSON. PII is included only when q.IncludePII is
+// true; the HTTP layer gates that flag on admin:write scope. The caller (HTTP
+// handler) is responsible for emitting the system.audit_export meta-audit row.
 func (s *ActivityService) Export(ctx context.Context, q audit.Query, format, exporterUserID string) ([]byte, string, error) {
 	if exporterUserID == "" {
 		exporterUserID = audit.AnonymousUserID
 	}
-	// Export always includes PII; the gate is at the HTTP layer.
-	q.IncludePII = true
-	rows, err := s.store.Query(ctx, q)
+	rows, err := s.Query(ctx, q)
 	if err != nil {
 		return nil, "", fmt.Errorf("audit export query: %w", err)
 	}

--- a/internal/admin/audit_service_test.go
+++ b/internal/admin/audit_service_test.go
@@ -18,7 +18,8 @@ import (
 
 // mockAuditStore implements audit.Store for ActivityService tests.
 type mockAuditStore struct {
-	queryFn func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	queryFn       func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	identityLinks []audit.IdentityLink
 }
 
 func (m *mockAuditStore) BeginTx(ctx context.Context) (audit.Tx, error) {
@@ -42,7 +43,24 @@ func (m *mockAuditStore) SaveCheckpoint(ctx context.Context, c audit.Checkpoint)
 func (m *mockAuditStore) LatestCheckpoint(ctx context.Context) (*audit.Checkpoint, error) {
 	return nil, nil
 }
-func (m *mockAuditStore) Close() error { return nil }
+func (m *mockAuditStore) ListIdentityLinks(ctx context.Context, principalUserID string) ([]audit.IdentityLink, error) {
+	if principalUserID == "" {
+		return m.identityLinks, nil
+	}
+	var out []audit.IdentityLink
+	for _, link := range m.identityLinks {
+		if link.PrincipalUserID == principalUserID {
+			out = append(out, link)
+		}
+	}
+	return out, nil
+}
+func (m *mockAuditStore) UpsertIdentityLink(ctx context.Context, link audit.IdentityLink) error {
+	m.identityLinks = append(m.identityLinks, link)
+	return nil
+}
+func (m *mockAuditStore) DeleteIdentityLink(ctx context.Context, id string) error { return nil }
+func (m *mockAuditStore) Close() error                                            { return nil }
 func (m *mockAuditStore) Dialect() dbutil.Dialect {
 	return dbutil.DialectSQLite
 }
@@ -121,6 +139,31 @@ func TestActivityService_QueryByUser(t *testing.T) {
 	require.Equal(t, "auth.login", capturedQuery.Action)
 }
 
+func TestActivityService_QueryPrincipal_ExpandsLinkedSubjects(t *testing.T) {
+	t.Parallel()
+	var gotQuery audit.Query
+	store := &mockAuditStore{
+		identityLinks: []audit.IdentityLink{
+			{PrincipalUserID: "u-local", Subject: "ou_feishu"},
+			{PrincipalUserID: "u-local", Subject: "U_slack"},
+			{PrincipalUserID: "other", Subject: "ignored"},
+		},
+		queryFn: func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error) {
+			gotQuery = q
+			return []audit.UserActivity{{ID: 1, UserID: "ou_feishu"}}, nil
+		},
+	}
+	svc := NewActivityService(store, slog.Default())
+
+	rows, resolved, err := svc.QueryPrincipal(context.Background(), "u-local", audit.Query{Action: audit.ActionMessageInbound})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, []string{"u-local", "ou_feishu", "U_slack"}, resolved)
+	require.Empty(t, gotQuery.UserID)
+	require.Equal(t, []string{"u-local", "ou_feishu", "U_slack"}, gotQuery.UserIDs)
+	require.Equal(t, audit.ActionMessageInbound, gotQuery.Action)
+}
+
 func TestActivityService_Query_StoreError(t *testing.T) {
 	t.Parallel()
 	store := &mockAuditStore{
@@ -150,7 +193,7 @@ func TestActivityService_Export_JSON(t *testing.T) {
 	data, contentType, err := svc.Export(context.Background(), audit.Query{}, "json", "admin-user")
 	require.NoError(t, err)
 	require.Equal(t, "application/json; charset=utf-8", contentType)
-	require.Contains(t, string(data), `"UserID": "u1"`)
+	require.Contains(t, string(data), `"user_id": "u1"`)
 }
 
 func TestActivityService_Export_CSV(t *testing.T) {

--- a/internal/admin/audit_service_test.go
+++ b/internal/admin/audit_service_test.go
@@ -19,6 +19,7 @@ import (
 // mockAuditStore implements audit.Store for ActivityService tests.
 type mockAuditStore struct {
 	queryFn       func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error)
+	statsFn       func(ctx context.Context, q audit.Query) (audit.ActivityStats, error)
 	identityLinks []audit.IdentityLink
 }
 
@@ -30,6 +31,12 @@ func (m *mockAuditStore) Query(ctx context.Context, q audit.Query) ([]audit.User
 		return m.queryFn(ctx, q)
 	}
 	return nil, nil
+}
+func (m *mockAuditStore) Stats(ctx context.Context, q audit.Query) (audit.ActivityStats, error) {
+	if m.statsFn != nil {
+		return m.statsFn(ctx, q)
+	}
+	return audit.ActivityStats{ByOutcome: map[string]int64{}, ByPlatform: map[string]int64{}}, nil
 }
 func (m *mockAuditStore) QueryAsc(ctx context.Context, fromID int64, limit int) ([]audit.UserActivity, error) {
 	return nil, nil // service tests don't exercise the verifier path
@@ -194,6 +201,58 @@ func TestActivityService_Export_JSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "application/json; charset=utf-8", contentType)
 	require.Contains(t, string(data), `"user_id": "u1"`)
+}
+
+func TestActivityService_Export_DefaultMasksPII(t *testing.T) {
+	t.Parallel()
+	store := &mockAuditStore{
+		queryFn: func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error) {
+			require.False(t, q.IncludePII)
+			return []audit.UserActivity{
+				{
+					ID:        1,
+					UserID:    "u1",
+					IP:        "192.168.1.100",
+					UserAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+				},
+			}, nil
+		},
+	}
+	svc := NewActivityService(store, slog.Default())
+
+	data, _, err := svc.Export(context.Background(), audit.Query{}, "json", "admin-user")
+	require.NoError(t, err)
+	var rows []audit.UserActivity
+	require.NoError(t, json.Unmarshal(data, &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, "192.168.1.0", rows[0].IP)
+	require.True(t, strings.HasSuffix(rows[0].UserAgent, "..."))
+}
+
+func TestActivityService_Export_IncludePII(t *testing.T) {
+	t.Parallel()
+	store := &mockAuditStore{
+		queryFn: func(ctx context.Context, q audit.Query) ([]audit.UserActivity, error) {
+			require.True(t, q.IncludePII)
+			return []audit.UserActivity{
+				{
+					ID:        1,
+					UserID:    "u1",
+					IP:        "192.168.1.100",
+					UserAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+				},
+			}, nil
+		},
+	}
+	svc := NewActivityService(store, slog.Default())
+
+	data, _, err := svc.Export(context.Background(), audit.Query{IncludePII: true}, "json", "admin-user")
+	require.NoError(t, err)
+	var rows []audit.UserActivity
+	require.NoError(t, json.Unmarshal(data, &rows))
+	require.Len(t, rows, 1)
+	require.Equal(t, "192.168.1.100", rows[0].IP)
+	require.Contains(t, rows[0].UserAgent, "Chrome/120.0.0.0")
 }
 
 func TestActivityService_Export_CSV(t *testing.T) {

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -28,6 +28,7 @@ const AuditAdvisoryLockKey int64 = 819207
 // Query holds the by-user activity search parameters.
 type Query struct {
 	UserID     string
+	UserIDs    []string
 	Action     string
 	Outcome    string
 	From       time.Time
@@ -49,6 +50,9 @@ type Store interface {
 	DeleteBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	SaveCheckpoint(ctx context.Context, c Checkpoint) error
 	LatestCheckpoint(ctx context.Context) (*Checkpoint, error)
+	ListIdentityLinks(ctx context.Context, principalUserID string) ([]IdentityLink, error)
+	UpsertIdentityLink(ctx context.Context, link IdentityLink) error
+	DeleteIdentityLink(ctx context.Context, id string) error
 	Close() error
 	Dialect() dbutil.Dialect
 }
@@ -126,7 +130,7 @@ func queryAsc(db *sql.DB, d dbutil.Dialect, ctx context.Context, fromID int64, l
 		if err := rows.Scan(
 			&ua.ID, &ua.Ts, &ua.UserID, &ua.UserIDType, &ua.Platform,
 			&sessionID, &ua.Action, &resourceType, &resourceID,
-			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &ua.UserAgent,
+			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &userAgent,
 			&ua.PrevHash, &ua.SelfHash,
 		); err != nil {
 			return nil, fmt.Errorf("audit: query_asc scan: %w", err)
@@ -182,9 +186,15 @@ func (s *sqliteStore) BeginTx(ctx context.Context) (Tx, error) {
 func (s *sqliteStore) Query(ctx context.Context, q Query) ([]UserActivity, error) {
 	var conditions []string
 	var args []any
-	if q.UserID != "" {
+	userIDs := normalizedUserIDs(q)
+	if len(userIDs) == 1 {
 		conditions = append(conditions, "user_id = ?")
-		args = append(args, q.UserID)
+		args = append(args, userIDs[0])
+	} else if len(userIDs) > 1 {
+		conditions = append(conditions, "user_id IN ("+strings.TrimRight(strings.Repeat("?,", len(userIDs)), ",")+")")
+		for _, id := range userIDs {
+			args = append(args, id)
+		}
 	}
 	if q.Action != "" {
 		conditions = append(conditions, "action = ?")
@@ -240,7 +250,7 @@ func (s *sqliteStore) Query(ctx context.Context, q Query) ([]UserActivity, error
 		if err := rows.Scan(
 			&ua.ID, &ua.Ts, &ua.UserID, &ua.UserIDType, &ua.Platform,
 			&sessionID, &ua.Action, &resourceType, &resourceID,
-			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &ua.UserAgent,
+			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &userAgent,
 			&ua.PrevHash, &ua.SelfHash,
 		); err != nil {
 			return nil, fmt.Errorf("audit: scan: %w", err)
@@ -254,6 +264,91 @@ func (s *sqliteStore) Query(ctx context.Context, q Query) ([]UserActivity, error
 		results = append(results, ua)
 	}
 	return results, rows.Err()
+}
+
+func normalizedUserIDs(q Query) []string {
+	seen := make(map[string]struct{}, len(q.UserIDs)+1)
+	var out []string
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	add(q.UserID)
+	for _, v := range q.UserIDs {
+		add(v)
+	}
+	return out
+}
+
+func listIdentityLinks(db *sql.DB, d dbutil.Dialect, ctx context.Context, principalUserID string) ([]IdentityLink, error) {
+	var conditions []string
+	var args []any
+	if strings.TrimSpace(principalUserID) != "" {
+		conditions = append(conditions, "principal_user_id = ?")
+		args = append(args, strings.TrimSpace(principalUserID))
+	}
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+	rows, err := db.QueryContext(ctx, d.Rebind(
+		"SELECT id, principal_user_id, provider, subject, subject_type, display_name, email, created_at, updated_at "+
+			"FROM audit_identity_links"+where+" ORDER BY provider, subject"), args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit: list identity links: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	links := make([]IdentityLink, 0)
+	for rows.Next() {
+		var l IdentityLink
+		if err := rows.Scan(&l.ID, &l.PrincipalUserID, &l.Provider, &l.Subject, &l.SubjectType, &l.DisplayName, &l.Email, &l.CreatedAt, &l.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("audit: scan identity link: %w", err)
+		}
+		links = append(links, l)
+	}
+	return links, rows.Err()
+}
+
+func (s *sqliteStore) ListIdentityLinks(ctx context.Context, principalUserID string) ([]IdentityLink, error) {
+	return listIdentityLinks(s.db, s.d, ctx, principalUserID)
+}
+
+func (s *sqliteStore) UpsertIdentityLink(ctx context.Context, link IdentityLink) error {
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, s.d.Rebind(`
+INSERT INTO audit_identity_links
+    (id, principal_user_id, provider, subject, subject_type, display_name, email, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(provider, subject) DO UPDATE SET
+    principal_user_id = excluded.principal_user_id,
+    subject_type = excluded.subject_type,
+    display_name = excluded.display_name,
+    email = excluded.email,
+    updated_at = excluded.updated_at`),
+			link.ID, link.PrincipalUserID, link.Provider, link.Subject, link.SubjectType,
+			link.DisplayName, link.Email, link.CreatedAt, link.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("audit: upsert identity link: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *sqliteStore) DeleteIdentityLink(ctx context.Context, id string) error {
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, s.d.Rebind("DELETE FROM audit_identity_links WHERE id = ?"), id)
+		if err != nil {
+			return fmt.Errorf("audit: delete identity link: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *sqliteStore) QueryAsc(ctx context.Context, fromID int64, limit int) ([]UserActivity, error) {
@@ -479,9 +574,15 @@ func (s *pgStore) Query(ctx context.Context, q Query) ([]UserActivity, error) {
 	// Same logic as SQLite — Rebind handles placeholder conversion.
 	var conditions []string
 	var args []any
-	if q.UserID != "" {
+	userIDs := normalizedUserIDs(q)
+	if len(userIDs) == 1 {
 		conditions = append(conditions, "user_id = ?")
-		args = append(args, q.UserID)
+		args = append(args, userIDs[0])
+	} else if len(userIDs) > 1 {
+		conditions = append(conditions, "user_id IN ("+strings.TrimRight(strings.Repeat("?,", len(userIDs)), ",")+")")
+		for _, id := range userIDs {
+			args = append(args, id)
+		}
 	}
 	if q.Action != "" {
 		conditions = append(conditions, "action = ?")
@@ -537,7 +638,7 @@ func (s *pgStore) Query(ctx context.Context, q Query) ([]UserActivity, error) {
 		if err := rows.Scan(
 			&ua.ID, &ua.Ts, &ua.UserID, &ua.UserIDType, &ua.Platform,
 			&sessionID, &ua.Action, &resourceType, &resourceID,
-			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &ua.UserAgent,
+			&ua.Outcome, &ua.DetailJSON, &eventRef, &ip, &userAgent,
 			&ua.PrevHash, &ua.SelfHash,
 		); err != nil {
 			return nil, fmt.Errorf("audit: pg scan: %w", err)
@@ -590,6 +691,37 @@ func (s *pgStore) LatestCheckpoint(ctx context.Context) (*Checkpoint, error) {
 	}
 	c.PrunedAt = time.UnixMilli(prunedAtMs)
 	return &c, nil
+}
+
+func (s *pgStore) ListIdentityLinks(ctx context.Context, principalUserID string) ([]IdentityLink, error) {
+	return listIdentityLinks(s.db, s.d, ctx, principalUserID)
+}
+
+func (s *pgStore) UpsertIdentityLink(ctx context.Context, link IdentityLink) error {
+	_, err := s.db.ExecContext(ctx, s.d.Rebind(`
+INSERT INTO audit_identity_links
+    (id, principal_user_id, provider, subject, subject_type, display_name, email, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(provider, subject) DO UPDATE SET
+    principal_user_id = excluded.principal_user_id,
+    subject_type = excluded.subject_type,
+    display_name = excluded.display_name,
+    email = excluded.email,
+    updated_at = excluded.updated_at`),
+		link.ID, link.PrincipalUserID, link.Provider, link.Subject, link.SubjectType,
+		link.DisplayName, link.Email, link.CreatedAt, link.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("audit: pg upsert identity link: %w", err)
+	}
+	return nil
+}
+
+func (s *pgStore) DeleteIdentityLink(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, s.d.Rebind("DELETE FROM audit_identity_links WHERE id = ?"), id)
+	if err != nil {
+		return fmt.Errorf("audit: pg delete identity link: %w", err)
+	}
+	return nil
 }
 
 func (s *pgStore) Close() error { return s.db.Close() }

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -27,21 +27,35 @@ const AuditAdvisoryLockKey int64 = 819207
 
 // Query holds the by-user activity search parameters.
 type Query struct {
-	UserID     string
-	UserIDs    []string
-	Action     string
-	Outcome    string
-	From       time.Time
-	To         time.Time
-	Limit      int
-	Offset     int
-	IncludePII bool
+	UserID       string
+	UserIDs      []string
+	Action       string
+	ActionPrefix string // match action by prefix (e.g. "tool." → all tool.*)
+	Outcome      string
+	Platform     string // exact platform match (webchat/feishu/slack/admin/api/cron)
+	SessionID    string // exact session_id match
+	ResourceType string // exact resource_type match (session/tool/bot/...)
+	From         time.Time
+	To           time.Time
+	Limit        int
+	Offset       int
+	IncludePII   bool
+}
+
+// ActivityStats holds aggregate counts for the activity timeline overview.
+// All counts are scoped by the same Query filters used by Query(); they reflect
+// the full filtered set (not just the current page).
+type ActivityStats struct {
+	Total      int64            `json:"total"`
+	ByOutcome  map[string]int64 `json:"by_outcome"`
+	ByPlatform map[string]int64 `json:"by_platform"`
 }
 
 // Store is the abstract audit storage layer.
 type Store interface {
 	BeginTx(ctx context.Context) (Tx, error)
 	Query(ctx context.Context, q Query) ([]UserActivity, error)
+	Stats(ctx context.Context, q Query) (ActivityStats, error)
 	// QueryAsc returns rows in ascending id order starting at FromID
 	// (inclusive). Used by the verifier to stream the chain without
 	// loading the whole table into memory (spec §5.5 chain verification).
@@ -184,39 +198,7 @@ func (s *sqliteStore) BeginTx(ctx context.Context) (Tx, error) {
 }
 
 func (s *sqliteStore) Query(ctx context.Context, q Query) ([]UserActivity, error) {
-	var conditions []string
-	var args []any
-	userIDs := normalizedUserIDs(q)
-	if len(userIDs) == 1 {
-		conditions = append(conditions, "user_id = ?")
-		args = append(args, userIDs[0])
-	} else if len(userIDs) > 1 {
-		conditions = append(conditions, "user_id IN ("+strings.TrimRight(strings.Repeat("?,", len(userIDs)), ",")+")")
-		for _, id := range userIDs {
-			args = append(args, id)
-		}
-	}
-	if q.Action != "" {
-		conditions = append(conditions, "action = ?")
-		args = append(args, q.Action)
-	}
-	if q.Outcome != "" {
-		conditions = append(conditions, "outcome = ?")
-		args = append(args, q.Outcome)
-	}
-	if !q.From.IsZero() {
-		conditions = append(conditions, "ts >= ?")
-		args = append(args, q.From.UnixMilli())
-	}
-	if !q.To.IsZero() {
-		conditions = append(conditions, "ts <= ?")
-		args = append(args, q.To.UnixMilli())
-	}
-
-	where := ""
-	if len(conditions) > 0 {
-		where = " WHERE " + strings.Join(conditions, " AND ")
-	}
+	where, args := buildActivityWhere(q)
 
 	limit := q.Limit
 	if limit <= 0 {
@@ -287,6 +269,69 @@ func normalizedUserIDs(q Query) []string {
 	return out
 }
 
+// buildActivityWhere constructs the WHERE clause and parameter args shared by
+// Query and Stats. Placeholders are dialect-agnostic (?) — callers pass the
+// resulting SQL through Rebind for $N conversion on PostgreSQL. Returns ("", nil)
+// when q has no effective filters (matches all rows).
+//
+// ActionPrefix uses LIKE with ESCAPE so that literal %/_ in the prefix (rare —
+// action tokens use only [a-z.]) are matched verbatim instead of as wildcards.
+func buildActivityWhere(q Query) (string, []any) {
+	var conditions []string
+	var args []any
+	userIDs := normalizedUserIDs(q)
+	if len(userIDs) == 1 {
+		conditions = append(conditions, "user_id = ?")
+		args = append(args, userIDs[0])
+	} else if len(userIDs) > 1 {
+		conditions = append(conditions, "user_id IN ("+strings.TrimRight(strings.Repeat("?,", len(userIDs)), ",")+")")
+		for _, id := range userIDs {
+			args = append(args, id)
+		}
+	}
+	if q.Action != "" {
+		conditions = append(conditions, "action = ?")
+		args = append(args, q.Action)
+	}
+	if q.ActionPrefix != "" {
+		// Escape LIKE metacharacters so the prefix matches literally before
+		// appending the trailing wildcard. Backslash is the ESCAPE char.
+		esc := strings.NewReplacer("\\", "\\\\", "%", "\\%", "_", "\\_").Replace(q.ActionPrefix)
+		conditions = append(conditions, "action LIKE ? ESCAPE '\\'")
+		args = append(args, esc+"%")
+	}
+	if q.Outcome != "" {
+		conditions = append(conditions, "outcome = ?")
+		args = append(args, q.Outcome)
+	}
+	if q.Platform != "" {
+		conditions = append(conditions, "platform = ?")
+		args = append(args, q.Platform)
+	}
+	if q.SessionID != "" {
+		conditions = append(conditions, "session_id = ?")
+		args = append(args, q.SessionID)
+	}
+	if q.ResourceType != "" {
+		conditions = append(conditions, "resource_type = ?")
+		args = append(args, q.ResourceType)
+	}
+	if !q.From.IsZero() {
+		conditions = append(conditions, "ts >= ?")
+		args = append(args, q.From.UnixMilli())
+	}
+	if !q.To.IsZero() {
+		conditions = append(conditions, "ts <= ?")
+		args = append(args, q.To.UnixMilli())
+	}
+
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+	return where, args
+}
+
 func listIdentityLinks(db *sql.DB, d dbutil.Dialect, ctx context.Context, principalUserID string) ([]IdentityLink, error) {
 	var conditions []string
 	var args []any
@@ -327,10 +372,12 @@ INSERT INTO audit_identity_links
     (id, principal_user_id, provider, subject, subject_type, display_name, email, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(provider, subject) DO UPDATE SET
+    id = excluded.id,
     principal_user_id = excluded.principal_user_id,
     subject_type = excluded.subject_type,
     display_name = excluded.display_name,
     email = excluded.email,
+    created_at = excluded.created_at,
     updated_at = excluded.updated_at`),
 			link.ID, link.PrincipalUserID, link.Provider, link.Subject, link.SubjectType,
 			link.DisplayName, link.Email, link.CreatedAt, link.UpdatedAt)
@@ -398,6 +445,77 @@ func (s *sqliteStore) LatestCheckpoint(ctx context.Context) (*Checkpoint, error)
 }
 
 func (s *sqliteStore) Close() error { return s.db.Close() }
+
+func (s *sqliteStore) Stats(ctx context.Context, q Query) (ActivityStats, error) {
+	return activityStats(s.db, s.d, ctx, q)
+}
+
+// activityStats computes the ActivityStats aggregates (total + per-outcome +
+// per-platform) over the row set matched by q. Shared by sqliteStore and
+// pgStore — the WHERE clause and placeholder binding are identical to Query,
+// only the GROUP BY dimension differs. Two SQL round-trips (outcome, platform)
+// keep each query simple and index-friendly; a third COUNT(*) provides total.
+// The filters in q are applied to every sub-query so the stats reflect the
+// exact same scoped set the timeline displays.
+func activityStats(db queryExecContext, d dbutil.Dialect, ctx context.Context, q Query) (ActivityStats, error) {
+	where, args := buildActivityWhere(q)
+	stats := ActivityStats{
+		ByOutcome:  make(map[string]int64),
+		ByPlatform: make(map[string]int64),
+	}
+
+	// Total count (scoped).
+	countSQL := d.Rebind("SELECT COUNT(*) FROM user_activity" + where)
+	var total int64
+	if err := db.QueryRowContext(ctx, countSQL, args...).Scan(&total); err != nil {
+		return stats, fmt.Errorf("audit: stats total: %w", err)
+	}
+	stats.Total = total
+
+	// Per-outcome breakdown.
+	outcomeSQL := d.Rebind("SELECT outcome, COUNT(*) FROM user_activity" + where + " GROUP BY outcome")
+	orows, err := db.QueryContext(ctx, outcomeSQL, args...)
+	if err != nil {
+		return stats, fmt.Errorf("audit: stats by outcome: %w", err)
+	}
+	for k, v := range scanGroupCounts(orows) {
+		stats.ByOutcome[k] = v
+	}
+
+	// Per-platform breakdown.
+	platformSQL := d.Rebind("SELECT platform, COUNT(*) FROM user_activity" + where + " GROUP BY platform")
+	prows, err := db.QueryContext(ctx, platformSQL, args...)
+	if err != nil {
+		return stats, fmt.Errorf("audit: stats by platform: %w", err)
+	}
+	for k, v := range scanGroupCounts(prows) {
+		stats.ByPlatform[k] = v
+	}
+	return stats, nil
+}
+
+// queryExecContext is the subset of *sql.DB used by activityStats, extracted so
+// the function works against any sqlbinder (currently *sql.DB on both stores).
+type queryExecContext interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// scanGroupCounts drains a two-column (key TEXT, count INTEGER) result set into
+// a map and closes the rows. Returns an empty map for an empty result set.
+func scanGroupCounts(rows *sql.Rows) map[string]int64 {
+	out := make(map[string]int64)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var key string
+		var n int64
+		if err := rows.Scan(&key, &n); err != nil {
+			continue
+		}
+		out[key] = n
+	}
+	return out
+}
 
 // sqliteTx implements Tx for SQLite. The store's writeMu is acquired in
 // BeginTx and held until Commit or Rollback releases it (exactly once, via
@@ -572,39 +690,7 @@ func (s *pgStore) BeginTx(ctx context.Context) (Tx, error) {
 
 func (s *pgStore) Query(ctx context.Context, q Query) ([]UserActivity, error) {
 	// Same logic as SQLite — Rebind handles placeholder conversion.
-	var conditions []string
-	var args []any
-	userIDs := normalizedUserIDs(q)
-	if len(userIDs) == 1 {
-		conditions = append(conditions, "user_id = ?")
-		args = append(args, userIDs[0])
-	} else if len(userIDs) > 1 {
-		conditions = append(conditions, "user_id IN ("+strings.TrimRight(strings.Repeat("?,", len(userIDs)), ",")+")")
-		for _, id := range userIDs {
-			args = append(args, id)
-		}
-	}
-	if q.Action != "" {
-		conditions = append(conditions, "action = ?")
-		args = append(args, q.Action)
-	}
-	if q.Outcome != "" {
-		conditions = append(conditions, "outcome = ?")
-		args = append(args, q.Outcome)
-	}
-	if !q.From.IsZero() {
-		conditions = append(conditions, "ts >= ?")
-		args = append(args, q.From.UnixMilli())
-	}
-	if !q.To.IsZero() {
-		conditions = append(conditions, "ts <= ?")
-		args = append(args, q.To.UnixMilli())
-	}
-
-	where := ""
-	if len(conditions) > 0 {
-		where = " WHERE " + strings.Join(conditions, " AND ")
-	}
+	where, args := buildActivityWhere(q)
 
 	limit := q.Limit
 	if limit <= 0 {
@@ -703,10 +789,12 @@ INSERT INTO audit_identity_links
     (id, principal_user_id, provider, subject, subject_type, display_name, email, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(provider, subject) DO UPDATE SET
+    id = excluded.id,
     principal_user_id = excluded.principal_user_id,
     subject_type = excluded.subject_type,
     display_name = excluded.display_name,
     email = excluded.email,
+    created_at = excluded.created_at,
     updated_at = excluded.updated_at`),
 		link.ID, link.PrincipalUserID, link.Provider, link.Subject, link.SubjectType,
 		link.DisplayName, link.Email, link.CreatedAt, link.UpdatedAt)
@@ -725,6 +813,10 @@ func (s *pgStore) DeleteIdentityLink(ctx context.Context, id string) error {
 }
 
 func (s *pgStore) Close() error { return s.db.Close() }
+
+func (s *pgStore) Stats(ctx context.Context, q Query) (ActivityStats, error) {
+	return activityStats(s.db, s.d, ctx, q)
+}
 
 // pgTx implements Tx for PostgreSQL with advisory lock serialization.
 type pgTx struct {

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -252,6 +252,98 @@ func TestSQLiteStore_Query_Filters(t *testing.T) {
 	require.Len(t, res, 5)
 }
 
+func TestSQLiteStore_Query_ExtendedFilters(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	// Seed rows that exercise the new filter dimensions. tool.call carries a
+	// session_id + resource_type so it is matchable by both; auth.login has
+	// no session/resource and serves as the negative-match control.
+	rows := []*UserActivity{
+		{Ts: 1000, UserID: "u1", UserIDType: UserIDTypePlatform, Platform: PlatformFeishu, Action: ActionToolCall, Outcome: OutcomeSuccess, SessionID: "sess-a", ResourceType: "tool", ResourceID: "call-1", DetailJSON: `{}`, PrevHash: "", SelfHash: "h1"},
+		{Ts: 2000, UserID: "u1", UserIDType: UserIDTypePlatform, Platform: PlatformFeishu, Action: ActionToolCall, Outcome: OutcomeSuccess, SessionID: "sess-a", ResourceType: "tool", ResourceID: "call-2", DetailJSON: `{}`, PrevHash: "h1", SelfHash: "h2"},
+		{Ts: 3000, UserID: "u2", UserIDType: UserIDTypeRegistered, Platform: PlatformWebChat, Action: ActionToolCall, Outcome: OutcomeFailure, SessionID: "sess-b", ResourceType: "tool", ResourceID: "call-3", DetailJSON: `{}`, PrevHash: "h2", SelfHash: "h3"},
+		{Ts: 4000, UserID: "u2", UserIDType: UserIDTypeRegistered, Platform: PlatformWebChat, Action: ActionSessionCreate, Outcome: OutcomeSuccess, SessionID: "sess-b", ResourceType: "session", ResourceID: "sess-b", DetailJSON: `{}`, PrevHash: "h3", SelfHash: "h4"},
+		{Ts: 5000, UserID: "u3", UserIDType: UserIDTypeAnonymous, Platform: PlatformAPI, Action: ActionAuthLogin, Outcome: OutcomeSuccess, DetailJSON: `{}`, PrevHash: "h4", SelfHash: "h5"},
+		{Ts: 6000, UserID: "u3", UserIDType: UserIDTypeAnonymous, Platform: PlatformAPI, Action: ActionAuthTokenValidated, Outcome: OutcomeSuccess, DetailJSON: `{}`, PrevHash: "h5", SelfHash: "h6"},
+	}
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.AppendBatch(ctx, rows))
+	require.NoError(t, tx.Commit())
+
+	cases := []struct {
+		name    string
+		q       Query
+		wantIDs []int64 // by SelfHash suffix for readability
+		wantCnt int
+	}{
+		{name: "platform feishu", q: Query{Platform: PlatformFeishu}, wantCnt: 2},
+		{name: "platform webchat", q: Query{Platform: PlatformWebChat}, wantCnt: 2},
+		{name: "session_id exact", q: Query{SessionID: "sess-a"}, wantCnt: 2},
+		{name: "resource_type tool", q: Query{ResourceType: "tool"}, wantCnt: 3},
+		{name: "resource_type session", q: Query{ResourceType: "session"}, wantCnt: 1},
+		{name: "action_prefix tool.", q: Query{ActionPrefix: "tool."}, wantCnt: 3},
+		{name: "action_prefix auth.", q: Query{ActionPrefix: "auth."}, wantCnt: 2},
+		// Prefix literal safety: "auth.login" must not match via wildcard "_" .
+		{name: "action_prefix literal underscore", q: Query{ActionPrefix: "auth_login"}, wantCnt: 0},
+		// Composed filters.
+		{name: "platform+action_prefix", q: Query{Platform: PlatformWebChat, ActionPrefix: "tool."}, wantCnt: 1},
+		{name: "session+resource_type", q: Query{SessionID: "sess-b", ResourceType: "tool"}, wantCnt: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := store.Query(ctx, tc.q)
+			require.NoError(t, err)
+			require.Len(t, res, tc.wantCnt, "query=%+v", tc.q)
+		})
+	}
+}
+
+func TestSQLiteStore_Stats(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	rows := []*UserActivity{
+		{Ts: 1000, UserID: "u1", UserIDType: UserIDTypePlatform, Platform: PlatformFeishu, Action: ActionAuthLogin, Outcome: OutcomeSuccess, DetailJSON: `{}`, PrevHash: "", SelfHash: "h1"},
+		{Ts: 2000, UserID: "u1", UserIDType: UserIDTypePlatform, Platform: PlatformFeishu, Action: ActionToolCall, Outcome: OutcomeSuccess, DetailJSON: `{}`, PrevHash: "h1", SelfHash: "h2"},
+		{Ts: 3000, UserID: "u2", UserIDType: UserIDTypeRegistered, Platform: PlatformWebChat, Action: ActionToolCall, Outcome: OutcomeFailure, DetailJSON: `{}`, PrevHash: "h2", SelfHash: "h3"},
+		{Ts: 4000, UserID: "u2", UserIDType: UserIDTypeRegistered, Platform: PlatformWebChat, Action: ActionAuthLogin, Outcome: OutcomeDenied, DetailJSON: `{}`, PrevHash: "h3", SelfHash: "h4"},
+	}
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.AppendBatch(ctx, rows))
+	require.NoError(t, tx.Commit())
+
+	// Unscoped stats: total=4, outcome {success:2, failure:1, denied:1}, platform {feishu:2, webchat:2}.
+	stats, err := store.Stats(ctx, Query{})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), stats.Total)
+	require.Equal(t, int64(2), stats.ByOutcome[OutcomeSuccess])
+	require.Equal(t, int64(1), stats.ByOutcome[OutcomeFailure])
+	require.Equal(t, int64(1), stats.ByOutcome[OutcomeDenied])
+	require.Equal(t, int64(2), stats.ByPlatform[PlatformFeishu])
+	require.Equal(t, int64(2), stats.ByPlatform[PlatformWebChat])
+
+	// Scoped stats: only tool.call → total=2, failure=1.
+	stats, err = store.Stats(ctx, Query{ActionPrefix: "tool."})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), stats.Total)
+	require.Equal(t, int64(1), stats.ByOutcome[OutcomeSuccess])
+	require.Equal(t, int64(1), stats.ByOutcome[OutcomeFailure])
+	require.Equal(t, int64(2), stats.ByPlatform[PlatformFeishu]+stats.ByPlatform[PlatformWebChat])
+
+	// Empty table scoped to impossible filter returns zero counts, not nil maps.
+	stats, err = store.Stats(ctx, Query{Platform: "nope"})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), stats.Total)
+	require.NotNil(t, stats.ByOutcome)
+	require.NotNil(t, stats.ByPlatform)
+}
+
 func TestSQLiteStore_DeleteBefore(t *testing.T) {
 	t.Parallel()
 	store := newTestSQLiteStore(t)
@@ -461,9 +553,10 @@ func TestSQLiteStore_IdentityLinks_CRUD(t *testing.T) {
 	require.Len(t, links, 1)
 	require.Equal(t, "ou_feishu", links[0].Subject)
 
-	link.ID = "ignored-on-conflict"
+	link.ID = "link-2"
 	link.PrincipalUserID = "u-other"
 	link.DisplayName = "Moved"
+	link.CreatedAt = 2000
 	link.UpdatedAt = 2000
 	require.NoError(t, store.UpsertIdentityLink(ctx, link))
 
@@ -473,7 +566,9 @@ func TestSQLiteStore_IdentityLinks_CRUD(t *testing.T) {
 	links, err = store.ListIdentityLinks(ctx, "u-other")
 	require.NoError(t, err)
 	require.Len(t, links, 1)
+	require.Equal(t, "link-2", links[0].ID)
 	require.Equal(t, "Moved", links[0].DisplayName)
+	require.Equal(t, int64(2000), links[0].CreatedAt)
 
 	require.NoError(t, store.DeleteIdentityLink(ctx, links[0].ID))
 	links, err = store.ListIdentityLinks(ctx, "u-other")

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -40,6 +40,20 @@ CREATE TABLE IF NOT EXISTS audit_chain_checkpoints (
     last_self_hash  TEXT    NOT NULL,
     next_id         INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS audit_identity_links (
+    id                TEXT PRIMARY KEY,
+    principal_user_id TEXT NOT NULL,
+    provider          TEXT NOT NULL,
+    subject           TEXT NOT NULL,
+    subject_type      TEXT NOT NULL DEFAULT 'platform',
+    display_name      TEXT NOT NULL DEFAULT '',
+    email             TEXT NOT NULL DEFAULT '',
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER NOT NULL,
+    UNIQUE(provider, subject)
+);
+CREATE INDEX idx_audit_identity_links_principal ON audit_identity_links(principal_user_id);
+CREATE INDEX idx_audit_identity_links_lookup ON audit_identity_links(provider, subject);
 `
 
 // newTestSQLiteStore creates a fresh SQLite-backed Store in t.TempDir().
@@ -387,4 +401,82 @@ func TestSQLiteStore_AppendAfterCommitErrors(t *testing.T) {
 	}
 	err = tx.Append(ctx, ua)
 	require.Error(t, err)
+}
+
+func TestSQLiteStore_Query_UserIDs(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+	for i, userID := range []string{"u-local", "ou_feishu", "U_slack", "other"} {
+		require.NoError(t, tx.Append(ctx, &UserActivity{
+			Ts:         int64(1000 + i),
+			UserID:     userID,
+			UserIDType: UserIDTypePlatform,
+			Platform:   PlatformFeishu,
+			Action:     ActionMessageInbound,
+			Outcome:    OutcomeSuccess,
+			DetailJSON: `{}`,
+			PrevHash:   "",
+			SelfHash:   "h",
+		}))
+	}
+	require.NoError(t, tx.Commit())
+
+	rows, err := store.Query(ctx, Query{UserIDs: []string{"u-local", "ou_feishu", "U_slack"}})
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	got := map[string]bool{}
+	for _, row := range rows {
+		got[row.UserID] = true
+	}
+	require.True(t, got["u-local"])
+	require.True(t, got["ou_feishu"])
+	require.True(t, got["U_slack"])
+	require.False(t, got["other"])
+}
+
+func TestSQLiteStore_IdentityLinks_CRUD(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	link := IdentityLink{
+		ID:              "link-1",
+		PrincipalUserID: "u-local",
+		Provider:        "feishu",
+		Subject:         "ou_feishu",
+		SubjectType:     UserIDTypePlatform,
+		DisplayName:     "Feishu User",
+		Email:           "user@example.com",
+		CreatedAt:       1000,
+		UpdatedAt:       1000,
+	}
+	require.NoError(t, store.UpsertIdentityLink(ctx, link))
+
+	links, err := store.ListIdentityLinks(ctx, "u-local")
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	require.Equal(t, "ou_feishu", links[0].Subject)
+
+	link.ID = "ignored-on-conflict"
+	link.PrincipalUserID = "u-other"
+	link.DisplayName = "Moved"
+	link.UpdatedAt = 2000
+	require.NoError(t, store.UpsertIdentityLink(ctx, link))
+
+	links, err = store.ListIdentityLinks(ctx, "u-local")
+	require.NoError(t, err)
+	require.Empty(t, links)
+	links, err = store.ListIdentityLinks(ctx, "u-other")
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	require.Equal(t, "Moved", links[0].DisplayName)
+
+	require.NoError(t, store.DeleteIdentityLink(ctx, links[0].ID))
+	links, err = store.ListIdentityLinks(ctx, "u-other")
+	require.NoError(t, err)
+	require.Empty(t, links)
 }

--- a/internal/audit/types.go
+++ b/internal/audit/types.go
@@ -55,22 +55,37 @@ const AnonymousUserID = "anonymous"
 // UserActivity is the row stored in the user_activity table.
 // Mirrors the 16-column schema in spec §5.1.
 type UserActivity struct {
-	ID           int64  // assigned by DB
-	Ts           int64  // Unix ms
-	UserID       string // NOT NULL
-	UserIDType   string // NOT NULL
-	Platform     string // NOT NULL
-	SessionID    string // empty for admin/api
-	Action       string // NOT NULL
-	ResourceType string // optional
-	ResourceID   string // optional
-	Outcome      string // NOT NULL: success/failure/denied
-	DetailJSON   string // NOT NULL: whitelisted fields per §5.9
-	EventRef     string // optional: events.id or turns.id
-	IP           string // optional
-	UserAgent    string // optional
-	PrevHash     string // NOT NULL: "" for genesis
-	SelfHash     string // NOT NULL: sha256(PrevHash || canonical(rest))
+	ID           int64  `json:"id"`            // assigned by DB
+	Ts           int64  `json:"ts"`            // Unix ms
+	UserID       string `json:"user_id"`       // NOT NULL
+	UserIDType   string `json:"user_id_type"`  // NOT NULL
+	Platform     string `json:"platform"`      // NOT NULL
+	SessionID    string `json:"session_id"`    // empty for admin/api
+	Action       string `json:"action"`        // NOT NULL
+	ResourceType string `json:"resource_type"` // optional
+	ResourceID   string `json:"resource_id"`   // optional
+	Outcome      string `json:"outcome"`       // NOT NULL: success/failure/denied
+	DetailJSON   string `json:"detail_json"`   // NOT NULL: whitelisted fields per §5.9
+	EventRef     string `json:"event_ref"`     // optional: events.id or turns.id
+	IP           string `json:"ip"`            // optional
+	UserAgent    string `json:"user_agent"`    // optional
+	PrevHash     string `json:"prev_hash"`     // NOT NULL: "" for genesis
+	SelfHash     string `json:"self_hash"`     // NOT NULL: sha256(PrevHash || canonical(rest))
+}
+
+// IdentityLink maps one immutable audit subject (provider + subject) to a
+// canonical principal user. Audit rows are never rewritten; queries expand a
+// principal into these linked native IDs.
+type IdentityLink struct {
+	ID              string `json:"id"`
+	PrincipalUserID string `json:"principal_user_id"`
+	Provider        string `json:"provider"`
+	Subject         string `json:"subject"`
+	SubjectType     string `json:"subject_type"`
+	DisplayName     string `json:"display_name"`
+	Email           string `json:"email"`
+	CreatedAt       int64  `json:"created_at"`
+	UpdatedAt       int64  `json:"updated_at"`
 }
 
 // Checkpoint is the rebase anchor written before pruning.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,17 @@ func (c *Config) Validate() []string {
 	if c.Log.Format != "" && c.Log.Format != "json" && c.Log.Format != "text" {
 		errs = append(errs, "log.format must be either 'json' or 'text'")
 	}
+	if c.Log.File.Enabled {
+		if c.Log.File.MaxSize < 0 {
+			errs = append(errs, "log.file.max_size must be non-negative")
+		}
+		if c.Log.File.MaxAge < 0 {
+			errs = append(errs, "log.file.max_age must be non-negative")
+		}
+		if c.Log.File.MaxBackups < 0 {
+			errs = append(errs, "log.file.max_backups must be non-negative")
+		}
+	}
 	// Exec mode was removed; force app-server mode.
 	if !c.Worker.CodexCLI.UseAppServer {
 		slog.Warn("config: codex_cli.use_app_server is deprecated, forcing app-server mode")
@@ -143,6 +154,11 @@ const DefaultConfigPath = "~/.hotplex/config.yaml"
 // It does not create the directory — callers should use ensureDir or rely on
 // the components that need the directory to create it on first use.
 func HotplexHome() string {
+	// HOTPLEX_HOME overrides the default location (primarily for tests and
+	// non-standard installs). Falls back to ~/.hotplex otherwise.
+	if h := os.Getenv("HOTPLEX_HOME"); h != "" {
+		return h
+	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return TempBaseDir()

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -121,6 +121,14 @@ func Default() *Config {
 		Log: LogConfig{
 			Level:  "info",
 			Format: "json",
+			File: LogFileConfig{
+				Enabled:    false, // default off: stderr-only (historical behavior)
+				MaxSize:    10,
+				MaxAge:     30,
+				MaxBackups: 100,
+				Compress:   true,
+				LocalTime:  true,
+			},
 		},
 		WebChat: WebChatConfig{
 			Addr:    "",

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -43,6 +43,13 @@ func Load(filePath string) (*Config, error) {
 	// Viper's AutomaticEnv only works during Unmarshal if keys are known.
 	_ = v.BindEnv("log.level")
 	_ = v.BindEnv("log.format")
+	_ = v.BindEnv("log.file.enabled")
+	_ = v.BindEnv("log.file.path")
+	_ = v.BindEnv("log.file.max_size")
+	_ = v.BindEnv("log.file.max_age")
+	_ = v.BindEnv("log.file.max_backups")
+	_ = v.BindEnv("log.file.compress")
+	_ = v.BindEnv("log.file.local_time")
 	_ = v.BindEnv("db.path")
 	_ = v.BindEnv("db.wal_mode")
 	_ = v.BindEnv("db.driver")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,18 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, "allowlist", cfg.Messaging.Feishu.GroupPolicy)
 	require.False(t, cfg.Messaging.Slack.Enabled)
 	require.False(t, cfg.Messaging.Feishu.Enabled)
+
+	// log.file defaults: disabled (preserves stderr-only behavior), with sane
+	// rotation params ready for opt-in.
+	require.Equal(t, "info", cfg.Log.Level)
+	require.Equal(t, "json", cfg.Log.Format)
+	require.False(t, cfg.Log.File.Enabled)
+	require.Empty(t, cfg.Log.File.Path) // empty → initLogging resolves default path
+	require.Equal(t, 10, cfg.Log.File.MaxSize)
+	require.Equal(t, 30, cfg.Log.File.MaxAge)
+	require.Equal(t, 100, cfg.Log.File.MaxBackups)
+	require.True(t, cfg.Log.File.Compress)
+	require.True(t, cfg.Log.File.LocalTime)
 }
 
 // TestDefaultPermissionMode: r3 (#804) — config.worker.default_permission_mode
@@ -174,6 +186,38 @@ func TestConfig_Validate(t *testing.T) {
 				return c
 			}(),
 			errCnt: 1,
+		},
+		{
+			name: "log.file disabled accepts negative rotation params (no-op)",
+			cfg: func() Config {
+				c := *Default()
+				c.Log.File.Enabled = false
+				c.Log.File.MaxSize = -1
+				return c
+			}(),
+			errCnt: 0,
+		},
+		{
+			name: "log.file enabled with negative max_size",
+			cfg: func() Config {
+				c := *Default()
+				c.Log.File.Enabled = true
+				c.Log.File.MaxSize = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+		{
+			name: "log.file enabled with multiple negative params",
+			cfg: func() Config {
+				c := *Default()
+				c.Log.File.Enabled = true
+				c.Log.File.MaxSize = -1
+				c.Log.File.MaxAge = -1
+				c.Log.File.MaxBackups = -1
+				return c
+			}(),
+			errCnt: 3,
 		},
 		{
 			name: "multiple errors",

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -294,8 +294,23 @@ type AdminConfig struct {
 
 // LogConfig holds logging settings.
 type LogConfig struct {
-	Level  string `mapstructure:"level"`
-	Format string `mapstructure:"format"` // "json" or "text"
+	Level  string        `mapstructure:"level"`
+	Format string        `mapstructure:"format"` // "json" or "text"
+	File   LogFileConfig `mapstructure:"file"`
+}
+
+// LogFileConfig holds file logging + rotation settings.
+// Enabled=false (default) keeps historical behavior: logs go to stderr only.
+// When Enabled=true, logs are teed to both the file (rotated via lumberjack)
+// and stderr, so daemon-mode stderr redirection and foreground debugging still work.
+type LogFileConfig struct {
+	Enabled    bool   `mapstructure:"enabled"`
+	Path       string `mapstructure:"path"`        // empty → default ~/.hotplex/logs/gateway.log
+	MaxSize    int    `mapstructure:"max_size"`    // MB per file before rotation; 0 → lumberjack default
+	MaxAge     int    `mapstructure:"max_age"`     // days to retain rotated logs
+	MaxBackups int    `mapstructure:"max_backups"` // number of rotated backups to keep
+	Compress   bool   `mapstructure:"compress"`    // gzip rotated backups
+	LocalTime  bool   `mapstructure:"local_time"`  // use local time for rotation filenames
 }
 
 // WebChatConfig holds webchat UI serving settings.

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -47,6 +47,13 @@ var staticFields = map[string]bool{
 	"gateway.read_buffer_size":     true,
 	"gateway.write_buffer_size":    true,
 	"log.format":                   true,
+	"log.file.enabled":             true, // lumberjack writer cannot be safely rebuilt at runtime
+	"log.file.path":                true,
+	"log.file.max_size":            true,
+	"log.file.max_age":             true,
+	"log.file.max_backups":         true,
+	"log.file.compress":            true,
+	"log.file.local_time":          true,
 	"security.tls_enabled":         true,
 	"security.tls_cert_file":       true,
 	"security.tls_key_file":        true,

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -126,6 +126,25 @@ func TestDiffConfigs_FullContentRetentionRequiresRestart(t *testing.T) {
 	require.False(t, changes[0].Hot)
 }
 
+// TestDiffConfigs_LogFileRequiresRestart locks in that log.file.* fields are
+// static: changing the rotation sink at runtime cannot rebuild the lumberjack
+// writer safely, so a restart is required.
+func TestDiffConfigs_LogFileRequiresRestart(t *testing.T) {
+	t.Parallel()
+	prev := Default()
+	next := Default()
+	next.Log.File.Enabled = true
+	next.Log.File.Path = "/var/log/hotplex/gateway.log"
+	next.Log.File.MaxSize = 50
+
+	changes := diffConfigs(prev, next)
+	// All three changed fields must be reported as static (Hot=false).
+	require.Len(t, changes, 3)
+	for _, c := range changes {
+		require.False(t, c.Hot, "field %s should require restart", c.Field)
+	}
+}
+
 func TestWatcher_Rollback_Triggers_Store(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -313,14 +313,15 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 
 // extractTurnContent extracts message/reasoning content for turn tracking.
 func (b *Bridge) extractTurnContent(env *events.Envelope, fc *forwardContext) (deltaContent, reasoningContent string) {
-	if env.Event.Type == events.MessageDelta || env.Event.Type == events.Message {
+	switch env.Event.Type {
+	case events.MessageDelta, events.Message:
 		if content := extractMessageContent(env); content != "" {
 			fc.turnText.WriteString(content)
 			if env.Event.Type == events.MessageDelta {
 				deltaContent = content
 			}
 		}
-	} else if env.Event.Type == events.Reasoning {
+	case events.Reasoning:
 		reasoningContent = extractReasoningContent(env)
 	}
 	return

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -60,12 +61,19 @@ func (h *Handler) SetAuditCollector(ac *audit.Collector) {
 }
 
 // emitAudit enqueues a non-blocking message.inbound audit event. No-op when collector is nil.
-func (h *Handler) emitAudit(outcome, userID, platform, sessionID string) {
+func (h *Handler) emitAudit(outcome, userID, platform, sessionID, content string) {
 	if h.auditCollector == nil {
 		return
 	}
 	if userID == "" {
 		userID = audit.AnonymousUserID
+	}
+	detailJSON := "{}"
+	if content != "" {
+		detail := map[string]any{"content": content}
+		if bytes, err := json.Marshal(detail); err == nil {
+			detailJSON = string(bytes)
+		}
 	}
 	_ = h.auditCollector.Enqueue(context.Background(), &audit.UserActivity{
 		Ts:         time.Now().UnixMilli(),
@@ -75,7 +83,7 @@ func (h *Handler) emitAudit(outcome, userID, platform, sessionID string) {
 		SessionID:  sessionID,
 		Action:     audit.ActionMessageInbound,
 		Outcome:    outcome,
-		DetailJSON: `{}`,
+		DetailJSON: detailJSON,
 	})
 }
 
@@ -242,7 +250,7 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 	si, err := h.sm.Get(ctx, env.SessionID)
 	if err != nil {
 		h.log.Warn("gateway: handleInput session not found", "session_id", env.SessionID, "err", err)
-		h.emitAudit(audit.OutcomeFailure, env.OwnerID, "", env.SessionID)
+		h.emitAudit(audit.OutcomeFailure, env.OwnerID, "", env.SessionID, content)
 		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "session not found")
 	}
 
@@ -256,21 +264,21 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 			resumeCancel()
 			if resumeErr != nil {
 				h.log.Warn("gateway: auto-resume failed", "session_id", env.SessionID, "err", resumeErr)
-				h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+				h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 				return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "session resume failed: %v", resumeErr)
 			}
 			prevPlatform := si.Platform
 			si, err = h.sm.Get(ctx, env.SessionID)
 			if err != nil {
-				h.emitAudit(audit.OutcomeFailure, env.OwnerID, prevPlatform, env.SessionID)
+				h.emitAudit(audit.OutcomeFailure, env.OwnerID, prevPlatform, env.SessionID, content)
 				return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "session not found after resume")
 			}
 			if !si.State.IsActive() {
-				h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+				h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 				return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session not active after resume: %s", si.State)
 			}
 		} else {
-			h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+			h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 			return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session not active: %s", si.State)
 		}
 	}
@@ -278,7 +286,7 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 	if si.State == events.StateIdle {
 		if err := h.sm.TransitionWithInput(ctx, env.SessionID, events.StateRunning, content, nil); err != nil {
 			h.log.Warn("gateway: handleInput transition failed", "session_id", env.SessionID, "err", err)
-			h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+			h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 			return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session busy: %v", err)
 		}
 	}
@@ -286,7 +294,7 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 	w := h.sm.GetWorker(env.SessionID)
 	if w == nil {
 		h.log.Warn("gateway: handleInput no worker found", "session_id", env.SessionID)
-		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "no worker attached to session")
 	}
 
@@ -298,6 +306,7 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		}
 		h.log.Debug("gateway: delivering input to worker", "session_id", env.SessionID, "content_len", len(content), "preview", preview)
 	}
+
 	if err := w.Input(ctx, content, nil); err != nil {
 		var we *worker.WorkerError
 		if errors.As(err, &we) && we.Kind == worker.ErrKindTimeout {
@@ -313,11 +322,11 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		if code == events.ErrCodeSessionTerminated && h.bridge != nil {
 			h.bridge.cleanupCrashedWorker(env.SessionID, w)
 		}
-		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID)
+		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 		return h.sendErrorf(ctx, env, code, "worker input failed: %v", err)
 	}
 	h.log.Debug("gateway: input delivered to worker", "session_id", env.SessionID)
-	h.emitAudit(audit.OutcomeSuccess, env.OwnerID, si.Platform, env.SessionID)
+	h.emitAudit(audit.OutcomeSuccess, env.OwnerID, si.Platform, env.SessionID, content)
 	if h.bridge != nil {
 		h.bridge.CaptureInbound(ctx, env.SessionID, env.Seq, events.Input, env.Event.Data, si.Platform, si.OwnerID)
 	}

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -851,6 +851,9 @@ func (mockAuditStore) BeginTx(_ context.Context) (audit.Tx, error) { return mock
 func (mockAuditStore) Query(_ context.Context, _ audit.Query) ([]audit.UserActivity, error) {
 	return nil, nil
 }
+func (mockAuditStore) Stats(_ context.Context, _ audit.Query) (audit.ActivityStats, error) {
+	return audit.ActivityStats{ByOutcome: map[string]int64{}, ByPlatform: map[string]int64{}}, nil
+}
 func (mockAuditStore) QueryAsc(_ context.Context, _ int64, _ int) ([]audit.UserActivity, error) {
 	return nil, nil // security tests don't exercise the verifier path
 }
@@ -907,6 +910,9 @@ func (s *capturingAuditStore) BeginTx(context.Context) (audit.Tx, error) {
 }
 func (s *capturingAuditStore) Query(context.Context, audit.Query) ([]audit.UserActivity, error) {
 	return nil, nil
+}
+func (s *capturingAuditStore) Stats(context.Context, audit.Query) (audit.ActivityStats, error) {
+	return audit.ActivityStats{ByOutcome: map[string]int64{}, ByPlatform: map[string]int64{}}, nil
 }
 func (s *capturingAuditStore) QueryAsc(context.Context, int64, int) ([]audit.UserActivity, error) {
 	return nil, nil

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -859,8 +859,13 @@ func (mockAuditStore) SaveCheckpoint(_ context.Context, _ audit.Checkpoint) erro
 func (mockAuditStore) LatestCheckpoint(_ context.Context) (*audit.Checkpoint, error) {
 	return nil, nil
 }
-func (mockAuditStore) Close() error            { return nil }
-func (mockAuditStore) Dialect() dbutil.Dialect { return dbutil.DialectSQLite }
+func (mockAuditStore) ListIdentityLinks(_ context.Context, _ string) ([]audit.IdentityLink, error) {
+	return nil, nil
+}
+func (mockAuditStore) UpsertIdentityLink(_ context.Context, _ audit.IdentityLink) error { return nil }
+func (mockAuditStore) DeleteIdentityLink(_ context.Context, _ string) error             { return nil }
+func (mockAuditStore) Close() error                                                     { return nil }
+func (mockAuditStore) Dialect() dbutil.Dialect                                          { return dbutil.DialectSQLite }
 
 type mockAuditTx struct{}
 
@@ -911,8 +916,15 @@ func (s *capturingAuditStore) SaveCheckpoint(context.Context, audit.Checkpoint) 
 func (s *capturingAuditStore) LatestCheckpoint(context.Context) (*audit.Checkpoint, error) {
 	return nil, nil
 }
-func (s *capturingAuditStore) Close() error            { return nil }
-func (s *capturingAuditStore) Dialect() dbutil.Dialect { return dbutil.DialectSQLite }
+func (s *capturingAuditStore) ListIdentityLinks(context.Context, string) ([]audit.IdentityLink, error) {
+	return nil, nil
+}
+func (s *capturingAuditStore) UpsertIdentityLink(context.Context, audit.IdentityLink) error {
+	return nil
+}
+func (s *capturingAuditStore) DeleteIdentityLink(context.Context, string) error { return nil }
+func (s *capturingAuditStore) Close() error                                     { return nil }
+func (s *capturingAuditStore) Dialect() dbutil.Dialect                          { return dbutil.DialectSQLite }
 func (s *capturingAuditStore) snapshot() []audit.UserActivity {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/session/sql/migrations-postgres/024_audit_identity_links.pg.sql
+++ b/internal/session/sql/migrations-postgres/024_audit_identity_links.pg.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- Issue #833 final follow-ups: explicit cross-channel audit identity links.
+-- Audit rows keep their original platform-native user_id; this table lets an
+-- admin query one principal across multiple native subjects without rewriting
+-- immutable audit rows.
+
+CREATE TABLE audit_identity_links (
+    id                TEXT PRIMARY KEY,
+    principal_user_id TEXT NOT NULL,
+    provider          TEXT NOT NULL,
+    subject           TEXT NOT NULL,
+    subject_type      TEXT NOT NULL DEFAULT 'platform',
+    display_name      TEXT NOT NULL DEFAULT '',
+    email             TEXT NOT NULL DEFAULT '',
+    created_at        BIGINT NOT NULL,
+    updated_at        BIGINT NOT NULL,
+    UNIQUE(provider, subject)
+);
+CREATE INDEX IF NOT EXISTS idx_audit_identity_links_principal ON audit_identity_links(principal_user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_identity_links_lookup ON audit_identity_links(provider, subject);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_identity_links_lookup;
+DROP INDEX IF EXISTS idx_audit_identity_links_principal;
+DROP TABLE IF EXISTS audit_identity_links;

--- a/internal/session/sql/migrations/024_audit_identity_links.sql
+++ b/internal/session/sql/migrations/024_audit_identity_links.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- Issue #833 final follow-ups: explicit cross-channel audit identity links.
+-- Audit rows keep their original platform-native user_id; this table lets an
+-- admin query one principal across multiple native subjects without rewriting
+-- immutable audit rows.
+
+CREATE TABLE audit_identity_links (
+    id                TEXT PRIMARY KEY,
+    principal_user_id TEXT NOT NULL,
+    provider          TEXT NOT NULL,
+    subject           TEXT NOT NULL,
+    subject_type      TEXT NOT NULL DEFAULT 'platform',
+    display_name      TEXT NOT NULL DEFAULT '',
+    email             TEXT NOT NULL DEFAULT '',
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER NOT NULL,
+    UNIQUE(provider, subject)
+);
+CREATE INDEX idx_audit_identity_links_principal ON audit_identity_links(principal_user_id);
+CREATE INDEX idx_audit_identity_links_lookup ON audit_identity_links(provider, subject);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_identity_links_lookup;
+DROP INDEX IF EXISTS idx_audit_identity_links_principal;
+DROP TABLE IF EXISTS audit_identity_links;

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { downloadActivity, listActivity, type ActivityFilters } from '@/lib/api/admin-activity';
+import type { AuditActivity } from '@/lib/types/admin';
+import { LoadingState, ErrorState, EmptyState } from '@/components/admin/resource-states';
+import { useAdminUI } from '@/context/admin-ui-context';
+import { useTranslation } from 'react-i18next';
+
+type OutcomeFilter = '' | 'success' | 'failure' | 'denied';
+
+function truncate(value: string, size = 18): string {
+  if (!value || value.length <= size) return value;
+  return `${value.slice(0, Math.max(0, size - 7))}...${value.slice(-4)}`;
+}
+
+function detailSummary(row: AuditActivity): string {
+  if (!row.detail_json) return '';
+  try {
+    const parsed = JSON.parse(row.detail_json);
+    if (typeof parsed !== 'object' || parsed === null) return row.detail_json;
+    return Object.entries(parsed)
+      .slice(0, 4)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(' · ');
+  } catch {
+    return row.detail_json;
+  }
+}
+
+function outcomeClass(outcome: string): string {
+  switch (outcome) {
+    case 'success':
+      return 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20';
+    case 'denied':
+      return 'text-amber-300 bg-amber-500/10 border-amber-500/20';
+    default:
+      return 'text-red-300 bg-red-500/10 border-red-500/20';
+  }
+}
+
+export default function AdminActivityPage() {
+  const { t } = useTranslation('admin');
+  const { t: tCommon } = useTranslation('common');
+  const { showToast } = useAdminUI();
+  const [rows, setRows] = useState<AuditActivity[]>([]);
+  const [resolvedUserIDs, setResolvedUserIDs] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState<'json' | 'csv' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [userId, setUserId] = useState('');
+  const [principalUserId, setPrincipalUserId] = useState('');
+  const [action, setAction] = useState('');
+  const [outcome, setOutcome] = useState<OutcomeFilter>('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+
+  const filters = useMemo<ActivityFilters>(() => ({
+    userId: userId.trim(),
+    principalUserId: principalUserId.trim(),
+    action: action.trim(),
+    outcome,
+    from,
+    to,
+    limit: 100,
+  }), [action, from, outcome, principalUserId, to, userId]);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await listActivity(filters);
+      setRows(data.rows ?? []);
+      setResolvedUserIDs(data.resolved_user_ids ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('activity.error.load_failed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, t]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial remote load
+    load();
+  }, [load]);
+
+  const handleExport = async (format: 'json' | 'csv') => {
+    try {
+      setExporting(format);
+      await downloadActivity(filters, format);
+      showToast(t('activity.toast.exported'), 'success');
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : t('activity.error.export_failed'), 'error');
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  const tableHeaders = [
+    t('activity.table.time'),
+    t('activity.table.user'),
+    t('activity.table.platform'),
+    t('activity.table.action'),
+    t('activity.table.outcome'),
+    t('activity.table.detail'),
+  ];
+
+  const labelForOutcome = (value: string) => {
+    switch (value) {
+      case 'success':
+        return t('activity.outcomes.success');
+      case 'failure':
+        return t('activity.outcomes.failure');
+      case 'denied':
+        return t('activity.outcomes.denied');
+      default:
+        return value;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-base)] p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-display font-bold text-[var(--text-primary)]">
+              {t('activity.title')}
+            </h1>
+            {!loading && !error && (
+              <span className="text-[11px] font-mono text-[var(--text-faint)] px-2 py-0.5 rounded-full bg-[var(--bg-hover)]">
+                {rows.length}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => handleExport('json')}
+              disabled={!!exporting || loading}
+              className="px-3 py-1.5 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-40"
+            >
+              {exporting === 'json' ? t('activity.action.exporting') : t('activity.action.export_json')}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleExport('csv')}
+              disabled={!!exporting || loading}
+              className="px-3 py-1.5 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-40"
+            >
+              {exporting === 'csv' ? t('activity.action.exporting') : t('activity.action.export_csv')}
+            </button>
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+              title={tCommon('action.refresh')}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={loading ? 'animate-spin' : ''}>
+                <path d="M21 2v6h-6" />
+                <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                <path d="M3 22v-6h6" />
+                <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="mb-5 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-3">
+          <input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder={t('activity.filters.user_id')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
+          <input value={principalUserId} onChange={(e) => setPrincipalUserId(e.target.value)} placeholder={t('activity.filters.principal_user_id')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
+          <input value={action} onChange={(e) => setAction(e.target.value)} placeholder={t('activity.filters.action')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
+          <select value={outcome} onChange={(e) => setOutcome(e.target.value as OutcomeFilter)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]">
+            <option value="">{t('activity.filters.any_outcome')}</option>
+            <option value="success">{t('activity.outcomes.success')}</option>
+            <option value="failure">{t('activity.outcomes.failure')}</option>
+            <option value="denied">{t('activity.outcomes.denied')}</option>
+          </select>
+          <input type="datetime-local" value={from} onChange={(e) => setFrom(e.target.value)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" aria-label={t('activity.filters.from')} />
+          <input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" aria-label={t('activity.filters.to')} />
+        </div>
+
+        {resolvedUserIDs.length > 0 && (
+          <div className="mb-5 text-xs text-[var(--text-muted)]">
+            {t('activity.resolved_ids')}: <span className="font-mono text-[var(--text-secondary)]">{resolvedUserIDs.join(', ')}</span>
+          </div>
+        )}
+
+        {loading && <LoadingState label={t('activity.loading')} />}
+        {error && <ErrorState message={error} onRetry={load} />}
+        {!loading && !error && rows.length === 0 && (
+          <EmptyState title={t('activity.empty.title')} description={t('activity.empty.description')} />
+        )}
+
+        {!loading && !error && rows.length > 0 && (
+          <div className="overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]">
+            <div className="grid grid-cols-[150px_1.2fr_90px_1.2fr_95px_1.6fr] gap-3 px-4 py-2.5 bg-[var(--bg-hover)]/60 border-b border-[var(--border-subtle)]">
+              {tableHeaders.map((label) => (
+                <div key={label} className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest">
+                  {label}
+                </div>
+              ))}
+            </div>
+            {rows.map((row) => (
+              <div key={row.id} className="grid grid-cols-[150px_1.2fr_90px_1.2fr_95px_1.6fr] items-center gap-3 px-4 py-3 border-t border-[var(--border-subtle)] hover:bg-[var(--bg-hover)]/40">
+                <div className="text-[11px] font-mono text-[var(--text-faint)]">{new Date(row.ts).toLocaleString()}</div>
+                <div className="min-w-0">
+                  <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.user_id}>{truncate(row.user_id, 24)}</div>
+                  <div className="text-[10px] text-[var(--text-faint)]">{row.user_id_type}</div>
+                </div>
+                <div className="text-xs text-[var(--text-secondary)]">{row.platform}</div>
+                <div className="min-w-0">
+                  <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.action}>{row.action}</div>
+                  {(row.resource_type || row.resource_id) && (
+                    <div className="text-[10px] text-[var(--text-faint)] truncate">
+                      {row.resource_type}{row.resource_id ? `:${truncate(row.resource_id, 16)}` : ''}
+                    </div>
+                  )}
+                </div>
+                <div className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-[10px] font-bold ${outcomeClass(row.outcome)}`}>
+                  {labelForOutcome(row.outcome)}
+                </div>
+                <div className="text-[11px] text-[var(--text-muted)] truncate" title={detailSummary(row)}>
+                  {detailSummary(row)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -508,7 +508,7 @@ export default function AdminActivityPage() {
                   </div>
 
                   {/* Body */}
-                  <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5">
+                  <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3.5">
                     {/* Message Content Section */}
                     {messageContent && (
                       <DrawerSection
@@ -529,7 +529,7 @@ export default function AdminActivityPage() {
                           </button>
                         }
                       >
-                        <div className="p-3 rounded-md bg-[var(--accent-gold)]/[0.02] border border-[var(--accent-gold)]/20 text-xs text-[var(--text-primary)] whitespace-pre-wrap break-all leading-relaxed font-sans mt-1">
+                        <div className="p-3 rounded-md bg-[var(--accent-gold)]/[0.02] border border-[var(--accent-gold)]/20 text-[11px] text-[var(--text-primary)] whitespace-pre-wrap break-all leading-normal font-sans mt-1">
                           {messageContent}
                         </div>
                       </DrawerSection>
@@ -766,16 +766,16 @@ function KV({
   hint?: string;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 py-2 border-b border-[var(--border-subtle)]/40 last:border-b-0 transition-all hover:bg-[var(--bg-hover)]/[0.04] -mx-2 px-2 rounded-[var(--radius-sm)]">
-      <span className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-wider shrink-0 pt-0.5 min-w-[95px] text-left">{label}</span>
+    <div className="flex items-center justify-between gap-4 py-1.5 border-b border-[var(--border-subtle)]/30 last:border-b-0 transition-all hover:bg-[var(--bg-hover)]/[0.04] -mx-2 px-2 rounded-[var(--radius-sm)]">
+      <span className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-wider shrink-0 min-w-[95px] text-left">{label}</span>
       <div className="min-w-0 flex-1 text-right">
-        <div className="inline-flex items-center justify-end gap-1.5 flex-wrap">
+        <div className="inline-flex items-center justify-end gap-1.5 flex-nowrap w-full">
           {link ? (
-            <Link href={link} className={`text-xs ${mono ? 'font-mono' : ''} text-[var(--accent-gold)] hover:underline break-all`} title={value}>
+            <Link href={link} className={`text-[11px] ${mono ? 'font-mono' : ''} text-[var(--accent-gold)] hover:underline truncate block max-w-[220px] text-right`} title={value}>
               {value}
             </Link>
           ) : (
-            <span className={`text-xs ${mono ? 'font-mono' : ''} text-[var(--text-secondary)] break-all`} title={value}>
+            <span className={`text-[11px] ${mono ? 'font-mono' : ''} text-[var(--text-secondary)] truncate block max-w-[220px] text-right`} title={value}>
               {value}
             </span>
           )}

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -766,7 +766,7 @@ function KV({
   hint?: string;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-1.5 border-b border-[var(--border-subtle)]/30 last:border-b-0 transition-all hover:bg-[var(--bg-hover)]/[0.04] -mx-2 px-2 rounded-[var(--radius-sm)]">
+    <div className="flex items-center justify-between gap-4 py-1 border-b border-[var(--border-subtle)]/30 last:border-b-0 transition-all hover:bg-[var(--bg-hover)]/[0.04] -mx-2 px-2 rounded-[var(--radius-sm)]">
       <span className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-wider shrink-0 min-w-[95px] text-left">{label}</span>
       <div className="min-w-0 flex-1 text-right">
         <div className="inline-flex items-center justify-end gap-1.5 flex-nowrap w-full">

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -387,7 +387,7 @@ export default function AdminActivityPage() {
                   key={row.id}
                   type="button"
                   onClick={() => setDrawerRow(row)}
-                  className={`w-full text-left grid grid-cols-[140px_1.4fr_100px_1.5fr_100px_2.5fr] items-center gap-3 px-4 py-3.5 border-t border-[var(--border-subtle)] transition-all duration-200 hover:translate-x-0.5 odd:bg-[var(--bg-surface)]/10 even:bg-[var(--bg-surface)]/40 hover:bg-[var(--bg-hover)]/30 ${
+                  className={`w-full text-left grid grid-cols-[140px_1.4fr_100px_1.5fr_100px_2.5fr] items-center gap-3 px-4 py-2 border-t border-[var(--border-subtle)] transition-all duration-200 hover:translate-x-0.5 odd:bg-[var(--bg-surface)]/10 even:bg-[var(--bg-surface)]/40 hover:bg-[var(--bg-hover)]/30 ${
                     selected ? 'bg-[var(--bg-active)] border-l-2 border-l-[var(--accent-gold)]' : ''
                   }`}
                 >

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -116,6 +116,14 @@ export default function AdminActivityPage() {
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
 
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(50);
+
+  // Reset page when filter search params change (avoid out-of-bounds offset queries)
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [userId, principalUserId, actionPrefix, outcome, platform, from, to]);
+
   const filters = useMemo<ActivityFilters>(
     () => ({
       userId: userId.trim(),
@@ -125,9 +133,10 @@ export default function AdminActivityPage() {
       platform,
       from,
       to,
-      limit: 100,
+      limit: pageSize,
+      offset: (currentPage - 1) * pageSize,
     }),
-    [actionPrefix, from, outcome, platform, principalUserId, to, userId],
+    [actionPrefix, from, outcome, platform, principalUserId, to, userId, pageSize, currentPage],
   );
 
   const load = useCallback(async () => {
@@ -196,6 +205,63 @@ export default function AdminActivityPage() {
   const failureCount = stats?.by_outcome?.failure ?? 0;
   const deniedCount = stats?.by_outcome?.denied ?? 0;
   const totalCount = stats?.total ?? 0;
+
+  const totalPages = Math.ceil(totalCount / pageSize);
+
+  const renderPageNumbers = () => {
+    if (totalPages <= 1) return null;
+
+    const pages: (number | string)[] = [];
+    const maxVisible = 5;
+
+    if (totalPages <= maxVisible) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      pages.push(1);
+      if (currentPage > 3) {
+        pages.push('...');
+      }
+
+      const start = Math.max(2, currentPage - 1);
+      const end = Math.min(totalPages - 1, currentPage + 1);
+
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+
+      if (currentPage < totalPages - 2) {
+        pages.push('...');
+      }
+      pages.push(totalPages);
+    }
+
+    return pages.map((p, idx) => {
+      if (p === '...') {
+        return (
+          <span key={`dots-${idx}`} className="px-1 text-[var(--text-faint)] select-none">
+            ...
+          </span>
+        );
+      }
+      const active = p === currentPage;
+      return (
+        <button
+          key={`page-${p}`}
+          type="button"
+          onClick={() => setCurrentPage(Number(p))}
+          className={`w-6 h-6 rounded text-[11px] font-mono font-bold flex items-center justify-center transition-all ${
+            active
+              ? 'bg-[var(--accent-gold)]/10 text-[var(--accent-gold)] border border-[var(--accent-gold)]/20 shadow-sm'
+              : 'bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+          }`}
+        >
+          {p}
+        </button>
+      );
+    });
+  };
 
   return (
     <div className="min-h-screen bg-[var(--bg-base)] p-6">
@@ -457,6 +523,49 @@ export default function AdminActivityPage() {
                 </button>
               );
             })}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {!loading && !error && rows.length > 0 && totalPages > 1 && (
+          <div className="mt-4 px-4 py-2 flex items-center justify-between border border-[var(--border-subtle)] rounded-[var(--radius-md)] bg-[var(--bg-surface)]/40 backdrop-blur-sm text-[11px] text-[var(--text-secondary)] shadow-sm">
+            <div className="flex items-center gap-1 text-[var(--text-muted)]">
+              <span>{t('activity.pagination.showing')}</span>
+              <span className="font-mono font-bold text-[var(--text-primary)]">
+                {Math.min(totalCount, (currentPage - 1) * pageSize + 1)}
+              </span>
+              <span>{t('activity.pagination.to')}</span>
+              <span className="font-mono font-bold text-[var(--text-primary)]">
+                {Math.min(totalCount, currentPage * pageSize)}
+              </span>
+              <span>{t('activity.pagination.of')}</span>
+              <span className="font-mono font-bold text-[var(--text-primary)]">{totalCount}</span>
+              <span>{t('activity.pagination.entries')}</span>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                className="px-2.5 py-1 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[10px] font-bold uppercase tracking-wider text-[var(--text-secondary)] disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[var(--bg-hover)] transition-all duration-200"
+              >
+                {t('activity.pagination.prev')}
+              </button>
+
+              <div className="flex items-center gap-1">
+                {renderPageNumbers()}
+              </div>
+
+              <button
+                type="button"
+                disabled={currentPage >= totalPages}
+                onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                className="px-2.5 py-1 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[10px] font-bold uppercase tracking-wider text-[var(--text-secondary)] disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[var(--bg-hover)] transition-all duration-200"
+              >
+                {t('activity.pagination.next')}
+              </button>
+            </div>
           </div>
         )}
 

--- a/webchat/app/admin/activity/page.tsx
+++ b/webchat/app/admin/activity/page.tsx
@@ -1,41 +1,84 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { downloadActivity, listActivity, type ActivityFilters } from '@/lib/api/admin-activity';
-import type { AuditActivity } from '@/lib/types/admin';
+import Link from 'next/link';
+import { motion, AnimatePresence } from 'framer-motion';
+
+import { StatusBadge } from '@/components/admin/status-badge';
+import { ActionIcon, actionCategory } from '@/components/admin/activity/action-icon';
+import { JsonViewer } from '@/components/admin/activity/json-viewer';
+import { OUTCOME_STATUS_MAP } from '@/components/admin/activity/outcome-map';
 import { LoadingState, ErrorState, EmptyState } from '@/components/admin/resource-states';
 import { useAdminUI } from '@/context/admin-ui-context';
+import { downloadActivity, listActivity, listActivityStats, type ActivityFilters } from '@/lib/api/admin-activity';
+import type { ActivityStats, AuditActivity } from '@/lib/types/admin';
+import { formatDateTime, formatRelative } from '@/lib/utils/format-time';
 import { useTranslation } from 'react-i18next';
 
 type OutcomeFilter = '' | 'success' | 'failure' | 'denied';
+
+// Action options grouped by category for the filter dropdown. The values are
+// sent verbatim as action_prefix (the category root + ".") so selecting
+// "Tool Call" returns every tool.* action. A specific action can still be
+// typed in the user_id-style box via the action input when needed.
+const ACTION_GROUPS: Array<{ groupKey: string; prefix: string }> = [
+  { groupKey: 'auth', prefix: 'auth.' },
+  { groupKey: 'session', prefix: 'session.' },
+  { groupKey: 'message', prefix: 'message.' },
+  { groupKey: 'tool', prefix: 'tool.' },
+  { groupKey: 'admin', prefix: 'admin.' },
+  { groupKey: 'system', prefix: 'system.' },
+];
+
+const PLATFORM_OPTIONS = ['webchat', 'feishu', 'slack', 'admin', 'api', 'cron'];
 
 function truncate(value: string, size = 18): string {
   if (!value || value.length <= size) return value;
   return `${value.slice(0, Math.max(0, size - 7))}...${value.slice(-4)}`;
 }
 
+// detailSummary renders a single-line, action-aware digest for the table cell.
+// Each action has a differently-shaped detail_json (see backend builders), so
+// we pull the most informative field per category rather than dumping keys.
 function detailSummary(row: AuditActivity): string {
   if (!row.detail_json) return '';
+  let parsed: Record<string, unknown>;
   try {
-    const parsed = JSON.parse(row.detail_json);
+    parsed = JSON.parse(row.detail_json);
     if (typeof parsed !== 'object' || parsed === null) return row.detail_json;
-    return Object.entries(parsed)
-      .slice(0, 4)
-      .map(([key, value]) => `${key}=${String(value)}`)
-      .join(' · ');
   } catch {
     return row.detail_json;
   }
-}
-
-function outcomeClass(outcome: string): string {
-  switch (outcome) {
-    case 'success':
-      return 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20';
-    case 'denied':
-      return 'text-amber-300 bg-amber-500/10 border-amber-500/20';
+  const get = (k: string) => (typeof parsed[k] === 'string' ? (parsed[k] as string) : '');
+  switch (actionCategory(row.action)) {
+    case 'message': {
+      const content = get('content');
+      if (content) return content;
+      return '';
+    }
+    case 'tool': {
+      const name = get('name');
+      const title = get('title');
+      if (name && title) return `${name} · ${title}`;
+      return name || JSON.stringify(parsed).slice(0, 80);
+    }
+    case 'auth':
+      return `${get('method') || ''} ${get('path') || ''}`.trim();
+    case 'session':
+      return get('worker_type') ? `worker: ${get('worker_type')}` : '';
+    case 'admin':
+      return `${get('method') || ''} ${get('path') || ''} → ${get('status') || ''}`.trim();
+    case 'system': {
+      const fmt = get('format');
+      const rows = parsed.rows as number | undefined;
+      if (fmt) return rows !== undefined ? `${fmt} · ${rows} rows` : fmt;
+      return '';
+    }
     default:
-      return 'text-red-300 bg-red-500/10 border-red-500/20';
+      return Object.entries(parsed)
+        .slice(0, 2)
+        .map(([k, v]) => `${k}=${String(v)}`)
+        .join(' · ');
   }
 }
 
@@ -43,35 +86,59 @@ export default function AdminActivityPage() {
   const { t } = useTranslation('admin');
   const { t: tCommon } = useTranslation('common');
   const { showToast } = useAdminUI();
+
   const [rows, setRows] = useState<AuditActivity[]>([]);
+  const [stats, setStats] = useState<ActivityStats | null>(null);
   const [resolvedUserIDs, setResolvedUserIDs] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState<'json' | 'csv' | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [drawerRow, setDrawerRow] = useState<AuditActivity | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [identityLinks, setIdentityLinks] = useState<Record<string, any>>({});
+
+  const messageContent = useMemo(() => {
+    if (!drawerRow || !drawerRow.detail_json) return '';
+    try {
+      const parsed = JSON.parse(drawerRow.detail_json);
+      if (parsed && typeof parsed.content === 'string') {
+        return parsed.content;
+      }
+    } catch {}
+    return '';
+  }, [drawerRow]);
+
   const [userId, setUserId] = useState('');
   const [principalUserId, setPrincipalUserId] = useState('');
-  const [action, setAction] = useState('');
+  const [actionPrefix, setActionPrefix] = useState('');
   const [outcome, setOutcome] = useState<OutcomeFilter>('');
+  const [platform, setPlatform] = useState('');
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
 
-  const filters = useMemo<ActivityFilters>(() => ({
-    userId: userId.trim(),
-    principalUserId: principalUserId.trim(),
-    action: action.trim(),
-    outcome,
-    from,
-    to,
-    limit: 100,
-  }), [action, from, outcome, principalUserId, to, userId]);
+  const filters = useMemo<ActivityFilters>(
+    () => ({
+      userId: userId.trim(),
+      principalUserId: principalUserId.trim(),
+      actionPrefix: actionPrefix.trim(),
+      outcome,
+      platform,
+      from,
+      to,
+      limit: 100,
+    }),
+    [actionPrefix, from, outcome, platform, principalUserId, to, userId],
+  );
 
   const load = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await listActivity(filters);
+      const [data, statsData] = await Promise.all([listActivity(filters), listActivityStats(filters)]);
       setRows(data.rows ?? []);
       setResolvedUserIDs(data.resolved_user_ids ?? []);
+      setIdentityLinks(data.identity_links ?? {});
+      setStats(statsData);
     } catch (err) {
       setError(err instanceof Error ? err.message : t('activity.error.load_failed'));
     } finally {
@@ -83,6 +150,16 @@ export default function AdminActivityPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial remote load
     load();
   }, [load]);
+
+  // Esc closes the drawer (matches the sessions page pattern).
+  useEffect(() => {
+    if (!drawerRow) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDrawerRow(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [drawerRow]);
 
   const handleExport = async (format: 'json' | 'csv') => {
     try {
@@ -96,6 +173,16 @@ export default function AdminActivityPage() {
     }
   };
 
+  const copyJson = async (row: AuditActivity) => {
+    try {
+      await navigator.clipboard.writeText(row.detail_json || '');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      showToast(t('activity.error.export_failed'), 'error');
+    }
+  };
+
   const tableHeaders = [
     t('activity.table.time'),
     t('activity.table.user'),
@@ -105,30 +192,21 @@ export default function AdminActivityPage() {
     t('activity.table.detail'),
   ];
 
-  const labelForOutcome = (value: string) => {
-    switch (value) {
-      case 'success':
-        return t('activity.outcomes.success');
-      case 'failure':
-        return t('activity.outcomes.failure');
-      case 'denied':
-        return t('activity.outcomes.denied');
-      default:
-        return value;
-    }
-  };
+  const successCount = stats?.by_outcome?.success ?? 0;
+  const failureCount = stats?.by_outcome?.failure ?? 0;
+  const deniedCount = stats?.by_outcome?.denied ?? 0;
+  const totalCount = stats?.total ?? 0;
 
   return (
     <div className="min-h-screen bg-[var(--bg-base)] p-6">
       <div className="max-w-7xl mx-auto">
+        {/* Header */}
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-5">
           <div className="flex items-center gap-3">
-            <h1 className="text-xl font-display font-bold text-[var(--text-primary)]">
-              {t('activity.title')}
-            </h1>
+            <h1 className="text-xl font-display font-bold text-[var(--text-primary)]">{t('activity.title')}</h1>
             {!loading && !error && (
               <span className="text-[11px] font-mono text-[var(--text-faint)] px-2 py-0.5 rounded-full bg-[var(--bg-hover)]">
-                {rows.length}
+                {totalCount}
               </span>
             )}
           </div>
@@ -156,7 +234,17 @@ export default function AdminActivityPage() {
               className="inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
               title={tCommon('action.refresh')}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={loading ? 'animate-spin' : ''}>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className={loading ? 'animate-spin' : ''}
+              >
                 <path d="M21 2v6h-6" />
                 <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
                 <path d="M3 22v-6h6" />
@@ -166,18 +254,108 @@ export default function AdminActivityPage() {
           </div>
         </div>
 
-        <div className="mb-5 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-3">
-          <input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder={t('activity.filters.user_id')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
-          <input value={principalUserId} onChange={(e) => setPrincipalUserId(e.target.value)} placeholder={t('activity.filters.principal_user_id')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
-          <input value={action} onChange={(e) => setAction(e.target.value)} placeholder={t('activity.filters.action')} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" />
-          <select value={outcome} onChange={(e) => setOutcome(e.target.value as OutcomeFilter)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]">
+        {/* Stats overview row */}
+        {!error && (
+          <div className="mb-5 grid grid-cols-2 md:grid-cols-4 gap-3">
+            <StatChip label={t('activity.stats.total')} value={totalCount} accent="gold" />
+            <StatChip label={t('activity.stats.success')} value={successCount} accent="emerald" />
+            <StatChip label={t('activity.stats.failure')} value={failureCount} accent="coral" />
+            <StatChip label={t('activity.stats.denied')} value={deniedCount} accent="amber" />
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="mb-6 p-4 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/40 backdrop-blur-sm grid grid-cols-1 md:grid-cols-2 xl:grid-cols-7 gap-3">
+          <div className="relative group flex items-center">
+            <input
+              value={userId}
+              onChange={(e) => setUserId(e.target.value)}
+              placeholder={t('activity.filters.user_id')}
+              className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm pl-3 pr-8 py-2 text-xs text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+            />
+            <div className="absolute right-2.5 text-[var(--text-faint)] hover:text-[var(--text-secondary)] cursor-help">
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+              </svg>
+            </div>
+            <div className="absolute z-30 bottom-full left-0 mb-2 hidden group-hover:block w-64 p-3 bg-[var(--bg-surface)]/95 backdrop-blur-sm border border-[var(--border-subtle)] rounded-lg shadow-xl text-[11px] text-[var(--text-secondary)] leading-normal pointer-events-none transition-all duration-200">
+              {t('activity.hints.user_id_tooltip')}
+            </div>
+          </div>
+          <div className="relative group flex items-center">
+            <input
+              value={principalUserId}
+              onChange={(e) => setPrincipalUserId(e.target.value)}
+              placeholder={t('activity.filters.principal_user_id')}
+              className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm pl-3 pr-8 py-2 text-xs text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+            />
+            <div className="absolute right-2.5 text-[var(--text-faint)] hover:text-[var(--text-secondary)] cursor-help">
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+              </svg>
+            </div>
+            <div className="absolute z-30 bottom-full left-0 mb-2 hidden group-hover:block w-64 p-3 bg-[var(--bg-surface)]/95 backdrop-blur-sm border border-[var(--border-subtle)] rounded-lg shadow-xl text-[11px] text-[var(--text-secondary)] leading-normal pointer-events-none transition-all duration-200">
+              {t('activity.hints.principal_tooltip')}
+            </div>
+          </div>
+          <select
+            value={actionPrefix}
+            onChange={(e) => setActionPrefix(e.target.value)}
+            className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm px-3 py-2 text-xs text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+          >
+            <option value="">{t('activity.filters.any_action')}</option>
+            {ACTION_GROUPS.map((g) => (
+              <option key={g.prefix} value={g.prefix}>
+                {t(`activity.action_groups.${g.groupKey}`, { defaultValue: g.groupKey })}
+              </option>
+            ))}
+          </select>
+          <select
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+            className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm px-3 py-2 text-xs text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+          >
+            <option value="">{t('activity.filters.any_platform')}</option>
+            {PLATFORM_OPTIONS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <select
+            value={outcome}
+            onChange={(e) => setOutcome(e.target.value as OutcomeFilter)}
+            className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm px-3 py-2 text-xs text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+          >
             <option value="">{t('activity.filters.any_outcome')}</option>
             <option value="success">{t('activity.outcomes.success')}</option>
             <option value="failure">{t('activity.outcomes.failure')}</option>
             <option value="denied">{t('activity.outcomes.denied')}</option>
           </select>
-          <input type="datetime-local" value={from} onChange={(e) => setFrom(e.target.value)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" aria-label={t('activity.filters.from')} />
-          <input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} className="rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--accent-gold)]" aria-label={t('activity.filters.to')} />
+          <div className="xl:col-span-2 flex gap-2">
+            <div className="flex-1 min-w-0 relative flex items-center">
+              <span className="absolute left-2.5 text-[9px] uppercase font-bold text-[var(--text-faint)] pointer-events-none tracking-wider">
+                {t('activity.filters.from_short')}
+              </span>
+              <input
+                type="datetime-local"
+                value={from}
+                onChange={(e) => setFrom(e.target.value)}
+                className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm pl-8 pr-2 py-2 text-[11px] text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+              />
+            </div>
+            <div className="flex-1 min-w-0 relative flex items-center">
+              <span className="absolute left-2.5 text-[9px] uppercase font-bold text-[var(--text-faint)] pointer-events-none tracking-wider">
+                {t('activity.filters.to_short')}
+              </span>
+              <input
+                type="datetime-local"
+                value={to}
+                onChange={(e) => setTo(e.target.value)}
+                className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]/80 backdrop-blur-sm pl-8 pr-2 py-2 text-[11px] text-[var(--text-primary)] outline-none transition-all focus:border-[var(--accent-gold)] focus:ring-2 focus:ring-[var(--accent-gold)]/20"
+              />
+            </div>
+          </div>
         </div>
 
         {resolvedUserIDs.length > 0 && (
@@ -192,42 +370,449 @@ export default function AdminActivityPage() {
           <EmptyState title={t('activity.empty.title')} description={t('activity.empty.description')} />
         )}
 
+        {/* Table */}
         {!loading && !error && rows.length > 0 && (
           <div className="overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--bg-surface)]">
-            <div className="grid grid-cols-[150px_1.2fr_90px_1.2fr_95px_1.6fr] gap-3 px-4 py-2.5 bg-[var(--bg-hover)]/60 border-b border-[var(--border-subtle)]">
+            <div className="grid grid-cols-[140px_1.4fr_100px_1.5fr_100px_2.5fr] gap-3 px-4 py-3 bg-[var(--bg-hover)]/60 border-b border-[var(--border-subtle)]">
               {tableHeaders.map((label) => (
                 <div key={label} className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest">
                   {label}
                 </div>
               ))}
             </div>
-            {rows.map((row) => (
-              <div key={row.id} className="grid grid-cols-[150px_1.2fr_90px_1.2fr_95px_1.6fr] items-center gap-3 px-4 py-3 border-t border-[var(--border-subtle)] hover:bg-[var(--bg-hover)]/40">
-                <div className="text-[11px] font-mono text-[var(--text-faint)]">{new Date(row.ts).toLocaleString()}</div>
-                <div className="min-w-0">
-                  <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.user_id}>{truncate(row.user_id, 24)}</div>
-                  <div className="text-[10px] text-[var(--text-faint)]">{row.user_id_type}</div>
-                </div>
-                <div className="text-xs text-[var(--text-secondary)]">{row.platform}</div>
-                <div className="min-w-0">
-                  <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.action}>{row.action}</div>
-                  {(row.resource_type || row.resource_id) && (
-                    <div className="text-[10px] text-[var(--text-faint)] truncate">
-                      {row.resource_type}{row.resource_id ? `:${truncate(row.resource_id, 16)}` : ''}
+            {rows.map((row) => {
+              const selected = drawerRow?.id === row.id;
+              return (
+                <button
+                  key={row.id}
+                  type="button"
+                  onClick={() => setDrawerRow(row)}
+                  className={`w-full text-left grid grid-cols-[140px_1.4fr_100px_1.5fr_100px_2.5fr] items-center gap-3 px-4 py-3.5 border-t border-[var(--border-subtle)] transition-all duration-200 hover:translate-x-0.5 odd:bg-[var(--bg-surface)]/10 even:bg-[var(--bg-surface)]/40 hover:bg-[var(--bg-hover)]/30 ${
+                    selected ? 'bg-[var(--bg-active)] border-l-2 border-l-[var(--accent-gold)]' : ''
+                  }`}
+                >
+                  <div className="text-[10px] font-mono text-[var(--text-faint)]" title={formatDateTime(row.ts)}>
+                    {formatRelative(row.ts)}
+                  </div>
+                  <div className="min-w-0">
+                    {identityLinks[row.user_id] ? (
+                      <>
+                        <div className="text-xs font-bold text-[var(--text-primary)] truncate" title={identityLinks[row.user_id].display_name || identityLinks[row.user_id].DisplayName || row.user_id}>
+                          {identityLinks[row.user_id].display_name || identityLinks[row.user_id].DisplayName}
+                        </div>
+                        <div className="text-[10px] font-mono text-[var(--text-faint)] truncate" title={row.user_id}>
+                          {truncate(row.user_id, 16)}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.user_id}>
+                          {truncate(row.user_id, 24)}
+                        </div>
+                        <div className="text-[10px] text-[var(--text-faint)]">{row.user_id_type}</div>
+                      </>
+                    )}
+                  </div>
+                  <div>
+                    <PlatformBadge platform={row.platform} />
+                  </div>
+                  <div className="min-w-0 flex items-center gap-1.5">
+                    <ActionIcon action={row.action} />
+                    <div className="min-w-0">
+                      <div className="text-xs font-mono text-[var(--text-primary)] truncate" title={row.action}>
+                        {row.action}
+                      </div>
+                      {row.session_id && (
+                        <Link
+                          href={`/admin/sessions/detail?id=${encodeURIComponent(row.session_id)}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-[10px] text-[var(--accent-gold)] hover:underline truncate block max-w-[160px]"
+                          title={row.session_id}
+                        >
+                          {truncate(row.session_id, 16)}
+                        </Link>
+                      )}
+                      {(row.resource_type || row.resource_id) && !row.session_id && (
+                        <div className="text-[10px] text-[var(--text-faint)] truncate">
+                          {row.resource_type}
+                          {row.resource_id ? `:${truncate(row.resource_id, 16)}` : ''}
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-                <div className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-[10px] font-bold ${outcomeClass(row.outcome)}`}>
-                  {labelForOutcome(row.outcome)}
-                </div>
-                <div className="text-[11px] text-[var(--text-muted)] truncate" title={detailSummary(row)}>
-                  {detailSummary(row)}
-                </div>
-              </div>
-            ))}
+                  </div>
+                  <div>
+                    <StatusBadge status={row.outcome} map={OUTCOME_STATUS_MAP} />
+                  </div>
+                  <div className="text-[11px] text-[var(--text-muted)] truncate flex items-center gap-1.5" title={detailSummary(row)}>
+                    {actionCategory(row.action) === 'message' ? (
+                      <span className="shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded bg-[var(--accent-gold)]/10 text-[var(--accent-gold)] border border-[var(--accent-gold)]/20 text-[9px] font-medium leading-none">
+                        <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                        </svg>
+                        MSG
+                      </span>
+                    ) : null}
+                    <span className="truncate">{detailSummary(row)}</span>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         )}
+
+        {/* Detail Drawer */}
+        <AnimatePresence>
+          {drawerRow && (
+            <div className="fixed inset-0 z-50 overflow-hidden" role="dialog" aria-modal="true">
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+                onClick={() => setDrawerRow(null)}
+              />
+              <div className="absolute inset-y-0 right-0 max-w-full flex">
+                <motion.div
+                  initial={{ x: '100%' }}
+                  animate={{ x: 0 }}
+                  exit={{ x: '100%' }}
+                  transition={{ type: 'spring', damping: 26, stiffness: 220 }}
+                  className="relative w-screen max-w-md bg-[var(--bg-surface)] border-l border-[var(--border-subtle)] shadow-2xl flex flex-col"
+                >
+                  {/* Header */}
+                  <div className="px-6 pt-7 pb-4 border-b border-[var(--border-subtle)] flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <ActionIcon action={drawerRow.action} className="px-0" />
+                        <h2 className="text-sm font-bold text-[var(--text-faint)] uppercase tracking-wider font-mono truncate">
+                          {drawerRow.action}
+                        </h2>
+                      </div>
+                      <div className="mt-2 flex items-center gap-2">
+                        <StatusBadge status={drawerRow.outcome} map={OUTCOME_STATUS_MAP} />
+                        <span className="text-[11px] text-[var(--text-faint)]" title={formatDateTime(drawerRow.ts)}>
+                          {formatRelative(drawerRow.ts)}
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setDrawerRow(null)}
+                      className="shrink-0 p-1.5 rounded-full text-[var(--text-faint)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-all"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+
+                  {/* Body */}
+                  <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5">
+                    {/* Message Content Section */}
+                    {messageContent && (
+                      <DrawerSection
+                        title={t('activity.drawer.message_content')}
+                        action={
+                          <button
+                            type="button"
+                            onClick={async () => {
+                              try {
+                                await navigator.clipboard.writeText(messageContent);
+                                setCopied(true);
+                                setTimeout(() => setCopied(false), 1500);
+                              } catch {}
+                            }}
+                            className="text-[9px] font-bold uppercase text-[var(--accent-gold)] hover:underline"
+                          >
+                            {copied ? t('activity.drawer.copied') : tCommon('action.copy')}
+                          </button>
+                        }
+                      >
+                        <div className="p-3 rounded-md bg-[var(--accent-gold)]/[0.02] border border-[var(--accent-gold)]/20 text-xs text-[var(--text-primary)] whitespace-pre-wrap break-all leading-relaxed font-sans mt-1">
+                          {messageContent}
+                        </div>
+                      </DrawerSection>
+                    )}
+
+                    {/* Identity */}
+                    <DrawerSection title={t('activity.drawer.identity')}>
+                      {identityLinks[drawerRow.user_id] && (
+                        <>
+                          <KV label="name" value={identityLinks[drawerRow.user_id].display_name || identityLinks[drawerRow.user_id].DisplayName || '—'} />
+                          {(identityLinks[drawerRow.user_id].email || identityLinks[drawerRow.user_id].Email) && (
+                            <KV label="email" value={identityLinks[drawerRow.user_id].email || identityLinks[drawerRow.user_id].Email || ''} />
+                          )}
+                          <KV label="principal" value={identityLinks[drawerRow.user_id].principal_user_id || identityLinks[drawerRow.user_id].PrincipalUserID || '—'} mono />
+                        </>
+                      )}
+                      <KV label={t('activity.table.user')} value={drawerRow.user_id} mono copyable onCopy={() => copyJson(drawerRow)} />
+                      <KV label="type" value={drawerRow.user_id_type} />
+                      <KV label={t('activity.table.platform')} value={drawerRow.platform} />
+                    </DrawerSection>
+
+                    {/* Context */}
+                    <DrawerSection title={t('activity.drawer.context')}>
+                      {drawerRow.session_id ? (
+                        <KV
+                          label={t('activity.table.session')}
+                          value={drawerRow.session_id}
+                          mono
+                          link={`/admin/sessions/detail?id=${encodeURIComponent(drawerRow.session_id)}`}
+                        />
+                      ) : (
+                        <KV label={t('activity.table.session')} value="—" />
+                      )}
+                      {(drawerRow.resource_type || drawerRow.resource_id) && (
+                        <KV
+                          label="resource"
+                          value={`${drawerRow.resource_type || ''}${drawerRow.resource_id ? ':' + drawerRow.resource_id : ''}`}
+                          mono
+                        />
+                      )}
+                      {drawerRow.event_ref && <KV label="event_ref" value={drawerRow.event_ref} mono />}
+                      <KV label={t('activity.table.time')} value={formatDateTime(drawerRow.ts)} />
+                    </DrawerSection>
+
+                    {/* Network */}
+                    <DrawerSection title={t('activity.drawer.network')}>
+                      <KV label="ip" value={drawerRow.ip || '—'} mono hint={drawerRow.ip ? t('activity.drawer.ip_masked') : undefined} />
+                      {drawerRow.user_agent && <KV label="user_agent" value={drawerRow.user_agent} mono />}
+                    </DrawerSection>
+
+                    {/* Detail JSON */}
+                    <DrawerSection
+                      title={t('activity.drawer.detail_json')}
+                      action={
+                        drawerRow.detail_json && drawerRow.detail_json !== '{}' && (
+                          <button
+                            type="button"
+                            onClick={() => copyJson(drawerRow)}
+                            className="text-[9px] font-bold uppercase text-[var(--accent-gold)] hover:underline"
+                          >
+                            {copied ? t('activity.drawer.copied') : t('activity.drawer.copy_json')}
+                          </button>
+                        )
+                      }
+                    >
+                      <div className="mt-1">
+                        <JsonViewer json={drawerRow.detail_json} />
+                      </div>
+                    </DrawerSection>
+
+                    <DrawerSection title={t('activity.drawer.hash_chain')} hint={t('activity.drawer.hash_hint')}>
+                      <div className="flex flex-col gap-4 relative pl-3 before:absolute before:left-[17px] before:top-2 before:bottom-2 before:w-[2px] before:bg-[color-mix(in_srgb,var(--border-subtle)_70%,transparent)]">
+                        <div className="flex items-start gap-3 relative">
+                          <div className="w-2.5 h-2.5 rounded-full border-2 border-[var(--border-subtle)] bg-[var(--bg-surface)] mt-1.5 z-10 shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <div className="text-[9px] font-bold text-[var(--text-faint)] uppercase tracking-wider">{t('activity.drawer.prev_hash')}</div>
+                            <div className="text-xs font-mono text-[var(--text-secondary)] break-all bg-[var(--bg-hover)]/30 px-3 py-1.5 rounded-md border border-[var(--border-subtle)]/40 mt-1" title={drawerRow.prev_hash || '—'}>
+                              {drawerRow.prev_hash || '—'}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="flex items-start gap-3 relative">
+                          <div className="w-2.5 h-2.5 rounded-full border-2 border-[var(--accent-gold)] bg-[var(--bg-surface)] mt-1.5 z-10 shrink-0 shadow-[0_0_8px_rgba(218,165,32,0.3)]" />
+                          <div className="flex-1 min-w-0">
+                            <div className="text-[9px] font-bold text-[var(--accent-gold)] uppercase tracking-wider flex items-center gap-1">
+                              <span>{t('activity.drawer.self_hash')}</span>
+                              <svg className="w-3 h-3 text-[var(--accent-gold)] animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                              </svg>
+                            </div>
+                            <div className="text-xs font-mono text-[var(--text-primary)] break-all bg-[var(--accent-gold)]/5 px-3 py-1.5 rounded-md border border-[var(--accent-gold)]/20 mt-1 shadow-[inset_0_1px_2px_rgba(0,0,0,0.05)]" title={drawerRow.self_hash}>
+                              {drawerRow.self_hash}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </DrawerSection>
+                  </div>
+ 
+                  {/* Footer */}
+                  {drawerRow.session_id && (
+                    <div className="p-5 border-t border-[var(--border-subtle)] bg-[var(--bg-hover)]/30">
+                      <Link
+                        href={`/admin/sessions/detail?id=${encodeURIComponent(drawerRow.session_id)}`}
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-[var(--radius-md)] text-[11px] font-bold uppercase tracking-widest text-[var(--accent-gold)] bg-[var(--accent-gold)]/[0.03] border border-[var(--accent-gold)]/20 hover:bg-[var(--accent-gold)]/[0.08] hover:border-[var(--accent-gold)]/40 hover:shadow-[0_0_12px_rgba(218,165,32,0.1)] transition-all duration-200 text-center"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.2} stroke="currentColor" className="w-3.5 h-3.5">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                        </svg>
+                        {t('activity.drawer.open_session')}
+                      </Link>
+                    </div>
+                  )}
+                </motion.div>
+              </div>
+            </div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
+  );
+}
+
+// StatChip — compact stat card for the overview row. Local to this page to
+// keep the surface small; reuse MetricCard if richer affordances are needed.
+function StatChip({ label, value, accent }: { label: string; value: number; accent: 'gold' | 'emerald' | 'coral' | 'amber' }) {
+  const color =
+    accent === 'gold'
+      ? 'text-[var(--accent-gold)]'
+      : accent === 'emerald'
+        ? 'text-[var(--accent-emerald)]'
+        : accent === 'coral'
+          ? 'text-[var(--accent-coral)]'
+          : 'text-[var(--accent-amber)]';
+
+  const getIcon = () => {
+    switch (accent) {
+      case 'gold':
+        return (
+          <svg className="w-5 h-5 opacity-60 text-[var(--accent-gold)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+          </svg>
+        );
+      case 'emerald':
+        return (
+          <svg className="w-5 h-5 opacity-60 text-[var(--accent-emerald)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        );
+      case 'coral':
+        return (
+          <svg className="w-5 h-5 opacity-60 text-[var(--accent-coral)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        );
+      case 'amber':
+        return (
+          <svg className="w-5 h-5 opacity-60 text-[var(--accent-amber)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+        );
+    }
+  };
+
+  const glowBg =
+    accent === 'gold'
+      ? 'hover:shadow-[0_0_20px_rgba(218,165,32,0.06)] border-[var(--accent-gold)]/20'
+      : accent === 'emerald'
+        ? 'hover:shadow-[0_0_20px_rgba(16,185,129,0.06)] border-[var(--accent-emerald)]/20'
+        : accent === 'coral'
+          ? 'hover:shadow-[0_0_20px_rgba(239,68,68,0.06)] border-[var(--accent-coral)]/20'
+          : 'hover:shadow-[0_0_20px_rgba(245,158,11,0.06)] border-[var(--accent-amber)]/20';
+
+  return (
+    <motion.div
+      whileHover={{ y: -2, scale: 1.01 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+      className={`rounded-[var(--radius-md)] border bg-[var(--bg-surface)]/80 backdrop-blur-sm px-5 py-4 flex items-center justify-between transition-all duration-300 ${glowBg}`}
+    >
+      <div>
+        <div className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-faint)]">{label}</div>
+        <div className={`text-2xl font-mono font-bold mt-1.5 ${color}`}>{value}</div>
+      </div>
+      <div className="p-2 rounded-lg bg-[var(--bg-hover)]/40 border border-[var(--border-subtle)]/40 shrink-0">
+        {getIcon()}
+      </div>
+    </motion.div>
+  );
+}
+
+// DrawerSection — titled block inside the drawer body.
+function DrawerSection({
+  title,
+  hint,
+  children,
+  action,
+}: {
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="px-4 py-3.5 rounded-[var(--radius-md)] bg-[var(--bg-surface)]/60 backdrop-blur-md border border-[var(--border-subtle)] space-y-2.5 shadow-[0_2px_8px_rgba(0,0,0,0.01)]">
+      <div className="flex items-center justify-between border-b border-[var(--border-subtle)]/30 pb-2 mb-1">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">{title}</span>
+          {hint && <span className="text-[9px] text-[var(--text-faint)] italic">· {hint}</span>}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+// KV — a single key/value row inside a DrawerSection. Supports mono font,
+// optional copy, optional link, and an optional hint tooltip.
+function KV({
+  label,
+  value,
+  mono,
+  link,
+  copyable,
+  onCopy,
+  hint,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  link?: string;
+  copyable?: boolean;
+  onCopy?: () => void;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2 border-b border-[var(--border-subtle)]/40 last:border-b-0 transition-all hover:bg-[var(--bg-hover)]/[0.04] -mx-2 px-2 rounded-[var(--radius-sm)]">
+      <span className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-wider shrink-0 pt-0.5 min-w-[95px] text-left">{label}</span>
+      <div className="min-w-0 flex-1 text-right">
+        <div className="inline-flex items-center justify-end gap-1.5 flex-wrap">
+          {link ? (
+            <Link href={link} className={`text-xs ${mono ? 'font-mono' : ''} text-[var(--accent-gold)] hover:underline break-all`} title={value}>
+              {value}
+            </Link>
+          ) : (
+            <span className={`text-xs ${mono ? 'font-mono' : ''} text-[var(--text-secondary)] break-all`} title={value}>
+              {value}
+            </span>
+          )}
+          {hint && <span className="text-[9px] text-[var(--text-faint)] italic shrink-0">({hint})</span>}
+          {copyable && (
+            <button type="button" onClick={onCopy} className="shrink-0 text-[9px] font-bold uppercase text-[var(--accent-gold)] hover:underline ml-1">
+              copy
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// PlatformBadge — a beautifully styled micro badge for communication platforms.
+function PlatformBadge({ platform }: { platform: string }) {
+  const lower = platform.toLowerCase();
+  let classes = "bg-[var(--bg-hover)]/60 text-[var(--text-muted)] border-[var(--border-subtle)]/60";
+  
+  if (lower === 'feishu') {
+    classes = "bg-blue-500/10 text-blue-400 border-blue-500/20";
+  } else if (lower === 'slack') {
+    classes = "bg-purple-500/10 text-purple-400 border-purple-500/20";
+  } else if (lower === 'webchat') {
+    classes = "bg-[var(--accent-gold)]/10 text-[var(--accent-gold)] border-[var(--accent-gold)]/20";
+  } else if (lower === 'cron') {
+    classes = "bg-emerald-500/10 text-emerald-400 border-emerald-500/20";
+  } else if (lower === 'admin') {
+    classes = "bg-amber-500/10 text-amber-400 border-amber-500/20";
+  } else if (lower === 'api') {
+    classes = "bg-cyan-500/10 text-cyan-400 border-cyan-500/20";
+  }
+
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold border leading-none shrink-0 ${classes}`}>
+      {platform}
+    </span>
   );
 }

--- a/webchat/components/admin/activity/action-icon.tsx
+++ b/webchat/components/admin/activity/action-icon.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+// ActionIcon renders a small inline SVG that classifies an audit action by its
+// first path segment (auth/session/message/tool/admin/system). Mirrors the
+// heroicons outline style used elsewhere in the admin shell (viewBox 0 0 24 24,
+// stroke=currentColor) and is color-tinted per category via className.
+//
+// The category lookup is shared with the timeline table and the drawer header
+// so the icon + color stay consistent across surfaces. Unknown prefixes fall
+// back to a neutral dot.
+
+export type ActionCategory = 'auth' | 'session' | 'message' | 'tool' | 'admin' | 'system' | 'other';
+
+export function actionCategory(action: string): ActionCategory {
+  const head = action.split('.', 1)[0];
+  switch (head) {
+    case 'auth':
+      return 'auth';
+    case 'session':
+      return 'session';
+    case 'message':
+      return 'message';
+    case 'tool':
+      return 'tool';
+    case 'admin':
+      return 'admin';
+    case 'system':
+      return 'system';
+    default:
+      return 'other';
+  }
+}
+
+const CATEGORY_COLOR: Record<ActionCategory, string> = {
+  auth: 'text-[var(--accent-blue)]',
+  session: 'text-[var(--accent-emerald)]',
+  message: 'text-[var(--accent-blue)]',
+  tool: 'text-[var(--accent-violet,#a78bfa)]',
+  admin: 'text-[var(--accent-amber)]',
+  system: 'text-[var(--text-muted)]',
+  other: 'text-[var(--text-faint)]',
+};
+
+function CategoryGlyph({ category }: { category: ActionCategory }) {
+  const common = {
+    xmlns: 'http://www.w3.org/2000/svg',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    strokeWidth: 1.8,
+    stroke: 'currentColor',
+    className: 'w-3.5 h-3.5',
+  } as const;
+  switch (category) {
+    case 'auth':
+      // lock
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 0h10.5a1.5 1.5 0 0 1 1.5 1.5v6.75a1.5 1.5 0 0 1-1.5 1.5H6.75A1.5 1.5 0 0 1 5.25 19.5v-6.75a1.5 1.5 0 0 1 1.5-1.5Z" />
+        </svg>
+      );
+    case 'session':
+      // window/stack
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5v10.5H3.75zM3.75 9.75h16.5M6.75 6.75v.01" />
+        </svg>
+      );
+    case 'message':
+      // chat bubble
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 5.25h15a1.5 1.5 0 0 1 1.5 1.5v8.25a1.5 1.5 0 0 1-1.5 1.5H9.75l-4.5 3.75v-3.75H4.5a1.5 1.5 0 0 1-1.5-1.5V6.75a1.5 1.5 0 0 1 1.5-1.5Z" />
+        </svg>
+      );
+    case 'tool':
+      // wrench
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 6 9.75a4.5 4.5 0 0 1 6.01-6.01l-2.34 2.34 2.25 2.25 2.34-2.34A4.5 4.5 0 0 1 15.17 12l5.42 5.42a2.1 2.1 0 0 1-2.97 2.97Z" />
+        </svg>
+      );
+    case 'admin':
+      // shield
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3 4.5 6v5.25c0 4.5 3.15 7.95 7.5 9 4.35-1.05 7.5-4.5 7.5-9V6L12 3Z" />
+        </svg>
+      );
+    case 'system':
+      // gear
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.59c.55 0 1.02.398 1.11.94l.21 1.06a7.7 7.7 0 0 1 1.7.98l1.03-.42a1.2 1.2 0 0 1 1.45.47l1.3 2.25c.29.5.17 1.13-.28 1.5l-.85.66a7.6 7.6 0 0 1 0 1.96l.85.66c.45.37.57 1 .28 1.5l-1.3 2.25a1.2 1.2 0 0 1-1.45.47l-1.03-.42a7.7 7.7 0 0 1-1.7.98l-.21 1.06c-.09.542-.56.94-1.11.94h-2.59c-.55 0-1.02-.398-1.11-.94l-.21-1.06a7.7 7.7 0 0 1-1.7-.98l-1.03.42a1.2 1.2 0 0 1-1.45-.47l-1.3-2.25a1.2 1.2 0 0 1 .28-1.5l.85-.66a7.6 7.6 0 0 1 0-1.96l-.85-.66a1.2 1.2 0 0 1-.28-1.5l1.3-2.25a1.2 1.2 0 0 1 1.45-.47l1.03.42a7.7 7.7 0 0 1 1.7-.98l.21-1.06Z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 12h.01" />
+        </svg>
+      );
+  }
+}
+
+export function ActionIcon({ action, className }: { action: string; className?: string }) {
+  const category = actionCategory(action);
+  return (
+    <span className={`inline-flex items-center justify-center ${CATEGORY_COLOR[category]} ${className ?? ''}`}>
+      <CategoryGlyph category={category} />
+    </span>
+  );
+}

--- a/webchat/components/admin/activity/json-viewer.tsx
+++ b/webchat/components/admin/activity/json-viewer.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { getHighlighter } from '@/lib/highlight';
+
+// JsonViewer renders a pretty-printed, syntax-highlighted JSON value inside a
+// scrollable <pre>. Used by the audit drawer to surface detail_json with the
+// same highlight.js pipeline as the chat code blocks (lib/highlight.ts, json
+// language already registered).
+//
+// Behavior:
+//   - empty / "{}" → localized "no detail" placeholder
+//   - invalid JSON → fall back to the raw string, monospace, no highlight
+//   - valid JSON → JSON.stringify(,2) → highlight async → dangerouslySetInnerHTML
+//
+// Highlighting is asynchronous (getHighlighter lazy-loads highlight.js). We
+// render the plain pretty-printed JSON immediately and swap in the highlighted
+// HTML once the highlighter resolves, so the content is readable before the
+// highlight lands.
+export function JsonViewer({ json, emptyLabel }: { json: string; emptyLabel?: string }) {
+  const { t } = useTranslation('admin');
+  const [html, setHtml] = useState<string>('');
+
+  const trimmed = (json ?? '').trim();
+  const isEmpty = trimmed === '' || trimmed === '{}';
+  const emptyText = emptyLabel ?? t('activity.drawer.no_detail', { defaultValue: 'No detail' });
+
+  // Parse once; keep the raw pretty string for the pre-highlight render and as
+  // the fallback when JSON is invalid.
+  let pretty = trimmed;
+  let invalid = false;
+  if (!isEmpty) {
+    try {
+      pretty = JSON.stringify(JSON.parse(trimmed), null, 2);
+    } catch {
+      invalid = true;
+    }
+  }
+
+  useEffect(() => {
+    if (isEmpty || invalid) {
+      // Render branches for empty/invalid don't read `html`, so nothing to
+      // clear. Skip the async highlight entirely.
+      return;
+    }
+    let cancelled = false;
+    getHighlighter()
+      .then((hljs) => {
+        if (cancelled) return;
+        try {
+          const out = hljs.highlight(pretty, { language: 'json' }).value;
+          setHtml(out);
+        } catch {
+          setHtml('');
+        }
+      })
+      .catch(() => setHtml(''));
+    return () => {
+      // Reset on re-run (json changed) so a stale highlighted string never
+      // outlives its source value.
+      cancelled = true;
+      setHtml('');
+    };
+    // pretty is derived from json; re-run when json changes.
+  }, [pretty, isEmpty, invalid]);
+
+  if (isEmpty) {
+    return <div className="text-xs text-[var(--text-faint)] italic">{emptyText}</div>;
+  }
+  if (invalid) {
+    return (
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs text-[var(--text-muted)] rounded-[var(--radius-sm)] bg-[var(--bg-hover)]/40 p-3">
+        {trimmed}
+      </pre>
+    );
+  }
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[var(--text-secondary)] rounded-[var(--radius-sm)] bg-[var(--bg-hover)]/40 p-3 overflow-x-auto">
+      {html ? <code dangerouslySetInnerHTML={{ __html: html }} /> : <code>{pretty}</code>}
+    </pre>
+  );
+}

--- a/webchat/components/admin/activity/json-viewer.tsx
+++ b/webchat/components/admin/activity/json-viewer.tsx
@@ -71,13 +71,13 @@ export function JsonViewer({ json, emptyLabel }: { json: string; emptyLabel?: st
   }
   if (invalid) {
     return (
-      <pre className="whitespace-pre-wrap break-words font-mono text-xs text-[var(--text-muted)] rounded-[var(--radius-sm)] bg-[var(--bg-hover)]/40 p-3">
+      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-[var(--text-muted)] rounded-md bg-[var(--bg-hover)]/40 p-2.5 max-h-48 overflow-y-auto border border-[var(--border-subtle)]/40">
         {trimmed}
       </pre>
     );
   }
   return (
-    <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[var(--text-secondary)] rounded-[var(--radius-sm)] bg-[var(--bg-hover)]/40 p-3 overflow-x-auto">
+    <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-normal text-[var(--text-secondary)] rounded-md bg-[var(--bg-hover)]/40 p-2.5 overflow-x-auto max-h-48 overflow-y-auto border border-[var(--border-subtle)]/40">
       {html ? <code dangerouslySetInnerHTML={{ __html: html }} /> : <code>{pretty}</code>}
     </pre>
   );

--- a/webchat/components/admin/activity/outcome-map.ts
+++ b/webchat/components/admin/activity/outcome-map.ts
@@ -1,0 +1,29 @@
+// Audit outcome → StatusBadge style map. Mirrors the shape of
+// SESSION_STATUS_MAP / BOT_STATUS_MAP in status-badge.tsx so the timeline and
+// the drawer can render outcomes via the shared <StatusBadge> component.
+//
+// Colors intentionally match the prior hardcoded outcomeClass() in the
+// activity page (emerald=success, coral=failure, amber=denied) so the visual
+// language is unchanged.
+import type { StatusMap } from '@/components/admin/status-badge';
+
+export const OUTCOME_STATUS_MAP: StatusMap = {
+  success: {
+    bg: 'rgba(52, 211, 153, 0.12)',
+    text: 'text-[var(--accent-emerald)]',
+    dot: 'bg-[var(--accent-emerald)]',
+    label: 'Success',
+  },
+  failure: {
+    bg: 'rgba(244, 63, 94, 0.12)',
+    text: 'text-[var(--accent-coral)]',
+    dot: 'bg-[var(--accent-coral)]',
+    label: 'Failure',
+  },
+  denied: {
+    bg: 'rgba(245, 158, 11, 0.12)',
+    text: 'text-[var(--accent-amber)]',
+    dot: 'bg-[var(--accent-amber)]',
+    label: 'Denied',
+  },
+};

--- a/webchat/components/admin/admin-nav.tsx
+++ b/webchat/components/admin/admin-nav.tsx
@@ -44,6 +44,16 @@ const NAV_ITEMS = [
     exact: false,
   },
   {
+    label: 'Activity',
+    href: '/admin/activity',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.5h16.5M3.75 9h16.5M3.75 13.5h16.5M3.75 18h16.5" />
+      </svg>
+    ),
+    exact: false,
+  },
+  {
     label: 'Workspaces',
     href: '/admin/workspaces',
     icon: (
@@ -100,6 +110,7 @@ export function AdminNav({ onLogout, showConnectionSettings = false }: AdminNavP
       case 'Dashboard': return t('admin:nav.dashboard', { defaultValue: 'Dashboard' });
       case 'Bots': return t('admin:nav.bots', { defaultValue: 'Bots' });
       case 'Sessions': return t('admin:nav.sessions', { defaultValue: 'Sessions' });
+      case 'Activity': return t('admin:nav.activity', { defaultValue: 'Activity' });
       case 'Workspaces': return t('admin:nav.workspaces', { defaultValue: 'Workspaces' });
       case 'Cron': return t('admin:nav.cron', { defaultValue: 'Cron' });
       case 'API Keys': return t('admin:nav.api_keys', { defaultValue: 'API Keys' });

--- a/webchat/lib/api/admin-activity.ts
+++ b/webchat/lib/api/admin-activity.ts
@@ -1,4 +1,4 @@
-import type { AuditActivityResponse } from '@/lib/types/admin';
+import type { ActivityStats, AuditActivityResponse } from '@/lib/types/admin';
 
 import { adminFetch, getStoredAdminConnection } from './admin-client';
 import { BASE, authOpts } from './client';
@@ -8,7 +8,11 @@ export interface ActivityFilters {
   userId?: string;
   principalUserId?: string;
   action?: string;
+  actionPrefix?: string;
   outcome?: string;
+  platform?: string;
+  sessionId?: string;
+  resourceType?: string;
   from?: string;
   to?: string;
   limit?: number;
@@ -20,7 +24,11 @@ function activityParams(filters: ActivityFilters, format?: 'json' | 'csv'): stri
   if (filters.userId) params.set('user_id', filters.userId);
   if (filters.principalUserId) params.set('principal_user_id', filters.principalUserId);
   if (filters.action) params.set('action', filters.action);
+  if (filters.actionPrefix) params.set('action_prefix', filters.actionPrefix);
   if (filters.outcome) params.set('outcome', filters.outcome);
+  if (filters.platform) params.set('platform', filters.platform);
+  if (filters.sessionId) params.set('session_id', filters.sessionId);
+  if (filters.resourceType) params.set('resource_type', filters.resourceType);
   if (filters.from) params.set('from', new Date(filters.from).toISOString());
   if (filters.to) params.set('to', new Date(filters.to).toISOString());
   if (filters.limit) params.set('limit', String(filters.limit));
@@ -30,13 +38,21 @@ function activityParams(filters: ActivityFilters, format?: 'json' | 'csv'): stri
   return query ? `?${query}` : '';
 }
 
+function activityBasePath(): string {
+  return getStoredAdminConnection() ? '/admin/activity' : '/api/admin/activity';
+}
+
 export async function listActivity(filters: ActivityFilters): Promise<AuditActivityResponse> {
-  return adminFetch<AuditActivityResponse>(`/admin/activity${activityParams(filters)}`);
+  return adminFetch<AuditActivityResponse>(`${activityBasePath()}${activityParams(filters)}`);
+}
+
+export async function listActivityStats(filters: ActivityFilters): Promise<ActivityStats> {
+  return adminFetch<ActivityStats>(`${activityBasePath()}/stats${activityParams(filters)}`);
 }
 
 export async function downloadActivity(filters: ActivityFilters, format: 'json' | 'csv'): Promise<void> {
   const conn = getStoredAdminConnection();
-  const path = `/admin/activity/export${activityParams(filters, format)}`;
+  const path = `${conn ? '/admin/activity' : '/api/admin/activity'}/export${activityParams(filters, format)}`;
   const res = conn
     ? await fetch(`${conn.url}${path}`, {
         headers: { Authorization: `Bearer ${conn.token}` },

--- a/webchat/lib/api/admin-activity.ts
+++ b/webchat/lib/api/admin-activity.ts
@@ -1,0 +1,60 @@
+import type { AuditActivityResponse } from '@/lib/types/admin';
+
+import { adminFetch, getStoredAdminConnection } from './admin-client';
+import { BASE, authOpts } from './client';
+import { parseApiError } from './errors';
+
+export interface ActivityFilters {
+  userId?: string;
+  principalUserId?: string;
+  action?: string;
+  outcome?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+function activityParams(filters: ActivityFilters, format?: 'json' | 'csv'): string {
+  const params = new URLSearchParams();
+  if (filters.userId) params.set('user_id', filters.userId);
+  if (filters.principalUserId) params.set('principal_user_id', filters.principalUserId);
+  if (filters.action) params.set('action', filters.action);
+  if (filters.outcome) params.set('outcome', filters.outcome);
+  if (filters.from) params.set('from', new Date(filters.from).toISOString());
+  if (filters.to) params.set('to', new Date(filters.to).toISOString());
+  if (filters.limit) params.set('limit', String(filters.limit));
+  if (filters.offset) params.set('offset', String(filters.offset));
+  if (format) params.set('format', format);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function listActivity(filters: ActivityFilters): Promise<AuditActivityResponse> {
+  return adminFetch<AuditActivityResponse>(`/admin/activity${activityParams(filters)}`);
+}
+
+export async function downloadActivity(filters: ActivityFilters, format: 'json' | 'csv'): Promise<void> {
+  const conn = getStoredAdminConnection();
+  const path = `/admin/activity/export${activityParams(filters, format)}`;
+  const res = conn
+    ? await fetch(`${conn.url}${path}`, {
+        headers: { Authorization: `Bearer ${conn.token}` },
+      })
+    : await fetch(`${BASE}${path}`, authOpts());
+
+  if (!res.ok) {
+    const info = await parseApiError(res);
+    throw new Error(info.message || info.raw || `Export failed: ${res.status}`);
+  }
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `activity-${new Date().toISOString().replace(/[:.]/g, '-')}.${format}`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/webchat/lib/types/admin.ts
+++ b/webchat/lib/types/admin.ts
@@ -70,6 +70,57 @@ export interface AdminSessionInfo {
   turn_count?: number;
 }
 
+// --- Audit Activity ---
+
+export interface AuditActivity {
+  id: number;
+  ts: number;
+  user_id: string;
+  user_id_type: string;
+  platform: string;
+  session_id?: string;
+  action: string;
+  resource_type?: string;
+  resource_id?: string;
+  outcome: string;
+  detail_json: string;
+  event_ref?: string;
+  ip?: string;
+  user_agent?: string;
+  prev_hash: string;
+  self_hash: string;
+}
+
+export interface AuditActivityResponse {
+  rows: AuditActivity[];
+  limit: number;
+  offset: number;
+  user_id?: string;
+  principal_user_id?: string;
+  resolved_user_ids?: string[];
+}
+
+export interface AuditIdentityLink {
+  ID?: string;
+  id?: string;
+  PrincipalUserID?: string;
+  principal_user_id?: string;
+  Provider?: string;
+  provider?: string;
+  Subject?: string;
+  subject?: string;
+  SubjectType?: string;
+  subject_type?: string;
+  DisplayName?: string;
+  display_name?: string;
+  Email?: string;
+  email?: string;
+  CreatedAt?: number;
+  created_at?: number;
+  UpdatedAt?: number;
+  updated_at?: number;
+}
+
 // --- Cron ---
 
 export interface CronSchedule {

--- a/webchat/lib/types/admin.ts
+++ b/webchat/lib/types/admin.ts
@@ -98,6 +98,15 @@ export interface AuditActivityResponse {
   user_id?: string;
   principal_user_id?: string;
   resolved_user_ids?: string[];
+  identity_links?: Record<string, AuditIdentityLink>;
+}
+
+// Audit activity aggregate counts returned by GET /admin/activity/stats.
+// total reflects the full filtered set (not just the current page).
+export interface ActivityStats {
+  total: number;
+  by_outcome: Record<string, number>;
+  by_platform: Record<string, number>;
 }
 
 export interface AuditIdentityLink {

--- a/webchat/locales/en/admin.json
+++ b/webchat/locales/en/admin.json
@@ -425,12 +425,35 @@
     "loading": "Loading activity...",
     "resolved_ids": "Resolved IDs",
     "filters": {
-      "user_id": "User ID",
-      "principal_user_id": "Principal User ID",
+      "user_id": "Platform Native ID (e.g. Feishu ou_ / Slack U...)",
+      "principal_user_id": "Unified Principal ID (e.g. zhangsan)",
       "action": "Action",
+      "any_action": "Any action",
       "any_outcome": "Any outcome",
+      "any_platform": "Any platform",
+      "platform": "Platform",
       "from": "From",
-      "to": "To"
+      "to": "To",
+      "from_short": "From",
+      "to_short": "To"
+    },
+    "hints": {
+      "user_id_tooltip": "The raw account ID assigned by the communication platform, e.g. ou_xxxx on Feishu or Uxxxx on Slack.",
+      "principal_tooltip": "The employee's unified primary identity ID. Searching this automatically resolves all linked accounts (Feishu/Slack/WebChat)."
+    },
+    "stats": {
+      "total": "Total",
+      "success": "Success",
+      "failure": "Failure",
+      "denied": "Denied"
+    },
+    "action_groups": {
+      "auth": "Authentication",
+      "session": "Session",
+      "message": "Message",
+      "tool": "Tool Call",
+      "admin": "Admin",
+      "system": "System"
     },
     "table": {
       "time": "Time",
@@ -438,12 +461,30 @@
       "platform": "Platform",
       "action": "Action",
       "outcome": "Outcome",
-      "detail": "Detail"
+      "detail": "Detail",
+      "session": "Session"
     },
     "outcomes": {
       "success": "Success",
       "failure": "Failure",
       "denied": "Denied"
+    },
+    "drawer": {
+      "title": "Activity Detail",
+      "identity": "Identity",
+      "context": "Context",
+      "network": "Network",
+      "detail_json": "Detail JSON",
+      "hash_chain": "Hash Chain",
+      "prev_hash": "Previous",
+      "self_hash": "Current",
+      "hash_hint": "Tamper-evident chain",
+      "no_detail": "No detail payload",
+      "copy_json": "Copy JSON",
+      "copied": "Copied",
+      "open_session": "Open session",
+      "ip_masked": "masked unless include_pii",
+      "message_content": "Message Content"
     },
     "action": {
       "export_json": "Export JSON",

--- a/webchat/locales/en/admin.json
+++ b/webchat/locales/en/admin.json
@@ -447,6 +447,14 @@
       "failure": "Failure",
       "denied": "Denied"
     },
+    "pagination": {
+      "showing": "Showing",
+      "to": "to",
+      "of": "of",
+      "entries": "entries",
+      "prev": "Prev",
+      "next": "Next"
+    },
     "action_groups": {
       "auth": "Authentication",
       "session": "Session",

--- a/webchat/locales/en/admin.json
+++ b/webchat/locales/en/admin.json
@@ -67,6 +67,7 @@
     "dashboard": "Dashboard",
     "bots": "Bots",
     "sessions": "Sessions",
+    "activity": "Activity",
     "workspaces": "Workspaces",
     "cron": "Cron",
     "api_keys": "API Keys",
@@ -419,6 +420,48 @@
       "description": "Optional description"
     }
   },
+  "activity": {
+    "title": "Activity",
+    "loading": "Loading activity...",
+    "resolved_ids": "Resolved IDs",
+    "filters": {
+      "user_id": "User ID",
+      "principal_user_id": "Principal User ID",
+      "action": "Action",
+      "any_outcome": "Any outcome",
+      "from": "From",
+      "to": "To"
+    },
+    "table": {
+      "time": "Time",
+      "user": "User",
+      "platform": "Platform",
+      "action": "Action",
+      "outcome": "Outcome",
+      "detail": "Detail"
+    },
+    "outcomes": {
+      "success": "Success",
+      "failure": "Failure",
+      "denied": "Denied"
+    },
+    "action": {
+      "export_json": "Export JSON",
+      "export_csv": "Export CSV",
+      "exporting": "Exporting..."
+    },
+    "toast": {
+      "exported": "Export started."
+    },
+    "error": {
+      "load_failed": "Failed to load activity",
+      "export_failed": "Export failed"
+    },
+    "empty": {
+      "title": "No activity",
+      "description": "Audit rows appear here after users authenticate, create sessions, send messages, call tools, or perform admin actions."
+    }
+  },
   "cron": {
     "title": "Cron Jobs",
     "loading": "Loading cron jobs...",
@@ -498,4 +541,3 @@
     }
   }
 }
-

--- a/webchat/locales/zh-CN/admin.json
+++ b/webchat/locales/zh-CN/admin.json
@@ -425,12 +425,35 @@
     "loading": "正在加载审计活动...",
     "resolved_ids": "已解析 ID",
     "filters": {
-      "user_id": "用户 ID",
-      "principal_user_id": "主体用户 ID",
+      "user_id": "平台原生账号 ID (如飞书 ou_ / Slack U...)",
+      "principal_user_id": "统一主账号 ID (Principal ID)",
       "action": "动作",
+      "any_action": "任意动作",
       "any_outcome": "任意结果",
+      "any_platform": "任意平台",
+      "platform": "平台",
       "from": "开始时间",
-      "to": "结束时间"
+      "to": "结束时间",
+      "from_short": "从",
+      "to_short": "至"
+    },
+    "hints": {
+      "user_id_tooltip": "通信平台分配给该用户的原始账号 ID，例如飞书里的 ou_xxxx，Slack 里的 Uxxxx 等。",
+      "principal_tooltip": "员工在系统中的统一主账号 ID。输入后系统会自动检索其绑定的所有通信平台账号（飞书/Slack/WebChat）的全部活动审计。"
+    },
+    "stats": {
+      "total": "总计",
+      "success": "成功",
+      "failure": "失败",
+      "denied": "拒绝"
+    },
+    "action_groups": {
+      "auth": "认证",
+      "session": "会话",
+      "message": "消息",
+      "tool": "工具调用",
+      "admin": "管理",
+      "system": "系统"
     },
     "table": {
       "time": "时间",
@@ -438,12 +461,30 @@
       "platform": "平台",
       "action": "动作",
       "outcome": "结果",
-      "detail": "详情"
+      "detail": "详情",
+      "session": "会话"
     },
     "outcomes": {
       "success": "成功",
       "failure": "失败",
       "denied": "拒绝"
+    },
+    "drawer": {
+      "title": "行为详情",
+      "identity": "身份",
+      "context": "上下文",
+      "network": "网络",
+      "detail_json": "详情 JSON",
+      "hash_chain": "哈希链",
+      "prev_hash": "前驱",
+      "self_hash": "当前",
+      "hash_hint": "防篡改链",
+      "no_detail": "无详情数据",
+      "copy_json": "复制 JSON",
+      "copied": "已复制",
+      "open_session": "打开会话",
+      "ip_masked": "未开启 include_pii 时已脱敏",
+      "message_content": "消息内容"
     },
     "action": {
       "export_json": "导出 JSON",

--- a/webchat/locales/zh-CN/admin.json
+++ b/webchat/locales/zh-CN/admin.json
@@ -447,6 +447,14 @@
       "failure": "失败",
       "denied": "拒绝"
     },
+    "pagination": {
+      "showing": "显示第",
+      "to": "至",
+      "of": "条，共",
+      "entries": "条记录",
+      "prev": "上一页",
+      "next": "下一页"
+    },
     "action_groups": {
       "auth": "认证",
       "session": "会话",

--- a/webchat/locales/zh-CN/admin.json
+++ b/webchat/locales/zh-CN/admin.json
@@ -67,6 +67,7 @@
     "dashboard": "控制台",
     "bots": "机器人管理",
     "sessions": "会话管理",
+    "activity": "行为审计",
     "workspaces": "工作区管理",
     "cron": "定时任务",
     "api_keys": "API 密钥",
@@ -419,6 +420,48 @@
       "description": "可选描述"
     }
   },
+  "activity": {
+    "title": "行为审计",
+    "loading": "正在加载审计活动...",
+    "resolved_ids": "已解析 ID",
+    "filters": {
+      "user_id": "用户 ID",
+      "principal_user_id": "主体用户 ID",
+      "action": "动作",
+      "any_outcome": "任意结果",
+      "from": "开始时间",
+      "to": "结束时间"
+    },
+    "table": {
+      "time": "时间",
+      "user": "用户",
+      "platform": "平台",
+      "action": "动作",
+      "outcome": "结果",
+      "detail": "详情"
+    },
+    "outcomes": {
+      "success": "成功",
+      "failure": "失败",
+      "denied": "拒绝"
+    },
+    "action": {
+      "export_json": "导出 JSON",
+      "export_csv": "导出 CSV",
+      "exporting": "导出中..."
+    },
+    "toast": {
+      "exported": "已开始导出。"
+    },
+    "error": {
+      "load_failed": "加载审计活动失败",
+      "export_failed": "导出失败"
+    },
+    "empty": {
+      "title": "暂无审计活动",
+      "description": "用户认证、创建会话、发送消息、调用工具或执行管理操作后，审计记录会显示在这里。"
+    }
+  },
   "cron": {
     "title": "定时任务",
     "loading": "正在加载定时任务...",
@@ -498,4 +541,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Summary

Resolves #833.

This PR closes the remaining user behavior audit follow-ups in one package:

- Adds docs/specs/User-Behavior-Audit-Final-Followups-Spec.md and updates the original audit spec status.
- Adds explicit cross-channel audit identity links via audit_identity_links, with SQLite and PostgreSQL migration 024.
- Expands /admin/activity?principal_user_id=... to query the principal plus linked platform-native subjects.
- Adds admin API endpoints for identity link list/create/delete.
- Adds the embedded webchat /admin/activity timeline with filters and JSON/CSV export.
- Documents activity and identity-link admin APIs and clarifies user_activity as the audit source of truth while admin_audit slog remains a compatibility stream.

## Scope Notes

This does not add a full alert rules engine. SIEM/SOC delivery remains behind the existing WebhookSink/AlertSink contract from P2, and the UI exposes existing JSON/CSV export for cold-archive workflows. PostgreSQL monthly partitioning is documented as requiring a staged table replacement plan rather than unsafe in-place conversion of the existing user_activity table.

## Testing

- go test -count=1 ./...
- go test -race -count=1 ./internal/audit ./internal/admin ./internal/security ./cmd/hotplex
- cd webchat && npx tsc --noEmit
- cd webchat && npx eslint app/admin/activity/page.tsx lib/api/admin-activity.ts lib/types/admin.ts components/admin/admin-nav.tsx
- make check
- pre-push hook: formatting, vet, go mod verify, lint, build, tests all passed
