### PR TITLE
fix(admin): augment debug session with DB-backed turn count + last seq (#879, PR 4/4)

### DIFF
--- a/cmd/hotplex/admin_adapters.go
+++ b/cmd/hotplex/admin_adapters.go
@@ -90,6 +90,10 @@ func (a *turnsStoreAdapter) TurnStats(ctx context.Context, sessionID string) (*e
 	return a.es.QueryTurnStats(ctx, sessionID)
 }
 
+func (a *turnsStoreAdapter) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	return a.es.LatestSeq(ctx, sessionID)
+}
+
 type bridgeAdapter struct {
 	bridge *gateway.Bridge
 }

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -58,6 +58,8 @@ type eventStoreProvider interface {
 	eventstore.TurnQuerier
 	QueryBySession(ctx context.Context, sessionID string, cursor int64, dir eventstore.CursorDirection, limit int) (*eventstore.EventPage, error)
 	DeleteExpired(ctx context.Context, cutoff time.Time) (int64, error)
+	// LatestSeq reads the max persisted event seq for SeqGen hydration (issue #879).
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 	Close() error
 }
 
@@ -356,6 +358,9 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	hub.LogHandler = func(level, msg, sessionID string) {
 		admin.AddLog(level, msg, sessionID)
 	}
+	// Hydrate SeqGen from persisted events on reconnect so seq continues
+	// monotonically instead of restarting from 1 (issue #879).
+	hub.SetSeqHydrator(stores.event)
 
 	var configWatcher *config.Watcher
 	if configPath != "" {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -53,13 +53,12 @@ import (
 )
 
 // eventStoreProvider combines the query and event-store interfaces needed by all consumers.
-// Both *eventstore.SQLiteStore and the internal pgEventStore satisfy it.
+// Both *eventstore.SQLiteStore and the internal pgEventStore satisfy it. LatestSeq is
+// inherited from TurnQuerier (promoted there in issue #879).
 type eventStoreProvider interface {
 	eventstore.TurnQuerier
 	QueryBySession(ctx context.Context, sessionID string, cursor int64, dir eventstore.CursorDirection, limit int) (*eventstore.EventPage, error)
 	DeleteExpired(ctx context.Context, cutoff time.Time) (int64, error)
-	// LatestSeq reads the max persisted event seq for SeqGen hydration (issue #879).
-	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 	Close() error
 }
 

--- a/docs/superpowers/plans/2026-07-14-issue-879-eventstore-persistence.md
+++ b/docs/superpowers/plans/2026-07-14-issue-879-eventstore-persistence.md
@@ -1,0 +1,171 @@
+# Issue #879 Eventstore 持久化断裂修复 实现计划
+
+> **执行方式**：inline 执行（已建立完整代码级上下文，PR4 依赖 PR1 的 LatestSeq）。
+
+**Goal:** 修复 issue #879 的 5 个独立问题（events 假性停写、seq 碰撞、webchat WS 横跳、updated_at 格式、debug 端点脱节），分 4 个 PR 交付。
+
+**Architecture:** 后端（eventstore/session/gateway/admin，Go）+ 前端（webchat，TS/React）。根因主线：seq 计数器 WS 断连即删→从 1 重置，引发问题 1+2；前端 workspace-error 反馈循环放大问题 3。
+
+**Tech Stack:** Go 1.23+（log/slog, database/sql, modernc sqlite / pgx）、TypeScript/React/Next.js、SQLite + PostgreSQL 双后端。
+
+## Global Constraints
+- Mutex 显式 `mu` 字段，不嵌入、不传指针；错误 `fmt.Errorf("...: %w", err)`
+- 测试 `testify/require` + table-driven + `t.Parallel()`，单模块 ≤5s，禁 `time.Sleep` 等异步（用 `require.Eventually`/channel）
+- SQL 文件经 `go:embed sql/queries/*.sql` 加载，key 去掉 `events.` 前缀；**SQLite + PG 双后端必须同步**
+- migrations 在 `internal/session/sql/migrations/`（SQLite）与 `migrations-postgres/`（PG），goose 格式，下一个编号 027
+- Fork-PR：push `myfork`(hotplex-ai) 优先，PR 到 `origin`(hrygo)；用 `gh auth token` 注入 credential.helper 避免 push 挂起
+- Edit 工具改源码（tab 缩进），禁 sed/awk
+
+## 核实修正（issue 路径偏差）
+- eventstore SQL 实际在 `internal/eventstore/sql/queries/`（issue 漏 `queries/` 一层）
+- PR2 前端 3/4 路径已变：`webchat/app/components/chat/ChatContainer.assistant-ui.tsx`、`webchat/lib/ai-sdk-transport/client/browser-client.ts`、`webchat/lib/hooks/useSessions.ts`；新增 `webchat/lib/session-select.ts`
+
+---
+
+## PR1: seq 计数器水合 + query_latest 排序（治本，最高优先级）
+
+**根因**：`SeqGen` 纯内存（seq.go:10-12），`removeSession`(hub.go:263) 断连即删→重连从 1 重置→(a) 旧 seq 段碰撞入库；(b) `events.query_latest.sql` 用 `ORDER BY seq DESC`，新事件 seq 小被埋末尾被 LIMIT 截断（假性停写）。turns 用 `ORDER BY id DESC` 不受影响。
+
+**Files:**
+- Create: `internal/eventstore/sql/queries/events.latest_seq.sql`
+- Modify: `internal/eventstore/store.go`（SQLiteStore.LatestSeq）+ `pg_store.go`（pgStore.LatestSeq）+ 接口
+- Modify: `internal/gateway/seq.go`（SeqGen.Init）+ `hub.go`（seqHydrator + EnsureSeqHydrated）+ `conn.go`（resolveSession 水合点）+ `deps.go`/`gateway_run.go`（DI）
+- Modify: `internal/eventstore/sql/queries/events.query_latest.sql`（ORDER BY id DESC）
+
+**Interfaces:**
+- 新增 `eventstore.LatestSeq(ctx, sessionID) (int64, error)` → `SELECT COALESCE(MAX(seq),0) FROM events WHERE session_id=?`
+- 新增 `gateway.SeqHydrator` 接口（仅 LatestSeq），Hub 持有
+
+### Tasks
+- [ ] T1.1 eventstore LatestSeq（SQLite + PG + 测试）
+  - 新建 `events.latest_seq.sql`；SQLiteStore/pgStore 仿 LatestGeneration 实现；加到 TurnQuerier 接口（或独立接口）。测试：空表返回 0；有数据返回 MAX。
+- [ ] T1.2 SeqGen.Init（CAS 只增）+ 单测
+  ```go
+  func (g *SeqGen) Init(sessionID string, start int64) {
+      val, _ := g.seq.LoadOrStore(sessionID, new(atomic.Int64))
+      cur := val.(*atomic.Int64)
+      for {
+          old := cur.Load()
+          if start <= old { return }
+          if cur.CompareAndSwap(old, start) { return }
+      }
+  }
+  ```
+  测试：Init 后 Next 连续；Init 不回退已有值；并发 Init+Next 安全。
+- [ ] T1.3 Hub.EnsureSeqHydrated + DI
+  - Hub 加 `seqHydrator SeqHydrator` 字段 + `SetSeqHydrator()`；`EnsureSeqHydrated(sessionID)` 调 LatestSeq→seqGen.Init（3s timeout，错误仅 log.Warn 不阻断握手）
+  - gateway_run.go 注入（eventstore store 同时实现 SeqHydrator）
+- [ ] T1.4 水合点：conn.resolveSession JoinSession(490) 后、resolveSessionState(492) 前
+  - `c.hub.EnsureSeqHydrated(sessionID)` —— 此时 worker 尚未启动，无并发 NextSeq；第一个 NextSeq 在 finalizeInit:734(init_ack)
+- [ ] T1.5 events.query_latest.sql 改 `ORDER BY id DESC`（止血，恢复历史数据）
+- [ ] T1.6 make check + push myfork + PR
+
+**风险**：水合在握手路径加一次 DB 查询（<10ms，握手 30s 超时，可接受）；首次创建的 session LatestSeq=0，Init 无效，Next 从 1 开始（正确）。
+
+---
+
+## PR2: 前端 WS 横跳止血（workspace-error 冷却 + sessionId debounce）
+
+**根因**：workspace 握手失败→onWorkspaceError(948)→handleWorkspaceError(311) 清 localStorage+loadWorkspaces→workspaceId 变→useSessions refetch→activeSessionId 变→ChatInterface remount(key=677)→重连→若新 workspace 也失败→循环。StrictMode 假设被反驳（reactStrictMode:false）。
+
+**Files:**
+- Modify: `webchat/app/components/chat/ChatContainer.assistant-ui.tsx`
+- Modify: `webchat/lib/adapters/hotplex-runtime-adapter.ts`（可选 debounce 备选）
+
+### Tasks
+- [ ] T2.1 handleWorkspaceError 加 5s 冷却（切断循环）
+  ```tsx
+  const lastWsErrorRef = useRef(0);  // 插入 218 行后 workspace state 区
+  const handleWorkspaceError = useCallback(() => {
+      const now = Date.now();
+      if (now - lastWsErrorRef.current < 5000) return;  // 5s 冷却
+      lastWsErrorRef.current = now;
+      localStorage.removeItem("hotplex_active_workspace_id");
+      loadWorkspaces();
+  }, [loadWorkspaces]);
+  ```
+- [ ] T2.2 ChatInterface debounce sessionId 150ms（通用减振，合并快速 remount）
+  ```tsx
+  // ChatInterface(55-112) 内，useHotPlexRuntime 前加：
+  const [stableSessionId, setStableSessionId] = useState(sessionId);
+  useEffect(() => {
+      const t = setTimeout(() => setStableSessionId(sessionId), 150);
+      return () => clearTimeout(t);
+  }, [sessionId]);
+  // adapter = useHotPlexRuntime({ sessionId: stableSessionId ?? undefined, ... })
+  ```
+- [ ] T2.3 tsc --noEmit + make check + push + PR
+
+**风险**：debounce 延迟所有 session 切换 150ms（可接受）；不移除 key=677（防跨 session 状态泄漏）。
+
+---
+
+## PR3: 防御层（UNIQUE 索引 + runWriter panic recovery）
+
+**Files:**
+- Create: `internal/session/sql/migrations/027_events_unique_session_seq.sql` + `migrations-postgres/027_events_unique_session_seq.pg.sql`
+- Modify: `internal/eventstore/collector.go`（runWriter panic recovery）
+
+### Tasks
+- [ ] T3.1 UNIQUE 索引 migration（027，SQLite + PG）
+  - **必须先去重**：现有重复 `(session_id,seq)` 会让 CREATE UNIQUE INDEX 失败。migration 先 `DELETE` 保留每组 (session_id,seq) 最大 id 的行，再建索引。
+  - SQLite: `DELETE FROM events WHERE id NOT IN (SELECT MAX(id) FROM events GROUP BY session_id, seq);` + `CREATE UNIQUE INDEX IF NOT EXISTS idx_events_session_seq_uq ON events(session_id, seq);`
+  - PG 同构（大写引号）
+  - 测试：重复数据 migration 后保留最新；新插入碰撞报错
+- [ ] T3.2 runWriter panic recovery（collector.go:362）
+  ```go
+  func (c *Collector) runWriter() {
+      defer c.closeWg.Done()
+      defer func() {
+          if r := recover(); r != nil {
+              c.log.Error("eventstore: runWriter panic, restarting", "panic", r, "stack", string(debug.Stack()))
+              c.closeWg.Add(1)
+              go c.runWriter()  // 重启而非永久死亡
+          }
+      }()
+      ...
+  }
+  ```
+  测试：注入 panic 的 store，验证 runWriter 重启后仍能写入。
+- [ ] T3.3 make check + push + PR
+
+**风险**：UNIQUE 索引让 seq 碰撞从静默腐败变为报错——Append 失败会导致该 event 丢失（batch 内 break）。需配合 PR1 水合（seq 不再重置）避免碰撞。去重 DELETE 在大表上慢（一次性 migration，可接受）。
+
+---
+
+## PR4: 清理项（updated_at 格式 + debug 端点 DB 字段）
+
+**Files:**
+- Modify: `internal/session/cleanup_outbox.go`（upsertSessionArgs:140 时间格式）
+- Modify: `internal/admin/handlers.go`（HandleDebugSession:357 补 DB 字段）+ `admin.go`（注入依赖）
+
+### Tasks
+- [ ] T4.1 upsertSessionArgs 时间转 RFC3339Nano UTC
+  ```go
+  func upsertSessionArgs(info *SessionInfo, ctxJSON, pkJSON []byte) []any {
+      return []any{..., info.CreatedAt.UTC().Format(time.RFC3339Nano),
+          info.UpdatedAt.UTC().Format(time.RFC3339Nano),
+          formatNullTime(info.ExpiresAt), formatNullTime(info.IdleExpiresAt), ...}
+  }
+  // formatNullTime: nil→nil, else UTC RFC3339Nano
+  ```
+  - **PG 验证**：PG TIMESTAMP 列收 RFC3339 字符串（pgx 能解析）；scanSession time.Time/NullTime 反向解析 RFC3339 兼容
+  - 测试：SQLite/PG 写入+读回 round-trip 时间一致
+- [ ] T4.2 HandleDebugSession 补 DB 字段（复用 PR1 LatestSeq + turnStore）
+  ```go
+  "db_turn_count": dbTurnCount,   // turnStore 查 turns 表
+  "db_last_seq":   dbLastSeq,     // LatestSeq（PR1）
+  "runtime_only":  true,          // 标注 turn_count/last_seq_sent 是 ephemeral
+  ```
+  - AdminAPI 注入 eventstore 依赖（或扩展 turnStore 接口加 LatestSeq）
+  - DB 查询失败时字段设 null，不阻断端点
+- [ ] T4.3 make check + push + PR
+
+**依赖**：T4.2 的 db_last_seq 复用 PR1 的 LatestSeq → PR4 在 PR1 之后。
+
+---
+
+## 执行顺序
+PR1（治本，最高优先级）→ PR2（前端，独立）→ PR3（防御层，依赖 PR1 减少碰撞）→ PR4（清理，依赖 PR1 LatestSeq）
+
+每个 PR：切分支 `fix/issue-879-prN-xxx` → TDD → make check → push myfork → PR origin → review loop。

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -74,6 +74,8 @@ type ConfigWatcherProvider interface {
 
 type TurnStatsProvider interface {
 	TurnStats(ctx context.Context, sessionID string) (*eventstore.TurnStats, error)
+	// LatestSeq returns the max persisted event seq for a session (issue #879 #5).
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 }
 
 type DebugSessionSnapshot struct {

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -375,15 +375,31 @@ func (a *AdminAPI) HandleDebugSession(w http.ResponseWriter, r *http.Request) {
 	// design: this is an admin-only debug endpoint gated by ScopeAdminRead above, and these
 	// fields are required for session troubleshooting. Do not JSON-whitelist them without an
 	// admin-visible alternative; track field-level redaction as a separate concern if ever needed.
+	//
+	// Augment the in-memory snapshot with DB-backed counts (issue #879 #5).
+	// snap.TurnCount (managedSession.TurnCount) and last_seq_sent (SeqGen) are
+	// volatile: both reset to 0 on resume/restart, so the endpoint would
+	// otherwise report a freshly-resumed session as "0 turns" while the turns
+	// and events tables still hold the durable history.
+	debug := map[string]any{
+		"available":     dbgOK,
+		"has_worker":    snap.HasWorker,
+		"turn_count":    snap.TurnCount,
+		"last_seq_sent": a.hub.NextSeqPeek(id),
+		"worker_health": snap.WorkerHealth,
+		"runtime_only":  true, // turn_count/last_seq_sent are ephemeral; see db_* below.
+	}
+	if a.turnStore != nil {
+		if stats, err := a.turnStore.TurnStats(r.Context(), id); err == nil && stats != nil {
+			debug["db_turn_count"] = stats.TotalTurns
+		}
+		if seq, err := a.turnStore.LatestSeq(r.Context(), id); err == nil {
+			debug["db_last_seq"] = seq
+		}
+	}
 	respondJSON(w, map[string]any{
 		"session": si,
-		"debug": map[string]any{
-			"available":     dbgOK,
-			"has_worker":    snap.HasWorker,
-			"turn_count":    snap.TurnCount,
-			"last_seq_sent": a.hub.NextSeqPeek(id),
-			"worker_health": snap.WorkerHealth,
-		},
+		"debug":   debug,
 	})
 }
 

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -208,11 +208,25 @@ func (c *Collector) flushBoth(sessionID string) {
 	delete(c.reasoningAccum, sessionID)
 	c.accumMu.Unlock()
 
-	if dAcc != nil && dAcc.count > 0 {
-		c.send(dAcc.toRequest(sessionID))
-	}
-	if rAcc != nil && rAcc.count > 0 {
+	// Send in firstSeq order so insertion order (id) matches the logical seq
+	// order. Without this, a message delta flushed ahead of the reasoning that
+	// produced it gets a smaller id, making ORDER BY id DESC disagree with
+	// ORDER BY seq DESC and mis-ordering concurrently-flushed deltas in
+	// query_latest (issue #879). reasoning typically precedes its message, but
+	// compare firstSeq so workers that emit message deltas first stay correct.
+	switch {
+	case dAcc != nil && dAcc.count > 0 && rAcc != nil && rAcc.count > 0:
+		if rAcc.firstSeq <= dAcc.firstSeq {
+			c.send(rAcc.toRequest(sessionID))
+			c.send(dAcc.toRequest(sessionID))
+		} else {
+			c.send(dAcc.toRequest(sessionID))
+			c.send(rAcc.toRequest(sessionID))
+		}
+	case rAcc != nil && rAcc.count > 0:
 		c.send(rAcc.toRequest(sessionID))
+	case dAcc != nil && dAcc.count > 0:
+		c.send(dAcc.toRequest(sessionID))
 	}
 }
 

--- a/internal/eventstore/pg_store.go
+++ b/internal/eventstore/pg_store.go
@@ -231,6 +231,19 @@ func (s *pgStore) LatestTurnNum(ctx context.Context, sessionID string, generatio
 	return tn, nil
 }
 
+// LatestSeq returns the maximum event seq for a session, or 0 if no events
+// exist. Used to hydrate the in-memory SeqGen on reconnect (issue #879).
+func (s *pgStore) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	var seq int64
+	err := s.db.QueryRowContext(ctx, s.sql["latest_seq"], sessionID).Scan(&seq)
+	if err != nil {
+		return 0, fmt.Errorf("eventstore: latest seq: %w", err)
+	}
+	return seq, nil
+}
+
 func (s *pgStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()

--- a/internal/eventstore/sql/queries/events.latest_seq.sql
+++ b/internal/eventstore/sql/queries/events.latest_seq.sql
@@ -1,0 +1,5 @@
+-- Latest event seq for a session, or 0 if none. Used to hydrate the in-memory
+-- SeqGen on reconnect so seq continues monotonically instead of restarting
+-- from 1 (issue #879: seq reset → collision + new events buried by
+-- ORDER BY seq DESC queries).
+SELECT COALESCE(MAX(seq), 0) FROM events WHERE session_id = ?

--- a/internal/eventstore/sql/queries/events.query_latest.sql
+++ b/internal/eventstore/sql/queries/events.query_latest.sql
@@ -1,5 +1,11 @@
+-- Latest N events by insertion id (DESC, reversed to ASC in Go).
+-- Uses id (monotonic auto-increment) rather than seq so the newest events are
+-- always returned even when seq was reset by a pre-issue-#879 WS reconnect —
+-- seq DESC would bury low-seq new events under the LIMIT. Mirrors
+-- turns.query_latest's ORDER BY t.id DESC. Correct because flushBoth now sends
+-- deltas in firstSeq order, so insertion order (id) matches logical seq order.
 SELECT session_id, seq, type, data, direction, source, created_at
 FROM events
 WHERE session_id = ?
-ORDER BY seq DESC
+ORDER BY id DESC
 LIMIT ?

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -460,6 +460,20 @@ func (s *SQLiteStore) LatestTurnNum(ctx context.Context, sessionID string, gener
 	return tn, nil
 }
 
+// LatestSeq returns the maximum event seq for a session, or 0 if no events
+// exist. Used to hydrate the in-memory SeqGen on reconnect so seq continues
+// monotonically instead of restarting from 1 (issue #879).
+func (s *SQLiteStore) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	var seq int64
+	err := s.db.QueryRowContext(ctx, queries["latest_seq"], sessionID).Scan(&seq)
+	if err != nil {
+		return 0, fmt.Errorf("eventstore: latest seq: %w", err)
+	}
+	return seq, nil
+}
+
 // DeleteExpiredTurns removes turns older than the cutoff by created_at.
 func (s *SQLiteStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error) {
 	ctx, cancel := withDefaultTimeout(ctx)

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -212,6 +212,10 @@ type TurnQuerier interface {
 	LatestGeneration(ctx context.Context, sessionID string) (int64, error)
 	LatestTurnNum(ctx context.Context, sessionID string, generation int64) (int, error)
 	DeleteExpiredTurns(ctx context.Context, cutoff time.Time) (int64, error)
+	// LatestSeq returns the maximum event seq persisted for a session, or 0 if
+	// none. Used to hydrate the in-memory SeqGen on resume/reconnect so new
+	// events do not collide with the prior seq range (issue #879).
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 }
 
 // SQLiteStore implements EventStore using a shared SQLite database connection.

--- a/internal/eventstore/store_test.go
+++ b/internal/eventstore/store_test.go
@@ -111,6 +111,44 @@ func TestSQLiteStore_DeleteBySession(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestSQLiteStore_LatestSeq(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty session → 0.
+	seq, err := store.LatestSeq(ctx, "empty")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), seq)
+
+	// Append events with seq 1,2,3 → MAX=3.
+	for i := int64(1); i <= 3; i++ {
+		require.NoError(t, store.Append(ctx, &StoredEvent{
+			SessionID: "sess1", Seq: i, Type: "message",
+			Data: json.RawMessage(`{}`), Direction: "outbound",
+			Source: SourceNormal, CreatedAt: time.Now().UnixMilli(),
+		}))
+	}
+	seq, err = store.LatestSeq(ctx, "sess1")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), seq)
+
+	// Different session is isolated; high seq does not leak across sessions.
+	require.NoError(t, store.Append(ctx, &StoredEvent{
+		SessionID: "sess2", Seq: 99, Type: "message",
+		Data: json.RawMessage(`{}`), Direction: "outbound",
+		Source: SourceNormal, CreatedAt: time.Now().UnixMilli(),
+	}))
+	seq, err = store.LatestSeq(ctx, "sess2")
+	require.NoError(t, err)
+	require.Equal(t, int64(99), seq)
+
+	// sess1 still 3 (unaffected by sess2).
+	seq, err = store.LatestSeq(ctx, "sess1")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), seq)
+}
+
 func TestSQLiteStore_DeleteExpired(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -196,6 +196,11 @@ func (m *mockTurnsStore) DeleteExpiredTurns(ctx context.Context, cutoff time.Tim
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *mockTurnsStore) LatestSeq(ctx context.Context, sessionID string) (int64, error) {
+	args := m.Called(ctx, sessionID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ─── Test helpers ───────────────────────────────────────────────────────────────
 
 func newTestAuth(t *testing.T) *security.Authenticator {

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -488,6 +488,13 @@ func (c *Conn) resolveSession(env *events.Envelope, initData InitData, sm connSM
 
 	c.hub.LeaveSession("", c)
 	c.hub.JoinSession(sessionID, c)
+	// Hydrate SeqGen from persisted events so the upcoming init_ack and worker
+	// events continue monotonically instead of restarting from 1 (issue #879:
+	// WS disconnect deleted the counter → reconnect collided with persisted seq
+	// segments and buried new events under ORDER BY seq DESC). Runs after
+	// JoinSession and before resolveSessionState starts the worker (which assigns
+	// seqs in a goroutine) and before finalizeInit's init_ack NextSeq.
+	c.hub.EnsureSeqHydrated(sessionID)
 
 	return c.resolveSessionState(sessionID, initData, workDir, sm, preResolved, env.SessionID)
 }

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -109,6 +109,9 @@ type Hub struct {
 
 	// Sequence generation per session
 	seqGen *SeqGen
+	// seqHydrator reads persisted event seqs to seed SeqGen on reconnect
+	// (issue #879). nil when eventstore is disabled — SeqGen then restarts at 1.
+	seqHydrator SeqHydrator
 
 	// Shutdown signals.
 	ctx    context.Context
@@ -632,6 +635,38 @@ func (h *Hub) NextSeq(sessionID string) int64 {
 // NextSeqPeek returns the current sequence number for a session without incrementing.
 func (h *Hub) NextSeqPeek(sessionID string) int64 {
 	return h.seqGen.Peek(sessionID)
+}
+
+// SetSeqHydrator injects the persisted-seq reader used to hydrate SeqGen on
+// reconnect (issue #879). Optional; when nil (eventstore disabled), SeqGen
+// restarts from 1 as before. Called once during gateway startup after the
+// eventstore is constructed.
+func (h *Hub) SetSeqHydrator(sh SeqHydrator) {
+	h.seqHydrator = sh
+}
+
+// EnsureSeqHydrated seeds the SeqGen counter for sessionID from persisted
+// events so the next NextSeq continues monotonically instead of restarting
+// from 1 (issue #879: WS disconnect deleted the counter → reconnect collided
+// with persisted seq segments and buried new events under ORDER BY seq DESC).
+// Best-effort: a DB error is logged and does not block the handshake (SeqGen
+// simply starts from 1). MUST be called after JoinSession and before the first
+// NextSeq (e.g. before starting the worker or sending init_ack).
+func (h *Hub) EnsureSeqHydrated(sessionID string) {
+	if h.seqHydrator == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(h.ctx, 3*time.Second)
+	defer cancel()
+	latest, err := h.seqHydrator.LatestSeq(ctx, sessionID)
+	if err != nil {
+		h.log.Warn("gateway: hydrate seq from db failed; starting from 1",
+			"session_id", sessionID, "err", err)
+		return
+	}
+	if latest > 0 {
+		h.seqGen.Init(sessionID, latest)
+	}
 }
 
 // ConnectionsOpen returns the number of currently open WebSocket connections.

--- a/internal/gateway/seq.go
+++ b/internal/gateway/seq.go
@@ -1,9 +1,17 @@
 package gateway
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 )
+
+// SeqHydrator reads the latest persisted event seq for a session, so the Hub
+// can seed the in-memory SeqGen on reconnect (issue #879). Both
+// *eventstore.SQLiteStore and *eventstore.pgStore satisfy it.
+type SeqHydrator interface {
+	LatestSeq(ctx context.Context, sessionID string) (int64, error)
+}
 
 // SeqGen generates monotonically increasing sequence numbers per session.
 // Uses sync.Map + per-session atomic.Int64 to eliminate cross-session contention.
@@ -34,4 +42,24 @@ func (g *SeqGen) Next(sessionID string) int64 {
 // Remove deletes the sequence counter for a session.
 func (g *SeqGen) Remove(sessionID string) {
 	g.seq.Delete(sessionID)
+}
+
+// Init seeds the sequence counter for a session to start, but only if start is
+// greater than the current value. This lets the gateway hydrate the counter
+// from persisted events on reconnect so seq continues monotonically instead of
+// restarting from 1 (issue #879: WS disconnect deleted the counter, reconnect
+// collided with persisted seq segments). CAS-based — safe against concurrent
+// Next/Init; never regresses an already-higher counter.
+func (g *SeqGen) Init(sessionID string, start int64) {
+	val, _ := g.seq.LoadOrStore(sessionID, new(atomic.Int64))
+	cur := val.(*atomic.Int64) //nolint:errcheck // LoadOrStore guarantees *atomic.Int64
+	for {
+		old := cur.Load()
+		if start <= old {
+			return
+		}
+		if cur.CompareAndSwap(old, start) {
+			return
+		}
+	}
 }

--- a/internal/gateway/seq_test.go
+++ b/internal/gateway/seq_test.go
@@ -1,0 +1,117 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeqGen_Init_ContinuesFromStart(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	g.Init("s1", 100)
+	require.Equal(t, int64(101), g.Next("s1"))
+	require.Equal(t, int64(102), g.Next("s1"))
+}
+
+func TestSeqGen_Init_DoesNotRegress(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	g.Init("s1", 100)
+	// A later Init with a smaller value (e.g. a concurrent hydrate racing with
+	// an in-flight Next) must NOT lower the floor.
+	g.Init("s1", 50)
+	require.Equal(t, int64(101), g.Next("s1"))
+}
+
+func TestSeqGen_Init_EmptySession(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// A fresh session with no persisted events hydrates from 0 → Next starts at 1.
+	g.Init("fresh", 0)
+	require.Equal(t, int64(1), g.Next("fresh"))
+}
+
+func TestSeqGen_Init_BeforeNextIsEquivalent(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// Init on a session that has never called Next must seed the counter.
+	g.Init("s1", 9899)
+	require.Equal(t, int64(9900), g.Next("s1"))
+	require.Equal(t, int64(9900), g.Peek("s1"))
+}
+
+func TestSeqGen_Init_ConcurrentWithNext(t *testing.T) {
+	t.Parallel()
+	g := NewSeqGen()
+	// Simulate an in-flight counter (e.g. an init_ack already took seq=1).
+	require.Equal(t, int64(1), g.Next("s1"))
+
+	var wg sync.WaitGroup
+	// Concurrent Init raising the floor to 1000.
+	for range 50 {
+		wg.Go(func() { g.Init("s1", 1000) })
+	}
+	// Concurrent Next callers.
+	for range 50 {
+		wg.Go(func() { _ = g.Next("s1") })
+	}
+	wg.Wait()
+	// After all Init(1000) settle, the next seq must be strictly above 1000
+	// (Init raised the floor; Nexts only go up from there).
+	require.Greater(t, g.Next("s1"), int64(1000))
+}
+
+// mockSeqHydrator implements SeqHydrator for Hub.EnsureSeqHydrated tests.
+type mockSeqHydrator struct {
+	seq   int64
+	err   error
+	calls int
+}
+
+func (m *mockSeqHydrator) LatestSeq(_ context.Context, _ string) (int64, error) {
+	m.calls++
+	return m.seq, m.err
+}
+
+func TestHub_EnsureSeqHydrated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil hydrator is no-op", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		// No SetSeqHydrator → nil; Next starts at 1 (pre-issue-#879 behavior).
+		h.EnsureSeqHydrated("s1")
+		require.Equal(t, int64(1), h.NextSeq("s1"))
+	})
+
+	t.Run("seeds counter from persisted seq", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{seq: 9899})
+		h.EnsureSeqHydrated("s1")
+		// Reconnect after a session that persisted 9899 events → next seq is 9900,
+		// not 1 (regression: seq collision + buried new events, issue #879).
+		require.Equal(t, int64(9900), h.NextSeq("s1"))
+	})
+
+	t.Run("zero persisted seq starts at 1", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{seq: 0})
+		h.EnsureSeqHydrated("fresh")
+		require.Equal(t, int64(1), h.NextSeq("fresh"))
+	})
+
+	t.Run("db error falls back to 1", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHub(t)
+		h.SetSeqHydrator(&mockSeqHydrator{err: errors.New("db down")})
+		// Best-effort: hydrate failure must not block the handshake.
+		h.EnsureSeqHydrated("s1")
+		require.Equal(t, int64(1), h.NextSeq("s1"))
+	})
+}

