### PR TITLE
feat(auth): accept bearer api keys and sync webchat runtime

### DIFF
--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -350,12 +350,22 @@ func (a *Authenticator) extractAPIKey(r *http.Request) (string, bool) {
 	}
 	key := r.Header.Get(header)
 	if key == "" {
+		key = bearerToken(r.Header.Get("Authorization"))
+	}
+	if key == "" {
 		key = r.URL.Query().Get(apiKeyQueryParam)
 	}
 	if key == "" {
 		return "", false
 	}
 	return key, true
+}
+
+func bearerToken(header string) string {
+	if !strings.HasPrefix(header, "Bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
 }
 
 // AuthenticateKey validates an API key string directly.

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -61,6 +61,7 @@ func TestAuthenticateRequest(t *testing.T) {
 		apiKeys    []string
 		headerName string
 		requestKey string
+		authHeader string
 		wantUserID string
 		wantErr    bool
 	}{
@@ -81,6 +82,13 @@ func TestAuthenticateRequest(t *testing.T) {
 			name:       "valid api key",
 			apiKeys:    []string{"secret1", "secret2"},
 			requestKey: "secret1",
+			wantUserID: "api_user",
+			wantErr:    false,
+		},
+		{
+			name:       "valid bearer api key",
+			apiKeys:    []string{"secret1"},
+			authHeader: "Bearer secret1",
 			wantUserID: "api_user",
 			wantErr:    false,
 		},
@@ -125,6 +133,9 @@ func TestAuthenticateRequest(t *testing.T) {
 					header = "X-API-Key"
 				}
 				req.Header.Set(header, tt.requestKey)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
 			}
 
 			userID, _, err := auth.AuthenticateRequest(req)
@@ -386,6 +397,15 @@ func TestExtractAPIKey(t *testing.T) {
 		key, ok := auth.ExtractAPIKey(req)
 		require.True(t, ok)
 		require.Equal(t, "query-key", key)
+	})
+
+	t.Run("from bearer authorization", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer bearer-key")
+		key, ok := auth.ExtractAPIKey(req)
+		require.True(t, ok)
+		require.Equal(t, "bearer-key", key)
 	})
 
 	t.Run("header takes precedence", func(t *testing.T) {

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -33,6 +33,7 @@ import { logout, getMe, type User } from "@/lib/api/auth";
 import { ApiError } from "@/lib/api/errors";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import type { WorkerType } from "@/lib/ai-sdk-transport/client/constants";
 
 // Clear all hotplex workspace/session selection state from localStorage.
 // Called on logout so a different account logging into the same browser does
@@ -53,12 +54,14 @@ function clearHotplexSessionStorage(): void {
 
 function ChatInterface({
     sessionId,
+    workerType,
     onMetricsChange,
     onSessionStateChange,
     workspaceId,
     onWorkspaceError,
 }: {
     sessionId: string | null;
+    workerType?: WorkerType;
     onMetricsChange?: (metrics: SessionMetrics) => void;
     onSessionStateChange?: (state: string) => void;
     workspaceId?: string;
@@ -67,6 +70,7 @@ function ChatInterface({
     const { skills, mergeSkills } = useSkillsCache(sessionId);
     const adapter = useHotPlexRuntime({
         sessionId: sessionId ?? undefined,
+        workerType,
         onMetricsChange,
         onSkillsChange: mergeSkills,
         onSessionStateChange,
@@ -672,6 +676,11 @@ export default function ChatContainer() {
                             <ChatInterface
                                 key={activeSessionId}
                                 sessionId={activeSessionId}
+                                workerType={
+                                    activeSession?.worker_type as
+                                        | WorkerType
+                                        | undefined
+                                }
                                 onMetricsChange={setSessionMetrics}
                                 onSessionStateChange={(state) =>
                                     activeSessionId &&

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -19,10 +19,13 @@ import type {
     QuestionRequestData,
     ElicitationRequestData,
 } from "@/lib/ai-sdk-transport/client/types";
-import { WorkerStdioCommand } from "@/lib/ai-sdk-transport/client/constants";
+import {
+    WorkerStdioCommand,
+    type WorkerType,
+} from "@/lib/ai-sdk-transport/client/constants";
 import {
     wsUrl,
-    workerType,
+    workerType as defaultWorkerType,
     apiKey,
     isSameOrigin,
     allowedTools,
@@ -82,6 +85,8 @@ type ThreadSuggestion = { title: string; label: string; prompt: string };
 export interface UseHotPlexRuntimeConfig {
     /** Initial session ID to resume (calls resume() instead of connect()). */
     sessionId?: string;
+    /** Worker type of the selected session. Defaults to HOTPLEX_WEBCHAT_WORKER_TYPE. */
+    workerType?: WorkerType;
     /** Active workspace ID (spec ⑥) */
     workspaceId?: string;
     /** Called when the server rejects the workspace during handshake
@@ -231,6 +236,7 @@ function historyToMessages(records: ConversationRecord[]): HotPlexMessage[] {
  */
 export function useHotPlexRuntime({
     sessionId,
+    workerType: sessionWorkerType,
     workspaceId,
     onWorkspaceError,
     onMetricsChange,
@@ -413,7 +419,7 @@ export function useHotPlexRuntime({
 
         const client = new BrowserHotPlexClient({
             url: wsUrl,
-            workerType,
+            workerType: sessionWorkerType ?? defaultWorkerType,
             apiKey: isSameOrigin() ? undefined : apiKey,
             authToken: isSameOrigin() ? undefined : apiKey,
             workspaceId,
@@ -570,6 +576,7 @@ export function useHotPlexRuntime({
                         toolName: data.name,
                         args: data.input,
                         toolCallId: data.id,
+                        status: { type: "running" as const },
                     };
                     // Replace previous todo tool-call instead of stacking duplicates
                     if (TODO_TOOLS.has(data.name?.toLowerCase())) {
@@ -601,7 +608,16 @@ export function useHotPlexRuntime({
                 if (lastMessage?.role === "assistant") {
                     const parts = lastMessage.parts.map((p) =>
                         p.type === "tool-call" && p.toolCallId === data.id
-                            ? { ...p, result: data.output }
+                            ? {
+                                  ...p,
+                                  result: data.error ?? data.output,
+                                  isError: !!data.error,
+                                  status: {
+                                      type: data.error
+                                          ? ("error" as const)
+                                          : ("complete" as const),
+                                  },
+                              }
                             : p,
                     );
                     return [...prev.slice(0, -1), { ...lastMessage, parts }];
@@ -623,6 +639,18 @@ export function useHotPlexRuntime({
                 const lastMessage = prev[prev.length - 1];
                 if (lastMessage?.role === "assistant") {
                     const parts = [...lastMessage.parts];
+                    for (let i = 0; i < parts.length; i += 1) {
+                        const part = parts[i];
+                        if (
+                            part.type === "tool-call" &&
+                            (!part.status || part.status.type === "running")
+                        ) {
+                            parts[i] = {
+                                ...part,
+                                status: { type: "complete" as const },
+                            };
+                        }
+                    }
                     // Inject turn-summary part from _session data
                     if (data?.stats?._session) {
                         parts.push({
@@ -761,7 +789,21 @@ export function useHotPlexRuntime({
                     ) {
                         return [
                             ...prev.slice(0, -1),
-                            { ...lastMessage, status: "complete" },
+                            {
+                                ...lastMessage,
+                                status: "complete",
+                                parts: lastMessage.parts.map((p) =>
+                                    p.type === "tool-call" &&
+                                    p.status?.type === "running"
+                                        ? {
+                                              ...p,
+                                              status: {
+                                                  type: "complete" as const,
+                                              },
+                                          }
+                                        : p,
+                                ),
+                            },
                         ];
                     }
                     return prev;
@@ -836,7 +878,21 @@ export function useHotPlexRuntime({
                     ) {
                         return [
                             ...prev.slice(0, -1),
-                            { ...lastMessage, status: "complete" },
+                            {
+                                ...lastMessage,
+                                status: "complete",
+                                parts: lastMessage.parts.map((p) =>
+                                    p.type === "tool-call" &&
+                                    p.status?.type === "running"
+                                        ? {
+                                              ...p,
+                                              status: {
+                                                  type: "error" as const,
+                                              },
+                                          }
+                                        : p,
+                                ),
+                            },
                         ];
                     }
                     return prev;
@@ -1164,7 +1220,7 @@ export function useHotPlexRuntime({
             clientRef.current = null;
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps -- connection lifecycle effect; refs/recordTurn intentionally excluded to avoid reconnect churn
-    }, [sessionId, workspaceId]);
+    }, [sessionId, workspaceId, sessionWorkerType]);
 
     // Track pending connection-wait state so useEffect cleanup can tear it down
     const connectionWaitRef = useRef<{

--- a/webchat/lib/config.ts
+++ b/webchat/lib/config.ts
@@ -12,9 +12,23 @@ import type { WorkerType } from "@/lib/ai-sdk-transport/client/constants";
 
 // -- Gateway -----------------------------------------------------------
 
+function browserReachableUrl(rawUrl: string): string {
+  if (typeof window === "undefined") return rawUrl;
+  try {
+    const url = new URL(rawUrl);
+    if (url.hostname === "0.0.0.0" || url.hostname === "::") {
+      url.hostname = window.location.hostname || "localhost";
+      return url.toString();
+    }
+  } catch {
+    // Keep malformed values unchanged so connection errors expose the bad config.
+  }
+  return rawUrl;
+}
+
 function resolveWsUrl(): string {
   const envUrl = process.env.HOTPLEX_WEBCHAT_WS_URL;
-  if (envUrl) return envUrl;
+  if (envUrl) return browserReachableUrl(envUrl);
   // Auto-detect when served from the same Go binary (zero-config).
   if (typeof window !== "undefined") {
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -66,4 +80,4 @@ export function httpBase(): string {
 // -- Admin -----------------------------------------------------------------
 
 export const adminUrl: string =
-  process.env.HOTPLEX_WEBCHAT_ADMIN_URL ?? 'http://localhost:9999';
+  browserReachableUrl(process.env.HOTPLEX_WEBCHAT_ADMIN_URL ?? 'http://localhost:9999');

--- a/webchat/lib/types/message-parts.ts
+++ b/webchat/lib/types/message-parts.ts
@@ -23,6 +23,7 @@ export interface ToolCallPart {
   toolCallId: string;
   result?: any;
   isError?: boolean;
+  status?: { type: 'running' } | { type: 'complete' } | { type: 'error' };
 }
 
 export interface ToolSummaryPart {


### PR DESCRIPTION
## Summary

- **Backend**: Accept API keys via `Authorization: Bearer <key>` header (fallback when `X-API-Key` is absent), enabling easier integration with standard HTTP clients
- **Webchat config**: Fix `0.0.0.0`/`::` wildcard hostname in WS/HTTP URLs — rewrite to `window.location.hostname` so browsers can actually connect
- **Webchat runtime**: Propagate per-session `workerType` to the AI SDK transport, add tool-call lifecycle status tracking (running → complete/error), fix stale `running` status leaks on session end

## Test plan

- [x] `Backend`: existing auth tests pass with new `Bearer` key test case
- [x] `Backend`: `TestExtractAPIKey` covers `Authorization: Bearer` extraction
- [ ] Webchat: verify `HOTPLEX_WEBCHAT_WS_URL` with `0.0.0.0` resolves correctly in browser
- [ ] Webchat: verify tool-call status transitions (running → complete/error) in UI