### PR TITLE
fix(eventstore): hydrate SeqGen on reconnect to stop seq reset (#879, PR 1/4)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -58,6 +58,8 @@ type eventStoreProvider interface {
 	eventstore.TurnQuerier
 	QueryBySession(ctx context.Context, sessionID string, cursor int64, dir eventstore.CursorDirection, limit int) (*eventstore.EventPage, error)
 	DeleteExpired(ctx context.Context, cutoff time.Time) (int64, error)
+	// LatestSeq reads the max persisted event seq for SeqGen hydration (issue #879).
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 	Close() error
 }
 
@@ -356,6 +358,9 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	hub.LogHandler = func(level, msg, sessionID string) {
 		admin.AddLog(level, msg, sessionID)
 	}
+	// Hydrate SeqGen from persisted events on reconnect so seq continues
+	// monotonically instead of restarting from 1 (issue #879).
+	hub.SetSeqHydrator(stores.event)
 
 	var configWatcher *config.Watcher
 	if configPath != "" {

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -208,11 +208,25 @@ func (c *Collector) flushBoth(sessionID string) {
 	delete(c.reasoningAccum, sessionID)
 	c.accumMu.Unlock()
 
-	if dAcc != nil && dAcc.count > 0 {
-		c.send(dAcc.toRequest(sessionID))
-	}
-	if rAcc != nil && rAcc.count > 0 {
+	// Send in firstSeq order so insertion order (id) matches the logical seq
+	// order. Without this, a message delta flushed ahead of the reasoning that
+	// produced it gets a smaller id, making ORDER BY id DESC disagree with
+	// ORDER BY seq DESC and mis-ordering concurrently-flushed deltas in
+	// query_latest (issue #879). reasoning typically precedes its message, but
+	// compare firstSeq so workers that emit message deltas first stay correct.
+	switch {
+	case dAcc != nil && dAcc.count > 0 && rAcc != nil && rAcc.count > 0:
+		if rAcc.firstSeq <= dAcc.firstSeq {
+			c.send(rAcc.toRequest(sessionID))
+			c.send(dAcc.toRequest(sessionID))
+		} else {
+			c.send(dAcc.toRequest(sessionID))
+			c.send(rAcc.toRequest(sessionID))
+		}
+	case rAcc != nil && rAcc.count > 0:
 		c.send(rAcc.toRequest(sessionID))
+	case dAcc != nil && dAcc.count > 0:
+		c.send(dAcc.toRequest(sessionID))
 	}
 }
 

--- a/internal/eventstore/pg_store.go
+++ b/internal/eventstore/pg_store.go
@@ -231,6 +231,19 @@ func (s *pgStore) LatestTurnNum(ctx context.Context, sessionID string, generatio
 	return tn, nil
 }
 
+// LatestSeq returns the maximum event seq for a session, or 0 if no events
+// exist. Used to hydrate the in-memory SeqGen on reconnect (issue #879).
+func (s *pgStore) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	var seq int64
+	err := s.db.QueryRowContext(ctx, s.sql["latest_seq"], sessionID).Scan(&seq)
+	if err != nil {
+		return 0, fmt.Errorf("eventstore: latest seq: %w", err)
+	}
+	return seq, nil
+}
+
 func (s *pgStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()

--- a/internal/eventstore/sql/queries/events.latest_seq.sql
+++ b/internal/eventstore/sql/queries/events.latest_seq.sql
@@ -1,0 +1,5 @@
+-- Latest event seq for a session, or 0 if none. Used to hydrate the in-memory
+-- SeqGen on reconnect so seq continues monotonically instead of restarting
+-- from 1 (issue #879: seq reset → collision + new events buried by
+-- ORDER BY seq DESC queries).
+SELECT COALESCE(MAX(seq), 0) FROM events WHERE session_id = ?

--- a/internal/eventstore/sql/queries/events.query_latest.sql
+++ b/internal/eventstore/sql/queries/events.query_latest.sql
@@ -1,5 +1,11 @@
+-- Latest N events by insertion id (DESC, reversed to ASC in Go).
+-- Uses id (monotonic auto-increment) rather than seq so the newest events are
+-- always returned even when seq was reset by a pre-issue-#879 WS reconnect —
+-- seq DESC would bury low-seq new events under the LIMIT. Mirrors
+-- turns.query_latest's ORDER BY t.id DESC. Correct because flushBoth now sends
+-- deltas in firstSeq order, so insertion order (id) matches logical seq order.
 SELECT session_id, seq, type, data, direction, source, created_at
 FROM events
 WHERE session_id = ?
-ORDER BY seq DESC
+ORDER BY id DESC
 LIMIT ?

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -460,6 +460,20 @@ func (s *SQLiteStore) LatestTurnNum(ctx context.Context, sessionID string, gener
 	return tn, nil
 }
 
+// LatestSeq returns the maximum event seq for a session, or 0 if no events
+// exist. Used to hydrate the in-memory SeqGen on reconnect so seq continues
+// monotonically instead of restarting from 1 (issue #879).
+func (s *SQLiteStore) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	var seq int64
+	err := s.db.QueryRowContext(ctx, queries["latest_seq"], sessionID).Scan(&seq)
+	if err != nil {
+		return 0, fmt.Errorf("eventstore: latest seq: %w", err)
+	}
+	return seq, nil
+}
+
 // DeleteExpiredTurns removes turns older than the cutoff by created_at.
 func (s *SQLiteStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)

--- a/internal/eventstore/store_test.go
+++ b/internal/eventstore/store_test.go
@@ -111,6 +111,44 @@ func TestSQLiteStore_DeleteBySession(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestSQLiteStore_LatestSeq(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty session → 0.
+	seq, err := store.LatestSeq(ctx, "empty")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), seq)
+
+	// Append events with seq 1,2,3 → MAX=3.
+	for i := int64(1); i <= 3; i++ {
+		require.NoError(t, store.Append(ctx, &StoredEvent{
+			SessionID: "sess1", Seq: i, Type: "message",
+			Data: json.RawMessage(`{}`), Direction: "outbound",
+			Source: SourceNormal, CreatedAt: time.Now().UnixMilli(),
+		}))
+	}
+	seq, err = store.LatestSeq(ctx, "sess1")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), seq)
+
+	// Different session is isolated; high seq does not leak across sessions.
+	require.NoError(t, store.Append(ctx, &StoredEvent{
+		SessionID: "sess2", Seq: 99, Type: "message",
+		Data: json.RawMessage(`{}`), Direction: "outbound",
+		Source: SourceNormal, CreatedAt: time.Now().UnixMilli(),
+	}))
+	seq, err = store.LatestSeq(ctx, "sess2")
+	require.NoError(t, err)
+	require.Equal(t, int64(99), seq)
+
+	// sess1 still 3 (unaffected by sess2).
+	seq, err = store.LatestSeq(ctx, "sess1")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), seq)
+}
+
 func TestSQLiteStore_DeleteExpired(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -488,6 +488,13 @@ func (c *Conn) resolveSession(env *events.Envelope, initData InitData, sm connSM
 
 	c.hub.LeaveSession("", c)
 	c.hub.JoinSession(sessionID, c)
+	// Hydrate SeqGen from persisted events so the upcoming init_ack and worker
+	// events continue monotonically instead of restarting from 1 (issue #879:
+	// WS disconnect deleted the counter → reconnect collided with persisted seq
+	// segments and buried new events under ORDER BY seq DESC). Runs after
+	// JoinSession and before resolveSessionState starts the worker (which assigns
+	// seqs in a goroutine) and before finalizeInit's init_ack NextSeq.
+	c.hub.EnsureSeqHydrated(sessionID)
 
 	return c.resolveSessionState(sessionID, initData, workDir, sm, preResolved, env.SessionID)
 }

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -109,6 +109,9 @@ type Hub struct {
 
 	// Sequence generation per session
 	seqGen *SeqGen
+	// seqHydrator reads persisted event seqs to seed SeqGen on reconnect
+	// (issue #879). nil when eventstore is disabled — SeqGen then restarts at 1.
+	seqHydrator SeqHydrator
 
 	// Shutdown signals.
 	ctx    context.Context
@@ -632,6 +635,38 @@ func (h *Hub) NextSeq(sessionID string) int64 {
 // NextSeqPeek returns the current sequence number for a session without incrementing.
 func (h *Hub) NextSeqPeek(sessionID string) int64 {
 	return h.seqGen.Peek(sessionID)
+}
+
+// SetSeqHydrator injects the persisted-seq reader used to hydrate SeqGen on
+// reconnect (issue #879). Optional; when nil (eventstore disabled), SeqGen
+// restarts from 1 as before. Called once during gateway startup after the
+// eventstore is constructed.
+func (h *Hub) SetSeqHydrator(sh SeqHydrator) {
+	h.seqHydrator = sh
+}
+
+// EnsureSeqHydrated seeds the SeqGen counter for sessionID from persisted
+// events so the next NextSeq continues monotonically instead of restarting
+// from 1 (issue #879: WS disconnect deleted the counter → reconnect collided
+// with persisted seq segments and buried new events under ORDER BY seq DESC).
+// Best-effort: a DB error is logged and does not block the handshake (SeqGen
+// simply starts from 1). MUST be called after JoinSession and before the first
+// NextSeq (e.g. before starting the worker or sending init_ack).
+func (h *Hub) EnsureSeqHydrated(sessionID string) {
+	if h.seqHydrator == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(h.ctx, 3*time.Second)
+	defer cancel()
+	latest, err := h.seqHydrator.LatestSeq(ctx, sessionID)
+	if err != nil {
+		h.log.Warn("gateway: hydrate seq from db failed; starting from 1",
+			"session_id", sessionID, "err", err)
+		return
+	}
+	if latest > 0 {
+		h.seqGen.Init(sessionID, latest)
+	}
 }
 
 // ConnectionsOpen returns the number of currently open WebSocket connections.

--- a/internal/gateway/seq.go
+++ b/internal/gateway/seq.go
@@ -1,9 +1,17 @@
 package gateway
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 )
+
+// SeqHydrator reads the latest persisted event seq for a session, so the Hub
+// can seed the in-memory SeqGen on reconnect (issue #879). Both
+// *eventstore.SQLiteStore and *eventstore.pgStore satisfy it.
+type SeqHydrator interface {
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
+}
 
 // SeqGen generates monotonically increasing sequence numbers per session.
 // Uses sync.Map + per-session atomic.Int64 to eliminate cross-session contention.
@@ -34,4 +42,24 @@ func (g *SeqGen) Next(sessionID string) int64 {
 // Remove deletes the sequence counter for a session.
 func (g *SeqGen) Remove(sessionID string) {
 	g.seq.Delete(sessionID)
+}
+
+// Init seeds the sequence counter for a session to start, but only if start is
+// greater than the current value. This lets the gateway hydrate the counter
+// from persisted events on reconnect so seq continues monotonically instead of
+// restarting from 1 (issue #879: WS disconnect deleted the counter, reconnect
+// collided with persisted seq segments). CAS-based — safe against concurrent
+// Next/Init; never regresses an already-higher counter.
+func (g *SeqGen) Init(sessionID string, start int64) {
+	val, _ := g.seq.LoadOrStore(sessionID, new(atomic.Int64))
+	cur := val.(*atomic.Int64) //nolint:errcheck // LoadOrStore guarantees *atomic.Int64
+	for {
+		old := cur.Load()
+		if start <= old {
+			return
+		}
+		if cur.CompareAndSwap(old, start) {
+			return
+		}
+	}
 }

--- a/internal/gateway/seq_test.go
+++ b/internal/gateway/seq_test.go
@@ -1,0 +1,117 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeqGen_Init_ContinuesFromStart(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	g.Init("s1", 100)
+	require.Equal(t, int64(101), g.Next("s1"))
+	require.Equal(t, int64(102), g.Next("s1"))
+}
+
+func TestSeqGen_Init_DoesNotRegress(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	g.Init("s1", 100)
+	// A later Init with a smaller value (e.g. a concurrent hydrate racing with
+	// an in-flight Next) must NOT lower the floor.
+	g.Init("s1", 50)
+	require.Equal(t, int64(101), g.Next("s1"))
+}
+
+func TestSeqGen_Init_EmptySession(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// A fresh session with no persisted events hydrates from 0 → Next starts at 1.
+	g.Init("fresh", 0)
+	require.Equal(t, int64(1), g.Next("fresh"))
+}
+
+func TestSeqGen_Init_BeforeNextIsEquivalent(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// Init on a session that has never called Next must seed the counter.
+	g.Init("s1", 9899)
+	require.Equal(t, int64(9900), g.Next("s1"))
+	require.Equal(t, int64(9900), g.Peek("s1"))
+}
+
+func TestSeqGen_Init_ConcurrentWithNext(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// Simulate an in-flight counter (e.g. an init_ack already took seq=1).
+	require.Equal(t, int64(1), g.Next("s1"))
+
+	var wg sync.WaitGroup
+	// Concurrent Init raising the floor to 1000.
+	for range 50 {
+		wg.Go(func() { g.Init("s1", 1000) })
+	}
+	// Concurrent Next callers.
+	for range 50 {
+		wg.Go(func() { _ = g.Next("s1") })
+	}
+	wg.Wait()
+	// After all Init(1000) settle, the next seq must be strictly above 1000
+	// (Init raised the floor; Nexts only go up from there).
+	require.Greater(t, g.Next("s1"), int64(1000))
+}
+
+// mockSeqHydrator implements SeqHydrator for Hub.EnsureSeqHydrated tests.
+type mockSeqHydrator struct {
+	seq   int64
+	err   error
+	calls int
+}
+
+func (m *mockSeqHydrator) LatestSeq(_ context.Context, _ string) (int64, error) {
+	m.calls++
+	return m.seq, m.err
+}
+
+func TestHub_EnsureSeqHydrated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil hydrator is no-op", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		// No SetSeqHydrator → nil; Next starts at 1 (pre-issue-#879 behavior).
+		h.EnsureSeqHydrated("s1")
+		require.Equal(t, int64(1), h.NextSeq("s1"))
+	})
+
+	t.Run("seeds counter from persisted seq", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{seq: 9899})
+		h.EnsureSeqHydrated("s1")
+		// Reconnect after a session that persisted 9899 events → next seq is 9900,
+		// not 1 (regression: seq collision + buried new events, issue #879).
+		require.Equal(t, int64(9900), h.NextSeq("s1"))
+	})
+
+	t.Run("zero persisted seq starts at 1", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{seq: 0})
+		h.EnsureSeqHydrated("fresh")
+		require.Equal(t, int64(1), h.NextSeq("fresh"))
+	})
+
+	t.Run("db error falls back to 1", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{err: errors.New("db down")})
+		// Best-effort: hydrate failure must not block the handshake.
+		h.EnsureSeqHydrated("s1")
+		require.Equal(t, int64(1), h.NextSeq("s1"))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes problems **1+2** of #879 (PR 1/4 of the issue's roadmap).