--- a/internal/session/cleanup_outbox.go
+++ b/internal/session/cleanup_outbox.go
@@ -137,6 +137,15 @@ func newCleanupTask(info *SessionInfo, now time.Time) *CleanupTask {
 	return &CleanupTask{ID: uuid.NewString(), SessionID: info.ID, WorkerType: info.WorkerType, WorkerSessionID: info.WorkerSessionID, NextAttemptAt: now, CreatedAt: now, UpdatedAt: now}
 }
 
+// upsertSessionArgs passes time.Time values to the driver unformatted. The
+// modernc/sqlite driver already serializes them to RFC3339Nano (verified in the
+// running DB, e.g. "2026-07-14T22:42:20.215036468+08:00") and binds both the
+// stored column and the get_expired_* comparison params in that same format,
+// keeping the lexicographic TEXT comparison correct. Manually UTC-formatting
+// only the write side (a prior attempt at issue #879 #4) broke that invariant:
+// GC expiry queries silently returned no rows. #879 #4's premise (driver uses
+// time.Time.String()) does not hold on modernc v1.51.0 — the format is already
+// canonical, so no write-side reformatting is applied here.
 func upsertSessionArgs(info *SessionInfo, ctxJSON, pkJSON []byte) []any {
 	return []any{info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
 		info.Platform, string(pkJSON), info.WorkDir, info.Title, info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,


### PR DESCRIPTION
## Summary

PR **4/4** of #879. Depends on **#882 (PR 1/4)** — `LatestSeq` is introduced there and promoted into `TurnQuerier` here.

### #5 — debug 端点补 DB 字段（核心交付）
`HandleDebugSession` 把易失内存状态当权威值上报：`turn_count`（resume 后归 0）与 `last_seq_sent`（SeqGen，重启后归 0）。一个刚 resume 的 session 会显示 "0 turns"，而 turns/events 表仍持有完整持久化历史。

增强：
- `db_turn_count` — turnStore 查 turns 表
- `db_last_seq` — `LatestSeq`（promote 进 `TurnQuerier`，复用 PR1 实现，DRY 掉独立接口声明）
- `runtime_only: true` — 标注 turn_count/last_seq_sent 是 ephemeral

DB 查询失败时省略字段，不阻断端点。

### #4 — updated_at 格式（调查后撤销）
实证发现 #879 #4 的前提不成立：modernc/sqlite **v1.51.0 已用 RFC3339Nano** 序列化 `time.Time`（运行实例验证 `2026-07-14T22:42:20.215036468+08:00`），并非 issue 诊断的 `time.Time.String()` Go 格式。

初版手动 UTC 格式化写入侧会破坏 `get_expired_max_lifetime`/`get_expired_idle` 依赖的字典序 TEXT 比较（driver 绑定的比较参数仍是本地 offset 格式），导致 GC 过期查询静默返回空行（两个 session 测试 FAIL）。已回退为 driver 原生绑定并留根因注释。

## Verification
- `make check` 全绿（build + test + lint + docs + webchat）
- `TestSQLiteStore_GetExpiredMaxLifetime` / `GetExpiredIdle` / `RetentionCleanupTombstone*` PASS

## Merge order
#882 (PR1) → #883 / #884（独立，#884 依赖 #882 减少碰撞）→ **本 PR**（依赖 #882 的 `LatestSeq`）

Refs #879