### PR TITLE
docs(patrol): 2026-07-14 文档维护

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -254,6 +254,8 @@ Worker 进程生命周期和环境配置。
 | `env_blocklist` | []string | `[]` | — | 需要从 Worker 环境中屏蔽的变量前缀列表（带尾部 `_`） |
 | `environment` | []string | 见下方 | — | 注入到所有 Worker 进程的额外环境变量。支持 `${VAR}` 展开，未设置且无默认值的条目被排除 |
 | `default_permission_mode` | string | `workspace` | — | workspace 无显式 override 时 bridge 注入的默认权限模式（r3 #804）。合法值 `read-only`/`workspace`/`auto-edit`/`bypass`/空，空与缺省均归一化为 `workspace`；非法值在启动与热重载时拒绝（防 typo fail-open）。仅 config.yaml 可配置，无 env 绑定 |
+| `permission_deny_dedup.enabled` | bool | `true` | `HOTPLEX_WORKER_PERMISSION_DENY_DEDUP_ENABLED` | 用户拒绝权限后，在 `window` 窗口内对相同 owner+fingerprint 的重复权限请求本地自动拒绝，不再转发新卡片给客户端——关闭「拒绝 → Agent 秒级重试同一工具 → 新卡片」循环。详见 `docs/specs/Permission-Deny-Dedup-Spec.md` |
+| `permission_deny_dedup.window` | duration | `60s` | `HOTPLEX_WORKER_PERMISSION_DENY_DEDUP_WINDOW` | 拒绝去重窗口长度。`enabled=true` 时必须 > 0，否则启动拒绝 |
 
 **默认 environment**：
 
@@ -282,6 +284,7 @@ LLM Provider 返回临时错误（429、529、400 等）时的自动重试配置
 | 字段 | 类型 | 默认值 | 环境变量 | 说明 |
 |------|------|--------|----------|------|
 | `command` | string | `claude` | `HOTPLEX_WORKER_CLAUDE_CODE_COMMAND` | Worker 启动命令。支持带子命令，如 `ccr code` |
+| `permission_mode` | string | `""` (= `bypass`) | `HOTPLEX_WORKER_CLAUDE_CODE_PERMISSION_MODE` | Claude Code 的 operator 默认/上限权限模式 tier。对 platform/cron 会话（bridge 注入空 sessionMode）直接作为有效模式；对 workspace 会话作为 permissiveness 上限，有效模式取 session 模式与 operator 的较低者（防越权）。合法值 `read-only`/`workspace`/`auto-edit`/`bypass`/空，空 = `bypass`（向后兼容 legacy 默认）。与 `codex_cli.sandbox`+`approval_mode`、`acp.auto_approve` 对应；区别于 `default_permission_mode`（后者是 bridge 为 workspace 会话解析的有效模式，归一化为 `workspace`） |
 | `permission_prompt` | bool | `false` | — | 启用 `--permission-prompt-tool` stdio 模式。开启后权限请求会转发到 Slack/飞书交互 UI |
 | `permission_auto_approve` | []string | `["ExitPlanMode"]` | — | 自动批准的工具名称列表（无需转发用户交互 UI） |
 | `mcp_servers` | map | `{}` | — | 用户配置的 MCP Server。空值 = 使用默认发现机制 |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -226,6 +226,7 @@ type QuestionRequestData struct {
 }
 
 type Question struct {
+    ID          string           `json:"id,omitempty"` // 问题标识符（可选），用于关联单个问题与其回答
     Question    string           `json:"question"`
     Header      string           `json:"header"`
     Options     []QuestionOption `json:"options"`


### PR DESCRIPTION
## Summary
- **configuration.md**：补充 `worker.permission_deny_dedup`（`enabled`/`window`，默认 `true`/`60s`）与 `worker.claude_code.permission_mode`（operator 权限上限/默认 tier，默认空 = `bypass`）—— v1.34.0 新增配置项
- **events.md**：`Question` 结构补充可选 `id` 字段（codexcli mapper 已生成）

## 变更窗口
v1.33.2 (`2b58347e`) → v1.34.0 (`07c2c63a`)，4 个提交。经分析仅 reference 文档需同步；#863（messaging 投递+卡片 UX 内部重构）与 #873（opencodeserver 重启保留会话 + cleanup outbox）不影响文档。

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)