### PR TITLE
fix(eventstore): unique (session_id,seq) index + runWriter panic recovery (#879, PR 3/4)

### DIFF
--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -361,6 +362,20 @@ func (c *Collector) DroppedEvents() int64 {
 
 func (c *Collector) runWriter() {
 	defer c.closeWg.Done()
+	// Recover from panics in flushBatch (e.g. a buggy driver call) so a single
+	// panic does not permanently kill the writer and silently drop ALL subsequent
+	// events + turns. The in-flight batch is lost (already the case on any
+	// flushBatch error), but the channel keeps draining under a fresh goroutine.
+	// The Add(1) here balances the new goroutine's deferred Done() (issue #879
+	// problem 1, reliability defense).
+	defer func() {
+		if r := recover(); r != nil {
+			c.log.Error("eventstore: runWriter panic, restarting goroutine",
+				"panic", r, "stack", string(debug.Stack()))
+			c.closeWg.Add(1)
+			go c.runWriter()
+		}
+	}()
 
 	ticker := time.NewTicker(c.flushInterval)
 	defer ticker.Stop()

--- a/internal/eventstore/collector_test.go
+++ b/internal/eventstore/collector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +13,53 @@ import (
 
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+// panicFirstTxStore wraps an EventStore and panics on the first BeginTx call,
+// to exercise runWriter's panic-recovery restart (issue #879 problem 1).
+type panicFirstTxStore struct {
+	EventStore
+	failed atomic.Bool
+}
+
+func (s *panicFirstTxStore) BeginTx(ctx context.Context) (EventTx, error) {
+	if !s.failed.Swap(true) {
+		panic("simulated runWriter panic during flushBatch")
+	}
+	return s.EventStore.BeginTx(ctx)
+}
+
+func TestCollector_RunWriterPanicRecovery(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ps := &panicFirstTxStore{EventStore: store}
+	// Short flush interval so the first batch flushes (and panics) quickly.
+	c := NewCollectorWithIntervals(ps, slog.Default(), 50*time.Millisecond, 3*time.Second)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// seq 1 lands in a batch; the next ticker flush calls BeginTx → panic.
+	c.Capture("s1", 1, events.Message, json.RawMessage(`{}`), "outbound", SourceNormal)
+
+	// Wait until the panic has fired (BeginTx was reached → failed flipped).
+	require.Eventually(t, func() bool { return ps.failed.Load() },
+		2*time.Second, 20*time.Millisecond, "flush never ran (BeginTx not called)")
+
+	// After the goroutine restarts, a NEW event must still persist — proving the
+	// writer survived instead of permanently dying. (seq 1 was in the panicked
+	// batch and is lost, the pre-existing behavior on any flush error.)
+	c.Capture("s1", 2, events.Done, json.RawMessage(`{}`), "outbound", SourceNormal)
+	require.Eventually(t, func() bool {
+		page, err := store.QueryBySession(context.Background(), "s1", 0, CursorLatest, 100)
+		if err != nil || len(page.Events) == 0 {
+			return false
+		}
+		for _, e := range page.Events {
+			if e.Seq == 2 {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 50*time.Millisecond, "runWriter did not recover from panic")
+}
 
 func TestCollector_CaptureDeltaString(t *testing.T) {
 	store := newTestStore(t)

--- a/internal/session/sql/migrations-postgres/027_events_unique_session_seq.pg.sql
+++ b/internal/session/sql/migrations-postgres/027_events_unique_session_seq.pg.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- issue #879 problem 2: enforce (session_id, seq) uniqueness so seq collisions
+-- surface as insert errors instead of silent corruption.
+--
+-- Dedup first: per (session_id, seq) pair keep only the newest row (MAX(id)) so
+-- CREATE UNIQUE INDEX succeeds on existing data; MAX(id) keeps the most recently
+-- inserted (post-reset, newest) row for each colliding pair.
+DELETE FROM "events"
+WHERE "id" NOT IN (
+    SELECT MAX("id") FROM "events" GROUP BY "session_id", "seq"
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_events_session_seq_unique"
+    ON "events"("session_id", "seq");
+
+-- +goose Down
+DROP INDEX IF EXISTS "idx_events_session_seq_unique";

--- a/internal/session/sql/migrations/027_events_unique_session_seq.sql
+++ b/internal/session/sql/migrations/027_events_unique_session_seq.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- issue #879 problem 2: enforce (session_id, seq) uniqueness so seq collisions
+-- (left by pre-hydration WS reconnects, before PR1's SeqGen hydration shipped)
+-- surface as insert errors instead of silent corruption.
+--
+-- Dedup first: per (session_id, seq) pair keep only the newest row (MAX(id)).
+-- Without this, CREATE UNIQUE INDEX fails on the pre-existing duplicates. The
+-- MAX(id) keeps the most recently inserted row for each colliding pair, which
+-- is the post-reset (newest) event once PR1's hydration prevents future resets.
+DELETE FROM events
+WHERE id NOT IN (
+    SELECT MAX(id) FROM events GROUP BY session_id, seq
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_session_seq_unique
+    ON events(session_id, seq);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_session_seq_unique;


### PR DESCRIPTION
## Summary

Issue #879 **defense layer** (PR 3/4) — two independent hardening fixes.

### 1. UNIQUE index on `events(session_id, seq)` — migration 027 (SQLite + PG)

`idx_events_session_seq` was a plain (non-unique) index, so seq collisions from pre-PR1 reconnects were inserted silently. Migration 027:
- **Dedups first** — `DELETE` keeping `MAX(id)` per `(session_id, seq)` pair, so the unique index builds on existing data (otherwise `CREATE UNIQUE INDEX` fails). `MAX(id)` keeps the most-recently-inserted (post-reset, newest) row per colliding pair.
- **Then** `CREATE UNIQUE INDEX idx_events_session_seq_unique`.

Future collisions now surface as insert errors instead of silent corruption. (PR1's SeqGen hydration prevents future resets; this is the belt-and-suspenders.)

### 2. `runWriter` panic recovery — `collector.go`

`runWriter` had no `recover()`, so a single panic in `flushBatch` permanently killed the writer → the 2048-cap channel fills → **both events and turns silently dropped**. Now `defer recover()` logs the panic + stack and restarts the goroutine (`closeWg.Add(1)` balances the new goroutine's deferred `Done()`). The in-flight batch is lost (pre-existing behavior on any flush error); the channel keeps draining under the fresh goroutine.

## Tests

- `TestCollector_RunWriterPanicRecovery`: first batch's `BeginTx` panics → goroutine restarts → a later event still persists.
- Session migration suite: 027 applies cleanly on SQLite + PG.

`make check` green.

Refs #879. PR 4/4 (updated_at format + debug-endpoint DB fields) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)