### PR TITLE
fix(webchat): support multi_select and multiple aliases for questions

### DIFF
--- a/configs/config-dev.yaml
+++ b/configs/config-dev.yaml
@@ -34,6 +34,8 @@ security:
   allowed_origins:
     - "http://127.0.0.1:3000"
     - "http://localhost:3000"
+    - "http://127.0.0.1:8888"
+    - "http://localhost:8888"
   cookie_same_site: "none"
 
 session:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -127,7 +127,8 @@ security:
   # (comma-separated list, e.g. "https://app.example.com,https://admin.example.com").
   # A startup WARN log fires when wildcard "*" is in effect.
   allowed_origins:
-    - "*"
+    - "http://127.0.0.1:3000"
+    - "http://localhost:3000"
   # Content-Security-Policy header served with the embedded webchat SPA and
   # docs portal. Leave empty to use the package-level default, which is
   # INTENTIONALLY permissive: connect-src uses the CSP scheme keywords

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -127,8 +127,8 @@ security:
   # (comma-separated list, e.g. "https://app.example.com,https://admin.example.com").
   # A startup WARN log fires when wildcard "*" is in effect.
   allowed_origins:
-    - "http://127.0.0.1:3000"
-    - "http://localhost:3000"
+    - "http://127.0.0.1:8888"
+    - "http://localhost:8888"
   # Content-Security-Policy header served with the embedded webchat SPA and
   # docs portal. Leave empty to use the package-level default, which is
   # INTENTIONALLY permissive: connect-src uses the CSP scheme keywords

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -185,6 +185,10 @@ worker:
   turn_timeout: 0  # per-turn kill timer; 0=disabled (execution_timeout catches zombies)
   default_work_dir: ~/.hotplex/workspace
   pid_dir: ~/.hotplex/.pids
+  # Default permission mode tier (read-only, workspace, auto-edit, bypass)
+  # applied to workspaces with no explicit override (seeded "workspace").
+  # Empty/unset in workspaces allows each worker to run under its own default/config.
+  default_permission_mode: "workspace"
 
   # Environment variables to block from workers (prefix match with trailing "_").
   env_blocklist: []

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/internal/worker/base"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -25,6 +26,9 @@ func (h *Handler) sendErrorf(ctx context.Context, env *events.Envelope, code eve
 // Timeout errors (ErrKindTimeout) are not treated as fatal — the worker is still alive.
 // ErrNotImplemented maps to ErrCodeNotSupported for unimplemented worker capabilities.
 func classifyWorkerError(err error) events.ErrorCode {
+	if errors.Is(err, base.ErrInvalidSchema) {
+		return events.ErrCodeInvalidMessage
+	}
 	if errors.Is(err, worker.ErrNotImplemented) {
 		return events.ErrCodeNotSupported
 	}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/skills"
 	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/internal/worker/base"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 
@@ -108,10 +109,12 @@ func (h *Handler) Handle(ctx context.Context, env *events.Envelope) (err error) 
 		return h.handleControl(ctx, env)
 	case events.WorkerCmd:
 		return h.handleWorkerCommand(ctx, env)
+	case events.PermissionResponse, events.QuestionResponse, events.ElicitationResponse:
+		return h.handleInteractionResponseEvent(ctx, env)
 	// AEP-011 / AEP-012: pass-through events from worker to all session clients.
-	case events.Reasoning, events.Step, events.PermissionRequest, events.PermissionResponse,
-		events.QuestionRequest, events.QuestionResponse,
-		events.ElicitationRequest, events.ElicitationResponse,
+	case events.Reasoning, events.Step, events.PermissionRequest,
+		events.QuestionRequest,
+		events.ElicitationRequest,
 		events.Message, events.MessageStart, events.MessageEnd:
 		return h.passthroughToSession(ctx, env)
 	default:
@@ -477,4 +480,109 @@ type defaultWorkerFactory struct{}
 
 func (defaultWorkerFactory) NewWorker(t worker.WorkerType) (worker.Worker, error) {
 	return worker.NewWorker(t)
+}
+
+func (h *Handler) handleInteractionResponseEvent(ctx context.Context, env *events.Envelope) error {
+	h.cancelRetryIfNeeded(env.SessionID)
+
+	si, err := h.sm.Get(ctx, env.SessionID)
+	if err != nil {
+		h.log.Warn("gateway: interaction response session not found", "session_id", env.SessionID, "err", err)
+		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "session not found")
+	}
+
+	w := h.sm.GetWorker(env.SessionID)
+	if w == nil {
+		h.log.Warn("gateway: interaction response no worker attached", "session_id", env.SessionID)
+		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "no worker attached to session")
+	}
+
+	metadata, err := interactionResponseMetadata(env.Event.Type, env.Event.Data)
+	if err != nil {
+		h.log.Warn("gateway: normalize interaction response failed", "err", err, "session_id", env.SessionID)
+		return h.sendErrorf(ctx, env, events.ErrCodeInvalidMessage, "invalid response data: %v", err)
+	}
+
+	if err := w.Input(ctx, "", metadata); err != nil {
+		h.log.Warn("gateway: worker interaction response delivery failed", "err", err, "session_id", env.SessionID)
+		code := classifyWorkerError(err)
+		if errors.Is(err, base.ErrInvalidSchema) {
+			code = events.ErrCodeInvalidMessage
+		}
+		// Send error envelope but include request_id in Metadata to allow UI correlation
+		var reqID string
+		if dataMap, ok := env.Event.Data.(map[string]any); ok {
+			reqID, _ = dataMap["id"].(string)
+			if reqID == "" {
+				reqID, _ = dataMap["request_id"].(string)
+			}
+		}
+		errEnv := events.NewEnvelope(aep.NewID(), env.SessionID, h.hub.NextSeq(env.SessionID), events.Error, events.ErrorData{
+			Code:    code,
+			Message: fmt.Sprintf("worker response failed: %v", err),
+		})
+		if reqID != "" {
+			errEnv.Metadata = map[string]any{
+				"interaction_error": map[string]any{
+					"request_id": reqID,
+				},
+			}
+		}
+		_ = h.hub.SendToSession(ctx, errEnv)
+		return fmt.Errorf("%s: worker response failed: %w", code, err)
+	}
+
+	h.emitAudit(audit.OutcomeSuccess, env.OwnerID, si.Platform, env.SessionID, "")
+	if h.bridge != nil {
+		h.bridge.CaptureInboundEvent(env.SessionID, env.Seq, env.Event.Type, env.Event.Data)
+	}
+	return nil
+}
+
+func interactionResponseMetadata(kind events.Kind, data any) (map[string]any, error) {
+	dataMap, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("response data must be a map")
+	}
+
+	metadata := make(map[string]any)
+	switch kind {
+	case events.PermissionResponse:
+		id, _ := dataMap["id"].(string)
+		if id == "" {
+			id, _ = dataMap["request_id"].(string)
+		}
+		allowed, _ := dataMap["allowed"].(bool)
+		reason, _ := dataMap["reason"].(string)
+
+		metadata["permission_response"] = map[string]any{
+			"id":         id,
+			"request_id": id,
+			"allowed":    allowed,
+			"reason":     reason,
+		}
+
+	case events.QuestionResponse:
+		id, _ := dataMap["id"].(string)
+		answers := dataMap["answers"]
+		metadata["question_response"] = map[string]any{
+			"id":      id,
+			"answers": answers,
+		}
+
+	case events.ElicitationResponse:
+		id, _ := dataMap["id"].(string)
+		action, _ := dataMap["action"].(string)
+		content := dataMap["content"]
+		metadata["elicitation_response"] = map[string]any{
+			"id":      id,
+			"action":  action,
+			"content": content,
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported interaction response kind: %s", kind)
+	}
+
+	return metadata, nil
 }

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -100,6 +100,9 @@ func (h *Handler) Handle(ctx context.Context, env *events.Envelope) (err error) 
 			err = fmt.Errorf("handler panic: %v", r)
 		}
 	}()
+	if env.Event.Type != events.Ping {
+		h.log.Info("gateway: Handle received event", "type", env.Event.Type, "session_id", env.SessionID, "seq", env.Seq, "data", env.Event.Data)
+	}
 	switch env.Event.Type {
 	case events.Input:
 		return h.handleInput(ctx, env)

--- a/internal/messaging/feishu/card_action.go
+++ b/internal/messaging/feishu/card_action.go
@@ -37,6 +37,7 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 	// "request_id" key — reading "id" here would silently miss every click.
 	requestID, _ := val["request_id"].(string)
 	actionType, _ := val["action"].(string)
+	summary, _ := val["summary"].(string)
 
 	openID := ""
 	if event.Event.Operator != nil {
@@ -81,7 +82,7 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 
 	default:
 		a.Log.Warn("feishu: unknown card action type", "action", actionType, "request_id", requestID)
-		return wrapResolvedCard(buildResolvedCard("deny", "未知操作", headerGrey)), nil
+		return wrapResolvedCard(buildResolvedCard("deny", "未知操作", headerGrey, summary, "")), nil
 	}
 
 	// Owner check BEFORE Complete — preserves the interaction for non-owner
@@ -92,7 +93,7 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 	// their own timeout.
 	pending, exists := a.Interactions.Get(requestID)
 	if !exists {
-		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", ""))
+		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", "", summary, ""))
 		return
 	}
 	if pending.OwnerID != "" && pending.OwnerID != openID {
@@ -103,7 +104,7 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 
 	pi, ok := a.Interactions.Complete(requestID)
 	if !ok {
-		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", ""))
+		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", "", summary, ""))
 		return
 	}
 
@@ -116,7 +117,7 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 		"action", actionType,
 		"operator", openID)
 
-	return wrapResolvedCard(buildResolvedCard(actionType, resolvedLabel, resolvedColor)), nil
+	return wrapResolvedCard(buildResolvedCard(actionType, resolvedLabel, resolvedColor, summary, openID)), nil
 }
 
 func wrapResolvedCard(card map[string]any) *callback.CardActionTriggerResponse {

--- a/internal/messaging/feishu/card_template.go
+++ b/internal/messaging/feishu/card_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -286,8 +287,13 @@ func buildPermissionCardWithButtons(data *events.PermissionRequestData) string {
 		}
 	}
 
