### PR TITLE
fix(opencodeserver): preserve sessions across worker restarts

### DIFF
--- a/.agents/skills/hotplex-cli/SKILL.md
+++ b/.agents/skills/hotplex-cli/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: hotplex-cli
+description: HotPlex Slack 与 Cron CLI 命令示例参考。当需要执行 hotplex slack 子命令（发消息、上传/下载文件、更新/定时消息、频道、书签、表情回复）或 hotplex cron 子命令（创建/列出/查看/更新/删除/触发/历史定时任务）时使用。
+---
+
+# HotPlex Slack / Cron CLI 示例
+
+> 从 AGENTS.md 迁移出的命令参考。构建/测试/开发命令请用 `make help`。
+
+## Slack 操作
+
+```bash
+hotplex slack send-message --text "Hello" --channel <id>
+hotplex slack upload-file --file ./report.pdf --title "Report"
+hotplex slack update-message --channel <id> --ts <ts> --text "Updated"
+hotplex slack schedule-message --text "Reminder" --at "2026-05-04T09:00:00+08:00"
+hotplex slack download-file --file-id <id> --output ./save.pdf
+hotplex slack list-channels --types im,public_channel --json
+hotplex slack bookmark add --channel <id> --title "Link" --url <url>
+hotplex slack bookmark list --channel <id>
+hotplex slack bookmark remove --channel <id> --bookmark-id <id>
+hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark
+```
+
+## Cron 定时任务
+
+```bash
+# 创建周期任务（必填：name, schedule, message, bot-id, owner-id, max-runs, expires-at）
+hotplex cron create \
+  --name "daily-health" \
+  --schedule "cron:0 9 * * 1-5" \
+  -m "检查系统健康状态" \
+  --bot-id "$BOT_ID" --owner-id "$USER_ID" \
+  --max-runs 100 --expires-at "2027-01-01T00:00:00+08:00"
+
+# 带短生命周期的周期任务
+hotplex cron create \
+  --name "remind" \
+  --schedule "every:30m" \
+  -m "提醒喝水" \
+  --bot-id "$BOT_ID" --owner-id "$USER_ID" \
+  --max-runs 6 --expires-at "2026-05-11T00:00:00+08:00"
+
+# 列出 / 查看 / 更新 / 删除
+hotplex cron list [--json] [--enabled]
+hotplex cron get <id|name>
+hotplex cron update <id|name> --enabled=false
+hotplex cron delete <id|name>
+
+# 手动触发（需 gateway 运行中）
+hotplex cron trigger <id|name>
+
+# 查看执行历史
+hotplex cron history <id|name> [--json]
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,50 +287,16 @@ gh api repos/hrygo/hotplex/pulls/{N}/reviews --jq 'max_by(.id) | {state, commit_
 
 ## 命令参考
 
-### 快速开始
+### 命令速查
 
 ```bash
-# 1. 环境配置
-cp configs/env.example .env
-# 编辑 .env 填入 API 密钥
+# 首次环境配置
+cp configs/env.example .env   # 编辑填入 API 密钥
+make quickstart               # check-tools + build + test-short
+make dev                      # 启动开发环境（gateway + webchat）
 
-# 2. 快速安装
-make quickstart  # check-tools + build + test-short
-
-# 3. 启动开发环境
-make dev  # gateway + webchat
-```
-
-验证：
-```bash
-make check       # 完整 CI: quality + build
-make dev-status  # 查看运行服务
-```
-
-### 构建与质量
-
-```bash
-make build          # 构建网关二进制
-make test           # 运行测试（含 -race）
-make test-short     # 快速测试（-short）
-make lint           # golangci-lint
-make coverage       # 覆盖率报告
-make check          # 完整 CI: quality + build
-make quality        # fmt + lint + test
-make fmt            # 格式化
-make clean          # 清理构建产物
-```
-
-### 开发
-
-```bash
-make quickstart      # 首次安装
-make run             # 构建并运行网关
-make dev             # 启动开发环境（gateway + webchat）
-make dev-stop        # 停止所有开发服务
-make dev-status      # 查看运行服务
-make dev-logs        # 查看网关日志
-make dev-reset       # 停止并重启
+# 所有 make 目标（build/test/lint/coverage/dev/gateway 等）的完整列表与说明
+make help
 ```
 
 ### 网关管理
@@ -369,52 +335,9 @@ hotplex update -y             # 跳过确认提示
 hotplex update --restart      # 更新后自动重启网关
 ```
 
-### Slack 操作
+### Slack / Cron CLI 示例
 
-```bash
-hotplex slack send-message --text "Hello" --channel <id>
-hotplex slack upload-file --file ./report.pdf --title "Report"
-hotplex slack update-message --channel <id> --ts <ts> --text "Updated"
-hotplex slack schedule-message --text "Reminder" --at "2026-05-04T09:00:00+08:00"
-hotplex slack download-file --file-id <id> --output ./save.pdf
-hotplex slack list-channels --types im,public_channel --json
-hotplex slack bookmark add --channel <id> --title "Link" --url <url>
-hotplex slack bookmark list --channel <id>
-hotplex slack bookmark remove --channel <id> --bookmark-id <id>
-hotplex slack react add --channel <id> --ts <ts> --emoji white_check_mark
-```
-
-### Cron 定时任务
-
-```bash
-# 创建周期任务（必填：name, schedule, message, bot-id, owner-id, max-runs, expires-at）
-hotplex cron create \
-  --name "daily-health" \
-  --schedule "cron:0 9 * * 1-5" \
-  -m "检查系统健康状态" \
-  --bot-id "$BOT_ID" --owner-id "$USER_ID" \
-  --max-runs 100 --expires-at "2027-01-01T00:00:00+08:00"
-
-# 带短生命周期的周期任务
-hotplex cron create \
-  --name "remind" \
-  --schedule "every:30m" \
-  -m "提醒喝水" \
-  --bot-id "$BOT_ID" --owner-id "$USER_ID" \
-  --max-runs 6 --expires-at "2026-05-11T00:00:00+08:00"
-
-# 列出 / 查看 / 更新 / 删除
-hotplex cron list [--json] [--enabled]
-hotplex cron get <id|name>
-hotplex cron update <id|name> --enabled=false
-hotplex cron delete <id|name>
-
-# 手动触发（需 gateway 运行中）
-hotplex cron trigger <id|name>
-
-# 查看执行历史
-hotplex cron history <id|name> [--json]
-```
+Slack（send-message / upload-file / bookmark / react 等）与 Cron（create / list / trigger / history 等）的详细命令示例见 skill `hotplex-cli`（`.claude/skills/hotplex-cli/SKILL.md`）——按需加载，不常驻上下文。
 
 ---
 

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -335,18 +335,13 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 			cronScheduler.CleanupForSession(sessionID)
 		}
 	}
-	sm.OnDelete = func(ctx context.Context, info session.SessionInfo) {
-		if err := worker.CleanupSession(ctx, info.WorkerType, info.WorkerSessionID); err != nil {
-			log.Warn("gateway: worker session cleanup failed",
-				"session_id", info.ID,
-				"worker_type", info.WorkerType,
-				"worker_session_id", info.WorkerSessionID,
-				"err", err)
-		}
-	}
-
 	// Wait for orphan process cleanup to finish before repairing sessions.
 	cleanupWG.Wait()
