### PR TITLE
docs(patrol): 2026-07-11 记录 Bearer API Key 认证方式

### DIFF
--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -48,7 +48,7 @@ HotPlex Gateway 的安全模型遵循两条核心原则：
 
 | 通道 | API Key | Bot ID | 适用场景 |
 |------|---------|--------|---------|
-| HTTP Header | `X-API-Key` | `X-Bot-ID` | REST API、CLI、服务端客户端 |
+| HTTP Header | `X-API-Key`（或 `Authorization: Bearer`） | `X-Bot-ID` | REST API、CLI、服务端客户端 |
 | Query Param | `api_key` | `bot_id` | 浏览器 WebSocket（无法发送自定义 Header） |
 | HMAC Cookie | 登录后签发 | `bot_id` | WebChat（登录后 Gateway 签发 HttpOnly cookie，绑定真实用户身份；SameSite=None 支持跨域） |
 | Init Envelope | `auth.token` | `auth.bot_id` | 浏览器 WebSocket 延迟认证（跨域场景） |
@@ -59,7 +59,7 @@ HotPlex Gateway 的安全模型遵循两条核心原则：
 
 ```
 Client ──X-API-Key──> HTTP Upgrade ──> Authenticator.AuthenticateRequest()
-         X-Bot-ID                     ├─ 提取 API Key（header 优先，query param 兜底）
+         X-Bot-ID                     ├─ 提取 API Key（X-API-Key header 优先，缺省回退 Authorization Bearer，最后 query param）
                                       ├─ 校验 Key 合法性（恒定时间比较）
                                       ├─ 解析 Bot ID
                                       └─ 返回 (userID, botID, nil) 或 ErrUnauthorized

--- a/docs/guides/developer/security-model.md
+++ b/docs/guides/developer/security-model.md
@@ -150,10 +150,11 @@ Cron 执行和 Session 启动时，Gateway 注入以下环境变量：
 
 ### API Key
 
-`internal/security/auth.go` 提供双层 Key 提取：
+`internal/security/auth.go` 提供三层 Key 提取（按优先级）：
 
 1. **HTTP Header**（`X-API-Key`，可自定义）
-2. **Query Parameter**（`api_key`，浏览器 WebSocket 客户端专用）
+2. **Authorization Bearer**（`Authorization: Bearer <key>`，缺省回退；适配 OpenAPI/Scalar 控制台与多数 SDK 默认行为）
+3. **Query Parameter**（`api_key`，浏览器 WebSocket 客户端专用）
 
 开发模式下未配置 API Key 时，所有请求以 `anonymous` 身份通过。生产环境必须配置 API Key。
 
@@ -161,7 +162,7 @@ Cron 执行和 Session 启动时，Gateway 注入以下环境变量：
 
 `internal/security/auth.go` 提供认证机制：
 
-1. **API Key**：通过 `X-API-Key` Header 或 `?api_key=` Query Param 携带。`Authenticator` 在内存 `map` 中验证，支持热重载（`ReloadKeys`）。
+1. **API Key**：通过 `X-API-Key` Header、`Authorization: Bearer <key>` 或 `?api_key=` Query Param 携带（三者等价，提取顺序见上文）。`Authenticator` 在内存 `map` 中验证，支持热重载（`ReloadKeys`）。
 2. **Bot ID**：通过 `X-Bot-ID` Header 或 `bot_id` 查询参数指定 Bot 身份。每个 Bot 只能操作属于自己的 Session，**禁止跨 Bot 访问**。使用 `security.BotIDFromRequest(r)` 提取 Bot ID。
 
 开发模式下未配置 API Key 时，所有请求以 `anonymous` 身份通过。生产环境必须配置 API Key。

--- a/docs/reference/security-policies.md
+++ b/docs/reference/security-policies.md
@@ -16,6 +16,8 @@ HotPlex Gateway 的安全策略分布在多个配置层：环境变量、`config
 
 API Key 通过 `HOTPLEX_SECURITY_API_KEY_1..N` 环境变量设置。为空时进入 dev mode（允许所有请求）。
 
+客户端可通过三种通道传递同一个 API Key（提取顺序见下方认证流程）：自定义 Header（默认 `X-API-Key`）、标准 `Authorization: Bearer <key>`（适配 OpenAPI/Scalar 控制台及多数 SDK 的默认行为）、query parameter。三者为同一 Key 的不同携带方式，校验逻辑一致。
+
 ### 环境变量
 
 ```bash
@@ -31,9 +33,10 @@ HOTPLEX_SECURITY_API_KEY_2=key-2
 
 ```
 1. 检查 HTTP Header（默认 X-API-Key）
-2. 若 Header 为空，检查 query parameter（api_key）
-3. Key 匹配 validKey map → 通过
-4. 未配置任何 Key → 开发模式（anonymous 通过）
+2. 若 Header 为空，检查 Authorization Bearer（Authorization: Bearer <key>）
+3. 若仍为空，检查 query parameter（api_key）
+4. Key 匹配 validKey map → 通过
+5. 未配置任何 Key → 开发模式（anonymous 通过）
 ```
 
 ### Admin Token


### PR DESCRIPTION
## Summary

**变更窗口**：`b6cb5e38` → `2b58347e`（31 commits，v1.32.2 → v1.33.2）

`2c3f71b4 feat(auth): accept bearer api keys` 引入 `Authorization: Bearer <key>` 作为 API Key 的第三种传递通道（提取顺序：`X-API-Key` header → `Authorization: Bearer` → `api_key` query）。WebChat runtime 已切换至 Bearer（`hotplex-runtime-adapter.ts`），但三篇安全文档系统性遗漏该认证方式。

- `reference/security-policies.md` — 认证流程补充 Bearer 提取步骤（reference 最高优先级，必须与代码严格同步）
- `guides/developer/security-model.md` — API Key 提取从双层改为三层，补充 Bearer 通道
- `explanation/security-model.md` — 传输方式表格与认证流程图注释补充 Bearer

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)