-	valAllow := map[string]any{"action": "allow", "request_id": data.ID}
-	valDeny := map[string]any{"action": "deny", "request_id": data.ID}
+	summary := fmt.Sprintf("工具执行: %s", data.ToolName)
+	if data.Description != "" && data.Description != data.ToolName {
+		summary += "\n描述: " + data.Description
+	}
+
+	valAllow := map[string]any{"action": "allow", "request_id": data.ID, "summary": summary}
+	valDeny := map[string]any{"action": "deny", "request_id": data.ID, "summary": summary}
 	elements := []map[string]any{
 		{"tag": "markdown", "content": content.String()},
 		{
@@ -347,6 +353,7 @@ func buildQuestionCardWithButtons(data *events.QuestionRequestData) string {
 				if len([]rune(display)) > 75 {
 					display = string([]rune(display)[:75])
 				}
+				summary := fmt.Sprintf("问题: %s", q.Question)
 				buttons = append(buttons, map[string]any{
 					"tag":  "button",
 					"text": map[string]any{"tag": "plain_text", "content": display},
@@ -356,6 +363,7 @@ func buildQuestionCardWithButtons(data *events.QuestionRequestData) string {
 						"request_id": data.ID,
 						"answer":     sanitized,
 						"label":      display,
+						"summary":    summary,
 					},
 				})
 			}
@@ -395,8 +403,9 @@ func buildElicitationCardWithButtons(data *events.ElicitationRequestData) string
 		}
 	}
 
-	valAccept := map[string]any{"action": "accept", "request_id": data.ID}
-	valDecline := map[string]any{"action": "decline", "request_id": data.ID}
+	summary := fmt.Sprintf("MCP Server: %s\n%s", data.MCPServerName, data.Message)
+	valAccept := map[string]any{"action": "accept", "request_id": data.ID, "summary": summary}
+	valDecline := map[string]any{"action": "decline", "request_id": data.ID, "summary": summary}
 	elements := []map[string]any{
 		{"tag": "markdown", "content": content.String()},
 		{
@@ -421,7 +430,7 @@ func buildElicitationCardWithButtons(data *events.ElicitationRequestData) string
 	return buildCard(header, map[string]any{"wide_screen_mode": true}, elements)
 }
 
-func buildResolvedCard(action, label, color string) map[string]any {
+func buildResolvedCard(action, label, color, summary, operatorID string) map[string]any {
 	if color == "" {
 		switch action {
 		case "allow", "answer", "accept":
@@ -430,11 +439,42 @@ func buildResolvedCard(action, label, color string) map[string]any {
 			color = "red"
 		}
 	}
+
+	var elements []map[string]any
+	if summary != "" {
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": "**原请求：**\n" + summary,
+		})
+	}
+
+	// Add context: operator and time
+	var ctxContent string
+	if operatorID != "" {
+		ctxContent = fmt.Sprintf("操作人: <at id=%s></at>  |  时间: %s", operatorID, time.Now().Format("2006-01-02 15:04:05"))
+	} else {
+		ctxContent = fmt.Sprintf("时间: %s", time.Now().Format("2006-01-02 15:04:05"))
+	}
+
+	elements = append(elements, map[string]any{
+		"tag": "note",
+		"elements": []map[string]any{
+			{
+				"tag":     "plain_text",
+				"content": ctxContent,
+			},
+		},
+	})
+
 	return map[string]any{
+		"schema": "2.0",
 		"config": map[string]any{"wide_screen_mode": true},
 		"header": map[string]any{
 			"title":    map[string]any{"tag": "plain_text", "content": label},
 			"template": color,
+		},
+		"body": map[string]any{
+			"elements": elements,
 		},
 	}
 }

--- a/internal/messaging/feishu/card_template_test.go
+++ b/internal/messaging/feishu/card_template_test.go
@@ -632,7 +632,7 @@ func TestBuildElicitationCardWithButtons(t *testing.T) {
 
 func TestBuildResolvedCard_Green(t *testing.T) {
 	t.Parallel()
-	card := buildResolvedCard("allow", "已允许", "")
+	card := buildResolvedCard("allow", "已允许", "", "test_summary", "ou_123")
 	require.NotNil(t, card)
 
 	cfg := card["config"].(map[string]any)
@@ -647,14 +647,14 @@ func TestBuildResolvedCard_Green(t *testing.T) {
 
 func TestBuildResolvedCard_Red(t *testing.T) {
 	t.Parallel()
-	card := buildResolvedCard("deny", "已拒绝", "")
+	card := buildResolvedCard("deny", "已拒绝", "", "test_summary", "")
 	hdr := card["header"].(map[string]any)
 	require.Equal(t, "red", hdr["template"])
 }
 
 func TestBuildResolvedCard_ExplicitColor(t *testing.T) {
 	t.Parallel()
-	card := buildResolvedCard("allow", "Custom Label", "blue")
+	card := buildResolvedCard("allow", "Custom Label", "blue", "", "")
 	hdr := card["header"].(map[string]any)
 	require.Equal(t, "blue", hdr["template"])
 	title := hdr["title"].(map[string]any)

--- a/internal/messaging/slack/interaction.go
+++ b/internal/messaging/slack/interaction.go
@@ -127,11 +127,29 @@ func (a *Adapter) handleInteractionEvent(ctx context.Context, evt socketmode.Eve
 		case "decline":
 			ackText = fmt.Sprintf("_Declined by <@%s>_", userID)
 		}
-		_, _, _, err := a.client.UpdateMessageContext(ctx, channelID, threadTS,
-			slack.MsgOptionText(ackText, false),
-		)
-		if err != nil {
-			a.Log.Debug("slack: update interaction message", "err", err)
+
+		var updateErr error
+		if len(callback.Message.Blocks.BlockSet) > 0 {
+			var updatedBlocks []slack.Block
+			for _, b := range callback.Message.Blocks.BlockSet {
+				if b.BlockType() != slack.MBTAction {
+					updatedBlocks = append(updatedBlocks, b)
+				}
+			}
+			ackSection := slack.NewContextBlock("",
+				slack.NewTextBlockObject(slack.MarkdownType, ackText, false, false),
+			)
+			updatedBlocks = append(updatedBlocks, ackSection)
+			_, _, _, updateErr = a.client.UpdateMessageContext(ctx, channelID, threadTS,
+				slack.MsgOptionBlocks(updatedBlocks...),
+			)
+		} else {
+			_, _, _, updateErr = a.client.UpdateMessageContext(ctx, channelID, threadTS,
+				slack.MsgOptionText(ackText, false),
+			)
+		}
+		if updateErr != nil {
+			a.Log.Debug("slack: update interaction message", "err", updateErr)
 		}
 
 		_ = threadTS // thread context

--- a/internal/worker/base/metadata.go
+++ b/internal/worker/base/metadata.go
@@ -1,6 +1,13 @@
 package base
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidSchema is returned when the interaction response payload does not match the expected schema.
+var ErrInvalidSchema = errors.New("invalid interaction response schema")
 
 // MetadataHandler dispatches control responses extracted from Input metadata.
 // Both ClaudeCode (stdin control) and OCS (HTTP POST) adapters implement this
@@ -19,21 +26,63 @@ func DispatchMetadata(ctx context.Context, metadata map[string]any, h MetadataHa
 		return false, nil
 	}
 	if permResp, ok := metadata["permission_response"].(map[string]any); ok {
-		reqID, _ := permResp["request_id"].(string)
+		reqID, _ := permResp["id"].(string)
+		if reqID == "" {
+			reqID, _ = permResp["request_id"].(string)
+		}
 		allowed, _ := permResp["allowed"].(bool)
 		reason, _ := permResp["reason"].(string)
 		return true, h.HandlePermissionResponse(ctx, reqID, allowed, reason)
 	}
 	if qResp, ok := metadata["question_response"].(map[string]any); ok {
 		reqID, _ := qResp["id"].(string)
-		answers, _ := qResp["answers"].(map[string]string)
+		var answers map[string]string
+		if answersRaw := qResp["answers"]; answersRaw != nil {
+			var err error
+			answers, err = parseAnswers(answersRaw)
+			if err != nil {
+				return true, fmt.Errorf("%w: %w", ErrInvalidSchema, err)
+			}
+		}
 		return true, h.HandleQuestionResponse(ctx, reqID, answers)
 	}
 	if eResp, ok := metadata["elicitation_response"].(map[string]any); ok {
 		reqID, _ := eResp["id"].(string)
 		action, _ := eResp["action"].(string)
-		content, _ := eResp["content"].(map[string]any)
+		if action != "accept" && action != "decline" && action != "cancel" {
+			return true, fmt.Errorf("%w: invalid elicitation action: %q", ErrInvalidSchema, action)
+		}
+		var content map[string]any
+		if contentRaw := eResp["content"]; contentRaw != nil {
+			var ok bool
+			content, ok = contentRaw.(map[string]any)
+			if !ok {
+				return true, fmt.Errorf("%w: elicitation content must be a map", ErrInvalidSchema)
+			}
+		}
 		return true, h.HandleElicitationResponse(ctx, reqID, action, content)
 	}
 	return false, nil
+}
+
+func parseAnswers(answersRaw any) (map[string]string, error) {
+	if answersRaw == nil {
+		return nil, nil
+	}
+	if mStr, ok := answersRaw.(map[string]string); ok {
+		return mStr, nil
+	}
+	mAny, ok := answersRaw.(map[string]any)
+	if !ok {
+		return nil, errors.New("answers must be a map")
+	}
+	res := make(map[string]string, len(mAny))
+	for k, v := range mAny {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("value for key %q must be a string", k)
+		}
+		res[k] = s
+	}
+	return res, nil
 }

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -243,6 +243,7 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 	for _, tool := range allowedTools {
 		rules = append(rules, map[string]any{"permission": "tool", "action": "allow", "pattern": tool})
 	}
+	slog.Info("opencode: applying permission rules to session", "session_id", c.getSessionID(), "mode", mode, "rules", rules)
 	if err := c.doPatch(ctx, "/session/"+url.PathEscape(c.getSessionID()), map[string]any{"permission": rules}); err != nil {
 		return nil, fmt.Errorf("opencode set permission: %w", err)
 	}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -319,6 +319,30 @@ type Question struct {
 	MultiSelect bool             `json:"multi_select"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshaling to support aliases for MultiSelect.
+func (q *Question) UnmarshalJSON(data []byte) error {
+	type Alias Question
+	aux := &struct {
+		IsMultiSelect *bool `json:"is_multi_select,omitempty"`
+		MultiSelect   *bool `json:"multi_select,omitempty"`
+		Multiple      *bool `json:"multiple,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(q),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.IsMultiSelect != nil {
+		q.MultiSelect = *aux.IsMultiSelect
+	} else if aux.MultiSelect != nil {
+		q.MultiSelect = *aux.MultiSelect
+	} else if aux.Multiple != nil {
+		q.MultiSelect = *aux.Multiple
+	}
+	return nil
+}
+
 // QuestionRequestData is the payload for QuestionRequest events (S→C — ask user a question).
 type QuestionRequestData struct {
 	ID        string     `json:"id"`

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -552,3 +552,48 @@ func TestClone_EmptyEnvelope(t *testing.T) {
 	require.Equal(t, emptyEnv, clone)
 	require.NotSame(t, emptyEnv, clone) // Should be different pointer
 }
+
+func TestQuestion_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		jsonStr  string
+		expected bool
+	}{
+		{
+			name:     "unmarshal standard multi_select key",
+			jsonStr:  `{"question": "test?", "header": "test", "multi_select": true}`,
+			expected: true,
+		},
+		{
+			name:     "unmarshal standard multi_select false",
+			jsonStr:  `{"question": "test?", "header": "test", "multi_select": false}`,
+			expected: false,
+		},
+		{
+			name:     "unmarshal alias is_multi_select key",
+			jsonStr:  `{"question": "test?", "header": "test", "is_multi_select": true}`,
+			expected: true,
+		},
+		{
+			name:     "unmarshal alias multiple key",
+			jsonStr:  `{"question": "test?", "header": "test", "multiple": true}`,
+			expected: true,
+		},
+		{
+			name:     "unmarshal default false when none provided",
+			jsonStr:  `{"question": "test?", "header": "test"}`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var q Question
+			err := json.Unmarshal([]byte(tt.jsonStr), &q)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, q.MultiSelect)
+		})
+	}
+}

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -20,9 +20,12 @@ import { MessageActions } from "./MessageActions";
 import { ReasoningBlock } from "./ReasoningBlock";
 import { getExt, messageVariants, extractCommand, extractFilePath, extractFileContent } from "./thread-helpers";
 import { useTranslation } from "react-i18next";