+	if cleanupStore, ok := stores.session.(session.CleanupTaskStore); ok {
+		go session.NewCleanupRunner(log, cleanupStore, worker.CleanupSession).Run(ctx)
+	} else {
+		log.Warn("gateway: durable session cleanup unavailable for session store")
+	}
 
 	repaired, repairErr := sm.RepairRunningSessions(ctx)
 	if repairErr != nil {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -41,6 +41,7 @@ import (
 	"github.com/hrygo/hotplex/internal/skills"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/webchat"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/internal/worker/acp"
 	"github.com/hrygo/hotplex/internal/worker/claudecode"
 	"github.com/hrygo/hotplex/internal/worker/codexcli"
@@ -332,6 +333,15 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		log.Info("gateway: session terminated", "session_id", sessionID)
 		if cronScheduler != nil {
 			cronScheduler.CleanupForSession(sessionID)
+		}
+	}
+	sm.OnDelete = func(ctx context.Context, info session.SessionInfo) {
+		if err := worker.CleanupSession(ctx, info.WorkerType, info.WorkerSessionID); err != nil {
+			log.Warn("gateway: worker session cleanup failed",
+				"session_id", info.ID,
+				"worker_type", info.WorkerType,
+				"worker_session_id", info.WorkerSessionID,
+				"err", err)
 		}
 	}
 

--- a/docs/superpowers/specs/2026-07-13-ocs-session-cleanup-outbox-design.md
+++ b/docs/superpowers/specs/2026-07-13-ocs-session-cleanup-outbox-design.md
@@ -1,0 +1,149 @@
+# OCS Session Cleanup Outbox Design
+
+## Goal
+
+Preserve OpenCode Server (OCS) conversation context across HotPlex worker and
+gateway restarts, while making remote OCS-session deletion durable and safe.
+The change addresses two review findings on PR #873:
+
+1. Retention GC can race a resumed session and later delete the remote session
+   that the resume needs.
+2. A remote deletion failure is only logged today, so it is lost on a gateway
+   restart and never retried.
+
+This is deliberately scoped to session cleanup infrastructure and the OCS
+cleaner. It does not change session retention policy or worker start/resume
+semantics.
+
+## Chosen approach
+
+Persist a cleanup task in the same database transaction as every lifecycle
+operation that makes a HotPlex session unavailable (`DELETED`, physical delete,
+or terminated-session retention GC). A gateway-owned worker leases due tasks,
+calls the existing worker cleanup registry, and removes a task only after the
+remote delete is confirmed. `404 Not Found` remains a successful, idempotent
+delete for OCS.
+
+The task row is also a deletion tombstone: while it exists, a stale in-memory
+session snapshot cannot recreate the deleted row. A resume that loses the race
+returns a retryable cleanup-pending error rather than starting a worker that
+could reuse a remote session scheduled for deletion.
+
+The considered alternative was an in-memory mutex plus bounded asynchronous
+retries. It is smaller but cannot survive gateway restart or provide a
+database-enforced barrier against stale `Upsert` writes, so it is rejected.
+
+## Data model
+
+Add matching SQLite and PostgreSQL migrations for `session_cleanup_tasks`.
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Generated task identifier. |
+| `session_id` | Owning HotPlex session ID; unique while deletion is pending. |
+| `worker_type` | Worker implementation to dispatch through the cleanup registry. |
+| `worker_session_id` | Immutable remote-session ID captured at deletion time. |
+| `attempts` | Number of claimed cleanup attempts. |
+| `next_attempt_at` | Earliest time the task may be leased again. |
+| `lease_until` | Lease expiry, so a task abandoned by process shutdown becomes runnable. |
+| `last_error` | Most recent bounded diagnostic error. |
+| `created_at` / `updated_at` | Audit and scheduling timestamps. |
+
+Only sessions with a non-empty `worker_session_id` create a task. Cleanup for
+workers without a registered cleaner is a successful no-op, preserving the
+current behavior for non-persistent workers.
+
+`session_id` is unique for an outstanding task. Successful completion deletes
+the task rather than retaining a historical tombstone; a later intentional new
+session with the same deterministic HotPlex ID can then be created normally.
+
+## Atomic lifecycle rules
+
+The store gains transactional operations instead of the current
+delete-then-callback pattern:
+
+- Logical delete changes the session to `DELETED` and enqueues its immutable
+  cleanup task in one transaction.
+- Physical delete removes the session and enqueues the task in one transaction.
+- Retention GC deletes only still-`TERMINATED` rows and enqueues tasks in the
+  same transaction.
+
+Each transaction returns the affected session metadata only for logging and
+audit; it does not run remote cleanup inline. The `Manager.OnDelete` callback
+and its fire-and-forget use are removed.
+
+The session store checks for a pending cleanup tombstone before every write
+that could recreate or revive the same session ID. If present, it returns the
+new sentinel `ErrSessionCleanupPending`. This check is enforced inside the
+write transaction, not as a preceding read, so a stale `transitionState`
+snapshot cannot win a check-then-write race.
+
+`Get` also reports `ErrSessionCleanupPending` when the session row is gone but
+its cleanup task remains. Gateway resume maps this error to a retryable
+lifecycle failure and never creates or resumes an OCS worker. Once cleanup
+finishes, the task is removed; a later request sees the normal not-found state
+and may create a fresh session through the existing path.
+
+## Cleanup execution
+
+A `session` cleanup runner is started after worker registration and after
+orphan-process cleanup. It:
+
+1. Drains due tasks once during gateway startup, then polls on a bounded
+   interval until the gateway context is cancelled.
+2. Atomically leases a small batch. Leases prevent duplicate deletion when two
+   gateway processes share PostgreSQL or a process is slow to exit.
+3. Calls `worker.CleanupSession` with a per-attempt timeout.
+4. Deletes the task on success, including the OCS cleaner's `404` success
+   result. On failure it records the error and schedules exponential backoff
+   with an upper bound; it never drops the task solely because the retry count
+   is high.
+
+Errors are logged with task/session/worker identifiers. Failure to schedule,
+lease, or execute one task must not stop remaining tasks or gateway startup.
+Shutdown cancels the runner; an unexpired lease is recovered automatically
+after its expiry on the next startup.
+
+## Concurrency and safety
+
+The durable tombstone is the source of truth for deletion ownership:
+
+- If resume transitions the row from `TERMINATED` before retention GC's
+  transaction, GC affects no row and creates no task.
+- If GC/delete commits first, the tombstone blocks stale `Upsert` and resume;
+  the remote ID captured in the task can never be attached to a new worker.
+- A newly created session cannot reuse the deterministic HotPlex ID until the
+  tombstone is removed, avoiding ambiguity between the old and new remote
+  session identity.
+- The remote delete always targets `worker_session_id` stored in the task, not
+  a later session row, so it cannot delete a newer remote session.
+
+Existing lock order remains `Manager.mu` then `managedSession.mu`. The store
+transaction is the cross-process synchronization boundary; no new long-lived
+manager lock is held during remote I/O.
+
+## Tests and acceptance criteria
+
+Add SQLite unit/integration coverage for:
+
+1. Logical delete, physical delete, and retention GC each atomically create a
+   task with the original OCS session ID.
+2. A retention-GC versus resume interleaving has exactly one winner: resume
+   leaves no task, or cleanup wins and resume receives
+   `ErrSessionCleanupPending`; no stale write recreates the row.
+3. A remote cleanup failure records a retry, backs off, and succeeds on a later
+   attempt; `404` completes immediately.
+4. A leased-but-unfinished task is recovered and run after runner restart.
+5. A task targets the old remote ID even if a new local session is later
+   created with the same HotPlex session ID.
+
+Run the existing session, gateway, worker, OCS, migration, race, and repository
+quality gates. PR #873 is complete only when the new tests pass and review
+findings no longer apply.
+
+## Non-goals
+
+- Changing OCS's session-preserving `release()` behavior from PR #873.
+- Deleting event history as part of the outbox operation.
+- Adding an operator UI for cleanup-task inspection or manual replay.
+- Replacing the existing worker cleanup registry.

--- a/docs/superpowers/specs/2026-07-13-ocs-session-cleanup-outbox-design.md
+++ b/docs/superpowers/specs/2026-07-13-ocs-session-cleanup-outbox-design.md
@@ -49,6 +49,12 @@ Add matching SQLite and PostgreSQL migrations for `session_cleanup_tasks`.
 | `last_error` | Most recent bounded diagnostic error. |
 | `created_at` / `updated_at` | Audit and scheduling timestamps. |
 
+PostgreSQL takes a transaction-scoped advisory lock derived from the HotPlex
+session ID before a session write or retention deletion. The lock disappears on
+commit/rollback, so it serializes lifecycle writes without retaining data after
+session GC; a waiting writer rechecks the committed tombstone instead of using
+an earlier read-committed snapshot. SQLite uses its existing single-writer lock.
+
 Only sessions with a non-empty `worker_session_id` create a task. Cleanup for
 workers without a registered cleaner is a successful no-op, preserving the
 current behavior for non-persistent workers.
@@ -91,8 +97,9 @@ orphan-process cleanup. It:
 
 1. Drains due tasks once during gateway startup, then polls on a bounded
    interval until the gateway context is cancelled.
-2. Atomically leases a small batch. Leases prevent duplicate deletion when two
-   gateway processes share PostgreSQL or a process is slow to exit.
+2. Atomically leases a small batch. Each lease has an opaque token; completion
+   and retry operations must match that token, so an expired worker cannot
+   complete or reschedule a task claimed by a newer runner.
 3. Calls `worker.CleanupSession` with a per-attempt timeout.
 4. Deletes the task on success, including the OCS cleaner's `404` success
    result. On failure it records the error and schedules exponential backoff
@@ -136,6 +143,9 @@ Add SQLite unit/integration coverage for:
 4. A leased-but-unfinished task is recovered and run after runner restart.
 5. A task targets the old remote ID even if a new local session is later
    created with the same HotPlex session ID.
+6. An expired lease cannot complete or reschedule a task after another runner
+   has claimed it, and PostgreSQL lifecycle locking prevents a stale write from
+   crossing a committed retention tombstone.
 
 Run the existing session, gateway, worker, OCS, migration, race, and repository
 quality gates. PR #873 is complete only when the new tests pass and review

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -511,6 +511,9 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, params worker.Session
 			b.log.Info("bridge: orphan platform session terminated, attempting resume", "session_id", sessionID)
 			injectSandbox(si.PlatformKey, sandbox)
 			if err := b.ResumeSession(ctx, sessionID, workDir); err != nil {
+				if errors.Is(err, worker.ErrResumeCheckFailed) {
+					return fmt.Errorf("bridge: resume verification failed for terminated session: %w", err)
+				}
 				b.log.Warn("bridge: resume failed for terminated session, falling back to new session",
 					"session_id", sessionID, "err", err)
 				return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, botName, injectExclude...)
@@ -527,6 +530,9 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, params worker.Session
 		// the latest config, not a potentially stale persisted value.
 		injectSandbox(si.PlatformKey, sandbox)
 		if err := b.ResumeSession(ctx, sessionID, workDir); err != nil {
+			if errors.Is(err, worker.ErrResumeCheckFailed) {
+				return fmt.Errorf("bridge: resume verification failed: %w", err)
+			}
 			b.log.Warn("bridge: resume failed, falling back to new session",
 				"session_id", sessionID, "state", si.State, "err", err)
 			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, botName, injectExclude...)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -184,6 +184,12 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	// Step 1: Retry resume once for transient failures (e.g., file lock, timing).
 	if p.retryDepth == 0 {
 		if err := b.resumeWithOpts(context.Background(), p.sessionID, p.workDir, forwardOpts{resumed: true, workDir: p.workDir, retryDepth: p.retryDepth + 1, lastInput: p.lastInput}); err != nil {
+			if errors.Is(err, worker.ErrResumeCheckFailed) {
+				b.log.Warn("bridge: resume verification failed during crash recovery; preserving session context",
+					"session_id", p.sessionID, "worker_type", p.workerType, "err", err)
+				b.sendError(p.sessionID, events.ErrCodeInternalError, "Unable to verify the previous worker session. Please retry later.")
+				return false
+			}
 			b.log.Warn("bridge: resume retry failed synchronously, falling back to fresh start", "session_id", p.sessionID, "worker_type", p.workerType, "err", err)
 		} else {
 			b.log.Info("bridge: resume retry succeeded", "session_id", p.sessionID, "worker_type", p.workerType)

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -528,6 +528,11 @@ func (c *Conn) resolveSessionState(sessionID string, initData InitData, workDir 
 }
 
 func (c *Conn) handleSessionNotFound(sessionID string, initData InitData, workDir string, sm connSM, lookupErr error, clientKey string) (*session.SessionInfo, error) {
+	if errors.Is(lookupErr, session.ErrSessionCleanupPending) {
+		c.hub.InitThrottle.RecordFailure(sessionID)
+		c.sendInitError(events.ErrCodeSessionBusy, "session cleanup in progress; retry later")
+		return nil, fmt.Errorf("get session: %w", lookupErr)
+	}
 	if !errors.Is(lookupErr, session.ErrSessionNotFound) {
 		c.hub.InitThrottle.RecordFailure(sessionID)
 		c.sendInitError(events.ErrCodeInternalError, lookupErr.Error())

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -663,6 +663,11 @@ func (c *Conn) handleExistingSession(sessionID, workDir string, sm connSM, si *s
 	defer resumeCancel()
 	resumeErr := c.starter.ResumeSession(resumeCtx, sessionID, workDir)
 	if resumeErr != nil {
+		if errors.Is(resumeErr, worker.ErrResumeCheckFailed) {
+			c.hub.InitThrottle.RecordFailure(sessionID)
+			c.sendInitError(events.ErrCodeInternalError, "unable to verify the previous worker session; retry later")
+			return nil, fmt.Errorf("resume verification failed: %w", resumeErr)
+		}
 		startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer startCancel()
 		if err := c.starter.StartSession(startCtx, worker.SessionStartParams{

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -180,6 +180,66 @@ func TestBuildInitAckError(t *testing.T) {
 	require.Equal(t, "invalid token", ack.Event.Data.(InitAckData).Error)
 }
 
+type resumeCheckStarter struct {
+	startCalled bool
+}
+
+func (s *resumeCheckStarter) StartSession(context.Context, worker.SessionStartParams) error {
+	s.startCalled = true
+	return nil
+}
+
+func (*resumeCheckStarter) ResumeSession(context.Context, string, string) error {
+	return worker.ErrResumeCheckFailed
+}
+
+func (*resumeCheckStarter) SwitchWorkDir(context.Context, string, string) (*SwitchWorkDirResult, error) {
+	return nil, nil
+}
+
+func (*resumeCheckStarter) GetWorkspaceByID(context.Context, string) (*session.Workspace, error) {
+	return nil, session.ErrSessionNotFound
+}
+
+type resumeCheckSM struct {
+	info *session.SessionInfo
+}
+
+func (m *resumeCheckSM) Get(context.Context, string) (*session.SessionInfo, error) {
+	return m.info, nil
+}
+
+func (*resumeCheckSM) GetWorker(string) worker.Worker { return nil }
+
+func (*resumeCheckSM) Transition(context.Context, string, events.SessionState) error { return nil }
+
+func (*resumeCheckSM) CreateWithBot(context.Context, string, string, string, string, worker.WorkerType, []string, string, map[string]string, string, string, string) (*session.SessionInfo, error) {
+	return nil, errors.New("StartSession must not be called after an uncertain resume check")
+}
+
+func (*resumeCheckSM) DeletePhysical(context.Context, string) error { return nil }
+
+func TestConnHandleExistingSession_DoesNotFreshStartOnResumeCheckFailure(t *testing.T) {
+	hub := newTestHub(t)
+	client, server := newTestWSConnPair(t)
+	defer client.Close()
+	defer server.Close()
+
+	starter := &resumeCheckStarter{}
+	c := newConn(hub, client, "sess-resume-check", starter)
+	defer c.Close()
+	sm := &resumeCheckSM{info: &session.SessionInfo{
+		ID:         "sess-resume-check",
+		UserID:     "user1",
+		WorkerType: worker.TypeOpenCodeSrv,
+		State:      events.StateTerminated,
+	}}
+
+	_, err := c.handleExistingSession("sess-resume-check", "", sm, sm.info, InitData{}, "")
+	require.ErrorIs(t, err, worker.ErrResumeCheckFailed)
+	require.False(t, starter.startCalled, "uncertain OCS availability must not discard context with a fresh start")
+}
+
 func TestBackoffDuration(t *testing.T) {
 	t.Parallel()
 
@@ -526,9 +586,15 @@ func (m *mockSessionStoreForBotID) GetExpiredIdle(ctx context.Context, now time.
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockSessionStoreForBotID) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
+func (m *mockSessionStoreForBotID) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*session.SessionInfo, error) {
 	args := m.Called(ctx, cronCutoff, defaultCutoff)
-	return args.Error(0)
+	if len(args) == 1 {
+		return nil, args.Error(0)
+	}
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*session.SessionInfo), args.Error(1)
 }
 
 func (m *mockSessionStoreForBotID) DeletePhysical(ctx context.Context, id string) error {

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -63,9 +63,15 @@ func (m *mockStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]string
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
+func (m *mockStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*session.SessionInfo, error) {
 	args := m.Called(ctx, cronCutoff, defaultCutoff)
-	return args.Error(0)
+	if len(args) == 1 {
+		return nil, args.Error(0)
+	}
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*session.SessionInfo), args.Error(1)
 }
 
 func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -428,6 +428,9 @@ func (h *Handler) validateOwner(ctx context.Context, env *events.Envelope) (*ses
 func (h *Handler) requireActiveOwner(ctx context.Context, env *events.Envelope) (*session.SessionInfo, error) {
 	si, err := h.validateOwner(ctx, env)
 	if err != nil {
+		if errors.Is(err, session.ErrSessionCleanupPending) {
+			return nil, h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session cleanup in progress; retry later")
+		}
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return nil, h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "session not found")
 		}

--- a/internal/session/cleanup_outbox.go
+++ b/internal/session/cleanup_outbox.go
@@ -1,0 +1,476 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+// CleanupTask is a durable request to delete a worker-owned remote session.
+// WorkerSessionID is captured at deletion time and is never read from a later
+// HotPlex session row.
+type CleanupTask struct {
+	ID              string
+	SessionID       string
+	WorkerType      worker.WorkerType
+	WorkerSessionID string
+	Attempts        int
+	NextAttemptAt   time.Time
+	LeaseUntil      *time.Time
+	LeaseToken      string
+	LastError       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// CleanupTaskStore is implemented by persistent session stores. Keeping this
+// separate from Store preserves lightweight manager test doubles.
+type CleanupTaskStore interface {
+	MarkDeletedWithCleanup(ctx context.Context, info *SessionInfo) error
+	DeletePhysicalWithCleanup(ctx context.Context, id string) (*SessionInfo, error)
+	ClaimCleanupTasks(ctx context.Context, now, leaseUntil time.Time, limit int) ([]CleanupTask, error)
+	CompleteCleanupTask(ctx context.Context, taskID, leaseToken string) error
+	RetryCleanupTask(ctx context.Context, taskID, leaseToken string, nextAttemptAt time.Time, lastError string) error
+	HasPendingCleanup(ctx context.Context, sessionID string) (bool, error)
+}
+
+// CleanupExecutor dispatches a task to the worker-type-specific cleaner.
+type CleanupExecutor func(context.Context, worker.WorkerType, string) error
+
+const (
+	cleanupBatchSize      = 16
+	cleanupLeaseDuration  = 30 * time.Second
+	cleanupAttemptTimeout = 10 * time.Second
+	cleanupPollInterval   = time.Second
+	cleanupRetryMax       = 5 * time.Minute
+)
+
+// CleanupRunner leases and executes persistent cleanup tasks until ctx ends.
+type CleanupRunner struct {
+	log     *slog.Logger
+	store   CleanupTaskStore
+	execute CleanupExecutor
+	now     func() time.Time
+}
+
+func NewCleanupRunner(log *slog.Logger, store CleanupTaskStore, execute CleanupExecutor) *CleanupRunner {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &CleanupRunner{log: log.With("component", "session_cleanup_outbox"), store: store, execute: execute, now: time.Now}
+}
+
+// Run drains due work at startup and then polls. A failed task never prevents
+// later tasks from running.
+func (r *CleanupRunner) Run(ctx context.Context) {
+	if r == nil || r.store == nil || r.execute == nil {
+		return
+	}
+	r.RunOnce(ctx)
+	ticker := time.NewTicker(cleanupPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.RunOnce(ctx)
+		}
+	}
+}
+
+// RunOnce executes one leased batch. It is exported for deterministic tests.
+func (r *CleanupRunner) RunOnce(ctx context.Context) {
+	if r == nil || r.store == nil || r.execute == nil {
+		return
+	}
+	now := r.now()
+	tasks, err := r.store.ClaimCleanupTasks(ctx, now, now.Add(cleanupLeaseDuration), cleanupBatchSize)
+	if err != nil {
+		r.log.Warn("session cleanup: claim tasks failed", "err", err)
+		return
+	}
+	for _, task := range tasks {
+		attemptCtx, cancel := context.WithTimeout(ctx, cleanupAttemptTimeout)
+		err := r.execute(attemptCtx, task.WorkerType, task.WorkerSessionID)
+		cancel()
+		if err == nil {
+			if completeErr := r.store.CompleteCleanupTask(ctx, task.ID, task.LeaseToken); completeErr != nil {
+				r.log.Warn("session cleanup: complete task failed", "task_id", task.ID, "session_id", task.SessionID, "err", completeErr)
+			}
+			continue
+		}
+		next := r.now().Add(cleanupBackoff(task.Attempts))
+		if retryErr := r.store.RetryCleanupTask(ctx, task.ID, task.LeaseToken, next, err.Error()); retryErr != nil {
+			r.log.Warn("session cleanup: retry scheduling failed", "task_id", task.ID, "session_id", task.SessionID, "err", retryErr)
+			continue
+		}
+		r.log.Warn("session cleanup: remote delete failed; retry scheduled", "task_id", task.ID, "session_id", task.SessionID, "worker_type", task.WorkerType, "attempt", task.Attempts, "next_attempt_at", next, "err", err)
+	}
+}
+
+func cleanupBackoff(attempts int) time.Duration {
+	if attempts < 1 {
+		attempts = 1
+	}
+	shift := min(attempts-1, 8)
+	delay := time.Second * time.Duration(math.Pow(2, float64(shift)))
+	if delay > cleanupRetryMax {
+		return cleanupRetryMax
+	}
+	return delay
+}
+
+func newCleanupTask(info *SessionInfo, now time.Time) *CleanupTask {
+	if info == nil || info.WorkerSessionID == "" {
+		return nil
+	}
+	return &CleanupTask{ID: uuid.NewString(), SessionID: info.ID, WorkerType: info.WorkerType, WorkerSessionID: info.WorkerSessionID, NextAttemptAt: now, CreatedAt: now, UpdatedAt: now}
+}
+
+func upsertSessionArgs(info *SessionInfo, ctxJSON, pkJSON []byte) []any {
+	return []any{info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
+		info.Platform, string(pkJSON), info.WorkDir, info.Title, info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
+		string(ctxJSON), info.Source, info.ClientKey, nullableString(info.WorkspaceID), info.ID}
+}
+
+func cleanupTaskColumns() string {
+	return "id, session_id, worker_type, worker_session_id, attempts, next_attempt_at, lease_until, COALESCE(lease_token, ''), last_error, created_at, updated_at"
+}
+
+func scanCleanupTask(sc interface{ Scan(...any) error }) (CleanupTask, error) {
+	var task CleanupTask
+	var lease sql.NullTime
+	err := sc.Scan(&task.ID, &task.SessionID, &task.WorkerType, &task.WorkerSessionID, &task.Attempts, &task.NextAttemptAt, &lease, &task.LeaseToken, &task.LastError, &task.CreatedAt, &task.UpdatedAt)
+	if err != nil {
+		return CleanupTask{}, err
+	}
+	if lease.Valid {
+		task.LeaseUntil = &lease.Time
+	}
+	return task, nil
+}
+
+func insertCleanupTask(ctx context.Context, execer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, info *SessionInfo, now time.Time) error {
+	task := newCleanupTask(info, now)
+	if task == nil {
+		return nil
+	}
+	_, err := execer.ExecContext(ctx, `INSERT INTO session_cleanup_tasks (id, session_id, worker_type, worker_session_id, attempts, next_attempt_at, lease_until, lease_token, last_error, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?) ON CONFLICT(session_id) DO NOTHING`, task.ID, task.SessionID, task.WorkerType, task.WorkerSessionID, task.Attempts, task.NextAttemptAt, task.LastError, task.CreatedAt, task.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("session cleanup: enqueue: %w", err)
+	}
+	return nil
+}
+
+func isCleanupPendingError(err error) bool {
+	return errors.Is(err, ErrSessionCleanupPending) || (err != nil && containsCleanupPending(err.Error()))
+}
+
+func containsCleanupPending(message string) bool {
+	return strings.Contains(message, "session cleanup pending") || strings.Contains(message, "session_cleanup_tasks")
+}
+
+func ensureSQLiteLifecycleLock(ctx context.Context, tx *sql.Tx, sessionID string) error {
+	// SQLiteStore already holds its process-wide writeMu for every caller of
+	// this helper. The transaction therefore has the required lifecycle lock
+	// without retaining a row after session retention GC.
+	return nil
+}
+
+func ensurePGLifecycleLock(ctx context.Context, tx *sql.Tx, rebind func(string) string, sessionID string) error {
+	// Transaction-scoped advisory locks disappear on commit/rollback. A hash
+	// collision only adds contention; it cannot permit conflicting lifecycle
+	// writes to run concurrently.
+	_, err := tx.ExecContext(ctx, rebind(`SELECT pg_advisory_xact_lock(hashtextextended(?, 0))`), sessionID)
+	return err
+}
+
+func (s *SQLiteStore) HasPendingCleanup(ctx context.Context, sessionID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM session_cleanup_tasks WHERE session_id = ?)`, sessionID).Scan(&exists)
+	return exists, err
+}
+
+func (s *SQLiteStore) MarkDeletedWithCleanup(ctx context.Context, info *SessionInfo) error {
+	ctxJSON, pkJSON, err := marshalSessionJSON(info)
+	if err != nil {
+		return err
+	}
+	return s.writeMu.WithLock(func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := ensureSQLiteLifecycleLock(ctx, tx, info.ID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, queries["sessions.upsert_session"], upsertSessionArgs(info, ctxJSON, pkJSON)...); err != nil {
+			if isCleanupPendingError(err) {
+				return ErrSessionCleanupPending
+			}
+			return fmt.Errorf("session cleanup: mark deleted: %w", err)
+		}
+		if err := insertCleanupTask(ctx, tx, info, time.Now()); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
+}
+
+func (s *SQLiteStore) DeletePhysicalWithCleanup(ctx context.Context, id string) (*SessionInfo, error) {
+	var deleted *SessionInfo
+	err := s.writeMu.WithLock(func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := ensureSQLiteLifecycleLock(ctx, tx, id); err != nil {
+			return err
+		}
+		info, err := scanSession(tx.QueryRowContext(ctx, queries["store.get_session"], id))
+		if errors.Is(err, sql.ErrNoRows) {
+			return tx.Commit()
+		}
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, queries["store.delete_physical"], id); err != nil {
+			return fmt.Errorf("session cleanup: physical delete: %w", err)
+		}
+		if err := insertCleanupTask(ctx, tx, info, time.Now()); err != nil {
+			return err
+		}
+		deleted = info
+		return tx.Commit()
+	})
+	return deleted, err
+}
+
+func (s *SQLiteStore) ClaimCleanupTasks(ctx context.Context, now, leaseUntil time.Time, limit int) ([]CleanupTask, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	tasks := make([]CleanupTask, 0, limit)
+	err := s.writeMu.WithLock(func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		rows, err := tx.QueryContext(ctx, `SELECT `+cleanupTaskColumns()+` FROM session_cleanup_tasks WHERE next_attempt_at <= ? AND (lease_until IS NULL OR lease_until <= ?) ORDER BY next_attempt_at, created_at LIMIT ?`, now, now, limit)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			task, err := scanCleanupTask(rows)
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+			leaseToken := uuid.NewString()
+			result, err := tx.ExecContext(ctx, `UPDATE session_cleanup_tasks SET attempts = attempts + 1, lease_until = ?, lease_token = ?, updated_at = ? WHERE id = ? AND (lease_until IS NULL OR lease_until <= ?)`, leaseUntil, leaseToken, now, task.ID, now)
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+			updated, err := result.RowsAffected()
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+			if updated == 1 {
+				task.Attempts++
+				task.LeaseUntil = &leaseUntil
+				task.LeaseToken = leaseToken
+				task.UpdatedAt = now
+				tasks = append(tasks, task)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
+	return tasks, err
+}
+
+func (s *SQLiteStore) CompleteCleanupTask(ctx context.Context, taskID, leaseToken string) error {
+	return s.writeMu.WithLock(func() error {
+		result, err := s.db.ExecContext(ctx, `DELETE FROM session_cleanup_tasks WHERE id = ? AND lease_token = ?`, taskID, leaseToken)
+		if err != nil {
+			return err
+		}
+		return cleanupLeaseResult(result)
+	})
+}
+
+func (s *SQLiteStore) RetryCleanupTask(ctx context.Context, taskID, leaseToken string, nextAttemptAt time.Time, lastError string) error {
+	return s.writeMu.WithLock(func() error {
+		result, err := s.db.ExecContext(ctx, `UPDATE session_cleanup_tasks SET next_attempt_at = ?, lease_until = NULL, lease_token = NULL, last_error = ?, updated_at = ? WHERE id = ? AND lease_token = ?`, nextAttemptAt, truncateCleanupError(lastError), time.Now(), taskID, leaseToken)
+		if err != nil {
+			return err
+		}
+		return cleanupLeaseResult(result)
+	})
+}
+
+func (s *pgStore) HasPendingCleanup(ctx context.Context, sessionID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, s.dialect.Rebind(`SELECT EXISTS(SELECT 1 FROM session_cleanup_tasks WHERE session_id = ?)`), sessionID).Scan(&exists)
+	return exists, err
+}
+
+func (s *pgStore) MarkDeletedWithCleanup(ctx context.Context, info *SessionInfo) error {
+	ctxJSON, pkJSON, err := marshalSessionJSON(info)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := ensurePGLifecycleLock(ctx, tx, s.dialect.Rebind, info.ID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, s.queries["sessions.upsert_session"], upsertSessionArgs(info, ctxJSON, pkJSON)...); err != nil {
+		if isCleanupPendingError(err) {
+			return ErrSessionCleanupPending
+		}
+		return fmt.Errorf("session cleanup: mark deleted: %w", err)
+	}
+	if err := insertCleanupTask(ctx, pgExec{tx: tx, rebind: s.dialect.Rebind}, info, time.Now()); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *pgStore) DeletePhysicalWithCleanup(ctx context.Context, id string) (*SessionInfo, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := ensurePGLifecycleLock(ctx, tx, s.dialect.Rebind, id); err != nil {
+		return nil, err
+	}
+	info, err := scanSession(tx.QueryRowContext(ctx, s.queries["store.get_session"], id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, tx.Commit()
+	}
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, s.queries["store.delete_physical"], id); err != nil {
+		return nil, err
+	}
+	if err := insertCleanupTask(ctx, pgExec{tx: tx, rebind: s.dialect.Rebind}, info, time.Now()); err != nil {
+		return nil, err
+	}
+	return info, tx.Commit()
+}
+
+func (s *pgStore) ClaimCleanupTasks(ctx context.Context, now, leaseUntil time.Time, limit int) ([]CleanupTask, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	query := s.dialect.Rebind(`SELECT ` + cleanupTaskColumns() + ` FROM session_cleanup_tasks WHERE next_attempt_at <= ? AND (lease_until IS NULL OR lease_until <= ?) ORDER BY next_attempt_at, created_at LIMIT ? FOR UPDATE SKIP LOCKED`)
+	rows, err := tx.QueryContext(ctx, query, now, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	tasks := make([]CleanupTask, 0, limit)
+	update := s.dialect.Rebind(`UPDATE session_cleanup_tasks SET attempts = attempts + 1, lease_until = ?, lease_token = ?, updated_at = ? WHERE id = ?`)
+	for rows.Next() {
+		task, err := scanCleanupTask(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		leaseToken := uuid.NewString()
+		if _, err := tx.ExecContext(ctx, update, leaseUntil, leaseToken, now, task.ID); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		task.Attempts++
+		task.LeaseUntil = &leaseUntil
+		task.LeaseToken = leaseToken
+		task.UpdatedAt = now
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return tasks, tx.Commit()
+}
+
+func (s *pgStore) CompleteCleanupTask(ctx context.Context, taskID, leaseToken string) error {
+	result, err := s.db.ExecContext(ctx, s.dialect.Rebind(`DELETE FROM session_cleanup_tasks WHERE id = ? AND lease_token = ?`), taskID, leaseToken)
+	if err != nil {
+		return err
+	}
+	return cleanupLeaseResult(result)
+}
+
+func (s *pgStore) RetryCleanupTask(ctx context.Context, taskID, leaseToken string, nextAttemptAt time.Time, lastError string) error {
+	result, err := s.db.ExecContext(ctx, s.dialect.Rebind(`UPDATE session_cleanup_tasks SET next_attempt_at = ?, lease_until = NULL, lease_token = NULL, last_error = ?, updated_at = ? WHERE id = ? AND lease_token = ?`), nextAttemptAt, truncateCleanupError(lastError), time.Now(), taskID, leaseToken)
+	if err != nil {
+		return err
+	}
+	return cleanupLeaseResult(result)
+}
+
+type pgExec struct {
+	tx     *sql.Tx
+	rebind func(string) string
+}
+
+func (e pgExec) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return e.tx.ExecContext(ctx, e.rebind(query), args...)
+}
+
+func truncateCleanupError(message string) string {
+	const maxLen = 1024
+	if len(message) <= maxLen {
+		return message
+	}
+	return message[:maxLen]
+}
+
+func cleanupLeaseResult(result sql.Result) error {
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if updated == 0 {
+		return ErrCleanupLeaseLost
+	}
+	return nil
+}

--- a/internal/session/cleanup_outbox_test.go
+++ b/internal/session/cleanup_outbox_test.go
@@ -55,6 +55,50 @@ func TestSQLiteStore_RetentionCleanupTombstoneBlocksStaleUpsert(t *testing.T) {
 	require.Equal(t, "ocs-old", tasks[0].WorkerSessionID)
 }
 
+func TestSQLiteStore_MarkDeletedEnqueuesCleanupTask(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	info := ocsTerminatedInfo("sess-logical-delete", "ocs-logical-delete", now)
+	info.State = events.StateRunning
+	require.NoError(t, store.Upsert(ctx, info))
+
+	deleted := *info
+	deleted.State = events.StateDeleted
+	deleted.UpdatedAt = now.Add(time.Second)
+	require.NoError(t, store.MarkDeletedWithCleanup(ctx, &deleted))
+
+	stored, err := store.Get(ctx, info.ID)
+	require.NoError(t, err)
+	require.Equal(t, events.StateDeleted, stored.State)
+
+	claimNow := time.Now().Add(time.Second)
+	tasks, err := store.ClaimCleanupTasks(ctx, claimNow, claimNow.Add(time.Minute), 1)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "ocs-logical-delete", tasks[0].WorkerSessionID)
+}
+
+func TestCleanupRunner_RunReturnsOnCancellation(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner := NewCleanupRunner(nil, store, func(context.Context, worker.WorkerType, string) error { return nil })
+	runner.Run(ctx)
+	require.True(t, isCleanupPendingError(ErrSessionCleanupPending))
+	require.True(t, containsCleanupPending("session cleanup pending"))
+}
+
+func TestSQLiteStore_DeletePhysicalWithCleanupNotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	deleted, err := store.DeletePhysicalWithCleanup(context.Background(), "missing-session")
+	require.NoError(t, err)
+	require.Nil(t, deleted)
+}
+
 func TestCleanupRunner_RetriesAndCompletesDurably(t *testing.T) {
 	t.Parallel()
 	store, _ := helperDB(t)

--- a/internal/session/cleanup_outbox_test.go
+++ b/internal/session/cleanup_outbox_test.go
@@ -1,0 +1,147 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func ocsTerminatedInfo(id, remoteID string, now time.Time) *SessionInfo {
+	return &SessionInfo{
+		ID:              id,
+		UserID:          "user-1",
+		WorkerType:      worker.TypeOpenCodeSrv,
+		WorkerSessionID: remoteID,
+		State:           events.StateTerminated,
+		CreatedAt:       now.Add(-time.Hour),
+		UpdatedAt:       now.Add(-time.Hour),
+	}
+}
+
+func TestSQLiteStore_RetentionCleanupTombstoneBlocksStaleUpsert(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	info := ocsTerminatedInfo("sess-retention-race", "ocs-old", now)
+	require.NoError(t, store.Upsert(ctx, info))
+
+	deleted, err := store.DeleteTerminated(ctx, now, now)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	require.Equal(t, "ocs-old", deleted[0].WorkerSessionID)
+
+	_, err = store.Get(ctx, info.ID)
+	require.ErrorIs(t, err, ErrSessionCleanupPending)
+
+	stale := *info
+	stale.State = events.StateRunning
+	stale.UpdatedAt = now.Add(time.Second)
+	require.ErrorIs(t, store.Upsert(ctx, &stale), ErrSessionCleanupPending,
+		"a resume snapshot must not recreate a retention-deleted OCS session")
+
+	claimNow := time.Now().Add(time.Second)
+	tasks, err := store.ClaimCleanupTasks(ctx, claimNow, claimNow.Add(time.Minute), 1)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.Equal(t, info.ID, tasks[0].SessionID)
+	require.Equal(t, "ocs-old", tasks[0].WorkerSessionID)
+}
+
+func TestCleanupRunner_RetriesAndCompletesDurably(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	info := ocsTerminatedInfo("sess-outbox-retry", "ocs-retry", now)
+	require.NoError(t, store.Upsert(ctx, info))
+	_, err := store.DeletePhysicalWithCleanup(ctx, info.ID)
+	require.NoError(t, err)
+
+	var calls atomic.Int32
+	runner := NewCleanupRunner(nil, store, func(_ context.Context, workerType worker.WorkerType, remoteID string) error {
+		require.Equal(t, worker.TypeOpenCodeSrv, workerType)
+		require.Equal(t, "ocs-retry", remoteID)
+		if calls.Add(1) == 1 {
+			return errors.New("ocs temporarily unavailable")
+		}
+		return nil
+	})
+	base := time.Now().Add(time.Second)
+	runner.now = func() time.Time { return base }
+	runner.RunOnce(ctx)
+
+	tasks, err := store.ClaimCleanupTasks(ctx, base, base.Add(time.Minute), 1)
+	require.NoError(t, err)
+	require.Empty(t, tasks, "failure must back off instead of losing or immediately re-leasing the task")
+
+	runner.now = func() time.Time { return base.Add(2 * time.Second) }
+	runner.RunOnce(ctx)
+	require.EqualValues(t, 2, calls.Load())
+
+	_, err = store.Get(ctx, info.ID)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+	var count int
+	require.NoError(t, store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM session_cleanup_tasks WHERE session_id = ?`, info.ID).Scan(&count))
+	require.Zero(t, count)
+}
+
+func TestCleanupRunner_ReclaimsExpiredLeaseAfterRestart(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	info := ocsTerminatedInfo("sess-outbox-lease", "ocs-lease", now)
+	require.NoError(t, store.Upsert(ctx, info))
+	_, err := store.DeletePhysicalWithCleanup(ctx, info.ID)
+	require.NoError(t, err)
+
+	claimNow := time.Now().Add(time.Second)
+	leaseUntil := claimNow.Add(time.Minute)
+	leased, err := store.ClaimCleanupTasks(ctx, claimNow, leaseUntil, 1)
+	require.NoError(t, err)
+	require.Len(t, leased, 1)
+
+	var calls atomic.Int32
+	runner := NewCleanupRunner(nil, store, func(context.Context, worker.WorkerType, string) error {
+		calls.Add(1)
+		return nil
+	})
+	runner.now = func() time.Time { return leaseUntil.Add(time.Second) }
+	runner.RunOnce(ctx)
+	require.EqualValues(t, 1, calls.Load())
+}
+
+func TestCleanupTask_ExpiredLeaseCannotCompleteOrRetryNewLease(t *testing.T) {
+	t.Parallel()
+	store, _ := helperDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	info := ocsTerminatedInfo("sess-outbox-fence", "ocs-fence", now)
+	require.NoError(t, store.Upsert(ctx, info))
+	_, err := store.DeletePhysicalWithCleanup(ctx, info.ID)
+	require.NoError(t, err)
+
+	firstNow := time.Now().Add(time.Second)
+	firstLeaseUntil := firstNow.Add(time.Minute)
+	first, err := store.ClaimCleanupTasks(ctx, firstNow, firstLeaseUntil, 1)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	secondNow := firstLeaseUntil.Add(time.Second)
+	second, err := store.ClaimCleanupTasks(ctx, secondNow, secondNow.Add(time.Minute), 1)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	require.NotEqual(t, first[0].LeaseToken, second[0].LeaseToken)
+
+	require.ErrorIs(t, store.CompleteCleanupTask(ctx, first[0].ID, first[0].LeaseToken), ErrCleanupLeaseLost)
+	require.ErrorIs(t, store.RetryCleanupTask(ctx, first[0].ID, first[0].LeaseToken, secondNow.Add(time.Minute), "late failure"), ErrCleanupLeaseLost)
+	require.NoError(t, store.CompleteCleanupTask(ctx, second[0].ID, second[0].LeaseToken))
+}

--- a/internal/session/coverage_test.go
+++ b/internal/session/coverage_test.go
@@ -141,7 +141,7 @@ func TestSQLiteStore_UpdateWorkspace_WorkDirChangeBlockedByActiveSession(t *test
 	// Active session inserted after the handler's hypothetical Count pre-check.
 	_, err := store.db.ExecContext(ctx, queries["sessions.upsert_session"],
 		"sess-1", "u-1", "u-1", "", "", "", "claude_code", "running", "webchat", "{}", "/tmp/old", "",
-		int64(1700000000), int64(1700000000), int64(1800000000), int64(1800000000), "{}", "", "ck-1", "ws-1")
+		int64(1700000000), int64(1700000000), int64(1800000000), int64(1800000000), "{}", "", "ck-1", "ws-1", "sess-1")
 	require.NoError(t, err)
 
 	ws, _ := store.GetWorkspaceByID(ctx, "ws-1")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -26,16 +26,18 @@ import (
 
 // Errors returned by the session manager.
 var (
-	ErrSessionNotFound   = errors.New("session: not found")
-	ErrSessionNotActive  = errors.New("session: not active")
-	ErrSessionBusy       = errors.New("session: busy")
-	ErrInvalidTransition = errors.New("session: invalid state transition")
-	ErrPoolExhausted     = errors.New("session: pool exhausted")
-	ErrUserQuotaExceeded = errors.New("session: user quota exceeded")
-	ErrOwnershipMismatch = errors.New("session: ownership mismatch")
-	ErrMaxTurnsReached   = errors.New("session: max turns reached")
-	ErrWorkerAttached    = errors.New("session: worker already attached")
-	ErrClientKeyTooLong  = errors.New("session: client_key too long")
+	ErrSessionNotFound       = errors.New("session: not found")
+	ErrSessionNotActive      = errors.New("session: not active")
+	ErrSessionBusy           = errors.New("session: busy")
+	ErrInvalidTransition     = errors.New("session: invalid state transition")
+	ErrPoolExhausted         = errors.New("session: pool exhausted")
+	ErrUserQuotaExceeded     = errors.New("session: user quota exceeded")
+	ErrOwnershipMismatch     = errors.New("session: ownership mismatch")
+	ErrMaxTurnsReached       = errors.New("session: max turns reached")
+	ErrWorkerAttached        = errors.New("session: worker already attached")
+	ErrClientKeyTooLong      = errors.New("session: client_key too long")
+	ErrSessionCleanupPending = errors.New("session: cleanup pending")
+	ErrCleanupLeaseLost      = errors.New("session: cleanup task lease lost")
 )
 
 // MaxClientKeyLen is the maximum allowed length for ClientKey.
@@ -190,6 +192,7 @@ type managedSession struct {
 	attachedWorkspaceID string
 	TurnCount           int
 	startedAt           time.Time
+	deleting            bool // guarded by mu; prevents AttachWorker during durable delete
 	log                 *slog.Logger
 	mu                  sync.RWMutex // protects state transitions and input handling; reads use RLock
 }
@@ -482,6 +485,9 @@ func (m *Manager) UpdateWorkDir(ctx context.Context, id, workDir string) error {
 // IMPORTANT: the caller MUST NOT call Terminate/Kill on the returned worker
 // while holding ms.mu — doing so re-introduces the deadlock described in #655.
 func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from, to events.SessionState, termReason string) (worker.Worker, error) {
+	if ms.deleting {
+		return nil, ErrSessionCleanupPending
+	}
 	// Build the candidate state as a value copy (never mutates ms.info in-place).
 	// NOTE: shallow copy — map fields (Context, PlatformKey) share headers.
 	// Safe here because only scalar fields (State, UpdatedAt, etc.) are mutated.
@@ -776,9 +782,13 @@ func (m *Manager) AttachWorker(ctx context.Context, id string, w worker.Worker) 
 	userID := ms.info.UserID
 	workspaceID := ms.info.WorkspaceID
 	alreadyAttached := ms.worker != nil
+	deleting := ms.deleting
 	ms.mu.RUnlock()
 	m.mu.RUnlock()
 
+	if deleting {
+		return ErrSessionCleanupPending
+	}
 	if alreadyAttached {
 		return ErrWorkerAttached
 	}
@@ -810,6 +820,13 @@ func (m *Manager) AttachWorker(ctx context.Context, id string, w worker.Worker) 
 		return ErrSessionNotFound
 	}
 	ms.mu.Lock()
+	if ms.deleting {
+		ms.mu.Unlock()
+		m.mu.Unlock()
+		m.pool.ReleaseForWorkspace(ctx, userID, workspaceID)
+		observability.PoolAcquire().Add(ctx, 1, metric.WithAttributes(attribute.String("result", "toctou_retry")))
+		return ErrSessionCleanupPending
+	}
 	if ms.worker != nil {
 		ms.mu.Unlock()
 		m.mu.Unlock()
@@ -926,9 +943,10 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	ms, ok := m.sessions[id]
 	if !ok {
 		m.mu.Unlock()
-		// Session not in memory — remove from database directly. Preserve its
-		// metadata first so an explicitly deleted persistent worker session can
-		// be cleaned up after the local delete succeeds.
+		if cleanup, ok := m.store.(CleanupTaskStore); ok {
+			_, err := cleanup.DeletePhysicalWithCleanup(ctx, id)
+			return err
+		}
 		var deletedInfo *SessionInfo
 		if m.OnDelete != nil {
 			if info, err := m.store.Get(ctx, id); err == nil {
@@ -945,7 +963,6 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	}
 
 	ms.mu.Lock()
-	hadWorkerBefore := ms.worker != nil
 	workerType := ms.info.WorkerType
 	uid := ms.info.UserID
 	platform := ms.info.Platform
@@ -955,42 +972,35 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	candidate := ms.info
 	candidate.State = events.StateDeleted
 	candidate.UpdatedAt = time.Now()
+	ms.deleting = true
 	ms.mu.Unlock()
 	m.mu.Unlock()
 
-	if err := m.store.Upsert(ctx, &candidate); err != nil {
+	var persistErr error
+	if cleanup, ok := m.store.(CleanupTaskStore); ok {
+		persistErr = cleanup.MarkDeletedWithCleanup(ctx, &candidate)
+	} else {
+		persistErr = m.store.Upsert(ctx, &candidate)
+	}
+	if persistErr != nil {
+		m.mu.Lock()
+		if current, exists := m.sessions[id]; exists {
+			current.mu.Lock()
+			current.deleting = false
+			current.mu.Unlock()
+		}
+		m.mu.Unlock()
 		m.emitSessionDeleteAudit(uid, botID, platform, id, string(workerType), audit.OutcomeFailure)
-		return err
+		return persistErr
 	}
 
-	// Persist succeeded — validate gap before committing in-memory.
-	// This must happen BEFORE setting ms.info = candidate to prevent
-	// leaving the session in DELETED state with a running worker when
-	// a concurrent AttachWorker slipped in during the DB write window.
+	// AttachWorker observes deleting under the same mutex, so no worker can be
+	// attached during the durable state-and-outbox transaction above.
 	m.mu.Lock()
 	if _, exists := m.sessions[id]; exists {
 		ms.mu.Lock()
-		hasWorkerAfter := ms.worker != nil
-		// If worker appeared during the gap (was nil before, now non-nil),
-		// a concurrent AttachWorker resurrected the session — abort deletion.
-		if !hadWorkerBefore && hasWorkerAfter {
-			ms.mu.Unlock()
-			m.mu.Unlock()
-			m.log.Warn("session: worker attached during delete gap, rolling back",
-				"session_id", id)
-			// Rollback DB: restore original state (ms.info hasn't been mutated yet).
-			ms.mu.RLock()
-			original := ms.info
-			ms.mu.RUnlock()
-			if rbErr := m.store.Upsert(ctx, &original); rbErr != nil {
-				m.log.Error("session: delete rollback failed", "session_id", id, "err", rbErr)
-			}
-			m.emitSessionDeleteAudit(uid, botID, platform, id, string(workerType), audit.OutcomeFailure)
-			return nil
-		}
-		// No gap worker — commit candidate and delete atomically under both locks.
 		ms.info = candidate
-		if hasWorkerAfter {
+		if ms.worker != nil {
 			workerToTerminate = ms.worker
 			workersRunningGauge(string(workerType)).Add(-1)
 			// Release against the workspace the quota was acquired on at attach
@@ -1007,7 +1017,9 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 
 	m.notifyStateChange(ctx, id, events.StateDeleted, "session deleted")
 	m.terminateWorkerGracefully(ctx, workerToTerminate, id)
-	m.notifyDelete(candidate)
+	if _, ok := m.store.(CleanupTaskStore); !ok {
+		m.notifyDelete(candidate)
+	}
 
 	m.log.Info("session: deleted", "session_id", id)
 	m.emitSessionDeleteAudit(uid, botID, platform, id, string(workerType), audit.OutcomeSuccess)
@@ -1024,6 +1036,7 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 	var deletedInfo *SessionInfo
 	if ok {
 		ms.mu.Lock()
+		ms.deleting = true
 		info := ms.info
 		deletedInfo = &info
 		wasRunning := ms.info.State == events.StateRunning
@@ -1040,12 +1053,6 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 		}
 	}
 	m.mu.Unlock()
-	if deletedInfo == nil && m.OnDelete != nil {
-		if info, err := m.store.Get(ctx, id); err == nil {
-			deletedInfo = info
-		}
-	}
-
 	if workerToKill != nil {
 		if err := workerToKill.Kill(); err != nil {
 			m.log.Warn("session: worker kill failed during physical delete",
@@ -1053,6 +1060,15 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 		}
 	}
 
+	if cleanup, ok := m.store.(CleanupTaskStore); ok {
+		_, err := cleanup.DeletePhysicalWithCleanup(ctx, id)
+		return err
+	}
+	if deletedInfo == nil && m.OnDelete != nil {
+		if info, err := m.store.Get(ctx, id); err == nil {
+			deletedInfo = info
+		}
+	}
 	if err := m.store.DeletePhysical(ctx, id); err != nil {
 		return err
 	}
@@ -1501,8 +1517,10 @@ func (m *Manager) gc(ctx context.Context) {
 	if err != nil {
 		m.log.Error("session: gc (delete_terminated) failed", "err", err)
 	} else {
-		for _, info := range deleted {
-			m.notifyDelete(*info)
+		if _, durable := m.store.(CleanupTaskStore); !durable {
+			for _, info := range deleted {
+				m.notifyDelete(*info)
+			}
 		}
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -123,6 +123,7 @@ type Manager struct {
 	gcReset chan time.Duration // signals GC ticker reset
 
 	OnTerminate   func(sessionID string)
+	OnDelete      func(ctx context.Context, info SessionInfo)
 	StateNotifier func(ctx context.Context, sessionID string, state events.SessionState, message string)
 
 	auditCollector *audit.Collector // issue #833 P1; nil = audit disabled
@@ -914,17 +915,33 @@ func (m *Manager) detachWorkerUnchecked(id string, expected worker.Worker) bool 
 	return true
 }
 
-// Delete marks a session as DELETED and removes it from the in-memory cache.
+// Delete marks a session as DELETED, terminates any attached worker, and removes
+// it from the in-memory cache.
 // Lock ordering: m.mu → ms.mu (same as AttachWorker/DetachWorker to avoid deadlock).
 // DB write is performed outside locks to avoid holding mutexes during I/O.
 func (m *Manager) Delete(ctx context.Context, id string) error {
 	// Acquire m.mu first to maintain consistent lock order with AttachWorker.
+	var workerToTerminate worker.Worker
 	m.mu.Lock()
 	ms, ok := m.sessions[id]
 	if !ok {
 		m.mu.Unlock()
-		// Session not in memory — remove from database directly.
-		return m.store.DeletePhysical(ctx, id)
+		// Session not in memory — remove from database directly. Preserve its
+		// metadata first so an explicitly deleted persistent worker session can
+		// be cleaned up after the local delete succeeds.
+		var deletedInfo *SessionInfo
+		if m.OnDelete != nil {
+			if info, err := m.store.Get(ctx, id); err == nil {
+				deletedInfo = info
+			}
+		}
+		if err := m.store.DeletePhysical(ctx, id); err != nil {
+			return err
+		}
+		if deletedInfo != nil {
+			m.notifyDelete(*deletedInfo)
+		}
+		return nil
 	}
 
 	ms.mu.Lock()
@@ -974,6 +991,7 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 		// No gap worker — commit candidate and delete atomically under both locks.
 		ms.info = candidate
 		if hasWorkerAfter {
+			workerToTerminate = ms.worker
 			workersRunningGauge(string(workerType)).Add(-1)
 			// Release against the workspace the quota was acquired on at attach
 			// time (review P2 quota-drift fix), not the live ms.info.WorkspaceID.
@@ -988,6 +1006,8 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	m.mu.Unlock()
 
 	m.notifyStateChange(ctx, id, events.StateDeleted, "session deleted")
+	m.terminateWorkerGracefully(ctx, workerToTerminate, id)
+	m.notifyDelete(candidate)
 
 	m.log.Info("session: deleted", "session_id", id)
 	m.emitSessionDeleteAudit(uid, botID, platform, id, string(workerType), audit.OutcomeSuccess)
@@ -1001,8 +1021,11 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 	ms, ok := m.sessions[id]
 	var workerToKill worker.Worker
 	var workerType string
+	var deletedInfo *SessionInfo
 	if ok {
 		ms.mu.Lock()
+		info := ms.info
+		deletedInfo = &info
 		wasRunning := ms.info.State == events.StateRunning
 		if ms.worker != nil {
 			workerToKill = ms.worker
@@ -1017,6 +1040,11 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 		}
 	}
 	m.mu.Unlock()
+	if deletedInfo == nil && m.OnDelete != nil {
+		if info, err := m.store.Get(ctx, id); err == nil {
+			deletedInfo = info
+		}
+	}
 
 	if workerToKill != nil {
 		if err := workerToKill.Kill(); err != nil {
@@ -1025,7 +1053,13 @@ func (m *Manager) DeletePhysical(ctx context.Context, id string) error {
 		}
 	}
 
-	return m.store.DeletePhysical(ctx, id)
+	if err := m.store.DeletePhysical(ctx, id); err != nil {
+		return err
+	}
+	if deletedInfo != nil {
+		m.notifyDelete(*deletedInfo)
+	}
+	return nil
 }
 
 // ValidateOwnership checks whether the given userID owns the session.
@@ -1463,8 +1497,13 @@ func (m *Manager) gc(ctx context.Context) {
 	}
 	cronCutoff := now.Add(-cfg.Session.CronTermRetention)
 	defaultCutoff := now.Add(-cfg.Session.TermRetention)
-	if err := m.store.DeleteTerminated(ctx, cronCutoff, defaultCutoff); err != nil {
+	deleted, err := m.store.DeleteTerminated(ctx, cronCutoff, defaultCutoff)
+	if err != nil {
 		m.log.Error("session: gc (delete_terminated) failed", "err", err)
+	} else {
+		for _, info := range deleted {
+			m.notifyDelete(*info)
+		}
 	}
 }
 
@@ -1492,6 +1531,15 @@ func (m *Manager) notifyStateChange(ctx context.Context, sessionID string, state
 	}
 	if (state == events.StateTerminated || state == events.StateDeleted) && m.OnTerminate != nil {
 		m.safeGo(func() { m.OnTerminate(sessionID) })
+	}
+}
+
+// notifyDelete runs the worker-runtime cleanup callback after an explicit
+// session deletion has been persisted. It intentionally does not run for
+// TERMINATED transitions: those sessions must remain resumable.
+func (m *Manager) notifyDelete(info SessionInfo) {
+	if m.OnDelete != nil {
+		m.safeGo(func() { m.OnDelete(context.Background(), info) })
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -62,9 +62,15 @@ func (m *mockStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]string
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
+func (m *mockStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error) {
 	args := m.Called(ctx, cronCutoff, defaultCutoff)
-	return args.Error(0)
+	if len(args) == 1 {
+		return nil, args.Error(0)
+	}
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*SessionInfo), args.Error(1)
 }
 
 func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {
@@ -442,6 +448,35 @@ func TestManager_Delete(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestManager_DeleteTerminatesAttachedWorker(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default()
+	store := new(mockStore)
+	store.Test(t)
+	store.On("Close").Return(nil)
+	m, err := NewManager(ctx, nil, cfg, nil, store)
+	require.NoError(t, err)
+	defer m.Close()
+
+	w := newMockWorker(worker.TypeOpenCodeSrv, 0)
+	w.On("Terminate", mock.Anything).Return(nil).Once()
+	seed := &SessionInfo{
+		ID:         "sess_delete_worker",
+		UserID:     "user1",
+		WorkerType: worker.TypeOpenCodeSrv,
+		State:      events.StateRunning,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	m.mu.Lock()
+	m.sessions[seed.ID] = &managedSession{info: *seed, worker: w}
+	m.mu.Unlock()
+	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
+
+	require.NoError(t, m.Delete(ctx, seed.ID))
+	w.AssertExpectations(t)
+}
+
 func TestManager_DeletePhysical(t *testing.T) {
 	t.Parallel()
 
@@ -498,6 +533,89 @@ func TestManager_DeletePhysical(t *testing.T) {
 		err := m.DeletePhysical(ctx, "db_fail")
 		require.Error(t, err)
 	})
+}
+
+func TestManager_DeleteNotifiesWorkerSessionCleanup(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default()
+	store := new(mockStore)
+	store.Test(t)
+	store.On("Close").Return(nil)
+
+	m, err := NewManager(ctx, nil, cfg, nil, store)
+	require.NoError(t, err)
+	defer m.Close()
+
+	seed := &SessionInfo{
+		ID:              "sess_cleanup",
+		UserID:          "user1",
+		WorkerType:      worker.TypeOpenCodeSrv,
+		WorkerSessionID: "ocs-session-1",
+		State:           events.StateTerminated,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	m.mu.Lock()
+	m.sessions[seed.ID] = &managedSession{info: *seed}
+	m.mu.Unlock()
+
+	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
+	cleaned := make(chan SessionInfo, 1)
+	m.OnDelete = func(_ context.Context, info SessionInfo) { cleaned <- info }
+
+	require.NoError(t, m.Delete(ctx, seed.ID))
+	require.Eventually(t, func() bool { return len(cleaned) == 1 }, time.Second, 10*time.Millisecond)
+	info := <-cleaned
+	require.Equal(t, worker.TypeOpenCodeSrv, info.WorkerType)
+	require.Equal(t, "ocs-session-1", info.WorkerSessionID)
+}
+
+func TestManager_DeleteNotInMemoryNotifiesWorkerSessionCleanup(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default()
+	store := new(mockStore)
+	store.Test(t)
+	store.On("Close").Return(nil)
+	store.On("Get", ctx, "sess_stored_cleanup").Return(&SessionInfo{
+		ID:              "sess_stored_cleanup",
+		WorkerType:      worker.TypeOpenCodeSrv,
+		WorkerSessionID: "ocs-stored",
+	}, nil)
+	store.On("DeletePhysical", ctx, "sess_stored_cleanup").Return(nil)
+
+	m, err := NewManager(ctx, nil, cfg, nil, store)
+	require.NoError(t, err)
+	defer m.Close()
+	cleaned := make(chan SessionInfo, 1)
+	m.OnDelete = func(_ context.Context, info SessionInfo) { cleaned <- info }
+
+	require.NoError(t, m.Delete(ctx, "sess_stored_cleanup"))
+	require.Eventually(t, func() bool { return len(cleaned) == 1 }, time.Second, 10*time.Millisecond)
+	info := <-cleaned
+	require.Equal(t, "ocs-stored", info.WorkerSessionID)
+}
+
+func TestManager_GC_NotifiesWorkerSessionCleanupForRetentionDeletion(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default()
+	store := new(mockStore)
+	store.Test(t)
+	store.On("Close").Return(nil)
+	store.On("GetExpiredMaxLifetime", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
+	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).Return([]string(nil), nil)
+	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return([]*SessionInfo{{ID: "sess_expired", WorkerType: worker.TypeOpenCodeSrv, WorkerSessionID: "ocs-expired"}}, nil)
+
+	m, err := NewManager(ctx, nil, cfg, nil, store)
+	require.NoError(t, err)
+	defer m.Close()
+	cleaned := make(chan SessionInfo, 1)
+	m.OnDelete = func(_ context.Context, info SessionInfo) { cleaned <- info }
+
+	m.gc(ctx)
+	require.Eventually(t, func() bool { return len(cleaned) == 1 }, time.Second, 10*time.Millisecond)
+	info := <-cleaned
+	require.Equal(t, "ocs-expired", info.WorkerSessionID)
 }
 
 func TestManager_ValidateOwnership(t *testing.T) {

--- a/internal/session/multitenancy_store_test.go
+++ b/internal/session/multitenancy_store_test.go
@@ -193,7 +193,7 @@ func TestWorkspacesStore_DeleteIfEmpty_BlockedByActiveSession(t *testing.T) {
 	// 插入一条活跃会话（state=running, workspace_id=ws-1）模拟 Count↔Delete 间的并发新建。
 	_, err := store.db.ExecContext(ctx, queries["sessions.upsert_session"],
 		"sess-1", "u-1", "u-1", "", "", "", "claude_code", "running", "webchat", "{}", "/tmp/x", "",
-		int64(1700000000), int64(1700000000), int64(1800000000), int64(1800000000), "{}", "", "ck-1", "ws-1")
+		int64(1700000000), int64(1700000000), int64(1800000000), int64(1800000000), "{}", "", "ck-1", "ws-1", "sess-1")
 	require.NoError(t, err)
 
 	// 有活跃会话：原子删除拒绝（防 TOCTOU 后 workspace_id 悬空）。

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -136,12 +136,21 @@ func (s *pgStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]string, 
 }
 
 // DeleteTerminated removes terminated sessions older than the respective cutoffs.
-func (s *pgStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
-	_, err := s.db.ExecContext(ctx, s.queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
+func (s *pgStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error) {
+	rows, err := s.db.QueryContext(ctx, s.queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
 	if err != nil {
-		return fmt.Errorf("session store: delete terminated: %w", err)
+		return nil, fmt.Errorf("session store: delete terminated: %w", err)
 	}
-	return nil
+	defer func() { _ = rows.Close() }()
+	deleted := make([]*SessionInfo, 0)
+	for rows.Next() {
+		info, err := scanSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("session store: scan deleted session: %w", err)
+		}
+		deleted = append(deleted, info)
+	}
+	return deleted, rows.Err()
 }
 
 // DeletePhysical deletes a session by ID, bypassing the state machine.

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -51,16 +51,29 @@ func (s *pgStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		return err
 	}
 
-	_, err = s.db.ExecContext(ctx, s.queries["sessions.upsert_session"],
-		info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
-		info.Platform, string(pkJSON), info.WorkDir, info.Title,
-		info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
-		string(ctxJSON), info.Source, info.ClientKey, nullableString(info.WorkspaceID),
-	)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := ensurePGLifecycleLock(ctx, tx, s.dialect.Rebind, info.ID); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, s.queries["sessions.upsert_session"], upsertSessionArgs(info, ctxJSON, pkJSON)...)
+	if err != nil {
+		if isCleanupPendingError(err) {
+			return ErrSessionCleanupPending
+		}
 		return fmt.Errorf("session store: upsert: %w", err)
 	}
-	return nil
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("session store: upsert rows affected: %w", err)
+	}
+	if updated == 0 {
+		return ErrSessionCleanupPending
+	}
+	return tx.Commit()
 }
 
 // UpdateWorkerSessionIDSQL performs a targeted UPDATE on the worker_session_id
@@ -70,9 +83,22 @@ func (s *pgStore) Upsert(ctx context.Context, info *SessionInfo) error {
 func (s *pgStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
 	ctx, cancel := upsertTimeout(ctx)
 	defer cancel()
-	_, err := s.db.ExecContext(ctx, s.queries["sessions.update_worker_session_id"], workerSessionID, id)
+	result, err := s.db.ExecContext(ctx, s.queries["sessions.update_worker_session_id"], workerSessionID, id)
 	if err != nil {
 		return fmt.Errorf("session store: update worker session id: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("session store: worker session id rows affected: %w", err)
+	}
+	if updated == 0 {
+		pending, err := s.HasPendingCleanup(ctx, id)
+		if err != nil {
+			return fmt.Errorf("session store: check cleanup task: %w", err)
+		}
+		if pending {
+			return ErrSessionCleanupPending
+		}
 	}
 	return nil
 }
@@ -81,6 +107,13 @@ func (s *pgStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessio
 func (s *pgStore) Get(ctx context.Context, id string) (*SessionInfo, error) {
 	info, err := scanSession(s.db.QueryRowContext(ctx, s.queries["store.get_session"], id))
 	if errors.Is(err, sql.ErrNoRows) {
+		pending, pendingErr := s.HasPendingCleanup(ctx, id)
+		if pendingErr != nil {
+			return nil, fmt.Errorf("session store: check cleanup task: %w", pendingErr)
+		}
+		if pending {
+			return nil, ErrSessionCleanupPending
+		}
 		return nil, ErrSessionNotFound
 	}
 	if err != nil {
@@ -137,20 +170,57 @@ func (s *pgStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]string, 
 
 // DeleteTerminated removes terminated sessions older than the respective cutoffs.
 func (s *pgStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error) {
-	rows, err := s.db.QueryContext(ctx, s.queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("session store: delete terminated: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-	deleted := make([]*SessionInfo, 0)
-	for rows.Next() {
-		info, err := scanSession(rows)
-		if err != nil {
-			return nil, fmt.Errorf("session store: scan deleted session: %w", err)
-		}
-		deleted = append(deleted, info)
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, s.queries["store.select_terminated_ids"], events.StateTerminated, cronCutoff, defaultCutoff)
+	if err != nil {
+		return nil, fmt.Errorf("session store: select terminated: %w", err)
 	}
-	return deleted, rows.Err()
+	ids, err := collectIDs(rows)
+	if err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	deleted := make([]*SessionInfo, 0, len(ids))
+	now := time.Now()
+	for _, id := range ids {
+		if err := ensurePGLifecycleLock(ctx, tx, s.dialect.Rebind, id); err != nil {
+			return nil, err
+		}
+		deletedRows, err := tx.QueryContext(ctx, s.queries["store.delete_terminated_by_id"], id, events.StateTerminated, cronCutoff, defaultCutoff)
+		if err != nil {
+			return nil, fmt.Errorf("session store: delete terminated: %w", err)
+		}
+		if deletedRows.Next() {
+			info, err := scanSession(deletedRows)
+			if err != nil {
+				_ = deletedRows.Close()
+				return nil, fmt.Errorf("session store: scan deleted session: %w", err)
+			}
+			deleted = append(deleted, info)
+			if err := insertCleanupTask(ctx, pgExec{tx: tx, rebind: s.dialect.Rebind}, info, now); err != nil {
+				_ = deletedRows.Close()
+				return nil, err
+			}
+		}
+		if err := deletedRows.Err(); err != nil {
+			_ = deletedRows.Close()
+			return nil, err
+		}
+		if err := deletedRows.Close(); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return deleted, nil
 }
 
 // DeletePhysical deletes a session by ID, bypassing the state machine.

--- a/internal/session/pg_store_test.go
+++ b/internal/session/pg_store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/dbutil"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -26,8 +27,10 @@ func newPGMock(t *testing.T) (*pgStore, sqlmock.Sqlmock, func()) {
 	q := make(map[string]string)
 	q["store.get_session"] = dbutil.DialectPostgres.Rebind(
 		"SELECT id, user_id, COALESCE(owner_id, user_id), worker_session_id, worker_type, state, bot_id, COALESCE(bot_name, ''), platform, platform_key_json, COALESCE(work_dir, ''), COALESCE(title, ''), created_at, updated_at, expires_at, idle_expires_at, context_json, source, COALESCE(client_key, ''), COALESCE(workspace_id, '') FROM sessions WHERE id = ?")
-	q["store.delete_terminated"] = dbutil.DialectPostgres.Rebind(
-		"DELETE FROM sessions WHERE state = ? AND ((source = 'cron' AND updated_at <= ?) OR (source != 'cron' AND updated_at <= ?))")
+	q["store.select_terminated_ids"] = dbutil.DialectPostgres.Rebind(
+		"SELECT id FROM sessions WHERE state = ? AND ((source = 'cron' AND updated_at <= ?) OR (source != 'cron' AND updated_at <= ?))")
+	q["store.delete_terminated_by_id"] = dbutil.DialectPostgres.Rebind(
+		"DELETE FROM sessions WHERE id = ? AND state = ? AND ((source = 'cron' AND updated_at <= ?) OR (source != 'cron' AND updated_at <= ?)) RETURNING id, user_id, COALESCE(owner_id, user_id), worker_session_id, worker_type, state, bot_id, COALESCE(bot_name, ''), platform, platform_key_json, COALESCE(work_dir, ''), COALESCE(title, ''), created_at, updated_at, expires_at, idle_expires_at, context_json, source, COALESCE(client_key, ''), COALESCE(workspace_id, '')")
 	q["store.get_sessions_by_state"] = dbutil.DialectPostgres.Rebind(
 		"SELECT id FROM sessions WHERE state = ?")
 	q["store.delete_physical"] = dbutil.DialectPostgres.Rebind(
@@ -88,6 +91,8 @@ func TestPGStore_Get_NotFound(t *testing.T) {
 		"SELECT id, user_id, COALESCE(owner_id, user_id), worker_session_id, worker_type, state, bot_id, COALESCE(bot_name, ''), platform, platform_key_json, COALESCE(work_dir, ''), COALESCE(title, ''), created_at, updated_at, expires_at, idle_expires_at, context_json, source, COALESCE(client_key, ''), COALESCE(workspace_id, '') FROM sessions WHERE id = ?")
 
 	mock.ExpectQuery(regexp.QuoteMeta(q)).WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+	pendingQuery := dbutil.DialectPostgres.Rebind(`SELECT EXISTS(SELECT 1 FROM session_cleanup_tasks WHERE session_id = ?)`)
+	mock.ExpectQuery(regexp.QuoteMeta(pendingQuery)).WithArgs("nonexistent").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
 	info, err := store.Get(context.Background(), "nonexistent")
 	require.ErrorIs(t, err, ErrSessionNotFound)
@@ -102,16 +107,26 @@ func TestPGStore_DeleteTerminated(t *testing.T) {
 	cronCutoff := time.UnixMilli(1000)
 	defaultCutoff := time.UnixMilli(2000)
 
-	q := store.queries["store.delete_terminated"]
+	selectQuery := store.queries["store.select_terminated_ids"]
+	deleteQuery := store.queries["store.delete_terminated_by_id"]
 	rows := sqlmock.NewRows([]string{
 		"id", "user_id", "owner_id", "worker_session_id", "worker_type", "state", "bot_id", "bot_name",
 		"platform", "platform_key_json", "work_dir", "title", "created_at", "updated_at",
 		"expires_at", "idle_expires_at", "context_json", "source", "client_key", "workspace_id",
 	}).AddRow("sess-old", "u1", "u1", "ocs-old", "opencode_server", string(events.StateTerminated), "", "",
 		"webchat", "", "", "", time.Now(), time.Now(), nil, nil, nil, "", "", "")
-	mock.ExpectQuery(regexp.QuoteMeta(q)).
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(selectQuery)).
 		WithArgs(string(events.StateTerminated), cronCutoff, defaultCutoff).
-		WillReturnRows(rows)
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("sess-old"))
+	mock.ExpectExec(regexp.QuoteMeta(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`)).
+		WithArgs("sess-old").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(deleteQuery)).
+		WithArgs("sess-old", string(events.StateTerminated), cronCutoff, defaultCutoff).WillReturnRows(rows)
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO session_cleanup_tasks (id, session_id, worker_type, worker_session_id, attempts, next_attempt_at, lease_until, lease_token, last_error, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, $7, $8, $9) ON CONFLICT(session_id) DO NOTHING`)).
+		WithArgs(sqlmock.AnyArg(), "sess-old", worker.TypeOpenCodeSrv, "ocs-old", 0, sqlmock.AnyArg(), "", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
 
 	deleted, err := store.DeleteTerminated(context.Background(), cronCutoff, defaultCutoff)
 	require.NoError(t, err)

--- a/internal/session/pg_store_test.go
+++ b/internal/session/pg_store_test.go
@@ -102,15 +102,21 @@ func TestPGStore_DeleteTerminated(t *testing.T) {
 	cronCutoff := time.UnixMilli(1000)
 	defaultCutoff := time.UnixMilli(2000)
 
-	q := dbutil.DialectPostgres.Rebind(
-		"DELETE FROM sessions WHERE state = ? AND ((source = 'cron' AND updated_at <= ?) OR (source != 'cron' AND updated_at <= ?))")
-
-	mock.ExpectExec(regexp.QuoteMeta(q)).
+	q := store.queries["store.delete_terminated"]
+	rows := sqlmock.NewRows([]string{
+		"id", "user_id", "owner_id", "worker_session_id", "worker_type", "state", "bot_id", "bot_name",
+		"platform", "platform_key_json", "work_dir", "title", "created_at", "updated_at",
+		"expires_at", "idle_expires_at", "context_json", "source", "client_key", "workspace_id",
+	}).AddRow("sess-old", "u1", "u1", "ocs-old", "opencode_server", string(events.StateTerminated), "", "",
+		"webchat", "", "", "", time.Now(), time.Now(), nil, nil, nil, "", "", "")
+	mock.ExpectQuery(regexp.QuoteMeta(q)).
 		WithArgs(string(events.StateTerminated), cronCutoff, defaultCutoff).
-		WillReturnResult(sqlmock.NewResult(0, 3))
+		WillReturnRows(rows)
 
-	err := store.DeleteTerminated(context.Background(), cronCutoff, defaultCutoff)
+	deleted, err := store.DeleteTerminated(context.Background(), cronCutoff, defaultCutoff)
 	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	require.Equal(t, "ocs-old", deleted[0].WorkerSessionID)
 }
 
 func TestPGStore_GetSessionsByState(t *testing.T) {

--- a/internal/session/sql/migrations-postgres/025_session_cleanup_outbox.pg.sql
+++ b/internal/session/sql/migrations-postgres/025_session_cleanup_outbox.pg.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE session_cleanup_tasks (
+    id                TEXT PRIMARY KEY,
+    session_id        TEXT NOT NULL UNIQUE,
+    worker_type       TEXT NOT NULL,
+    worker_session_id TEXT NOT NULL,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ NOT NULL,
+    lease_until       TIMESTAMPTZ NULL,
+	lease_token       TEXT NULL,
+    last_error        TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMPTZ NOT NULL,
+    updated_at        TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_session_cleanup_tasks_due
+    ON session_cleanup_tasks(next_attempt_at, lease_until);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_session_cleanup_tasks_due;
+DROP TABLE IF EXISTS session_cleanup_tasks;

--- a/internal/session/sql/migrations/025_session_cleanup_outbox.sql
+++ b/internal/session/sql/migrations/025_session_cleanup_outbox.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE session_cleanup_tasks (
+    id                TEXT PRIMARY KEY,
+    session_id        TEXT NOT NULL UNIQUE,
+    worker_type       TEXT NOT NULL,
+    worker_session_id TEXT NOT NULL,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMP NOT NULL,
+    lease_until       TIMESTAMP NULL,
+	lease_token       TEXT NULL,
+    last_error        TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMP NOT NULL,
+    updated_at        TIMESTAMP NOT NULL
+);
+CREATE INDEX idx_session_cleanup_tasks_due
+    ON session_cleanup_tasks(next_attempt_at, lease_until);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_session_cleanup_tasks_due;
+DROP TABLE IF EXISTS session_cleanup_tasks;

--- a/internal/session/sql/queries/sessions.upsert_session.sql
+++ b/internal/session/sql/queries/sessions.upsert_session.sql
@@ -8,7 +8,8 @@
 --     two-layer persistence design.
 --   See also: manager.go transitionState guard (WorkerSessionID empty→nonempty).
 INSERT INTO sessions (id, user_id, owner_id, bot_id, bot_name, worker_session_id, worker_type, state, platform, platform_key_json, work_dir, title, created_at, updated_at, expires_at, idle_expires_at, context_json, source, client_key, workspace_id)
- VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+ WHERE NOT EXISTS (SELECT 1 FROM session_cleanup_tasks WHERE session_id = ?)
  ON CONFLICT(id) DO UPDATE SET
   state=excluded.state,
   owner_id=CASE WHEN excluded.owner_id != '' THEN excluded.owner_id ELSE sessions.owner_id END,
@@ -21,4 +22,5 @@ INSERT INTO sessions (id, user_id, owner_id, bot_id, bot_name, worker_session_id
   source=CASE WHEN excluded.source != '' THEN excluded.source ELSE sessions.source END,
   client_key=CASE WHEN excluded.client_key != '' THEN excluded.client_key ELSE sessions.client_key END,
   -- workspace_id 创建后不可变：仅当原值为 NULL 或空串（未绑定）时接受，防后续 upsert 覆盖。
-  workspace_id=CASE WHEN sessions.workspace_id IS NULL OR sessions.workspace_id = '' THEN excluded.workspace_id ELSE sessions.workspace_id END;
+  workspace_id=CASE WHEN sessions.workspace_id IS NULL OR sessions.workspace_id = '' THEN excluded.workspace_id ELSE sessions.workspace_id END
+ WHERE NOT EXISTS (SELECT 1 FROM session_cleanup_tasks WHERE session_id = excluded.id);

--- a/internal/session/sql/queries/store.delete_terminated.sql
+++ b/internal/session/sql/queries/store.delete_terminated.sql
@@ -1,7 +1,11 @@
--- delete_terminated removes terminated sessions older than the respective cutoffs.
--- cronCutoff applies to source='cron'; defaultCutoff applies to all other sessions.
--- Events lifecycle is managed independently — session deletion does not cascade.
+-- delete_terminated atomically removes terminated sessions and returns their
+-- metadata so worker-runtime cleanup runs only after local deletion succeeds.
 DELETE FROM sessions WHERE state = ? AND (
     (source = 'cron' AND updated_at <= ?) OR
     (source != 'cron' AND updated_at <= ?)
-);
+)
+RETURNING id, user_id, COALESCE(owner_id, user_id), worker_session_id, worker_type, state,
+          bot_id, COALESCE(bot_name, ''), platform, platform_key_json,
+          COALESCE(work_dir, ''), COALESCE(title, ''), created_at, updated_at,
+          expires_at, idle_expires_at, context_json, source, COALESCE(client_key, ''),
+          COALESCE(workspace_id, '');

--- a/internal/session/sql/queries/store.delete_terminated_by_id.sql
+++ b/internal/session/sql/queries/store.delete_terminated_by_id.sql
@@ -1,0 +1,9 @@
+DELETE FROM sessions WHERE id = ? AND state = ? AND (
+    (source = 'cron' AND updated_at <= ?) OR
+    (source != 'cron' AND updated_at <= ?)
+)
+RETURNING id, user_id, COALESCE(owner_id, user_id), worker_session_id, worker_type, state,
+          bot_id, COALESCE(bot_name, ''), platform, platform_key_json,
+          COALESCE(work_dir, ''), COALESCE(title, ''), created_at, updated_at,
+          expires_at, idle_expires_at, context_json, source, COALESCE(client_key, ''),
+          COALESCE(workspace_id, '');

--- a/internal/session/sql/queries/store.select_terminated_ids.sql
+++ b/internal/session/sql/queries/store.select_terminated_ids.sql
@@ -1,0 +1,4 @@
+SELECT id FROM sessions WHERE state = ? AND (
+    (source = 'cron' AND updated_at <= ?) OR
+    (source != 'cron' AND updated_at <= ?)
+);

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	List(ctx context.Context, userID, platform, workspaceID string, limit, offset int) ([]*SessionInfo, error)
 	GetExpiredMaxLifetime(ctx context.Context, now time.Time) ([]string, error)
 	GetExpiredIdle(ctx context.Context, now time.Time) ([]string, error)
-	DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error
+	DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error)
 	DeletePhysical(ctx context.Context, id string) error
 	GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error)
 	Close() error
@@ -230,14 +230,24 @@ func (s *SQLiteStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]stri
 }
 
 // Events lifecycle is managed independently — session deletion does not cascade to events.
-func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error {
-	return s.writeMu.WithLock(func() error {
-		_, err := s.db.ExecContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
+func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error) {
+	deleted := make([]*SessionInfo, 0)
+	err := s.writeMu.WithLock(func() error {
+		rows, err := s.db.QueryContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
 		if err != nil {
 			return fmt.Errorf("session store: delete terminated: %w", err)
 		}
-		return nil
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			info, err := scanSession(rows)
+			if err != nil {
+				return fmt.Errorf("session store: scan deleted session: %w", err)
+			}
+			deleted = append(deleted, info)
+		}
+		return rows.Err()
 	})
+	return deleted, err
 }
 
 func (s *SQLiteStore) DeletePhysical(ctx context.Context, id string) error {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -98,16 +98,29 @@ func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
 	}
 
 	return s.writeMu.WithLock(func() error {
-		_, err := s.db.ExecContext(ctx, queries["sessions.upsert_session"],
-			info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
-			info.Platform, string(pkJSON), info.WorkDir, info.Title,
-			info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
-			string(ctxJSON), info.Source, info.ClientKey, nullableString(info.WorkspaceID),
-		)
+		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := ensureSQLiteLifecycleLock(ctx, tx, info.ID); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, queries["sessions.upsert_session"], upsertSessionArgs(info, ctxJSON, pkJSON)...)
+		if err != nil {
+			if isCleanupPendingError(err) {
+				return ErrSessionCleanupPending
+			}
 			return fmt.Errorf("session store: upsert: %w", err)
 		}
-		return nil
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("session store: upsert rows affected: %w", err)
+		}
+		if updated == 0 {
+			return ErrSessionCleanupPending
+		}
+		return tx.Commit()
 	})
 }
 
@@ -117,9 +130,22 @@ func (s *SQLiteStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSe
 	ctx, cancel := upsertTimeout(ctx)
 	defer cancel()
 	return s.writeMu.WithLock(func() error {
-		_, err := s.db.ExecContext(ctx, queries["sessions.update_worker_session_id"], workerSessionID, id)
+		result, err := s.db.ExecContext(ctx, queries["sessions.update_worker_session_id"], workerSessionID, id)
 		if err != nil {
 			return fmt.Errorf("session store: update worker session id: %w", err)
+		}
+		updated, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("session store: worker session id rows affected: %w", err)
+		}
+		if updated == 0 {
+			pending, err := s.HasPendingCleanup(ctx, id)
+			if err != nil {
+				return fmt.Errorf("session store: check cleanup task: %w", err)
+			}
+			if pending {
+				return ErrSessionCleanupPending
+			}
 		}
 		return nil
 	})
@@ -166,6 +192,13 @@ func scanSession(sc rowScanner) (*SessionInfo, error) {
 func (s *SQLiteStore) Get(ctx context.Context, id string) (*SessionInfo, error) {
 	info, err := scanSession(s.db.QueryRowContext(ctx, queries["store.get_session"], id))
 	if errors.Is(err, sql.ErrNoRows) {
+		pending, pendingErr := s.HasPendingCleanup(ctx, id)
+		if pendingErr != nil {
+			return nil, fmt.Errorf("session store: check cleanup task: %w", pendingErr)
+		}
+		if pending {
+			return nil, ErrSessionCleanupPending
+		}
 		return nil, ErrSessionNotFound
 	}
 	if err != nil {
@@ -233,19 +266,53 @@ func (s *SQLiteStore) GetExpiredIdle(ctx context.Context, now time.Time) ([]stri
 func (s *SQLiteStore) DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) ([]*SessionInfo, error) {
 	deleted := make([]*SessionInfo, 0)
 	err := s.writeMu.WithLock(func() error {
-		rows, err := s.db.QueryContext(ctx, queries["store.delete_terminated"], events.StateTerminated, cronCutoff, defaultCutoff)
+		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("session store: delete terminated: %w", err)
+			return err
 		}
-		defer func() { _ = rows.Close() }()
-		for rows.Next() {
-			info, err := scanSession(rows)
-			if err != nil {
-				return fmt.Errorf("session store: scan deleted session: %w", err)
+		defer func() { _ = tx.Rollback() }()
+		rows, err := tx.QueryContext(ctx, queries["store.select_terminated_ids"], events.StateTerminated, cronCutoff, defaultCutoff)
+		if err != nil {
+			return fmt.Errorf("session store: select terminated: %w", err)
+		}
+		ids, err := collectIDs(rows)
+		if err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		now := time.Now()
+		for _, id := range ids {
+			if err := ensureSQLiteLifecycleLock(ctx, tx, id); err != nil {
+				return err
 			}
-			deleted = append(deleted, info)
+			deletedRows, err := tx.QueryContext(ctx, queries["store.delete_terminated_by_id"], id, events.StateTerminated, cronCutoff, defaultCutoff)
+			if err != nil {
+				return fmt.Errorf("session store: delete terminated: %w", err)
+			}
+			if deletedRows.Next() {
+				info, err := scanSession(deletedRows)
+				if err != nil {
+					_ = deletedRows.Close()
+					return fmt.Errorf("session store: scan deleted session: %w", err)
+				}
+				deleted = append(deleted, info)
+				if err := insertCleanupTask(ctx, tx, info, now); err != nil {
+					_ = deletedRows.Close()
+					return err
+				}
+			}
+			if err := deletedRows.Err(); err != nil {
+				_ = deletedRows.Close()
+				return err
+			}
+			if err := deletedRows.Close(); err != nil {
+				return err
+			}
 		}
-		return rows.Err()
+		return tx.Commit()
 	})
 	return deleted, err
 }

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -220,8 +220,9 @@ func TestSQLiteStore_DeleteTerminated(t *testing.T) {
 
 	cronCutoff := now.Add(-24 * time.Hour)
 	defaultCutoff := now.Add(-7 * 24 * time.Hour)
-	err := store.DeleteTerminated(ctx, cronCutoff, defaultCutoff)
+	deleted, err := store.DeleteTerminated(ctx, cronCutoff, defaultCutoff)
 	require.NoError(t, err)
+	require.Len(t, deleted, 2)
 
 	_, err = store.Get(ctx, "cron_old")
 	require.ErrorIs(t, err, ErrSessionNotFound, "old cron session should be deleted")

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -1,5 +1,14 @@
 package worker
 
+import "errors"
+
+var (
+	// ErrResumeCheckFailed means the worker could not determine whether its
+	// persisted runtime session still exists. Callers must not silently create a
+	// fresh session, because doing so discards conversation context.
+	ErrResumeCheckFailed = errors.New("worker: resume session check failed")
+)
+
 // WorkerErrorKind classifies worker errors for gateway-level handling.
 type WorkerErrorKind int
 

--- a/internal/worker/opencodeserver/AGENTS.md
+++ b/internal/worker/opencodeserver/AGENTS.md
@@ -39,7 +39,7 @@ commands.go       # ServerCommander: HTTP REST for Compact/Clear/Rewind + Contro
 
 **HTTP client**: Shared `http.Client` with 30s timeout; `doGet`/`doPost`/`doRequest` helpers with JSON marshaling
 
-**Server-side session cleanup**: `release()` calls `deleteOCSSession` (DELETE /session/{id}) to clean up OCS server state on worker detach. Best-effort — failures logged at Debug level, never block cleanup. Prevents resource accumulation across many session lifecycle cycles.
+**Server-side session cleanup**: `release()` only closes SSE and releases the singleton reference, preserving OCS state for resume. `DeletePersistedSession()` sends DELETE /session/{id} only after HotPlex explicitly deletes the owning session.
 
 ## ANTI-PATTERNS
 - ❌ Call `Terminate()`/`Kill()` to stop the singleton process — only releases ref + closes SSE

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -337,7 +337,12 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 	ocsSessionID := session.WorkerSessionID
 	if ocsSessionID != "" {
 		w.Log.Debug("opencodeserver: resume step 3 - checking session existence", "ocs_session_id", ocsSessionID)
-		if w.ocsSessionExists(ctx, ocsSessionID) {
+		exists, err := w.ocsSessionExists(ctx, ocsSessionID)
+		if err != nil {
+			w.release()
+			return err
+		}
+		if exists {
 			w.Log.Info("opencodeserver: resuming existing OCS session",
 				"ocs_session_id", ocsSessionID, "hotplex_session_id", session.SessionID)
 			w.initSessionConn(ctx, ocsSessionID, session)
@@ -476,7 +481,7 @@ func (w *Worker) ResetContext(ctx context.Context) (worker.ResetResult, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 		return worker.ResetResult{}, fmt.Errorf("opencodeserver: reset: status %d: %s", resp.StatusCode, string(body))
 	}
@@ -751,19 +756,25 @@ func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, se
 
 // ocsSessionExists checks whether a session exists on the OpenCode server
 // by issuing a lightweight GET to the session messages endpoint.
-func (w *Worker) ocsSessionExists(ctx context.Context, sessionID string) bool {
-	checkURL := fmt.Sprintf("%s/session/%s/message?limit=1", w.httpAddr, url.QueryEscape(sessionID))
+func (w *Worker) ocsSessionExists(ctx context.Context, sessionID string) (bool, error) {
+	checkURL := fmt.Sprintf("%s/session/%s/message?limit=1", w.httpAddr, url.PathEscape(sessionID))
 	req, err := http.NewRequestWithContext(ctx, "GET", checkURL, http.NoBody)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("%w: build OCS session request: %w", worker.ErrResumeCheckFailed, err)
 	}
 	resp, err := w.client.Do(req)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("%w: query OCS session: %w", worker.ErrResumeCheckFailed, err)
 	}
-	_, _ = io.Copy(io.Discard, resp.Body)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 	_ = resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("%w: OCS session query returned status %d: %s", worker.ErrResumeCheckFailed, resp.StatusCode, string(body))
+	}
+	return true, nil
 }
 
 // ─── Shared Lifecycle Helpers ──────────────────────────────────────────────────
@@ -865,14 +876,13 @@ func (w *Worker) forwardBusEvents(ctx context.Context, sessionID string, busCh c
 	}
 }
 
-// release closes the SSE subscription, deletes the server-side session, and
-// releases the singleton ref.
+// release closes the SSE subscription and releases the singleton ref. The OCS
+// session is deliberately retained so a later HotPlex resume can reuse its
+// conversation context.
 func (w *Worker) release() {
 	w.Mu.Lock()
 	sseCancel := w.sseCancel
 	sessionID := ""
-	httpAddr := w.httpAddr
-	client := w.client
 	if w.httpConn != nil {
 		sessionID = w.httpConn.getSessionID()
 	}
@@ -884,12 +894,6 @@ func (w *Worker) release() {
 
 	if sessionID != "" && w.singleton != nil {
 		w.singleton.Unsubscribe(sessionID)
-	}
-
-	// Delete the server-side session to prevent resource accumulation.
-	// Best-effort: errors are logged but do not block cleanup.
-	if sessionID != "" && httpAddr != "" && client != nil {
-		w.deleteOCSSession(sessionID, httpAddr, client)
 	}
 
 	w.releaseOnce.Do(func() {
@@ -908,27 +912,38 @@ func (w *Worker) release() {
 	}
 }
 
-// deleteOCSSession sends DELETE /session/{id} to the OCS server to clean up
-// server-side session state. Best-effort — failures are logged, not returned.
-func (w *Worker) deleteOCSSession(sessionID, httpAddr string, client *http.Client) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+// DeletePersistedSession removes a server-side session after its owning
+// HotPlex session has been explicitly deleted. It acquires a short-lived
+// singleton reference so cleanup also works for already-terminated sessions.
+func DeletePersistedSession(ctx context.Context, sessionID string) error {
+	mgr := singleton.Load()
+	if mgr == nil {
+		return fmt.Errorf("opencodeserver: singleton not initialized")
+	}
+	httpAddr, client, _, _, err := mgr.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("opencodeserver: acquire server for session cleanup: %w", err)
+	}
+	defer mgr.Release()
+	return deleteOCSSession(ctx, sessionID, httpAddr, client)
+}
+
+// deleteOCSSession sends DELETE /session/{id} to the OCS server.
+func deleteOCSSession(ctx context.Context, sessionID, httpAddr string, client *http.Client) error {
 	req, err := http.NewRequestWithContext(ctx, "DELETE", httpAddr+"/session/"+url.PathEscape(sessionID), http.NoBody)
 	if err != nil {
-		w.Log.Debug("opencodeserver: delete session request error", "err", err)
-		return
+		return fmt.Errorf("opencodeserver: build delete request: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		w.Log.Debug("opencodeserver: delete session failed", "session_id", sessionID, "err", err)
-		return
+		return fmt.Errorf("opencodeserver: delete session %s: %w", sessionID, err)
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		w.Log.Debug("opencodeserver: delete session unexpected status",
-			"session_id", sessionID, "status", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("opencodeserver: delete session %s: unexpected status %d", sessionID, resp.StatusCode)
 	}
+	return nil
 }
 
 func (w *Worker) httpPost(ctx context.Context, path string, payload any) error {
@@ -1204,4 +1219,5 @@ func init() {
 	worker.Register(worker.TypeOpenCodeSrv, func() (worker.Worker, error) {
 		return New(), nil
 	})
+	worker.RegisterSessionCleanup(worker.TypeOpenCodeSrv, DeletePersistedSession)
 }

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -123,6 +123,103 @@ func TestOpenCodeServerWorker_Terminate_CallsSSECancel(t *testing.T) {
 	}
 }
 
+func TestOpenCodeServerWorker_TerminatePreservesServerSession(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	mgr := NewSingletonProcessManager(slog.New(slog.NewTextHandler(io.Discard, nil)), config.OpenCodeServerConfig{IdleDrainPeriod: time.Hour})
+	mgr.mu.Lock()
+	mgr.state = stateRunning
+	mgr.refs = 1
+	mgr.mu.Unlock()
+
+	w := New()
+	w.singleton = mgr
+	w.httpAddr = server.URL
+	w.client = server.Client()
+	w.httpConn = &conn{sessionID: "ocs-session-1", recvCh: make(chan *events.Envelope)}
+
+	require.NoError(t, w.Terminate(context.Background()))
+	require.Zero(t, requests, "ordinary worker termination must preserve the resumable OCS session")
+}
+
+func TestDeleteOCSSession(t *testing.T) {
+	for _, status := range []int{http.StatusNoContent, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var deleted string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodDelete, r.Method)
+				deleted = r.URL.Path
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			require.NoError(t, deleteOCSSession(context.Background(), "ocs-session-1", server.URL, server.Client()))
+			require.Equal(t, "/session/ocs-session-1", deleted)
+		})
+	}
+}
+
+func TestOCSSessionExists_OnlyNotFoundAllowsFreshStart(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		exists     bool
+		wantErr    bool
+	}{
+		{name: "exists", statusCode: http.StatusOK, exists: true},
+		{name: "not found", statusCode: http.StatusNotFound, exists: false},
+		{name: "server failure", statusCode: http.StatusServiceUnavailable, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			w := New()
+			w.httpAddr = server.URL
+			w.client = server.Client()
+			exists, err := w.ocsSessionExists(context.Background(), "ocs-session-1")
+			require.Equal(t, tt.exists, exists)
+			if tt.wantErr {
+				require.ErrorIs(t, err, worker.ErrResumeCheckFailed)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOpenCodeServerWorker_ResumeDoesNotFreshStartAfterCheckFailure(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	mgr := NewSingletonProcessManager(slog.New(slog.NewTextHandler(io.Discard, nil)), config.OpenCodeServerConfig{IdleDrainPeriod: time.Hour})
+	mgr.mu.Lock()
+	mgr.state = stateRunning
+	mgr.httpAddr = server.URL
+	mgr.client = server.Client()
+	mgr.mu.Unlock()
+
+	w := New()
+	w.singleton = mgr
+	err := w.Resume(context.Background(), worker.SessionInfo{SessionID: "hotplex-session-1", WorkerSessionID: "ocs-session-1"})
+	require.ErrorIs(t, err, worker.ErrResumeCheckFailed)
+	require.Equal(t, []string{"GET /session/ocs-session-1/message"}, requests)
+}
+
 func TestOpenCodeServerWorker_Kill_CallsSSECancel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/session_cleanup.go
+++ b/internal/worker/session_cleanup.go
@@ -1,0 +1,46 @@
+package worker
+
+import (
+	"context"
+	"sync"
+)
+
+// SessionCleanupFunc removes a worker-runtime session after its owning
+// HotPlex session has been explicitly deleted. It must be idempotent because
+// a deleted session can later be physically removed from the local store.
+type SessionCleanupFunc func(context.Context, string) error
+
+var (
+	sessionCleanupMu sync.RWMutex
+	sessionCleaners  = make(map[WorkerType]SessionCleanupFunc)
+)
+
+// RegisterSessionCleanup associates a worker type with its persistent-session
+// cleanup implementation. Workers without persistent remote sessions do not
+// register a cleaner.
+func RegisterSessionCleanup(t WorkerType, cleanup SessionCleanupFunc) {
+	if cleanup == nil {
+		panic("worker: session cleanup is nil")
+	}
+	sessionCleanupMu.Lock()
+	defer sessionCleanupMu.Unlock()
+	if _, exists := sessionCleaners[t]; exists {
+		panic("worker: session cleanup registered twice for type " + string(t))
+	}
+	sessionCleaners[t] = cleanup
+}
+
+// CleanupSession removes the worker-runtime session for an explicitly deleted
+// HotPlex session. Empty IDs and worker types without a cleaner are no-ops.
+func CleanupSession(ctx context.Context, t WorkerType, workerSessionID string) error {
+	if workerSessionID == "" {
+		return nil
+	}
+	sessionCleanupMu.RLock()
+	cleanup := sessionCleaners[t]
+	sessionCleanupMu.RUnlock()
+	if cleanup == nil {
+		return nil
+	}
+	return cleanup(ctx, workerSessionID)
+}

--- a/internal/worker/session_cleanup_test.go
+++ b/internal/worker/session_cleanup_test.go
@@ -1,0 +1,23 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupSession(t *testing.T) {
+	const testType WorkerType = "cleanup-test-worker"
+	called := false
+	RegisterSessionCleanup(testType, func(_ context.Context, id string) error {
+		called = true
+		require.Equal(t, "worker-session-1", id)
+		return nil
+	})
+
+	require.NoError(t, CleanupSession(context.Background(), testType, "worker-session-1"))
+	require.True(t, called)
+	require.NoError(t, CleanupSession(context.Background(), testType, ""))
+	require.NoError(t, CleanupSession(context.Background(), "unregistered-worker", "worker-session-1"))
+}


### PR DESCRIPTION
## 结论

本 PR 解决了“OCS worker / Gateway 重启后，用户继续对话时 LLM 丢失前文上下文”的根因，并补齐了远端 OCS session 删除的可靠性与并发安全性。

核心方案是：HotPlex 只在会话被显式删除或保留期 GC 物理删除时，才删除对应的 OCS 服务端 session；删除动作通过持久化 outbox 执行，而不是原来的内存异步回调。这样 worker 重启、Gateway 重启、短暂网络故障都不会让可恢复会话丢失上下文，也不会让远端清理任务因进程退出而永久丢失。

Closes #874

## 问题根因

此前 OCS worker 在 `Terminate` / `release` 时会删除远端 OCS session。Gateway 为会话恢复创建新 worker 后，即使本地仍保存了 `worker_session_id`，远端上下文已经被删，只能退化为 fresh start，表现为 LLM 遗忘历史对话。

初始修复已将 worker release 改为仅关闭 SSE、释放 OCS singleton 引用，并在恢复前检查远端 session 是否存在；不再把网络错误或 5xx 误判为“session 不存在”。

本轮进一步处理审查发现的两个边界问题：

- 保留期 GC 与恢复并发时，旧快照可能在本地删除后写回，再被异步远端删除误伤。
- 远端删除失败仅日志记录；OCS 暂不可用或 Gateway 退出时，任务无法跨重启重试。

## 实现方案

### 1. OCS session 保留与安全恢复

- `release()` 仅关闭事件流并释放 singleton 引用，不再删除远端 OCS session。
- 仅当 HotPlex session 显式删除、物理删除或 retention GC 删除时，才计划删除远端 session。
- Resume 会验证已持久化的 OCS session：仅 `404` 可降级为新会话；网络错误、超时与 5xx 返回可重试错误，避免静默丢失上下文。

### 2. 持久化 cleanup outbox

新增 `session_cleanup_tasks` 迁移（SQLite 与 PostgreSQL），保存不可变的：

- HotPlex session ID、worker 类型、待删除的旧 `worker_session_id`
- 重试次数、下次执行时间、失败原因
- lease 截止时间与 lease token

逻辑删除、物理删除和 terminated retention GC 均在同一个数据库事务中完成本地状态变更与 outbox 入队。远端删除不再依赖 `Manager.OnDelete` 的 fire-and-forget goroutine。

### 3. 并发删除权与 tombstone 保护

- 待处理 outbox 任务是 session tombstone：任何可能复活 session 的 `Upsert` 会在数据库语句内检查 tombstone；若已进入清理，返回 `ErrSessionCleanupPending`，不会创建或恢复使用旧 OCS 上下文的 worker。
- PostgreSQL 在 session 写入与 retention 删除前使用事务级 `pg_advisory_xact_lock` 串行化同一 session ID 的生命周期操作；锁随事务结束释放，不产生永久锁行，也避免 Read Committed 旧快照越过已提交 tombstone。
- SQLite 使用既有单写锁覆盖同一事务边界。
- 删除任务保存的是删除瞬间的 remote session ID，永不从后续 session 行读取，因此不会误删新会话。

### 4. 可恢复执行与 lease fencing

- Gateway 启动时先 drain 一次 due task，随后定时处理；进程重启后未完成任务自动恢复。
- 任务以批量 lease 执行，失败采用有上限的指数退避；任务不会因达到重试次数而被丢弃。
- 每次领取生成独立 lease token；完成或重试必须匹配 token。过期 worker 不能删除、解锁或重排已被新 runner 重新领取的任务。
- OCS 返回 `404` 仍视为幂等清理成功。
- cleanup pending 会被 Gateway 映射为 `SESSION_BUSY`（提示客户端稍后重试），不再伪装成内部错误或鉴权失败。

## 主要改动

- 新增 durable cleanup runner、任务租约、退避重试与启动恢复。
- 新增 SQLite/PostgreSQL migration 与查询，覆盖 outbox、GC 按 session 串行删除及 tombstone 写入保护。
- 删除 Gateway 中原有的异步 `OnDelete` 清理回调接线。
- 为 Manager 删除流程增加 deletion claim，阻止同进程旧指针并发 transition/attach。
- 更新设计文档，记录 outbox、advisory lock 和 lease fencing 的约束。

## 验证

新增覆盖：

- retention GC 删除与 stale resume 写回竞争：tombstone 阻止 session 复活。
- 远端删除失败后的退避与后续成功。
- lease 到期后的重启恢复。
- 旧 lease 完成或失败不能影响新 lease。
- SQLite / PostgreSQL store 路径与迁移。

已通过：

- `make check`
- `go test ./internal/session ./internal/session/sql ./internal/gateway ./internal/worker ./internal/worker/opencodeserver -short -count=1`
- `go test -race ./internal/session ./internal/gateway ./internal/worker ./internal/worker/opencodeserver -short -count=1`
- pre-push 门禁：fmt、go vet、go mod verify、lint、build、tests
- 两轮独立代码审查：最终无 P0/P1