**Shared root cause:** `SeqGen` is in-memory only and is deleted on WS disconnect (`hub.removeSession`), so reconnect restarts seq from 1. This:
- **Problem 2 (seq collision):** re-connecting inserts events with seq=1,2,3… that collide with persisted segments — `idx_events_session_seq` is non-unique, so duplicates land silently.
- **Problem 1 (apparent stop-write):** those new low-seq events are buried under `ORDER BY seq DESC` + LIMIT in `events.query_latest.sql`. Data is **not lost**, just unqueryable. turns are unaffected because `turns.query_latest` already uses `ORDER BY id DESC`.

## Changes

- `eventstore.LatestSeq` (SQLite + PG) + `events.latest_seq.sql` — reads `COALESCE(MAX(seq),0)`.
- `SeqGen.Init(sessionID, start)` — CAS-based seed that only raises the floor (never regresses); safe under concurrent `Next`/`Init`.
- `Hub.SeqHydrator` dep + `Hub.EnsureSeqHydrated` — best-effort hydration (3s timeout, errors logged, never blocks the handshake).
- `conn.resolveSession` hydrates **after** `JoinSession`, **before** the worker starts (which assigns seqs in a goroutine) and before `finalizeInit`'s init_ack `NextSeq`.
- `gateway_run` wires `hub.SetSeqHydrator(stores.event)`.
- `events.query_latest.sql` → `ORDER BY id DESC` (aligns with `turns.query_latest`; restores history made invisible by prior seq resets).
- `collector.flushBoth` now sends reasoning/message deltas in `firstSeq` order so insertion order (id) matches logical seq order — required for `id DESC` to agree with `seq DESC` on concurrently-flushed deltas (without it, `TestCollector_ReasoningDeltaInterleave` regresses).

## Tests

- `TestSQLiteStore_LatestSeq` (empty→0, MAX, per-session isolation)
- `TestSeqGen_Init_*` (continue, no-regress, empty session, concurrent Init+Next)
- `TestHub_EnsureSeqHydrated` (nil no-op, seed from DB, zero→1, db error→1)
- Full `make check` green (gofmt + golangci-lint + all tests).

Refs #879. Remaining roadmap: PR2 frontend WS-bounce cooldown, PR3 UNIQUE index + runWriter panic recovery, PR4 updated_at format + debug-endpoint DB fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)