### PR TITLE
fix(webchat): cooldown workspace-handshake errors to stop WS bounce (#879, PR 2/4)

### DIFF
--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -217,6 +217,15 @@ export default function ChatContainer() {
     const [currentUser, setCurrentUser] = useState<User | null>(null);
     const [showNewWsModal, setShowNewWsModal] = useState(false);
 
+    // Cooldown timestamp for workspace-handshake errors (issue #879 problem 3).
+    // Without it, a workspace whose handshake keeps failing (access denied /
+    // disabled / not found) drives a feedback loop: onWorkspaceError →
+    // loadWorkspaces → workspaceId change → useSessions refetch → activeSessionId
+    // change → ChatInterface remount (key={activeSessionId}) → reconnect → fail
+    // again, oscillating across sessions 6+ times in 8s. The cooldown collapses
+    // rapid retries into one recovery attempt per 5s window.
+    const lastWsErrorRef = useRef(0);
+
     // Fetch workspaces list
     const loadWorkspaces = useCallback(async (selectId?: string) => {
         try {
@@ -308,7 +317,14 @@ export default function ChatContainer() {
     // active workspace as list[0] (only owned workspaces are returned), which
     // changes the workspaceId prop → useSessions refetches → activeSessionId
     // changes → ChatInterface remounts and reconnects with a valid workspace.
+    // A 5s cooldown breaks the remount→reconnect→fail feedback loop (issue #879
+    // problem 3): once a workspace handshake fails, repeated identical failures
+    // within the window are ignored instead of re-triggering loadWorkspaces and
+    // bouncing across sessions.
     const handleWorkspaceError = useCallback(() => {
+        const now = Date.now();
+        if (now - lastWsErrorRef.current < 5000) return;
+        lastWsErrorRef.current = now;
         localStorage.removeItem("hotplex_active_workspace_id");
         loadWorkspaces();
     }, [loadWorkspaces]);


### PR DESCRIPTION
## Summary

Fixes problem **3** of #879 (PR 2/4): webchat WebSocket bouncing across sessions 6+ times in 8s.

**Root cause (StrictMode ruled out — `reactStrictMode: false`):** a workspace whose handshake keeps failing (access denied / not found / disabled) drives a feedback loop — `onWorkspaceError` → `handleWorkspaceError` → `loadWorkspaces` → `workspaceId` change → `useSessions` refetch → `activeSessionId` change → `ChatInterface` remount (`key={activeSessionId}`) → reconnect → fail again.

## Change

`handleWorkspaceError` now ignores repeated errors within a **5s window** (`lastWsErrorRef`), collapsing the loop into one recovery attempt per window. This lives in `ChatContainer` (which does **not** remount), so the cooldown persists across the remounts it suppresses.

## Not implemented (deliberate)

The issue's proposed "debounce `sessionId` 150ms in `ChatInterface`" (change 2). Under `key={activeSessionId}`, every `sessionId` change is a **full remount** that resets `useState`, so the debounce effect always fires on an equal value and never delays/merges a connection — it would be dead code (YAGNI). The cooldown in `ChatContainer` is the effective root-cause fix.

`key={activeSessionId}` is intentionally kept (removing it leaks cross-session messages/refs).

## Verification

`npx tsc --noEmit` (webchat) clean; `make check` green via pre-push gate.

Refs #879. PR 3/4 (UNIQUE index + runWriter panic recovery) and PR 4/4 (time format + debug endpoint) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)