+import { PermissionApprovalCard } from "./tools/PermissionApprovalCard";
+import { QuestionResponseCard } from "./tools/QuestionResponseCard";
+import { ElicitationFormCard } from "./tools/ElicitationFormCard";
 
  
-const AssistantMessage = memo(function AssistantMessage({ message, onInteractionRespond }: { message: any; onInteractionRespond?: (toolCallId: string, allowed: boolean) => void }) {
+const AssistantMessage = memo(function AssistantMessage({ message, onInteractionRespond }: { message: any; onInteractionRespond?: (toolCallId: string, response: any) => void }) {
   const { t } = useTranslation('chat');
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
   const isError = message?.status === "error";
@@ -88,7 +91,57 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
                         case "list": return <ListTool toolName={p.toolName} path={extractFilePath(args)} items={p.result} status={status} onToggle={!isLastPart ? toggle : undefined} />;
                         case "todo": return <TodoTool todo={args.todo} todos={args.todos} status={status === "running" ? "running" : "complete"} onToggle={!isLastPart ? toggle : undefined} />;
                         case "ai": return <AgentTool description={args.description} prompt={args.prompt} subagent_type={args.subagent_type} run_in_background={args.run_in_background} status={status === "running" ? "running" : "complete"} onToggle={!isLastPart ? toggle : undefined} />;
-                        case "permission": return <PermissionCard toolName={p.toolName} args={args} status={status === "error" ? "complete" : status as "running" | "complete"} onRespond={p.toolCallId && onInteractionRespond ? (allowed: boolean) => onInteractionRespond(p.toolCallId, allowed) : undefined} onToggle={!isLastPart ? toggle : undefined} />;
+                        case "permission": {
+                          const interaction = p.args?.interaction;
+                          const resolvedStatus = interaction?.status || (status === "error" ? "failed" : status === "complete" ? "resolved" : "pending");
+
+                          if (p.toolName === "question_request") {
+                            const onRespondQuestion = p.toolCallId && onInteractionRespond
+                              ? (answers: Record<string, string>) => onInteractionRespond(p.toolCallId, { type: "question", answers })
+                              : undefined;
+                            return (
+                              <QuestionResponseCard
+                                toolName={p.toolName}
+                                questions={args.questions}
+                                status={resolvedStatus}
+                                interactionState={interaction}
+                                onRespond={onRespondQuestion}
+                                onToggle={!isLastPart ? toggle : undefined}
+                              />
+                            );
+                          } else if (p.toolName === "elicitation") {
+                            const onRespondElicitation = p.toolCallId && onInteractionRespond
+                              ? (action: "accept" | "decline" | "cancel", content?: Record<string, any>) => onInteractionRespond(p.toolCallId, { type: "elicitation", action, content })
+                              : undefined;
+                            return (
+                              <ElicitationFormCard
+                                toolName={p.toolName}
+                                message={args.message}
+                                mcpServerName={args.mcp_server_name}
+                                url={args.url}
+                                status={resolvedStatus}
+                                interactionState={interaction}
+                                onRespond={onRespondElicitation}
+                                onToggle={!isLastPart ? toggle : undefined}
+                              />
+                            );
+                          } else {
+                            const onRespondPerm = p.toolCallId && onInteractionRespond
+                              ? (allowed: boolean, reason?: string) => onInteractionRespond(p.toolCallId, { type: "permission", allowed, reason })
+                              : undefined;
+                            return (
+                              <PermissionApprovalCard
+                                toolName={p.toolName}
+                                args={args.args}
+                                description={args.description}
+                                status={resolvedStatus}
+                                interactionState={interaction}
+                                onRespond={onRespondPerm}
+                                onToggle={!isLastPart ? toggle : undefined}
+                              />
+                            );
+                          }
+                        }
                         default: {
                           const content = p.result || args;
                           const summary = typeof content === 'string' ? content : JSON.stringify(content, null, 2);

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -20,9 +20,9 @@ import { MessageActions } from "./MessageActions";
 import { ReasoningBlock } from "./ReasoningBlock";
 import { getExt, messageVariants, extractCommand, extractFilePath, extractFileContent } from "./thread-helpers";
 import { useTranslation } from "react-i18next";
-import { PermissionApprovalCard } from "./tools/PermissionApprovalCard";
-import { QuestionResponseCard } from "./tools/QuestionResponseCard";
-import { ElicitationFormCard } from "./tools/ElicitationFormCard";
+import { PermissionApprovalCard } from "@/components/assistant-ui/tools/PermissionApprovalCard";
+import { QuestionResponseCard } from "@/components/assistant-ui/tools/QuestionResponseCard";
+import { ElicitationFormCard } from "@/components/assistant-ui/tools/ElicitationFormCard";
 
  
 const AssistantMessage = memo(function AssistantMessage({ message, onInteractionRespond }: { message: any; onInteractionRespond?: (toolCallId: string, response: any) => void }) {

--- a/webchat/components/assistant-ui/tools/ElicitationFormCard.tsx
+++ b/webchat/components/assistant-ui/tools/ElicitationFormCard.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+
+interface ElicitationFormCardProps {
+  toolName: string;
+  message: string;
+  mcpServerName: string;
+  url?: string;
+  requestedSchema?: {
+    type?: string;
+    properties?: Record<
+      string,
+      {
+        type?: string;
+        description?: string;
+        enum?: string[];
+      }
+    >;
+    required?: string[];
+  };
+  status: InteractionStatus;
+  interactionState?: InteractionState;
+  onRespond?: (action: "accept" | "decline" | "cancel", content?: Record<string, any>) => void;
+  onToggle?: () => void;
+}
+
+export function ElicitationFormCard({
+  toolName,
+  message,
+  mcpServerName,
+  url,
+  requestedSchema,
+  status: initialStatus,
+  interactionState,
+  onRespond,
+  onToggle,
+}: ElicitationFormCardProps) {
+  const { t } = useTranslation("chat");
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+
+  // Local state for schema form fields
+  const [formValues, setFormValues] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
+      setTimeLeft(null);
+      return;
+    }
+    const updateTime = () => {
+      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
+      setTimeLeft(diff);
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, [initialStatus, interactionState?.expiresAt]);
+
+  const activeStatus: InteractionStatus =
+    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
+
+  const isInteractive = activeStatus === "pending" || activeStatus === "failed";
+
+  const handleInputChange = (key: string, value: any) => {
+    if (!isInteractive) return;
+    setFormValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleAction = (action: "accept" | "decline" | "cancel") => {
+    if (!isInteractive) return;
+    if (action === "accept") {
+      onRespond?.(action, requestedSchema ? formValues : undefined);
+    } else {
+      onRespond?.(action);
+    }
+  };
+
+  const title = t("tool.interaction.elicitation.title", { defaultValue: "Interactive Request" });
+  const descText = t("tool.interaction.elicitation.description", { defaultValue: "Input request from MCP server" });
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const schemaProperties = requestedSchema?.properties || {};
+  const hasSchema = Object.keys(schemaProperties).length > 0;
+
+  return (
+    <motion.div
+      className="rounded-[var(--radius-md)] overflow-hidden border border-[rgba(139,92,246,0.2)] my-4 shadow-[var(--shadow-md)] bg-[var(--bg-surface)]"
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: "spring", stiffness: 260, damping: 20 }}
+    >
+      {/* Header */}
+      <div
+        className={`flex items-center gap-2 px-4 py-3 bg-[rgba(139,92,246,0.06)] border-b border-[rgba(139,92,246,0.12)] ${
+          onToggle ? "cursor-pointer hover:bg-[rgba(139,92,246,0.1)] transition-colors" : ""
+        }`}
+        onClick={onToggle}
+      >
+        <div className="w-7 h-7 rounded-[var(--radius-sm)] bg-[rgba(139,92,246,0.1)] flex items-center justify-center">
+          <svg className="w-4 h-4 text-[var(--accent-gold)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+          </svg>
+        </div>
+        <span className="text-[11px] font-display font-bold text-[var(--accent-gold)] uppercase tracking-wider">
+          {mcpServerName ? `${mcpServerName} - ${title}` : title}
+        </span>
+        
+        {timeLeft !== null && timeLeft > 0 && activeStatus === "pending" && (
+          <span className="ml-2 px-1.5 py-0.5 text-[10px] font-mono rounded bg-[rgba(139,92,246,0.1)] text-[var(--accent-gold)]">
+            {formatTime(timeLeft)}
+          </span>
+        )}
+
+        {onToggle && (
+          <div className="ml-auto text-[var(--text-faint)]">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3 space-y-4">
+        {descText && (
+          <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{message || descText}</p>
+        )}
+
+        {/* URL Link */}
+        {url && (
+          <div className="pt-1">
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-[var(--radius-sm)] bg-[rgba(139,92,246,0.1)] text-[rgba(139,92,246,1)] hover:bg-[rgba(139,92,246,0.15)] font-bold text-xs transition-colors border border-[rgba(139,92,246,0.2)]"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+              {t("tool.interaction.elicitation.open_url", { defaultValue: "Open Form URL" })}
+            </a>
+          </div>
+        )}
+
+        {/* Dynamic Form Schema */}
+        {hasSchema && (
+          <div className="space-y-3 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-base)] border border-[var(--border-subtle)]">
+            {Object.entries(schemaProperties).map(([key, prop]) => {
+              const label = key;
+              const type = prop.type || "string";
+              const isRequired = requestedSchema?.required?.includes(key);
+
+              return (
+                <div key={key} className="space-y-1">
+                  <label className="text-xs font-bold text-[var(--text-secondary)]">
+                    {label}
+                    {isRequired && <span className="text-[var(--accent-coral)] ml-0.5">*</span>}
+                  </label>
+                  
+                  {prop.enum && prop.enum.length > 0 ? (
+                    <select
+                      value={formValues[key] || ""}
+                      disabled={!isInteractive}
+                      onChange={(e) => handleInputChange(key, e.target.value)}
+                      className="w-full text-xs font-mono p-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] transition-colors disabled:opacity-75 disabled:cursor-not-allowed"
+                    >
+                      <option value="">Select option...</option>
+                      {prop.enum.map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  ) : type === "boolean" ? (
+                    <label className="flex items-center gap-2.5 py-1 text-xs cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        checked={!!formValues[key]}
+                        disabled={!isInteractive}
+                        onChange={(e) => handleInputChange(key, e.target.checked)}
+                        className="hidden"
+                      />
+                      <div className={`w-4 h-4 flex items-center justify-center border rounded transition-all ${
+                        formValues[key]
+                          ? "border-[var(--accent-gold)] bg-[var(--accent-gold)] text-black"
+                          : "border-[var(--text-faint)]"
+                      }`}>
+                        {formValues[key] && (
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                          </svg>
+                        )}
+                      </div>
+                      <span className="text-[var(--text-primary)] font-medium">{prop.description || "Enable"}</span>
+                    </label>
+                  ) : (
+                    <input
+                      type="text"
+                      value={formValues[key] || ""}
+                      disabled={!isInteractive}
+                      onChange={(e) => handleInputChange(key, e.target.value)}
+                      placeholder={prop.description || `Enter ${label}...`}
+                      className="w-full text-xs font-mono p-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] transition-colors disabled:opacity-75 disabled:cursor-not-allowed"
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Action Buttons */}
+      {(activeStatus === "pending" || activeStatus === "failed") && (
+        <div className="flex flex-col gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)]">
+          {activeStatus === "failed" && interactionState?.error && (
+            <div className="text-xs text-[var(--accent-coral)] mb-2 px-3 py-2 rounded bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] leading-normal">
+              {t("tool.interaction.elicitation.failed", { error: interactionState.error, defaultValue: `Submission failed: ${interactionState.error}` })}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => handleAction("accept")}
+              className="flex-grow py-2 rounded-[var(--radius-sm)] bg-[var(--accent-emerald)] text-black font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98]"
+            >
+              {t("tool.interaction.elicitation.accept", { defaultValue: "Accept" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleAction("decline")}
+              className="flex-grow py-2 rounded-[var(--radius-sm)] bg-[var(--accent-coral)] text-white font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98]"
+            >
+              {t("tool.interaction.elicitation.decline", { defaultValue: "Decline" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleAction("cancel")}
+              className="py-2 px-4 rounded-[var(--radius-sm)] bg-[var(--bg-base)] text-[var(--text-secondary)] font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98] border border-[var(--border-subtle)]"
+            >
+              {t("tool.interaction.elicitation.cancel", { defaultValue: "Cancel" })}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {activeStatus === "submitting" && (
+        <div className="flex items-center justify-center gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)] text-xs text-[var(--text-secondary)]">
+          <div className="w-3.5 h-3.5 border-2 border-[var(--accent-gold)] border-t-transparent rounded-full animate-spin" />
+          <span>{t("tool.interaction.elicitation.submitting", { defaultValue: "Submitting response..." })}</span>
+        </div>
+      )}
+
+      {activeStatus === "resolved" && (
+        <div className="border-t border-[var(--border-subtle)] bg-[rgba(16,185,129,0.04)]">
+          <div className="flex items-center gap-2 px-4 py-2.5">
+            <svg className="w-4 h-4 text-[var(--accent-emerald)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+            <span className="text-xs font-mono font-medium text-[var(--accent-emerald)]">
+              {t("tool.interaction.elicitation.accepted", { defaultValue: "Request Accepted" })}
+            </span>
+          </div>
+
+          {interactionState?.response?.content && Object.keys(interactionState.response.content).length > 0 && (
+            <div className="px-4 pb-3 space-y-1 text-xs text-[var(--text-secondary)] font-mono pl-10 border-t border-[rgba(16,185,129,0.08)] pt-2 leading-relaxed">
+              {Object.entries(interactionState.response.content).map(([k, v]) => (
+                <div key={k}>
+                  <span className="text-[var(--text-faint)]">{k}:</span> <span className="text-[var(--text-primary)]">{String(v)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeStatus === "rejected" && (
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[rgba(239,68,68,0.04)]">
+          <svg className="w-4 h-4 text-[var(--accent-coral)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <span className="text-xs font-mono font-medium text-[var(--accent-coral)]">
+            {t("tool.interaction.elicitation.declined", { defaultValue: "Request Declined" })}
+          </span>
+        </div>
+      )}
+
+      {activeStatus === "expired" && (
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[var(--bg-base)]">
+          <svg className="w-4 h-4 text-[var(--text-faint)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-xs font-mono text-[var(--text-faint)]">
+            {t("tool.interaction.elicitation.expired", { defaultValue: "Request Expired" })}
+          </span>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/webchat/components/assistant-ui/tools/ElicitationFormCard.tsx
+++ b/webchat/components/assistant-ui/tools/ElicitationFormCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+import { useInteractionTimeout } from "@/hooks/useInteractionTimeout";
 
 interface ElicitationFormCardProps {
   toolName: string;
@@ -40,27 +41,10 @@ export function ElicitationFormCard({
   onToggle,
 }: ElicitationFormCardProps) {
   const { t } = useTranslation("chat");
-  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+  const { timeLeft, activeStatus } = useInteractionTimeout(initialStatus, interactionState?.expiresAt);
 
   // Local state for schema form fields
   const [formValues, setFormValues] = useState<Record<string, any>>({});
-
-  useEffect(() => {
-    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
-      setTimeLeft(null);
-      return;
-    }
-    const updateTime = () => {
-      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
-      setTimeLeft(diff);
-    };
-    updateTime();
-    const interval = setInterval(updateTime, 1000);
-    return () => clearInterval(interval);
-  }, [initialStatus, interactionState?.expiresAt]);
-
-  const activeStatus: InteractionStatus =
-    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
 
   const isInteractive = activeStatus === "pending" || activeStatus === "failed";
 

--- a/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
+++ b/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+import { useInteractionTimeout } from "@/hooks/useInteractionTimeout";
 
 interface PermissionApprovalCardProps {
   toolName: string;
@@ -25,24 +25,7 @@ export function PermissionApprovalCard({
   onToggle,
 }: PermissionApprovalCardProps) {
   const { t } = useTranslation("chat");
-  const [timeLeft, setTimeLeft] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
-      setTimeLeft(null);
-      return;
-    }
-    const updateTime = () => {
-      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
-      setTimeLeft(diff);
-    };
-    updateTime();
-    const interval = setInterval(updateTime, 1000);
-    return () => clearInterval(interval);
-  }, [initialStatus, interactionState?.expiresAt]);
-
-  const activeStatus: InteractionStatus =
-    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
+  const { timeLeft, activeStatus } = useInteractionTimeout(initialStatus, interactionState?.expiresAt);
 
   const title = t("tool.interaction.permission.title", { defaultValue: "Tool Execution Approval" });
   const descText = description || t("tool.interaction.permission.description", { defaultValue: "Agent requests permission to execute the following tool" });

--- a/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
+++ b/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+
+interface PermissionApprovalCardProps {
+  toolName: string;
+  args?: Record<string, any>;
+  description?: string;
+  status: InteractionStatus;
+  interactionState?: InteractionState;
+  onRespond?: (approved: boolean, reason?: string) => void;
+  onToggle?: () => void;
+}
+
+export function PermissionApprovalCard({
+  toolName,
+  args,
+  description,
+  status: initialStatus,
+  interactionState,
+  onRespond,
+  onToggle,
+}: PermissionApprovalCardProps) {
+  const { t } = useTranslation("chat");
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
+      setTimeLeft(null);
+      return;
+    }
+    const updateTime = () => {
+      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
+      setTimeLeft(diff);
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, [initialStatus, interactionState?.expiresAt]);
+
+  const activeStatus: InteractionStatus =
+    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
+
+  const title = t("tool.interaction.permission.title", { defaultValue: "Tool Execution Approval" });
+  const descText = description || t("tool.interaction.permission.description", { defaultValue: "Agent requests permission to execute the following tool" });
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <motion.div
+      className="rounded-[var(--radius-md)] overflow-hidden border border-[rgba(251,191,36,0.2)] my-4 shadow-[var(--shadow-md)] bg-[var(--bg-surface)]"
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: "spring", stiffness: 260, damping: 20 }}
+    >
+      {/* Header */}
+      <div
+        className={`flex items-center gap-2 px-4 py-3 bg-[rgba(251,191,36,0.06)] border-b border-[rgba(251,191,36,0.12)] ${
+          onToggle ? "cursor-pointer hover:bg-[rgba(251,191,36,0.1)] transition-colors" : ""
+        }`}
+        onClick={onToggle}
+      >
+        <div className="w-7 h-7 rounded-[var(--radius-sm)] bg-[rgba(251,191,36,0.1)] flex items-center justify-center">
+          <svg className="w-4 h-4 text-[var(--accent-gold)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+        <span className="text-[11px] font-display font-bold text-[var(--accent-gold)] uppercase tracking-wider">
+          {title}
+        </span>
+        
+        {timeLeft !== null && timeLeft > 0 && activeStatus === "pending" && (
+          <span className="ml-2 px-1.5 py-0.5 text-[10px] font-mono rounded bg-[rgba(251,191,36,0.1)] text-[var(--accent-gold)]">
+            {formatTime(timeLeft)}
+          </span>
+        )}
+
+        {onToggle && (
+          <div className="ml-auto text-[var(--text-faint)]">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3">
+        <div className="mb-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-[var(--bg-base)] border border-[var(--border-subtle)]">
+          <span className="font-mono text-[12px] text-[var(--accent-emerald)] select-none mr-1.5">$</span>
+          <span className="font-mono text-[12px] text-[var(--text-primary)]">{toolName}</span>
+        </div>
+        {descText && (
+          <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-3">{descText}</p>
+        )}
+
+        {args && Object.keys(args).length > 0 && (
+          <div className="mt-2 text-xs font-mono bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded p-2.5 max-h-[160px] overflow-y-auto custom-scrollbar whitespace-pre-wrap text-[var(--text-primary)]">
+            {JSON.stringify(args, null, 2)}
+          </div>
+        )}
+      </div>
+
+      {/* Action Buttons */}
+      {(activeStatus === "pending" || activeStatus === "failed") && (
+        <div className="flex flex-col gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)]">
+          {activeStatus === "failed" && interactionState?.error && (
+            <div className="text-xs text-[var(--accent-coral)] mb-2 px-3 py-2 rounded bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] leading-normal">
+              {t("tool.interaction.permission.failed", { error: interactionState.error, defaultValue: `Submission failed: ${interactionState.error}` })}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onRespond?.(true)}
+              className="flex-1 py-2 rounded-[var(--radius-sm)] bg-[var(--accent-emerald)] text-black font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98]"
+            >
+              {t("tool.interaction.permission.approve", { defaultValue: "Approve" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => onRespond?.(false)}
+              className="flex-1 py-2 rounded-[var(--radius-sm)] bg-[var(--accent-coral)] text-white font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98]"
+            >
+              {t("tool.interaction.permission.reject", { defaultValue: "Reject" })}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {activeStatus === "submitting" && (
+        <div className="flex items-center justify-center gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)] text-xs text-[var(--text-secondary)]">
+          <div className="w-3.5 h-3.5 border-2 border-[var(--accent-gold)] border-t-transparent rounded-full animate-spin" />
+          <span>{t("tool.interaction.permission.submitting", { defaultValue: "Submitting approval..." })}</span>
+        </div>
+      )}
+
+      {activeStatus === "resolved" && (
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[rgba(16,185,129,0.04)]">
+          <svg className="w-4 h-4 text-[var(--accent-emerald)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+          </svg>
+          <span className="text-xs font-mono font-medium text-[var(--accent-emerald)]">
+            {t("tool.interaction.permission.approved", { defaultValue: "Approved" })}
+          </span>
+        </div>
+      )}
+
+      {activeStatus === "rejected" && (
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[rgba(239,68,68,0.04)]">
+          <svg className="w-4 h-4 text-[var(--accent-coral)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <span className="text-xs font-mono font-medium text-[var(--accent-coral)]">
+            {t("tool.interaction.permission.rejected", { defaultValue: "Rejected" })}
+          </span>
+        </div>
+      )}
+
+      {activeStatus === "expired" && (
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[var(--bg-base)]">
+          <svg className="w-4 h-4 text-[var(--text-faint)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-xs font-mono text-[var(--text-faint)]">
+            {t("tool.interaction.permission.expired", { defaultValue: "Expired" })}
+          </span>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
+++ b/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+import { useInteractionTimeout } from "@/hooks/useInteractionTimeout";
 
 interface QuestionItem {
   id: string;
@@ -32,7 +33,7 @@ export function QuestionResponseCard({
   onToggle,
 }: QuestionResponseCardProps) {
   const { t } = useTranslation("chat");
-  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+  const { timeLeft, activeStatus } = useInteractionTimeout(initialStatus, interactionState?.expiresAt);
 
   // Local state for answers: questionId -> value (or comma-separated values for multi-select)
   const [answers, setAnswers] = useState<Record<string, string>>({});
@@ -40,23 +41,6 @@ export function QuestionResponseCard({
   const [selectedMulti, setSelectedMulti] = useState<Record<string, Set<string>>>({});
   // Local state for custom text inputs: questionId -> string
   const [textAnswers, setTextAnswers] = useState<Record<string, string>>({});
-
-  useEffect(() => {
-    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
-      setTimeLeft(null);
-      return;
-    }
-    const updateTime = () => {
-      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
-      setTimeLeft(diff);
-    };
-    updateTime();
-    const interval = setInterval(updateTime, 1000);
-    return () => clearInterval(interval);
-  }, [initialStatus, interactionState?.expiresAt]);
-
-  const activeStatus: InteractionStatus =
-    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
 
   const isInteractive = activeStatus === "pending" || activeStatus === "failed";
 

--- a/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
+++ b/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
@@ -74,8 +74,9 @@ export function QuestionResponseCard({
     // Validate that all questions have some answer
     const finalAnswers: Record<string, string> = {};
     for (const q of questions) {
-      const ans = answers[q.id] || textAnswers[q.id] || "";
-      finalAnswers[q.id] = ans;
+      const qKey = q.id || q.question;
+      const ans = answers[qKey] || textAnswers[qKey] || "";
+      finalAnswers[qKey] = ans;
     }
 
     onRespond?.(finalAnswers);
@@ -136,12 +137,13 @@ export function QuestionResponseCard({
           )}
 
           {questions.map((q, idx) => {
+            const qKey = q.id || q.question;
             const isMulti = !!(q.is_multi_select || q.multiSelect);
             const hasOptions = q.options && q.options.length > 0;
-            const currentAnswer = answers[q.id] || "";
+            const currentAnswer = answers[qKey] || "";
 
             return (
-              <div key={q.id || idx} className="space-y-2.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-base)] border border-[var(--border-subtle)]">
+              <div key={qKey || idx} className="space-y-2.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-base)] border border-[var(--border-subtle)]">
                 <div className="flex items-start gap-2">
                   <span className="font-mono text-xs text-[var(--text-faint)] mt-0.5">{idx + 1}.</span>
                   <div>
@@ -164,7 +166,7 @@ export function QuestionResponseCard({
                     {q.options!.map((opt, oIdx) => {
                       const optVal = opt.value !== undefined ? opt.value : opt.label;
                       const isSelected = isMulti
-                        ? !!(selectedMulti[q.id]?.has(optVal))
+                        ? !!(selectedMulti[qKey]?.has(optVal))
                         : currentAnswer === optVal;
 
                       return (
@@ -178,11 +180,11 @@ export function QuestionResponseCard({
                         >
                           <input
                             type={isMulti ? "checkbox" : "radio"}
-                            name={q.id}
+                            name={qKey}
                             value={optVal}
                             checked={isSelected}
                             disabled={!isInteractive}
-                            onChange={() => handleOptionSelect(q.id, optVal, isMulti)}
+                            onChange={() => handleOptionSelect(qKey, optVal, isMulti)}
                             className="hidden"
                           />
                           <div className={`w-3.5 h-3.5 flex items-center justify-center border transition-all ${
@@ -207,9 +209,9 @@ export function QuestionResponseCard({
                   <div className="pl-5">
                     <textarea
                       rows={3}
-                      value={textAnswers[q.id] || ""}
+                      value={textAnswers[qKey] || ""}
                       disabled={!isInteractive}
-                      onChange={(e) => handleTextChange(q.id, e.target.value)}
+                      onChange={(e) => handleTextChange(qKey, e.target.value)}
                       placeholder={t("tool.interaction.question.custom_placeholder", { defaultValue: "Type custom answer..." })}
                       className="w-full text-xs font-mono p-2.5 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] transition-colors disabled:opacity-75 disabled:cursor-not-allowed resize-none"
                     />
@@ -258,7 +260,7 @@ export function QuestionResponseCard({
             {interactionState?.response?.answers && (
               <div className="px-4 pb-3 space-y-1 text-xs text-[var(--text-secondary)] font-mono pl-10 border-t border-[rgba(16,185,129,0.08)] pt-2 leading-relaxed">
                 {Object.entries(interactionState.response.answers).map(([qId, val]) => {
-                  const q = questions.find((qi) => qi.id === qId);
+                  const q = questions.find((qi) => (qi.id || qi.question) === qId);
                   const qLabel = q?.header || q?.question || qId;
                   return (
                     <div key={qId}>

--- a/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
+++ b/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+
+interface QuestionItem {
+  id: string;
+  header?: string;
+  question: string;
+  options?: Array<{ value?: string; label: string }>;
+  is_multi_select?: boolean;
+  multiSelect?: boolean;
+}
+
+interface QuestionResponseCardProps {
+  toolName: string;
+  questions?: QuestionItem[];
+  status: InteractionStatus;
+  interactionState?: InteractionState;
+  onRespond?: (answers: Record<string, string>) => void;
+  onToggle?: () => void;
+}
+
+export function QuestionResponseCard({
+  toolName,
+  questions = [],
+  status: initialStatus,
+  interactionState,
+  onRespond,
+  onToggle,
+}: QuestionResponseCardProps) {
+  const { t } = useTranslation("chat");
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+
+  // Local state for answers: questionId -> value (or comma-separated values for multi-select)
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  // Local state for multi-select checkboxes: questionId -> Set of selected values
+  const [selectedMulti, setSelectedMulti] = useState<Record<string, Set<string>>>({});
+  // Local state for custom text inputs: questionId -> string
+  const [textAnswers, setTextAnswers] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (initialStatus !== "pending" || !interactionState?.expiresAt) {
+      setTimeLeft(null);
+      return;
+    }
+    const updateTime = () => {
+      const diff = Math.max(0, Math.floor((interactionState.expiresAt! - Date.now()) / 1000));
+      setTimeLeft(diff);
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, [initialStatus, interactionState?.expiresAt]);
+
+  const activeStatus: InteractionStatus =
+    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
+
+  const isInteractive = activeStatus === "pending" || activeStatus === "failed";
+
+  const handleOptionSelect = (qId: string, val: string, isMulti: boolean) => {
+    if (!isInteractive) return;
+
+    if (isMulti) {
+      const currentSet = new Set(selectedMulti[qId] || []);
+      if (currentSet.has(val)) {
+        currentSet.delete(val);
+      } else {
+        currentSet.add(val);
+      }
+      setSelectedMulti((prev) => ({ ...prev, [qId]: currentSet }));
+      setAnswers((prev) => ({ ...prev, [qId]: Array.from(currentSet).join(", ") }));
+    } else {
+      setAnswers((prev) => ({ ...prev, [qId]: val }));
+    }
+  };
+
+  const handleTextChange = (qId: string, val: string) => {
+    if (!isInteractive) return;
+    setTextAnswers((prev) => ({ ...prev, [qId]: val }));
+    setAnswers((prev) => ({ ...prev, [qId]: val }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isInteractive) return;
+
+    // Validate that all questions have some answer
+    const finalAnswers: Record<string, string> = {};
+    for (const q of questions) {
+      const ans = answers[q.id] || textAnswers[q.id] || "";
+      finalAnswers[q.id] = ans;
+    }
+
+    onRespond?.(finalAnswers);
+  };
+
+  const title = t("tool.interaction.question.title", { defaultValue: "Input Request" });
+  const descText = t("tool.interaction.question.description", { defaultValue: "Agent requires your input on the following questions" });
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <motion.div
+      className="rounded-[var(--radius-md)] overflow-hidden border border-[rgba(245,158,11,0.2)] my-4 shadow-[var(--shadow-md)] bg-[var(--bg-surface)]"
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: "spring", stiffness: 260, damping: 20 }}
+    >
+      {/* Header */}
+      <div
+        className={`flex items-center gap-2 px-4 py-3 bg-[rgba(245,158,11,0.06)] border-b border-[rgba(245,158,11,0.12)] ${
+          onToggle ? "cursor-pointer hover:bg-[rgba(245,158,11,0.1)] transition-colors" : ""
+        }`}
+        onClick={onToggle}
+      >
+        <div className="w-7 h-7 rounded-[var(--radius-sm)] bg-[rgba(245,158,11,0.1)] flex items-center justify-center">
+          <svg className="w-4 h-4 text-[var(--accent-gold)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </div>
+        <span className="text-[11px] font-display font-bold text-[var(--accent-gold)] uppercase tracking-wider">
+          {title}
+        </span>
+        
+        {timeLeft !== null && timeLeft > 0 && activeStatus === "pending" && (
+          <span className="ml-2 px-1.5 py-0.5 text-[10px] font-mono rounded bg-[rgba(245,158,11,0.1)] text-[var(--accent-gold)]">
+            {formatTime(timeLeft)}
+          </span>
+        )}
+
+        {onToggle && (
+          <div className="ml-auto text-[var(--text-faint)]">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <form onSubmit={handleSubmit}>
+        <div className="px-4 py-3 space-y-4">
+          {descText && (
+            <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{descText}</p>
+          )}
+
+          {questions.map((q, idx) => {
+            const isMulti = !!(q.is_multi_select || q.multiSelect);
+            const hasOptions = q.options && q.options.length > 0;
+            const currentAnswer = answers[q.id] || "";
+
+            return (
+              <div key={q.id || idx} className="space-y-2.5 p-3 rounded-[var(--radius-sm)] bg-[var(--bg-base)] border border-[var(--border-subtle)]">
+                <div className="flex items-start gap-2">
+                  <span className="font-mono text-xs text-[var(--text-faint)] mt-0.5">{idx + 1}.</span>
+                  <div>
+                    <h4 className="text-sm font-semibold text-[var(--text-primary)] leading-snug">
+                      {q.header || q.question}
+                      {isMulti && (
+                        <span className="text-xs font-normal text-[var(--text-faint)] ml-1">
+                          {t("tool.interaction.question.multi_select_hint", { defaultValue: " (Multiple choice)" })}
+                        </span>
+                      )}
+                    </h4>
+                    {q.header && q.question && (
+                      <p className="text-xs text-[var(--text-secondary)] mt-1">{q.question}</p>
+                    )}
+                  </div>
+                </div>
+
+                {hasOptions ? (
+                  <div className="space-y-1.5 pl-5">
+                    {q.options!.map((opt, oIdx) => {
+                      const optVal = opt.value !== undefined ? opt.value : opt.label;
+                      const isSelected = isMulti
+                        ? !!(selectedMulti[q.id]?.has(optVal))
+                        : currentAnswer === optVal;
+
+                      return (
+                        <label
+                          key={oIdx}
+                          className={`flex items-center gap-2.5 px-3 py-2 rounded border text-xs cursor-pointer select-none transition-all ${
+                            isSelected
+                              ? "bg-[rgba(245,158,11,0.06)] border-[var(--accent-gold)] text-[var(--text-primary)]"
+                              : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+                          } ${!isInteractive ? "opacity-75 cursor-not-allowed" : ""}`}
+                        >
+                          <input
+                            type={isMulti ? "checkbox" : "radio"}
+                            name={q.id}
+                            value={optVal}
+                            checked={isSelected}
+                            disabled={!isInteractive}
+                            onChange={() => handleOptionSelect(q.id, optVal, isMulti)}
+                            className="hidden"
+                          />
+                          <div className={`w-3.5 h-3.5 flex items-center justify-center border transition-all ${
+                            isMulti ? "rounded-[3px]" : "rounded-full"
+                          } ${
+                            isSelected
+                              ? "border-[var(--accent-gold)] bg-[var(--accent-gold)] text-black"
+                              : "border-[var(--text-faint)]"
+                          }`}>
+                            {isSelected && (
+                              <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                              </svg>
+                            )}
+                          </div>
+                          <span className="font-medium leading-none">{opt.label}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="pl-5">
+                    <textarea
+                      rows={3}
+                      value={textAnswers[q.id] || ""}
+                      disabled={!isInteractive}
+                      onChange={(e) => handleTextChange(q.id, e.target.value)}
+                      placeholder={t("tool.interaction.question.custom_placeholder", { defaultValue: "Type custom answer..." })}
+                      className="w-full text-xs font-mono p-2.5 rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-gold)] transition-colors disabled:opacity-75 disabled:cursor-not-allowed resize-none"
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Action Buttons */}
+        {(activeStatus === "pending" || activeStatus === "failed") && (
+          <div className="flex flex-col gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)]">
+            {activeStatus === "failed" && interactionState?.error && (
+              <div className="text-xs text-[var(--accent-coral)] mb-2 px-3 py-2 rounded bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] leading-normal">
+                {t("tool.interaction.question.failed", { error: interactionState.error, defaultValue: `Submission failed: ${interactionState.error}` })}
+              </div>
+            )}
+            <button
+              type="submit"
+              className="w-full py-2 rounded-[var(--radius-sm)] bg-[var(--accent-gold)] text-black font-bold text-xs transition-all hover:opacity-90 active:scale-[0.98]"
+            >
+              {t("tool.interaction.question.submit", { defaultValue: "Submit Answer" })}
+            </button>
+          </div>
+        )}
+
+        {activeStatus === "submitting" && (
+          <div className="flex items-center justify-center gap-2 px-4 py-3 border-t border-[var(--border-subtle)] bg-[var(--bg-surface)] text-xs text-[var(--text-secondary)]">
+            <div className="w-3.5 h-3.5 border-2 border-[var(--accent-gold)] border-t-transparent rounded-full animate-spin" />
+            <span>{t("tool.interaction.question.submitting", { defaultValue: "Submitting answers..." })}</span>
+          </div>
+        )}
+
+        {activeStatus === "resolved" && (
+          <div className="border-t border-[var(--border-subtle)] bg-[rgba(16,185,129,0.04)]">
+            <div className="flex items-center gap-2 px-4 py-2.5">
+              <svg className="w-4 h-4 text-[var(--accent-emerald)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+              </svg>
+              <span className="text-xs font-mono font-medium text-[var(--accent-emerald)]">
+                {t("tool.interaction.question.answered", { defaultValue: "Answered" })}
+              </span>
+            </div>
+            
+            {interactionState?.response?.answers && (
+              <div className="px-4 pb-3 space-y-1 text-xs text-[var(--text-secondary)] font-mono pl-10 border-t border-[rgba(16,185,129,0.08)] pt-2 leading-relaxed">
+                {Object.entries(interactionState.response.answers).map(([qId, val]) => {
+                  const q = questions.find((qi) => qi.id === qId);
+                  const qLabel = q?.header || q?.question || qId;
+                  return (
+                    <div key={qId}>
+                      <span className="text-[var(--text-faint)]">{qLabel}:</span> <span className="text-[var(--text-primary)]">{val as string}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeStatus === "expired" && (
+          <div className="flex items-center gap-2 px-4 py-2.5 border-t border-[var(--border-subtle)] bg-[var(--bg-base)]">
+            <svg className="w-4 h-4 text-[var(--text-faint)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="text-xs font-mono text-[var(--text-faint)]">
+              {t("tool.interaction.question.expired", { defaultValue: "Question Expired" })}
+            </span>
+          </div>
+        )}
+      </form>
+    </motion.div>
+  );
+}

--- a/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
+++ b/webchat/components/assistant-ui/tools/QuestionResponseCard.tsx
@@ -13,6 +13,8 @@ interface QuestionItem {
   options?: Array<{ value?: string; label: string }>;
   is_multi_select?: boolean;
   multiSelect?: boolean;
+  multi_select?: boolean;
+  multiple?: boolean;
 }
 
 interface QuestionResponseCardProps {
@@ -138,7 +140,7 @@ export function QuestionResponseCard({
 
           {questions.map((q, idx) => {
             const qKey = q.id || q.question;
-            const isMulti = !!(q.is_multi_select || q.multiSelect);
+            const isMulti = !!(q.is_multi_select || q.multiSelect || q.multi_select || q.multiple);
             const hasOptions = q.options && q.options.length > 0;
             const currentAnswer = answers[qKey] || "";
 

--- a/webchat/hooks/useInteractionTimeout.ts
+++ b/webchat/hooks/useInteractionTimeout.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import type { InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
+
+export function useInteractionTimeout(
+  initialStatus: InteractionStatus,
+  expiresAt?: number
+) {
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (initialStatus !== "pending" || !expiresAt) {
+      setTimeLeft(null);
+      return;
+    }
+    const updateTime = () => {
+      const diff = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
+      setTimeLeft(diff);
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, [initialStatus, expiresAt]);
+
+  const activeStatus: InteractionStatus =
+    initialStatus === "pending" && timeLeft !== null && timeLeft <= 0 ? "expired" : initialStatus;
+
+  return { timeLeft, activeStatus };
+}

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -78,6 +78,25 @@ export type {
 // ThreadSuggestion shape — matches @assistant-ui/core ThreadSuggestion
 type ThreadSuggestion = { title: string; label: string; prompt: string };
 
+export type InteractionKind = "permission" | "question" | "elicitation";
+export type InteractionStatus =
+  | "pending"
+  | "submitting"
+  | "resolved"
+  | "rejected"
+  | "expired"
+  | "failed";
+
+export interface InteractionState {
+  kind: InteractionKind;
+  requestId: string;
+  status: InteractionStatus;
+  createdAt: number;
+  expiresAt?: number;
+  response?: any;
+  error?: string;
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -765,6 +784,41 @@ export function useHotPlexRuntime({
 
         const handleError = (data: ErrorData, env: Envelope) => {
             const isBusy = (data?.code as string) === "SESSION_BUSY";
+
+            // Mark any submitting interaction as failed if this is an interaction error
+            const isInteractionError = (data?.message || "").includes("worker response failed") || 
+                                       (data?.message || "").includes("invalid response data");
+            if (isInteractionError) {
+                const reqId = env?.metadata?.interaction_error?.request_id;
+                setMessages((prev) => {
+                    return prev.map((msg) => {
+                        if (msg.role !== "assistant") return msg;
+                        let found = false;
+                        const parts = msg.parts.map((p) => {
+                            if (p.type === "tool-call" && p.args?.interaction) {
+                                const inter = p.args.interaction;
+                                if ((reqId && p.toolCallId === reqId) || (!reqId && inter.status === "submitting")) {
+                                    found = true;
+                                    return {
+                                        ...p,
+                                        args: {
+                                            ...p.args,
+                                            interaction: {
+                                                ...inter,
+                                                status: "failed" as const,
+                                                error: data?.message || "Failed to deliver response to worker",
+                                            },
+                                        },
+                                    };
+                                }
+                            }
+                            return p;
+                        });
+                        return found ? { ...msg, parts } : msg;
+                    });
+                });
+            }
+
             const isResumeRetry = (data?.code as string) === "RESUME_RETRY";
             const isShutdown = (data?.message || "").includes(
                 "during shutdown",
@@ -1084,6 +1138,13 @@ export function useHotPlexRuntime({
                                         description: data.description,
                                         tool_name: data.tool_name,
                                         args: data.args,
+                                        interaction: {
+                                            kind: "permission",
+                                            requestId: data.id,
+                                            status: "pending",
+                                            createdAt: Date.now(),
+                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                        },
                                     },
                                     toolCallId: data.id,
                                 },
@@ -1119,6 +1180,13 @@ export function useHotPlexRuntime({
                                     args: {
                                         description: questionText,
                                         questions: data.questions,
+                                        interaction: {
+                                            kind: "question",
+                                            requestId: data.id,
+                                            status: "pending",
+                                            createdAt: Date.now(),
+                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                        },
                                     },
                                     toolCallId: data.id,
                                 },
@@ -1153,6 +1221,13 @@ export function useHotPlexRuntime({
                                         message: data.message,
                                         mcp_server_name: data.mcp_server_name,
                                         url: data.url,
+                                        interaction: {
+                                            kind: "elicitation",
+                                            requestId: data.id,
+                                            status: "pending",
+                                            createdAt: Date.now(),
+                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                        },
                                     },
                                     toolCallId: data.id,
                                 },
@@ -1429,28 +1504,127 @@ export function useHotPlexRuntime({
 
     // Interaction response callback — routes to the correct send method
     const handleInteractionRespond = useCallback(
-        (toolCallId: string, allowed: boolean) => {
+        async (
+            toolCallId: string,
+            response: {
+                type: "permission" | "question" | "elicitation";
+                allowed?: boolean;
+                reason?: string;
+                answers?: Record<string, string>;
+                action?: "accept" | "decline" | "cancel";
+                content?: Record<string, unknown>;
+            },
+        ) => {
             const client = clientRef.current;
             if (!client) return;
-            const entry = interactionMapRef.current.get(toolCallId);
-            if (!entry) return;
-            interactionMapRef.current.delete(toolCallId);
 
-            switch (entry.type) {
-                case "permission":
-                    client.sendPermissionResponse(toolCallId, allowed);
-                    break;
-                case "question":
-                    client.sendQuestionResponse(toolCallId, {
-                        default: allowed ? "yes" : "no",
+            // Transition status to submitting
+            setMessages((prev) => {
+                return prev.map((msg) => {
+                    if (msg.role !== "assistant") return msg;
+                    let found = false;
+                    const parts = msg.parts.map((p) => {
+                        if (p.type === "tool-call" && p.toolCallId === toolCallId) {
+                            found = true;
+                            const inter = p.args?.interaction;
+                            return {
+                                ...p,
+                                args: {
+                                    ...p.args,
+                                    interaction: {
+                                        ...inter,
+                                        status: "submitting" as const,
+                                    },
+                                },
+                            };
+                        }
+                        return p;
                     });
-                    break;
-                case "elicitation":
-                    client.sendElicitationResponse(
-                        toolCallId,
-                        allowed ? "accept" : "decline",
-                    );
-                    break;
+                    return found ? { ...msg, parts } : msg;
+                });
+            });
+
+            try {
+                switch (response.type) {
+                    case "permission":
+                        await client.sendPermissionResponse(
+                            toolCallId,
+                            response.allowed ?? false,
+                            response.reason,
+                        );
+                        break;
+                    case "question":
+                        await client.sendQuestionResponse(toolCallId, response.answers ?? {});
+                        break;
+                    case "elicitation":
+                        await client.sendElicitationResponse(
+                            toolCallId,
+                            response.action ?? "cancel",
+                            response.content,
+                        );
+                        break;
+                }
+
+                // Transition status to resolved/rejected
+                setMessages((prev) => {
+                    return prev.map((msg) => {
+                        if (msg.role !== "assistant") return msg;
+                        let found = false;
+                        const parts = msg.parts.map((p) => {
+                            if (p.type === "tool-call" && p.toolCallId === toolCallId) {
+                                found = true;
+                                const inter = p.args?.interaction;
+                                let nextStatus: InteractionStatus = "resolved";
+                                if (response.type === "permission" && !response.allowed) {
+                                    nextStatus = "rejected";
+                                } else if (response.type === "elicitation" && response.action !== "accept") {
+                                    nextStatus = "rejected";
+                                }
+                                return {
+                                    ...p,
+                                    args: {
+                                        ...p.args,
+                                        interaction: {
+                                            ...inter,
+                                            status: nextStatus,
+                                            response: response,
+                                        },
+                                    },
+                                };
+                            }
+                            return p;
+                        });
+                        return found ? { ...msg, parts } : msg;
+                    });
+                });
+                interactionMapRef.current.delete(toolCallId);
+            } catch (err) {
+                // Transition status to failed
+                setMessages((prev) => {
+                    return prev.map((msg) => {
+                        if (msg.role !== "assistant") return msg;
+                        let found = false;
+                        const parts = msg.parts.map((p) => {
+                            if (p.type === "tool-call" && p.toolCallId === toolCallId) {
+                                found = true;
+                                const inter = p.args?.interaction;
+                                return {
+                                    ...p,
+                                    args: {
+                                        ...p.args,
+                                        interaction: {
+                                            ...inter,
+                                            status: "failed" as const,
+                                            error: String(err),
+                                        },
+                                    },
+                                };
+                            }
+                            return p;
+                        });
+                        return found ? { ...msg, parts } : msg;
+                    });
+                });
             }
         },
         [],

--- a/webchat/lib/ai-sdk-transport/client/types.ts
+++ b/webchat/lib/ai-sdk-transport/client/types.ts
@@ -12,6 +12,7 @@ export interface Envelope<T = unknown> {
   session_id: string;
   timestamp: number;
   event: Event<T>;
+  metadata?: Record<string, any>;
 }
 
 export interface Event<T = unknown> {

--- a/webchat/lib/api/admin-activity.ts
+++ b/webchat/lib/api/admin-activity.ts
@@ -1,6 +1,6 @@
 import type { ActivityStats, AuditActivityResponse } from '@/lib/types/admin';
 
-import { adminFetch, getStoredAdminConnection } from './admin-client';
+import { getStoredAdminConnection } from './admin-client';
 import { BASE, authOpts } from './client';
 import { parseApiError } from './errors';
 
@@ -42,12 +42,40 @@ function activityBasePath(): string {
   return getStoredAdminConnection() ? '/admin/activity' : '/api/admin/activity';
 }
 
+// Cannot reuse adminFetch: its cookie channel targets adminUrl (port 9999
+// adminMux), but /api/admin/activity is registered on the gateway mux (BASE,
+// port 8888) to avoid collisions with the SPA /admin/activity HTML fallback.
+async function adminActivityFetch<T>(path: string): Promise<T> {
+  const conn = getStoredAdminConnection();
+  const res = conn
+    ? await fetch(`${conn.url}${path}`, { headers: { Authorization: `Bearer ${conn.token}` } })
+    : await fetch(`${BASE}${path}`, authOpts());
+
+  if (!res.ok) {
+    const info = await parseApiError(res);
+    const message = info.message || info.raw || `Admin request failed: ${res.status}`;
+    const err = new Error(message);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (err as any).status = info.status;
+    if (info.code) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err as any).code = info.code;
+    }
+    throw err;
+  }
+
+  if (res.status === 204 || res.status === 202) {
+    return undefined as unknown as T;
+  }
+  return res.json();
+}
+
 export async function listActivity(filters: ActivityFilters): Promise<AuditActivityResponse> {
-  return adminFetch<AuditActivityResponse>(`${activityBasePath()}${activityParams(filters)}`);
+  return adminActivityFetch<AuditActivityResponse>(`${activityBasePath()}${activityParams(filters)}`);
 }
 
 export async function listActivityStats(filters: ActivityFilters): Promise<ActivityStats> {
-  return adminFetch<ActivityStats>(`${activityBasePath()}/stats${activityParams(filters)}`);
+  return adminActivityFetch<ActivityStats>(`${activityBasePath()}/stats${activityParams(filters)}`);
 }
 
 export async function downloadActivity(filters: ActivityFilters, format: 'json' | 'csv'): Promise<void> {

--- a/webchat/lib/api/admin-client.ts
+++ b/webchat/lib/api/admin-client.ts
@@ -17,6 +17,7 @@ import type { AdminConnection } from '@/lib/types/admin';
 
 import { BASE, authOpts } from './client';
 import { parseApiError } from './errors';
+import { adminUrl } from '@/lib/config';
 
 const STORAGE_URL_KEY = 'hotplex_admin_url';
 const STORAGE_TOKEN_KEY = 'hotplex_admin_token';
@@ -118,7 +119,7 @@ async function adminFetchCookie<T>(
   path: string,
   options?: AdminFetchOptions,
 ): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  const res = await fetch(`${adminUrl}${path}`, {
     ...options,
     ...authOpts(),
     headers: {

--- a/webchat/locales/en/chat.json
+++ b/webchat/locales/en/chat.json
@@ -233,7 +233,47 @@
     "search": { "loading": "Searching..." },
     "list": { "loading": "Listing directory..." },
     "todo": { "loading": "Retrieving latest tasks..." },
-    "filediff": { "loading": "Synthesizing file patch..." }
+    "filediff": { "loading": "Synthesizing file patch..." },
+    "interaction": {
+      "timeout": "Expires in {{seconds}}s",
+      "permission": {
+        "title": "Tool Execution Approval",
+        "description": "Agent requests permission to execute the following tool",
+        "approved": "Execution Approved",
+        "rejected": "Execution Rejected",
+        "expired": "Approval Expired",
+        "submitting": "Submitting approval...",
+        "failed": "Submission failed: {{error}}",
+        "approve": "Approve",
+        "reject": "Reject"
+      },
+      "question": {
+        "title": "Input Request",
+        "description": "Agent requires your input on the following questions",
+        "answered": "Answered",
+        "expired": "Question Expired",
+        "submitting": "Submitting answers...",
+        "failed": "Submission failed: {{error}}",
+        "submit": "Submit Answer",
+        "custom_placeholder": "Type custom answer...",
+        "custom_answer": "Custom Answer",
+        "multi_select_hint": " (Multiple choice)"
+      },
+      "elicitation": {
+        "title": "Interactive Request",
+        "description": "Input request from MCP server",
+        "accepted": "Request Accepted",
+        "declined": "Request Declined",
+        "cancelled": "Request Cancelled",
+        "expired": "Request Expired",
+        "submitting": "Submitting response...",
+        "failed": "Submission failed: {{error}}",
+        "accept": "Accept",
+        "decline": "Decline",
+        "cancel": "Cancel",
+        "open_url": "Open Form URL"
+      }
+    }
   },
   "aria": {
     "send": "Send message",

--- a/webchat/locales/zh-CN/chat.json
+++ b/webchat/locales/zh-CN/chat.json
@@ -233,7 +233,47 @@
     "search": { "loading": "搜索中..." },
     "list": { "loading": "列出目录中..." },
     "todo": { "loading": "获取最新任务中..." },
-    "filediff": { "loading": "合成文件补丁中..." }
+    "filediff": { "loading": "合成文件补丁中..." },
+    "interaction": {
+      "timeout": "剩余时间 {{seconds}}秒",
+      "permission": {
+        "title": "工具执行授权",
+        "description": "智能体请求执行以下工具",
+        "approved": "已允许执行",
+        "rejected": "已拒绝执行",
+        "expired": "授权已过期",
+        "submitting": "正在提交授权...",
+        "failed": "提交失败：{{error}}",
+        "approve": "允许",
+        "reject": "拒绝"
+      },
+      "question": {
+        "title": "输入请求",
+        "description": "智能体需要您回答以下问题",
+        "answered": "已回答",
+        "expired": "问题已过期",
+        "submitting": "正在提交回答...",
+        "failed": "回答失败：{{error}}",
+        "submit": "提交回答",
+        "custom_placeholder": "输入自定义回答...",
+        "custom_answer": "自定义回答",
+        "multi_select_hint": "（可多选）"
+      },
+      "elicitation": {
+        "title": "交互输入请求",
+        "description": "来自 MCP 服务器的输入请求",
+        "accepted": "已接受请求",
+        "declined": "已拒绝请求",
+        "cancelled": "已取消请求",
+        "expired": "请求已过期",
+        "submitting": "正在提交响应...",
+        "failed": "提交失败：{{error}}",
+        "accept": "接受",
+        "decline": "拒绝",
+        "cancel": "取消",
+        "open_url": "打开表单链接"
+      }
+    }
   },
   "aria": {
     "send": "发送消息",


### PR DESCRIPTION
This PR fixes the issue where `multiple: true` or standard backend parameter `multi_select: true` were not respected in the `QuestionResponseCard` component, causing it to render as radio buttons instead of checkboxes.

### Changes
1. **Frontend**:
   - Updated `QuestionItem` in `webchat/components/assistant-ui/tools/QuestionResponseCard.tsx` to support `multi_select` and `multiple`.
   - Updated `isMulti` calculation to check these additional aliases.
2. **Backend**:
   - Added custom JSON unmarshaling to `events.Question` in `pkg/events/events.go` to support `is_multi_select`, `multi_select`, and `multiple` interchangeably.
   - Added unit test coverage for the unmarshaler in `pkg/events/events_test.go`.

Verified:
- `pnpm build` in webchat compiles successfully.
- Frontend vitest tests passed.
- Backend Go tests (`pkg/events`) passed.