### PR TITLE
fix: cross-platform turn integrity, GetHistory refresh bug, and trace_id logger (closes #889)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -444,7 +444,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	if stores.sqlDB != nil {
 		rows, err := stores.sqlDB.QueryContext(ctx, "SELECT api_key FROM api_key_users")
 		if err != nil {
-			log.Warn("gateway: preload DB API keys failed", "error", err)
+			log.Warn("gateway: preload DB API keys failed", "err", err)
 		} else {
 			defer func() { _ = rows.Close() }()
 			for rows.Next() {
@@ -454,7 +454,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 				}
 			}
 			if err := rows.Err(); err != nil {
-				log.Warn("gateway: preload DB API keys incomplete", "error", err)
+				log.Warn("gateway: preload DB API keys incomplete", "err", err)
 			}
 		}
 	}
@@ -616,7 +616,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		cronDelivery = cron.NewDelivery(log,
 			func(ctx context.Context, sessionID string) (string, error) {
 				if err := stores.collector.Flush(); err != nil {
-					log.Warn("cron: flush before query", "error", err)
+					log.Warn("cron: flush before query", "err", err)
 				}
 				turns, err := stores.event.QueryTurns(ctx, sessionID, 1, 0)
 				if err != nil || len(turns) == 0 {
@@ -685,11 +685,11 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	if cookieAuth != nil {
 		oauthManager = security.NewOAuthManager(cookieAuth)
 		if err := cfg.OAuth.Validate(); err != nil {
-			log.Warn("oauth config validation failed", "error", err)
+			log.Warn("oauth config validation failed", "err", err)
 		} else if len(cfg.OAuth.Providers) > 0 {
 			count, err := oauthManager.Reload(ctx, cfg.OAuth)
 			if err != nil {
-				log.Error("oauth manager init failed", "error", err)
+				log.Error("oauth manager init failed", "err", err)
 			}
 			log.Info("gateway: oauth SSO providers loaded", "count", count)
 		}
@@ -698,12 +698,12 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 				return
 			}
 			if err := next.OAuth.Validate(); err != nil {
-				log.Warn("oauth config reload skipped: validation failed", "error", err)
+				log.Warn("oauth config reload skipped: validation failed", "err", err)
 				return
 			}
 			count, err := oauthManager.Reload(ctx, next.OAuth)
 			if err != nil {
-				log.Error("oauth config reload completed with provider errors", "count", count, "error", err)
+				log.Error("oauth config reload completed with provider errors", "count", count, "err", err)
 				return
 			}
 			log.Info("oauth config reloaded", "count", count)
@@ -746,7 +746,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 
 	// Brain: lightweight LLM layer for TTS summarization (fail-open).
 	if err := brain.Init(log); err != nil {
-		log.Warn("Brain initialization failed (fail-open)", "error", err)
+		log.Warn("Brain initialization failed (fail-open)", "err", err)
 	}
 
 	// Effective events/turns retention: when audit is enabled, extend the TTL
@@ -1298,7 +1298,7 @@ func shutdownGateway(
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer func() {
 		if err := observability.Shutdown(shutdownCtx); err != nil {
-			log.Warn("observability: shutdown", "error", err)
+			log.Warn("observability: shutdown", "err", err)
 		}
 		shutdownCancel()
 	}()

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -915,10 +915,18 @@ func initLogging(cfg *config.Config) (*slog.Logger, *config.ConfigStore, *slog.L
 	}
 
 	opts := &slog.HandlerOptions{
-		Level: levelVar,
+		Level:     levelVar,
+		AddSource: true,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if len(groups) == 0 && a.Key == slog.TimeKey {
 				return slog.String(slog.TimeKey, a.Value.Time().Format("2006-01-02T15:04:05.0000"))
+			}
+			// Compact source attribution to "file.go:42 function" so Warn/Error
+			// records are locatable without bloating every log line with full paths.
+			if len(groups) == 0 && a.Key == slog.SourceKey {
+				if s, ok := a.Value.Any().(*slog.Source); ok && s != nil {
+					return slog.String(slog.SourceKey, fmt.Sprintf("%s:%d %s", filepath.Base(s.File), s.Line, s.Function))
+				}
 			}
 			return a
 		},

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -255,7 +255,7 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 			phrasesDir := filepath.Join(homeDir, ".hotplex", "phrases")
 			phr, phrasesErr := phrases.Load(phrasesDir, string(entry.Platform), entry.Name)
 			if phrasesErr != nil {
-				log.Warn("phrases: load failed, using defaults", "error", phrasesErr)
+				log.Warn("phrases: load failed, using defaults", "err", phrasesErr)
 				phr = phrases.Defaults()
 			}
 			if setter, ok := adapter.(interface{ SetPhrases(*phrases.Phrases) }); ok {

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -246,7 +246,7 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 		defer func() {
 			if rv := recover(); rv != nil {
 				a.log.Error("admin: panic recovered",
-					"error", rv,
+					"err", rv,
 					"path", r.URL.Path,
 					"method", r.Method,
 					"stack", string(debug.Stack()),

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -335,7 +335,7 @@ func (a *AdminAPI) HandleAPIKeyUserList(w http.ResponseWriter, r *http.Request) 
 	}
 	users, err := a.akStore.list(r.Context())
 	if err != nil {
-		a.log.Error("admin: list api key users", "error", err)
+		a.log.Error("admin: list api key users", "err", err)
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "internal error")
 		return
 	}
@@ -389,7 +389,7 @@ func (a *AdminAPI) HandleAPIKeyUserCreate(w http.ResponseWriter, r *http.Request
 	}
 	canonicalUserID, err := a.canonicalizeAPIKeyUserID(r.Context(), u.UserID)
 	if err != nil {
-		a.log.Error("admin: canonicalize api key user_id", "error", err)
+		a.log.Error("admin: canonicalize api key user_id", "err", err)
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "internal error")
 		return
 	}
@@ -509,7 +509,7 @@ func (a *AdminAPI) HandleAPIKeyUserUpdate(w http.ResponseWriter, r *http.Request
 	}
 	canonicalUserID, err := a.canonicalizeAPIKeyUserID(r.Context(), u.UserID)
 	if err != nil {
-		a.log.Error("admin: canonicalize api key user_id", "error", err)
+		a.log.Error("admin: canonicalize api key user_id", "err", err)
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "internal error")
 		return
 	}

--- a/internal/admin/bot_config_handlers.go
+++ b/internal/admin/bot_config_handlers.go
@@ -260,7 +260,7 @@ func (a *AdminAPI) HandleDeleteBot(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := a.botConfig.DeleteBot(r.Context(), name); err != nil {
 		if errors.Is(err, ErrBotRunning) {
-			a.log.Error("admin: delete bot conflict", "bot", name, "error", err)
+			a.log.Error("admin: delete bot conflict", "bot", name, "err", err)
 			web.WriteAppError(w, http.StatusConflict, "CONFLICT", "bot is currently running")
 		} else {
 			respondStoreError(w, a.log, "admin: delete bot", err)

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -329,7 +329,7 @@ func (a *AdminAPI) HandleConfigRollback(w http.ResponseWriter, r *http.Request) 
 
 	_, idx, err := a.configWatcher.Rollback(body.Version)
 	if err != nil {
-		a.log.Error("admin: config rollback failed", "error", err)
+		a.log.Error("admin: config rollback failed", "err", err)
 		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "rollback failed")
 		return
 	}
@@ -435,6 +435,6 @@ func respondStoreError(w http.ResponseWriter, log *slog.Logger, op string, err e
 		web.WriteAppError(w, http.StatusNotFound, "NOT_FOUND", "not found")
 		return
 	}
-	log.Error(op, "error", err)
+	log.Error(op, "err", err)
 	web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "internal error")
 }

--- a/internal/brain/init.go
+++ b/internal/brain/init.go
@@ -16,7 +16,7 @@ func Init(logger *slog.Logger) error {
 	config, validationErrs := LoadConfigFromEnv()
 
 	for _, err := range validationErrs {
-		logger.Warn("Brain config validation warning", "error", err)
+		logger.Warn("Brain config validation warning", "err", err)
 	}
 
 	if !config.Enabled {
@@ -255,7 +255,7 @@ func (w *enhancedBrainWrapper) selectModel(ctx context.Context, model string, sc
 	if err == nil {
 		model = selectedModel.Name
 	} else if w.logger != nil {
-		w.logger.Warn("Model selection failed, using default", "error", err)
+		w.logger.Warn("Model selection failed, using default", "err", err)
 		model = w.config.Model.Model
 	}
 

--- a/internal/brain/llm/anthropic.go
+++ b/internal/brain/llm/anthropic.go
@@ -156,7 +156,7 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, prompt string) (<-chan
 		}
 
 		if err := stream.Err(); err != nil {
-			c.logger.Error("Anthropic stream error", "error", err)
+			c.logger.Error("Anthropic stream error", "err", err)
 		}
 	}()
 

--- a/internal/brain/llm/stream.go
+++ b/internal/brain/llm/stream.go
@@ -42,7 +42,7 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, prompt string) (<-chan st
 				return
 			}
 			if err != nil {
-				c.logger.Error("stream receive error", "error", err)
+				c.logger.Error("stream receive error", "err", err)
 				return
 			}
 

--- a/internal/config/config_env.go
+++ b/internal/config/config_env.go
@@ -150,7 +150,7 @@ func applyMessagingEnv(cfg *Config) {
 					"env", m.env,
 					"field", m.field,
 					"target", "config.Messaging",
-					"error", err,
+					"err", err,
 				)
 			}
 		}
@@ -200,7 +200,7 @@ func applyPlatformEnv(target any, strs, bools, slices []envMapping) {
 					"env", m.env,
 					"field", m.field,
 					"target", fmt.Sprintf("%T", target),
-					"error", err,
+					"err", err,
 				)
 			}
 		}
@@ -212,7 +212,7 @@ func applyPlatformEnv(target any, strs, bools, slices []envMapping) {
 					"env", m.env,
 					"field", m.field,
 					"target", fmt.Sprintf("%T", target),
-					"error", err,
+					"err", err,
 				)
 			}
 		}
@@ -224,7 +224,7 @@ func applyPlatformEnv(target any, strs, bools, slices []envMapping) {
 					"env", m.env,
 					"field", m.field,
 					"target", fmt.Sprintf("%T", target),
-					"error", err,
+					"err", err,
 				)
 			}
 		}

--- a/internal/eventstore/query_shared.go
+++ b/internal/eventstore/query_shared.go
@@ -145,7 +145,7 @@ func collectTurnStats(
 		var toolsJSON sql.NullString
 		var toolCount sql.NullInt64
 		if err := rows.Scan(turnStatScanDest(&gen, &ts, scanner.ScanPointer(), &toolsJSON, &toolCount)...); err != nil {
-			log.Warn("eventstore: scan turn stats row", "session_id", sessionID, "error", err)
+			log.Warn("eventstore: scan turn stats row", "session_id", sessionID, "err", err)
 			continue
 		}
 		if stats.Generation == 0 {

--- a/internal/execution/lease.go
+++ b/internal/execution/lease.go
@@ -90,7 +90,7 @@ func (m *LeaseManager) renewLoop(ctx context.Context) {
 			renewed, err := m.store.RenewLeases(ctx, m.ownerID, int64(LeaseTTL), excluded)
 			if err != nil {
 				observability.LeaseRenewFailure().Add(ctx, 1)
-				m.log.Warn("lease renew failed", "error", err)
+				m.log.Warn("lease renew failed", "err", err)
 				continue
 			}
 			if renewed > 0 {
@@ -129,7 +129,7 @@ func (m *LeaseManager) recoverOnce(ctx context.Context) {
 	}
 	result, err := m.store.RecoverExpiredLeases(ctx, tracked)
 	if err != nil {
-		m.log.Warn("expired lease recovery failed", "error", err)
+		m.log.Warn("expired lease recovery failed", "err", err)
 		return
 	}
 	if m.exclusions != nil && len(result.ConvergedExecutionIDs) > 0 {
@@ -151,7 +151,7 @@ func (m *LeaseManager) Shutdown(ctx context.Context) error {
 
 	terminated, err := m.store.TerminateOwnerLeases(ctx, m.ownerID, "GATEWAY_SHUTDOWN")
 	if err != nil {
-		m.log.Error("failed to terminate owner leases on shutdown", "error", err)
+		m.log.Error("failed to terminate owner leases on shutdown", "err", err)
 	} else if terminated > 0 {
 		m.log.Info("terminated active leases on shutdown", "terminated", terminated)
 	}

--- a/internal/execution/repairer.go
+++ b/internal/execution/repairer.go
@@ -243,7 +243,7 @@ func (r *Repairer) tryProcess(ctx context.Context, intent *RepairIntent) {
 	}
 
 	r.log.Debug("repair attempt failed",
-		"execution_id", intent.ExecutionID, "attempt", intent.attempts, "error", err)
+		"execution_id", intent.ExecutionID, "attempt", intent.attempts, "err", err)
 
 	backoff := r.cfg.InitialBackoff << uint(intent.attempts)
 	if backoff > r.cfg.MaxBackoff {

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -601,7 +601,9 @@ func (g *GatewayAPI) GetHistory(w http.ResponseWriter, r *http.Request) {
 
 	hasMore := len(records) > limit
 	if hasMore {
-		records = records[:limit]
+		// Store returns ASC (newest at the end). Slicing from the END keeps
+		// the latest exchange; `records[:limit]` would drop it (refresh bug).
+		records = records[len(records)-limit:]
 	}
 
 	respondJSON(w, map[string]any{"records": records, "has_more": hasMore})

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -318,7 +318,7 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 			if err := worker.ValidateType(pref); err == nil {
 				wt = pref
 			} else {
-				g.log.Warn("workspace worker_preference invalid, falling back to default",
+				g.log.Info("workspace worker_preference invalid, falling back to default",
 					"workspace_id", ws.ID, "worker_preference", pref, "err", err)
 			}
 		}

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -774,10 +774,14 @@ func TestGetHistory_HasMore(t *testing.T) {
 	api := newTestAPIWithTurns(t, sm, bridge, ts)
 
 	sm.On("Get", "sess-1").Return(&session.SessionInfo{ID: "sess-1", UserID: "anonymous"}, nil)
+	// Store returns ASC (oldest first, newest last). With limit=2 and 3 records,
+	// the API must keep the NEWEST 2 (Seq 2, 3) and report has_more=true.
+	// Regression guard: previously the code sliced `records[:limit]`, which
+	// returned the OLDEST 2 (Seq 1, 2) and dropped the latest exchange on refresh.
 	records := []*eventstore.TurnRecord{
-		{Seq: 1},
-		{Seq: 2},
-		{Seq: 3},
+		{ID: 1, Seq: 1, Content: "oldest"},
+		{ID: 2, Seq: 2, Content: "middle"},
+		{ID: 3, Seq: 3, Content: "newest"},
 	}
 	ts.On("QueryLatestTurns", mock.Anything, "sess-1", 3).Return(records, nil)
 
@@ -794,6 +798,9 @@ func TestGetHistory_HasMore(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Records, 2)
 	require.True(t, resp.HasMore)
+	require.Equal(t, int64(2), resp.Records[0].ID, "must keep middle record, not oldest")
+	require.Equal(t, int64(3), resp.Records[1].ID, "must keep newest record, not drop it")
+	require.Equal(t, "newest", resp.Records[1].Content)
 }
 
 func TestGetHistory_NoRecords(t *testing.T) {

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -738,7 +738,7 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	go func() {
 		defer b.fwdWg.Done()
 		defer b.clearWorkerRun(sessionID, w, workerRunID)
-		b.forwardEvents(w, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
+		b.launchForwarderLocked(w, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
 	}()
 
 	return nil
@@ -1034,7 +1034,7 @@ func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *sessio
 	if si.WorkerType == worker.TypeCodexCLI && b.turnsQuerier != nil {
 		turns, err := b.turnsQuerier.QueryTurns(b.shutdownCtx, sessionID, 50, 0)
 		if err != nil {
-			b.log.Warn("bridge: query turns for history recovery failed", "session_id", sessionID, "error", err)
+			b.log.Warn("bridge: query turns for history recovery failed", "session_id", sessionID, "err", err)
 		} else if len(turns) > 0 {
 			compressor := NewHistoryCompressor(b.log, b.hub)
 			latestCreatedAt := turns[len(turns)-1].CreatedAt

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -66,7 +66,11 @@ func (b *Bridge) bgCtx() context.Context {
 }
 
 func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwardOpts) {
-	ctx, span := observability.Tracer().Start(opts.ctx, "bridge.forward_events")
+	parent := opts.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, span := observability.Tracer().Start(parent, "bridge.forward_events")
 	defer span.End()
 	flog := b.log.With("trace_id", observability.TraceID(ctx))
 	defer func() {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -50,6 +50,18 @@ type forwardContext struct {
 	pendingError   *events.Envelope
 	turnTimerFired atomic.Bool
 	turnTimer      *time.Timer
+	// flog carries trace_id from the forwardEvents OTel span. Helpers must
+	// use fc.flog (not b.log) to keep log lines correlatable with the span.
+	// Nil-safe via bridge.flogOf; tests build forwardContext without it.
+	flog *slog.Logger
+}
+
+// flogOf returns fc.flog or b.log when fc is nil or fc.flog is unset.
+func (b *Bridge) flogOf(fc *forwardContext) *slog.Logger {
+	if fc != nil && fc.flog != nil {
+		return fc.flog
+	}
+	return b.log
 }
 
 // forwardEvents proxies worker events to the hub with seq assignment.
@@ -99,6 +111,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		startTime:     time.Now(),
 		turnStartTime: time.Now(),
 		firstEvent:    true,
+		flog:          flog,
 	}
 
 	if b.collector != nil && b.sm != nil {
@@ -188,7 +201,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
 			flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
 		}
-		b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data)
+		b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, flog)
 		fc.pendingError = nil
 	}
 
@@ -204,6 +217,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		sessPlatform:   fc.sessPlatform,
 		sessOwner:      fc.sessOwner,
 		resetGen:       myResetGen,
+		flog:           flog,
 	})
 }
 
@@ -232,7 +246,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 
 	// Buffer error events for potential LLM retry.
 	if env.Event.Type == events.Error {
-		b.log.Warn("bridge: received error from worker", "session_id", sessionID, "worker_type", workerType, "data", env.Event.Data)
+		b.flogOf(fc).Warn("bridge: received error from worker", "session_id", sessionID, "worker_type", workerType, "data", env.Event.Data)
 		if ed, ok := env.Event.Data.(events.ErrorData); ok {
 			fc.lastError = &ed
 		}
@@ -297,7 +311,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	}
 
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {
-		b.log.Warn("bridge: forward event failed", "err", err, "session_id", sessionID, "worker_type", workerType, "event_type", env.Event.Type)
+		b.flogOf(fc).Warn("bridge: forward event failed", "err", err, "session_id", sessionID, "worker_type", workerType, "event_type", env.Event.Type)
 	}
 
 	b.captureForwardedEvent(env, deltaContent, reasoningContent, fc)
@@ -382,7 +396,7 @@ func (b *Bridge) finishRuntimeOnDone(sessionID string, fc *forwardContext, env *
 	// Correlate with the emitting forwarder's immutable attach run. A stale
 	// forwarder must never finish the newest open execution for the session.
 	if err := b.executionStore.FinishRuntime(context.Background(), rec.ExecutionID, fc.workerRunID, rtStatus, ""); err != nil {
-		b.log.Debug("bridge: finish runtime on done", "err", err,
+		b.flogOf(fc).Debug("bridge: finish runtime on done", "err", err,
 			"session_id", sessionID, "execution_id", rec.ExecutionID, "status", rtStatus)
 		if errors.Is(err, execution.ErrRunMismatch) {
 			return
@@ -507,7 +521,7 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 			acc.TurnDurationMs = time.Now().UnixMilli() - startMs
 		} else {
 			acc.TurnDurationMs = time.Since(fc.turnStartTime).Milliseconds()
-			b.log.Debug("bridge: turn start stamp missing on done, using first-event fallback",
+			b.flogOf(fc).Debug("bridge: turn start stamp missing on done, using first-event fallback",
 				"session_id", sessionID, "worker_type", fc.workerType, "fallback_since", time.Since(fc.turnStartTime).Round(time.Millisecond))
 		}
 		acc.computePerTurnDeltas()
@@ -521,8 +535,8 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 		b.captureAssistantTurn(sessionID, env.Seq, acc, fc.turnText.String(),
 			fc.sessOwner, fc.sessPlatform, env.Timestamp)
 		acc.resetPerTurn()
-		if b.log.Enabled(context.Background(), slog.LevelDebug) {
-			b.log.Debug("bridge: turn completed",
+		if b.flogOf(fc).Enabled(context.Background(), slog.LevelDebug) {
+			b.flogOf(fc).Debug("bridge: turn completed",
 				"session_id", sessionID, "worker_type", fc.workerType, "turn", acc.TurnCount.Load(),
 				"duration", time.Since(fc.turnStartTime).Round(time.Millisecond),
 				"text_len", fc.turnText.Len(), "tools", acc.ToolCallCount.Load())
@@ -591,10 +605,10 @@ func (b *Bridge) emitDoneFallbackMessage(sessionID string, fc *forwardContext, t
 		if emptySuccess {
 			tag = "empty_success"
 		}
-		b.log.Warn("bridge: done fallback send failed", "session_id", sessionID, "kind", tag, "err", err)
+		b.flogOf(fc).Warn("bridge: done fallback send failed", "session_id", sessionID, "kind", tag, "err", err)
 	}
 	// Persist to the events table so WS event replay also surfaces the fallback.
-	b.captureEvent(sessionID, env.Seq, events.Message, env.Event.Data)
+	b.captureEvent(sessionID, env.Seq, events.Message, env.Event.Data, b.flogOf(fc))
 }
 
 // maybeTransitionIdleAfterDone transitions a messaging session to IDLE after
@@ -611,7 +625,7 @@ func (b *Bridge) maybeTransitionIdleAfterDone(sessionID string, fc *forwardConte
 		return
 	}
 	if err := b.sm.Transition(context.Background(), sessionID, events.StateIdle); err != nil {
-		b.log.Debug("bridge: post-done transition to idle rejected",
+		b.flogOf(fc).Debug("bridge: post-done transition to idle rejected",
 			"session_id", sessionID, "platform", fc.sessPlatform, "err", err)
 	}
 }
@@ -624,7 +638,7 @@ func (b *Bridge) captureForwardedEvent(env *events.Envelope, deltaContent, reaso
 	} else if reasoningContent != "" && b.collector != nil {
 		b.collector.CaptureReasoningString(sessionID, env.Seq, reasoningContent)
 	} else if env.Event.Type != events.MessageDelta && env.Event.Type != events.Reasoning {
-		b.captureEvent(sessionID, env.Seq, env.Event.Type, env.Event.Data)
+		b.captureEvent(sessionID, env.Seq, env.Event.Type, env.Event.Data, b.flogOf(fc))
 	}
 }
 
@@ -639,9 +653,9 @@ func (b *Bridge) flushPendingError(fc *forwardContext, skipOnDone bool) {
 		return
 	}
 	if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
-		b.log.Warn("bridge: forward buffered error failed", "err", err, "session_id", fc.sessionID, "worker_type", fc.workerType)
+		b.flogOf(fc).Warn("bridge: forward buffered error failed", "err", err, "session_id", fc.sessionID, "worker_type", fc.workerType)
 	}
-	b.captureEvent(fc.sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data)
+	b.captureEvent(fc.sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, b.flogOf(fc))
 	fc.pendingError = nil
 }
 
@@ -661,6 +675,9 @@ type workerExitParams struct {
 	// If the current generation differs, another reset replaced this goroutine's
 	// worker and we must NOT cleanupCrashedWorker (would detach the NEW worker).
 	resetGen int64
+	// flog carries trace_id from the originating forwardEvents span so exit-path
+	// logs stay correlatable with the run that produced them.
+	flog *slog.Logger
 }
 
 // handleWorkerExit processes worker exit after the recv channel closes.
@@ -668,13 +685,17 @@ type workerExitParams struct {
 // and performs cleanup.
 func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	workerType := p.workerType
+	lg := p.flog
+	if lg == nil {
+		lg = b.log
+	}
 
 	// P0 guard: if the worker was reset (generation changed), a NEW forwardEvents
 	// goroutine is already managing the replacement worker. This OLD goroutine must
 	// exit silently — cleanupCrashedWorker would detach the NEW worker and delete
 	// the accumulator, breaking the session.
 	if rg, ok := w.(worker.ResetGenerationer); ok && rg.LoadResetGeneration() != p.resetGen {
-		b.log.Info("bridge: worker exit from stale forwardEvents after reset, skipping cleanup",
+		lg.Info("bridge: worker exit from stale forwardEvents after reset, skipping cleanup",
 			"session_id", p.sessionID, "worker_type", workerType,
 			"forwarder_reset_gen", p.resetGen, "current_reset_gen", rg.LoadResetGeneration(),
 			"worker_run_id", p.opts.workerRunID)
@@ -699,7 +720,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		defer close(ch)
 		defer func() {
 			if r := recover(); r != nil {
-				b.log.Error("bridge: panic in waitWorker", "session_id", p.sessionID, "panic", r, "stack", string(debug.Stack()))
+				lg.Error("bridge: panic in waitWorker", "session_id", p.sessionID, "panic", r, "stack", string(debug.Stack()))
 			}
 		}()
 		exitCode, _ = w.Wait()
@@ -707,7 +728,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	select {
 	case <-ch:
 	case <-time.After(waitTimeout):
-		b.log.Warn("bridge: Wait() timed out, force-killing", "session_id", p.sessionID, "worker_type", workerType)
+		lg.Warn("bridge: Wait() timed out, force-killing", "session_id", p.sessionID, "worker_type", workerType)
 		_ = w.Kill()
 		// Secondary timeout: if Wait() still doesn't return after Kill()
 		// (e.g., Go runtime deadlock or zombie process), abandon the wait
@@ -718,7 +739,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		case <-ch:
 			// Wait completed after Kill.
 		case <-killTimeout.C:
-			b.log.Warn("bridge: Wait() did not return after Kill(), abandoning",
+			lg.Warn("bridge: Wait() did not return after Kill(), abandoning",
 				"session_id", p.sessionID, "worker_type", workerType)
 		}
 	}
@@ -729,7 +750,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	// to fresh Start() for workers that cannot preserve conversation history.
 	fallbackAttempted := b.sm != nil && !b.closed.Load() && !p.doneReceived && exitCode != 143 && exitCode != -1 && p.opts.retryDepth < 2 && time.Since(p.startTime) < 15*time.Second
 	if fallbackAttempted && p.turnTextLen == 0 && time.Since(p.startTime) < 5*time.Second {
-		b.log.Info("bridge: session files missing after resume, skipping retry",
+		lg.Info("bridge: session files missing after resume, skipping retry",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode)
 		p.opts.retryDepth = 1
 	}
@@ -769,7 +790,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	if b.sm != nil {
 		si, smErr := b.sm.Get(context.Background(), p.sessionID)
 		if smErr == nil && si.State == events.StateTerminated {
-			b.log.Debug("bridge: session already terminated, skipping error for handler-killed worker", "session_id", p.sessionID, "worker_type", workerType)
+			lg.Debug("bridge: session already terminated, skipping error for handler-killed worker", "session_id", p.sessionID, "worker_type", workerType)
 			if !fallbackAttempted {
 				b.cleanupCrashedWorker(p.sessionID, w)
 			}
@@ -782,14 +803,14 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	// 2. Worker was intentionally terminated: SIGTERM (exit 143) is always
 	//    bridge/handler/GC-initiated, never an unexpected crash.
 	if p.doneReceived && p.turnTextLen == 0 {
-		b.log.Info("bridge: worker exit clean (done received, no pending output)",
+		lg.Info("bridge: worker exit clean (done received, no pending output)",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode)
 	} else if exitCode == 143 {
-		b.log.Info("bridge: worker exit intentional (SIGTERM)",
+		lg.Info("bridge: worker exit intentional (SIGTERM)",
 			"session_id", p.sessionID, "worker_type", workerType)
 	} else if exitCode != 0 && exitCode != -1 {
 		acc := b.getOrInitAccum(p.sessionID, "", p.startTime)
-		b.log.Warn("bridge: worker exited with non-zero code, sending crash error",
+		lg.Warn("bridge: worker exited with non-zero code, sending crash error",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode,
 			"duration", time.Since(p.startTime).Round(time.Millisecond), "turn_count", acc.TurnCount.Load())
 		observability.WorkerCrashes().Add(context.TODO(), 1, metric.WithAttributes(attribute.String("worker_type", string(workerType)), attribute.String("exit_code", fmt.Sprintf("%d", exitCode))))
@@ -808,7 +829,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	} else if exitCode == -1 {
 		b.sendError(p.sessionID, events.ErrCodeSessionTerminated, "worker terminated (killed)")
 	} else if !p.doneReceived {
-		b.log.Debug("bridge: sending error for platform cleanup (no done received)", "session_id", p.sessionID, "worker_type", workerType)
+		lg.Debug("bridge: sending error for platform cleanup (no done received)", "session_id", p.sessionID, "worker_type", workerType)
 		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker exited without sending done")
 	}
 
@@ -817,9 +838,10 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	}
 }
 
-// captureEvent persists an outbound event for replay.
-func (b *Bridge) captureEvent(sessionID string, seq int64, eventType events.Kind, data any) {
-	b.captureDirected(sessionID, seq, eventType, data, "outbound")
+// captureEvent persists an outbound event for replay. flog is optional;
+// when non-nil (forwardEvents path) it carries trace_id; otherwise b.log is used.
+func (b *Bridge) captureEvent(sessionID string, seq int64, eventType events.Kind, data any, flog ...*slog.Logger) {
+	b.captureDirected(sessionID, seq, eventType, data, "outbound", flog...)
 }
 
 // CaptureInboundEvent persists an inbound event for replay only (no turn write).
@@ -872,16 +894,21 @@ func (b *Bridge) CaptureInbound(ctx context.Context, sessionID string, seq int64
 }
 
 // captureDirected marshals event data and sends it to the collector with the given direction.
-func (b *Bridge) captureDirected(sessionID string, seq int64, eventType events.Kind, data any, direction string) {
+// flog is optional; when non-nil, capture diagnostics carry trace_id.
+func (b *Bridge) captureDirected(sessionID string, seq int64, eventType events.Kind, data any, direction string, flog ...*slog.Logger) {
+	lg := b.log
+	if len(flog) > 0 && flog[0] != nil {
+		lg = flog[0]
+	}
 	if b.collector == nil {
-		if b.log.Enabled(context.Background(), slog.LevelDebug) {
-			b.log.Debug("bridge: capture skipped, collector is nil", "session_id", sessionID, "type", eventType, "direction", direction)
+		if lg.Enabled(context.Background(), slog.LevelDebug) {
+			lg.Debug("bridge: capture skipped, collector is nil", "session_id", sessionID, "type", eventType, "direction", direction)
 		}
 		return
 	}
 	ed, err := json.Marshal(data)
 	if err != nil {
-		b.log.Warn("bridge: capture marshal failed", "session_id", sessionID, "type", eventType, "direction", direction, "err", err)
+		lg.Warn("bridge: capture marshal failed", "session_id", sessionID, "type", eventType, "direction", direction, "err", err)
 		return
 	}
 	if eventType == events.ToolResult {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -65,21 +65,23 @@ func (b *Bridge) bgCtx() context.Context {
 	return context.Background()
 }
 
-func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOpts) {
+func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwardOpts) {
 	defer func() {
 		if r := recover(); r != nil {
 			b.log.Error("bridge: panic in forwardEvents", "session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
+	w := fb.worker
 	workerType := w.Type()
-	b.log.Debug("bridge: forwardEvents goroutine started", "session_id", sessionID, "worker_type", workerType, "resumed", opts.resumed)
+	b.log.Debug("bridge: forwardEvents goroutine started", "session_id", sessionID,
+		"worker_type", workerType, "resumed", opts.resumed,
+		"has_frozen_conn", fb.conn != nil, "forwarder_reset_gen", fb.resetGen,
+		"worker_run_id", opts.workerRunID)
 
-	// Capture reset generation at goroutine start to detect stale goroutine after /reset.
-	var myResetGen int64
-	if rg, ok := w.(worker.ResetGenerationer); ok {
-		myResetGen = rg.LoadResetGeneration()
-	}
+	// reset generation was frozen at launch (Fix A). A stale forwarder whose
+	// worker was since reset detects the mismatch in handleWorkerExit.
+	myResetGen := fb.resetGen
 
 	fc := &forwardContext{
 		sessionID:     sessionID,
@@ -125,7 +127,7 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		tn, err := b.turnsQuerier.LatestTurnNum(tnCtx, sessionID, acc.Generation.Load())
 		tnCancel()
 		if err != nil {
-			b.log.Warn("turns: restore turn num", "error", err)
+			b.log.Warn("turns: restore turn num", "err", err)
 		}
 		if tn > 0 {
 			acc.TurnCount.Store(int32(tn))
@@ -157,7 +159,19 @@ func (b *Bridge) forwardEvents(w worker.Worker, sessionID string, opts forwardOp
 		defer fc.turnTimer.Stop()
 	}
 
-	recvCh := w.Conn().Recv()
+	// Event source: the frozen Conn captured at launch (Fix A). forwardEvents
+	// MUST NOT call w.Conn() here — doing so would re-read the mutable field and
+	// could bind a stale forwarder to a replacement Conn after /reset, splitting
+	// the event stream. The nil fallback is purely defensive: real workers
+	// always publish a Conn before launch, and the (synchronous) launch path
+	// already captured the best value available at that instant.
+	recvSource := fb.conn
+	if recvSource == nil {
+		b.log.Error("bridge: frozen conn is nil at forwardEvents start, falling back to live Conn()",
+			"session_id", sessionID, "worker_type", workerType)
+		recvSource = w.Conn()
+	}
+	recvCh := recvSource.Recv()
 	for env := range recvCh {
 		b.processForwardedEvent(env, w, opts, fc)
 	}
@@ -315,7 +329,10 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 
 	if env.Event.Type == events.Done {
 		fc.turnText.Reset()
-		fc.turnStartTime = time.Now()
+		// Do NOT reset fc.turnStartTime here. The previous code did
+		// `fc.turnStartTime = time.Now()` at Done, which started the NEXT turn's
+		// clock at this Done — so inter-turn idle was billed to the next turn.
+		// Turn start is now recorded by the input path (Fix D) and read on Done.
 	}
 
 }
@@ -474,7 +491,18 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 			acc.mergePerTurnStats(dd)
 		}
 		acc.TurnCount.Add(1)
-		acc.TurnDurationMs = time.Since(fc.turnStartTime).Milliseconds()
+		// Turn duration: prefer the input-path start stamp so the timer covers
+		// only this turn's processing and excludes inter-turn idle (Fix D). On
+		// miss (crash recovery / replay with no recorded start), fall back to
+		// the first worker event time and leave a debug breadcrumb.
+		startMs := b.consumeTurnStartMs(sessionID)
+		if startMs > 0 {
+			acc.TurnDurationMs = time.Now().UnixMilli() - startMs
+		} else {
+			acc.TurnDurationMs = time.Since(fc.turnStartTime).Milliseconds()
+			b.log.Debug("bridge: turn start stamp missing on done, using first-event fallback",
+				"session_id", sessionID, "worker_type", fc.workerType, "fallback_since", time.Since(fc.turnStartTime).Round(time.Millisecond))
+		}
 		acc.computePerTurnDeltas()
 
 		if cr, ok := w.(worker.ControlRequester); ok {
@@ -495,41 +523,68 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 	}
 }
 
-// maybeSendDoneFallback synthesizes a user-facing Message event when a turn
-// did tool work but produced no assistant text — so feishu/slack don't show an
-// empty reply for tool-only turns (e.g. "build and deploy" tasks where the
-// worker only calls tools and never writes a reply). Mirrors sendCommandFeedback
-// (worker_cmds.go). Skipped for webchat (its UI renders the tool_call list
-// independently), and when the turn already produced text or made no tool calls.
+// maybeSendDoneFallback classifies a successful turn's user-visible result and
+// synthesizes a Message event when the worker produced no assistant text. Three
+// states (Turn-Integrity spec Fix C, invariant I-5/I-9):
+//  1. assistant text > 0 → real content delivered; no fallback.
+//  2. text == 0 && tool_count > 0 → legitimate tool-only turn; emit one
+//     "✅ 已完成 · 🔧 …" fallback on feishu/slack (webchat renders tools itself).
+//  3. text == 0 && tool_count == 0 → empty-success integrity failure; emit an
+//     explicit retryable terminal on ALL platforms (incl. webchat) so no card
+//     is left showing a placeholder and no session ends silently.
+//
+// Classification uses THIS turn's real delivery ledger only — never placeholder,
+// status copy, the previous turn, or a wrong forwarder's partial state.
 //
 // Must run BEFORE captureAssistantTurn: it backfills fc.turnText with the
 // fallback text so the turns table records it (history/replay shows the
 // fallback instead of an empty assistant turn). Also persists to the events
 // table via captureEvent so WS event replay surfaces it too.
 func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator, fc *forwardContext) {
-	if fc.turnText.Len() != 0 || acc.ToolCallCount.Load() == 0 {
+	if fc.turnText.Len() > 0 {
+		return // state 1: real assistant content
+	}
+	toolCount := acc.ToolCallCount.Load()
+	if toolCount == 0 {
+		// state 3: empty-success integrity failure. Emit a retryable terminal
+		// on every platform. WebChat is NOT skipped here — an empty assistant
+		// turn leaves a blank reply, which this message replaces.
+		b.emitDoneFallbackMessage(sessionID, fc, messaging.FormatEmptySuccess(), true)
+		if b.collector != nil {
+			observability.WorkerEmptySuccess().Add(context.Background(), 1,
+				metric.WithAttributes(attribute.String("worker_type", string(fc.workerType))),
+				metric.WithAttributes(attribute.String("platform", fc.sessPlatform)))
+		}
 		return
 	}
+	// state 2: tool-only turn. WebChat renders the tool list independently.
 	if fc.sessPlatform == platformWebChat {
 		return
 	}
 	d := messaging.TurnSummaryData{
-		ToolCallCount:  int(acc.ToolCallCount.Load()),
+		ToolCallCount:  int(toolCount),
 		ToolNames:      acc.ToolNames,
 		TurnDurationMs: acc.TurnDurationMs,
 	}
-	text := messaging.FormatDoneFallback(d)
-	// Backfill turnText so captureAssistantTurn records the fallback to the
-	// turns table (history/replay shows it, not an empty assistant turn).
-	fc.turnText.WriteString(text)
+	b.emitDoneFallbackMessage(sessionID, fc, messaging.FormatDoneFallback(d), false)
+}
 
+// emitDoneFallbackMessage sends a synthesized user-facing Message, backfills
+// fc.turnText so the turns table records it, and persists it for replay.
+// emptySuccess flags the message for the empty-success metric path.
+func (b *Bridge) emitDoneFallbackMessage(sessionID string, fc *forwardContext, text string, emptySuccess bool) {
+	fc.turnText.WriteString(text)
 	env := events.NewEnvelope(
 		aep.NewID(), sessionID, b.hub.NextSeq(sessionID),
 		events.Message,
 		events.MessageData{Content: text},
 	)
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {
-		b.log.Warn("bridge: done fallback send failed", "session_id", sessionID, "err", err)
+		tag := "done_fallback"
+		if emptySuccess {
+			tag = "empty_success"
+		}
+		b.log.Warn("bridge: done fallback send failed", "session_id", sessionID, "kind", tag, "err", err)
 	}
 	// Persist to the events table so WS event replay also surfaces the fallback.
 	b.captureEvent(sessionID, env.Seq, events.Message, env.Event.Data)
@@ -614,7 +669,14 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	if rg, ok := w.(worker.ResetGenerationer); ok && rg.LoadResetGeneration() != p.resetGen {
 		b.log.Info("bridge: worker exit from stale forwardEvents after reset, skipping cleanup",
 			"session_id", p.sessionID, "worker_type", workerType,
-			"my_gen", p.resetGen, "current_gen", rg.LoadResetGeneration())
+			"forwarder_reset_gen", p.resetGen, "current_reset_gen", rg.LoadResetGeneration(),
+			"worker_run_id", p.opts.workerRunID)
+		// Diagnostic (Turn-Integrity Fix E): a non-zero count means a stale
+		// forwarder observed the replacement. With the frozen binding (Fix A)
+		// this forwarder read only its own (closed) Conn, so it consumed no
+		// replacement events — the metric tracks the exit, not a real split.
+		observability.StaleForwarderEvents().Add(context.Background(), 1,
+			metric.WithAttributes(attribute.String("worker_type", string(workerType))))
 		return
 	}
 
@@ -805,7 +867,9 @@ func (b *Bridge) CaptureInbound(ctx context.Context, sessionID string, seq int64
 // captureDirected marshals event data and sends it to the collector with the given direction.
 func (b *Bridge) captureDirected(sessionID string, seq int64, eventType events.Kind, data any, direction string) {
 	if b.collector == nil {
-		b.log.Debug("bridge: capture skipped, collector is nil", "session_id", sessionID, "type", eventType, "direction", direction)
+		if b.log.Enabled(context.Background(), slog.LevelDebug) {
+			b.log.Debug("bridge: capture skipped, collector is nil", "session_id", sessionID, "type", eventType, "direction", direction)
+		}
 		return
 	}
 	ed, err := json.Marshal(data)
@@ -1006,6 +1070,12 @@ func (b *Bridge) getOrInitAccum(sessionID, workDir string, startTime time.Time) 
 	}
 
 	b.accumMu.Lock()
+	// Lazily init the accum map for Bridges constructed without NewBridge
+	// (handler-focused tests build &Bridge{} literals). Nil-map reads are safe,
+	// only the write below would panic.
+	if b.accum == nil {
+		b.accum = make(map[string]*sessionAccumulator)
+	}
 	// Double-check after acquiring write lock.
 	if acc, ok := b.accum[sessionID]; ok {
 		if workDir != "" && acc.WorkDir == "" {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -66,15 +66,18 @@ func (b *Bridge) bgCtx() context.Context {
 }
 
 func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwardOpts) {
+	ctx, span := observability.Tracer().Start(opts.ctx, "bridge.forward_events")
+	defer span.End()
+	flog := b.log.With("trace_id", observability.TraceID(ctx))
 	defer func() {
 		if r := recover(); r != nil {
-			b.log.Error("bridge: panic in forwardEvents", "session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
+			flog.Error("bridge: panic in forwardEvents", "session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
 	w := fb.worker
 	workerType := w.Type()
-	b.log.Debug("bridge: forwardEvents goroutine started", "session_id", sessionID,
+	flog.Debug("bridge: forwardEvents goroutine started", "session_id", sessionID,
 		"worker_type", workerType, "resumed", opts.resumed,
 		"has_frozen_conn", fb.conn != nil, "forwarder_reset_gen", fb.resetGen,
 		"worker_run_id", opts.workerRunID)
@@ -88,7 +91,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		workerType:    workerType,
 		workerRunID:   opts.workerRunID,
 		workDir:       opts.workDir,
-		ctx:           opts.ctx,
+		ctx:           ctx,
 		startTime:     time.Now(),
 		turnStartTime: time.Now(),
 		firstEvent:    true,
@@ -127,7 +130,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		tn, err := b.turnsQuerier.LatestTurnNum(tnCtx, sessionID, acc.Generation.Load())
 		tnCancel()
 		if err != nil {
-			b.log.Warn("turns: restore turn num", "err", err)
+			flog.Warn("turns: restore turn num", "err", err)
 		}
 		if tn > 0 {
 			acc.TurnCount.Store(int32(tn))
@@ -139,7 +142,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 			if !fc.turnTimerFired.CompareAndSwap(false, true) {
 				return
 			}
-			b.log.Warn("bridge: turn timeout exceeded, terminating worker",
+			flog.Warn("bridge: turn timeout exceeded, terminating worker",
 				"session_id", sessionID, "worker_type", workerType, "turn_timeout", b.turnTimeout)
 			b.sendError(sessionID, events.ErrCodeTurnTimeout, "Turn exceeded %v time limit and was terminated.", b.turnTimeout)
 			acc := b.getOrInitAccum(sessionID, fc.workDir, fc.startTime)
@@ -167,7 +170,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	// already captured the best value available at that instant.
 	recvSource := fb.conn
 	if recvSource == nil {
-		b.log.Error("bridge: frozen conn is nil at forwardEvents start, falling back to live Conn()",
+		flog.Error("bridge: frozen conn is nil at forwardEvents start, falling back to live Conn()",
 			"session_id", sessionID, "worker_type", workerType)
 		recvSource = w.Conn()
 	}
@@ -179,7 +182,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	// Flush buffered error that never reached a retry decision point.
 	if fc.pendingError != nil {
 		if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
-			b.log.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+			flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
 		}
 		b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data)
 		fc.pendingError = nil

--- a/internal/gateway/bridge_forward_fallback_test.go
+++ b/internal/gateway/bridge_forward_fallback_test.go
@@ -88,23 +88,43 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected when turn has text")
 	})
 
-	t.Run("skipped_when_no_tools", func(t *testing.T) {
+	t.Run("empty_success_emits_terminal_on_feishu", func(t *testing.T) {
 		t.Parallel()
 		b, acc, fc, server := setup(t, "feishu")
-		// ToolCallCount stays 0
-
+		// No text AND no tool calls → empty-success integrity failure. The turn
+		// must NOT end silently leaving a placeholder; emit a retryable terminal
+		// (Turn-Integrity Fix C, invariant I-5).
 		b.maybeSendDoneFallback("s1", acc, fc)
 
-		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected when no tool calls")
+		env := tryReadEnvelope(t, server)
+		require.NotNil(t, env, "empty-success must emit a terminal Message")
+		require.Equal(t, events.Message, env.Event.Type)
+		data, ok := env.Event.Data.(map[string]any)
+		require.True(t, ok)
+		content, _ := data["content"].(string)
+		require.NotEmpty(t, content, "terminal text must be non-empty")
+		require.Greater(t, fc.turnText.Len(), 0, "turnText must be backfilled for the turns table")
 	})
 
-	t.Run("skipped_for_webchat", func(t *testing.T) {
+	t.Run("empty_success_emits_terminal_on_webchat", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, platformWebChat)
+		// WebChat is skipped for tool-only fallbacks, but empty-success still
+		// needs an explicit terminal so the assistant turn is not left blank.
+		b.maybeSendDoneFallback("s1", acc, fc)
+
+		env := tryReadEnvelope(t, server)
+		require.NotNil(t, env, "webchat empty-success must emit a terminal Message, not a blank assistant turn")
+		require.Equal(t, events.Message, env.Event.Type)
+	})
+
+	t.Run("skipped_for_webchat_tool_only", func(t *testing.T) {
 		t.Parallel()
 		b, acc, fc, server := setup(t, platformWebChat)
 		acc.ToolCallCount.Store(3)
-
+		// Tool-only turn on webchat: UI renders the tool list independently, no fallback.
 		b.maybeSendDoneFallback("s1", acc, fc)
 
-		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected for webchat")
+		require.Nil(t, tryReadEnvelope(t, server), "no tool-only fallback expected for webchat")
 	})
 }

--- a/internal/gateway/bridge_forward_lastio_test.go
+++ b/internal/gateway/bridge_forward_lastio_test.go
@@ -48,7 +48,7 @@ func TestBridge_ForwardEvents_RefreshesLastIO(t *testing.T) {
 	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 	done := make(chan struct{})
 	go func() {
-		b.forwardEvents(fw, "sess_lastio", forwardOpts{ctx: ctx})
+		b.forwardEvents(forwarderBinding{worker: fw, conn: fw.Conn()}, "sess_lastio", forwardOpts{ctx: ctx})
 		close(done)
 	}()
 

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -113,10 +113,37 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	go func() {
 		defer b.fwdWg.Done()
 		defer b.clearWorkerRun(sid, w, params.forwardOpts.workerRunID)
-		b.forwardEvents(w, sid, *params.forwardOpts)
+		b.launchForwarderLocked(w, sid, *params.forwardOpts)
 	}()
 
 	return w, nil
+}
+
+// forwarderBinding is the immutable ownership contract captured synchronously
+// before a forwardEvents goroutine is spawned. Freezing the Conn and reset
+// generation at launch — instead of reading w.Conn() from inside the spawned
+// goroutine — prevents a stale forwarder from binding to a replacement Conn
+// after /reset and splitting the event stream with the new forwarder
+// (Turn-Integrity spec RC-1 / Fix A, invariant I-1/I-2).
+type forwarderBinding struct {
+	worker   worker.Worker
+	conn     worker.SessionConn // frozen event source; forwardEvents reads ONLY this
+	resetGen int64              // frozen reset generation for stale-exit detection
+}
+
+// launchForwarderLocked is the single entry point for spawning a forwardEvents
+// goroutine. It MUST be called from the launching (synchronous) goroutine so
+// the Conn is captured before any concurrent ResetContext can replace it.
+// All four launch paths — fresh Start, Resume, /reset ConnReplaced, and crash
+// recovery — route through here (Fix A).
+func (b *Bridge) launchForwarderLocked(w worker.Worker, sessionID string, opts forwardOpts) {
+	conn := w.Conn()
+	var resetGen int64
+	if rg, ok := w.(worker.ResetGenerationer); ok {
+		resetGen = rg.LoadResetGeneration()
+	}
+	fb := forwarderBinding{worker: w, conn: conn, resetGen: resetGen}
+	b.forwardEvents(fb, sessionID, opts)
 }
 
 func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) string {
@@ -125,6 +152,31 @@ func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) 
 	}
 	b.workerRuns.Store(sessionID, workerRunBinding{worker: w, id: runID})
 	return runID
+}
+
+// RecordTurnStart stamps the current turn's start time on the session
+// accumulator. Called by the input path immediately before delivering the
+// user's input to the worker. Safe to call when the accumulator does not yet
+// exist (it is created on-demand). Turn-Integrity Fix D.
+func (b *Bridge) RecordTurnStart(sessionID string) {
+	b.getOrInitAccum(sessionID, "", time.Now()).recordTurnStart(time.Now())
+}
+
+// ClearTurnStart clears the current turn's start stamp. Called by the input
+// path when delivery to the worker failed, so the subsequent Done does not
+// bill a turn that never started. Turn-Integrity Fix D.
+func (b *Bridge) ClearTurnStart(sessionID string) {
+	acc := b.getOrInitAccum(sessionID, "", time.Now())
+	acc.clearTurnStart()
+}
+
+// consumeTurnStartMs reads and clears the current turn's start stamp. Called by
+// the forwarder on Done to compute a duration that excludes inter-turn idle.
+// Returns 0 when no start was recorded (crash recovery / replay); the caller
+// falls back to the first worker event time.
+func (b *Bridge) consumeTurnStartMs(sessionID string) int64 {
+	acc := b.getOrInitAccum(sessionID, "", time.Now())
+	return acc.consumeTurnStartMs()
 }
 
 // clearWorkerRun conditionally removes a binding. Matching both Worker and run

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -1431,7 +1431,7 @@ func TestBridge_ForwardEvents_NormalEvent(t *testing.T) {
 	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 	done := make(chan struct{})
 	go func() {
-		b.forwardEvents(fw, "sess_fwd", forwardOpts{})
+		b.forwardEvents(forwarderBinding{worker: fw, conn: fw.Conn()}, "sess_fwd", forwardOpts{})
 		close(done)
 	}()
 
@@ -1470,7 +1470,7 @@ func TestBridge_ForwardEvents_CrashExitCode(t *testing.T) {
 	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 	done := make(chan struct{})
 	go func() {
-		b.forwardEvents(fw, "sess_crash", forwardOpts{})
+		b.forwardEvents(forwarderBinding{worker: fw, conn: fw.Conn()}, "sess_crash", forwardOpts{})
 		close(done)
 	}()
 

--- a/internal/gateway/forwarder_binding_test.go
+++ b/internal/gateway/forwarder_binding_test.go
@@ -1,0 +1,78 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TestForwarderBinding_ReadsOnlyFrozenConn (T-A1/T-A2) proves the forwarder
+// reads events from the Conn captured at launch time and NEVER from a later
+// w.Conn() replacement. This is the core invariant of Fix A (RC-1): without a
+// frozen binding, a stale forwarder could bind to a reset's replacement Conn
+// and split the event stream with the new forwarder.
+func TestForwarderBinding_ReadsOnlyFrozenConn(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(t)
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+
+	connA := &fakeWorkerConn{ch: make(chan *events.Envelope, 1)}
+	connB := &fakeWorkerConn{ch: make(chan *events.Envelope, 1)}
+
+	w := &mockBridgeWorker{workerType: "claude_code", conn: connA, exitCode: 0}
+
+	// Simulate the synchronous launch: capture the binding NOW (connA).
+	// launchForwarderLocked does exactly this before spawning the goroutine.
+	binding := forwarderBinding{worker: w, conn: w.Conn(), resetGen: 0}
+	require.Same(t, connA, binding.conn, "binding must freeze connA at launch")
+
+	// AFTER capture, /reset replaces the worker's Conn (connA → connB).
+	// A non-frozen forwarder reading w.Conn() here would bind to connB.
+	w.conn = connB
+	require.Same(t, connB, w.Conn(), "sanity: live Conn() now returns connB")
+	require.Same(t, connA, binding.conn, "FROZEN binding must still point at connA despite the swap")
+
+	// Join a WS conn so forwardEvents can deliver to the hub.
+	done := make(chan struct{})
+	go func() {
+		b.forwardEvents(binding, "sess_frozen", forwardOpts{ctx: context.Background()})
+		close(done)
+	}()
+
+	// Send on connA (frozen source) and connB (replacement). Only connA must
+	// be consumed by THIS forwarder.
+	deltaA := events.NewEnvelope("idA", "sess_frozen", 1, events.MessageDelta, events.MessageDeltaData{Content: "from-frozen"})
+	deltaB := events.NewEnvelope("idB", "sess_frozen", 1, events.MessageDelta, events.MessageDeltaData{Content: "from-replacement"})
+	connA.ch <- deltaA
+	connB.ch <- deltaB
+
+	// Drain connA: the frozen forwarder consumed it.
+	select {
+	case <-connA.ch:
+	default:
+	}
+
+	// connB's event must NOT have been consumed by this forwarder — it belongs
+	// to the new forwarder that the reset path would launch.
+	select {
+	case remaining := <-connB.ch:
+		require.Equal(t, "from-replacement", remaining.Event.Data.(events.MessageDeltaData).Content,
+			"frozen forwarder must NOT consume the replacement conn's events")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("connB event was consumed by the frozen forwarder — binding is not frozen")
+	}
+
+	// Close connA so forwardEvents exits cleanly.
+	close(connA.ch)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwardEvents did not exit after frozen conn closed")
+	}
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -453,6 +453,13 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		h.log.Debug("gateway: delivering input to worker", "session_id", env.SessionID, "content_len", len(content), "preview", preview)
 	}
 
+	// Stamp the turn start immediately before delivery so the Done-bound timer
+	// measures only this turn's processing, excluding inter-turn idle
+	// (Turn-Integrity spec RC-4 / Fix D).
+	if h.bridge != nil {
+		h.bridge.RecordTurnStart(env.SessionID)
+	}
+
 	if err := w.Input(ctx, content, nil); err != nil {
 		var we *worker.WorkerError
 		if errors.As(err, &we) && we.Kind == worker.ErrKindTimeout {
@@ -461,6 +468,11 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 			return nil
 		}
 		h.log.Warn("gateway: worker input", "err", err, "session_id", env.SessionID)
+		// Input never reached the worker: clear the turn start so a later Done
+		// (or crash-cleanup) cannot bill idle time to a turn that never ran.
+		if h.bridge != nil {
+			h.bridge.ClearTurnStart(env.SessionID)
+		}
 		code := classifyWorkerError(err)
 		finishOutcome(execution.StatusFailed, code)
 		// ErrKindUnavailable (e.g. ACP session lost) means the worker's

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -207,7 +207,7 @@ func (c *HistoryCompressor) callBrain(
 	result, err := b.ChatWithOptions(compressCtx, userPrompt, opts)
 	if err != nil {
 		c.log.Warn("history: brain compression failed, falling back to truncation",
-			"session_id", sessionID, "error", err)
+			"session_id", sessionID, "err", err)
 		return "", false
 	}
 

--- a/internal/gateway/oauth_handlers.go
+++ b/internal/gateway/oauth_handlers.go
@@ -114,7 +114,7 @@ func (h *OAuthHandlers) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Check for IdP error response.
 	if errCode := r.URL.Query().Get("error"); errCode != "" {
-		h.log.Warn("oauth callback: idp error", "provider", providerName, "error", errCode)
+		h.log.Warn("oauth callback: idp error", "provider", providerName, "err", errCode)
 		redirectAuthError(w, r, "IDP_ERROR")
 		return
 	}
@@ -176,7 +176,7 @@ func (h *OAuthHandlers) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Issue session cookie (same as password login).
 	if err := h.cookieAuth.SetCookie(w, r, userID); err != nil {
-		h.log.Error("oauth callback: cookie issuance failed", "provider", providerName, "err", err)
+		h.log.Error("oauth callback: cookie issuance failed", "provider", providerName, "user_id", userID, "err", err)
 		redirectAuthError(w, r, "INTERNAL")
 		return
 	}

--- a/internal/gateway/reset_contract_test.go
+++ b/internal/gateway/reset_contract_test.go
@@ -1,0 +1,155 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/aep"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// connReplacingWorker is a mockBridgeWorker whose ResetContext swaps its Conn to
+// a fresh channel and (optionally) reports ConnReplaced=true, bumping a reset
+// generation like real per-process workers (Claude Code / Codex CLI).
+type connReplacingWorker struct {
+	mockBridgeWorker
+	resetGen atomic.Int64
+	replaced bool
+}
+
+func (w *connReplacingWorker) LoadResetGeneration() int64 { return w.resetGen.Load() }
+func (w *connReplacingWorker) IncResetGeneration() int64  { return w.resetGen.Add(1) }
+
+func (w *connReplacingWorker) ResetContext(context.Context) (worker.ResetResult, error) {
+	w.resetGen.Add(1)
+	// Swap to a fresh buffered conn so the new forwarder has its own channel.
+	w.conn = &fakeWorkerConn{ch: make(chan *events.Envelope, 8)}
+	res := worker.ResetResult{}
+	if w.replaced {
+		res.ConnReplaced = true
+	}
+	return res, nil
+}
+
+var _ worker.ResetGenerationer = (*connReplacingWorker)(nil)
+
+// readN reads up to n WS messages within a deadline, returning the contents.
+func readN(t *testing.T, server interface {
+	ReadMessage() (int, []byte, error)
+	SetReadDeadline(time.Time) error
+}, n int, timeout time.Duration) []string {
+	t.Helper()
+	var out []string
+	deadline := time.Now().Add(timeout)
+	for len(out) < n {
+		_ = server.SetReadDeadline(deadline)
+		_, data, err := server.ReadMessage()
+		if err != nil {
+			break
+		}
+		out = append(out, string(data))
+	}
+	_ = server.SetReadDeadline(time.Time{})
+	return out
+}
+
+// TestResetSession_ConnReplaced_LaunchesSingleForwarder (T-A5, §9 跨 Worker 验收):
+// a per-process /reset (ConnReplaced=true) must launch exactly ONE new forwarder
+// on the replacement Conn. Events injected on the new Conn are delivered in order
+// and processed exactly once — no dual consumer splits or duplicates them.
+func TestResetSession_ConnReplaced_LaunchesSingleForwarder(t *testing.T) {
+	t.Parallel()
+	hub := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	c := newConn(hub, conn, "sess-reset-replaced", nil)
+	hub.JoinSession("sess-reset-replaced", c)
+
+	w := &connReplacingWorker{replaced: true}
+	w.workerType = worker.TypeClaudeCode
+	w.conn = &fakeWorkerConn{ch: make(chan *events.Envelope, 8)} // original connA
+	sm := new(mockBridgeSM)
+	sm.On("GetWorker", "sess-reset-replaced").Return(w)
+	sm.On("Get", "sess-reset-replaced").Return(&session.SessionInfo{ID: "sess-reset-replaced", Platform: "webchat"}, nil)
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: sm})
+	b.workerRuns.Store("sess-reset-replaced", workerRunBinding{worker: w, id: "run-old"})
+
+	// Drive the reset. ResetContext swaps the conn (connA→connB) and reports
+	// ConnReplaced=true, so the bridge must launch one new forwarder on connB.
+	require.NoError(t, b.ResetSession(context.Background(), "sess-reset-replaced"))
+
+	// Inject three ordered events on the NEW conn (connB).
+	newConn := w.Conn().(*fakeWorkerConn)
+	for i, txt := range []string{"delta-1", "delta-2", "delta-3"} {
+		newConn.ch <- events.NewEnvelope(aep.NewID(), "sess-reset-replaced", 0,
+			events.MessageDelta, events.MessageDeltaData{Content: txt, MessageID: "msg_new"})
+		_ = i
+	}
+
+	got := readN(t, server, 3, 2*time.Second)
+	require.Len(t, got, 3, "all three events on the replacement conn must be delivered (single consumer, in order)")
+	require.Contains(t, got[0], "delta-1")
+	require.Contains(t, got[1], "delta-2")
+	require.Contains(t, got[2], "delta-3")
+
+	// No fifth message arrives — proves there is no second consumer duplicating.
+	if extra := readN(t, server, 1, 250*time.Millisecond); len(extra) > 0 {
+		t.Fatalf("unexpected duplicate/extra event from a second consumer: %v", extra)
+	}
+}
+
+// TestResetSession_InPlace_NoNewForwarder (T-A6, §9 跨 Worker 验收): an in-place
+// reset (OCS / ACP, ConnReplaced=false) must NOT launch a second forwarder. The
+// existing forwarder keeps consuming the same Conn.
+func TestResetSession_InPlace_NoNewForwarder(t *testing.T) {
+	t.Parallel()
+	hub := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	c := newConn(hub, conn, "sess-reset-inplace", nil)
+	hub.JoinSession("sess-reset-inplace", c)
+
+	w := &connReplacingWorker{replaced: false} // in-place: ConnReplaced=false
+	w.workerType = worker.TypeOpenCodeSrv
+	origConn := &fakeWorkerConn{ch: make(chan *events.Envelope, 8)}
+	w.conn = origConn
+	sm := new(mockBridgeSM)
+	sm.On("GetWorker", "sess-reset-inplace").Return(w)
+	sm.On("Get", "sess-reset-inplace").Return(&session.SessionInfo{ID: "sess-reset-inplace", Platform: "webchat"}, nil)
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: sm})
+	b.workerRuns.Store("sess-reset-inplace", workerRunBinding{worker: w, id: "run-stable"})
+
+	// Start the single forwarder the in-place worker is supposed to keep.
+	done := make(chan struct{})
+	go func() {
+		b.forwardEvents(forwarderBinding{worker: w, conn: origConn}, "sess-reset-inplace", forwardOpts{ctx: context.Background()})
+		close(done)
+	}()
+
+	// In-place reset: ConnReplaced=false → no new forwarder, conn unchanged.
+	require.NoError(t, b.ResetSession(context.Background(), "sess-reset-inplace"))
+
+	// The SAME conn still has exactly one consumer: events still deliver in order.
+	for _, txt := range []string{"inplace-1", "inplace-2"} {
+		origConn.ch <- events.NewEnvelope(aep.NewID(), "sess-reset-inplace", 0,
+			events.MessageDelta, events.MessageDeltaData{Content: txt, MessageID: "msg_same"})
+	}
+	got := readN(t, server, 2, 2*time.Second)
+	require.Len(t, got, 2, "in-place reset must not disrupt the single existing forwarder")
+	require.Contains(t, got[0], "inplace-1")
+	require.Contains(t, got[1], "inplace-2")
+
+	close(origConn.ch)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-place forwarder did not exit after conn closed")
+	}
+}

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -41,6 +41,13 @@ type sessionAccumulator struct {
 	PerTurnCost    float64
 	TurnDurationMs int64 // current turn duration in milliseconds
 
+	// turnStartUnixMilli is the wall-clock start of the CURRENT turn, recorded
+	// by the input path when a turn is about to be delivered to the worker and
+	// consumed by the forwarder on Done. It excludes inter-turn idle time, which
+	// the previous "reset clock at Done" approach incorrectly billed to the
+	// next turn (Turn-Integrity spec RC-4 / Fix D). 0 = not set this turn.
+	turnStartUnixMilli atomic.Int64
+
 	// Cumulative totals at the end of the previous turn (for delta computation).
 	PrevTotalIn   int64
 	PrevTotalOut  int64
@@ -127,6 +134,26 @@ func (a *sessionAccumulator) resetPerTurn() {
 	a.PerTurnCacheRead = 0
 	a.TurnDurationMs = 0
 	a.ContextFill = 0
+}
+
+// recordTurnStart stamps the start of the current turn in unix milliseconds.
+// Called by the input path right before delivering the user's input to the
+// worker (Turn-Integrity Fix D).
+func (a *sessionAccumulator) recordTurnStart(now time.Time) {
+	a.turnStartUnixMilli.Store(now.UnixMilli())
+}
+
+// clearTurnStart clears the turn start stamp. Called when input delivery fails
+// so a subsequent Done does not bill a turn that never started (Fix D).
+func (a *sessionAccumulator) clearTurnStart() {
+	a.turnStartUnixMilli.Store(0)
+}
+
+// consumeTurnStartMs atomically reads and clears the turn start stamp, returning
+// it in unix milliseconds. Returns 0 (and leaves it cleared) when no start was
+// recorded for this turn — the caller falls back to the first worker event time.
+func (a *sessionAccumulator) consumeTurnStartMs() int64 {
+	return a.turnStartUnixMilli.Swap(0)
 }
 
 // mergeContextUsage sets ContextFill, ContextWindow, and ModelName from the worker's

--- a/internal/gateway/turn_clock_test.go
+++ b/internal/gateway/turn_clock_test.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTurnClockBridge() *Bridge {
+	return NewBridge(BridgeDeps{Log: slog.Default()})
+}
+
+// TestTurnClock_ExcludesInterTurnIdle (T-D1): a duration measured from a turn
+// start stamp does not include idle time that elapsed before the stamp.
+func TestTurnClock_ExcludesInterTurnIdle(t *testing.T) {
+	b := newTurnClockBridge()
+	sid := "sess-idle"
+
+	// Simulate the input path recording turn start AFTER a long idle gap.
+	time.Sleep(20 * time.Millisecond)
+	b.RecordTurnStart(sid)
+
+	// Processing the turn takes a short time.
+	time.Sleep(30 * time.Millisecond)
+
+	startMs := b.consumeTurnStartMs(sid)
+	require.Greater(t, startMs, int64(0), "consume must return the recorded stamp")
+	duration := time.Now().UnixMilli() - startMs
+	// ~30ms processing, NOT ~50ms (idle + processing). Allow generous upper
+	// bound for CI jitter, but it must be well under the idle+processing sum.
+	require.Less(t, duration, int64(60), "duration should approximate processing only, not include idle")
+}
+
+// TestTurnClock_InputFailureClearsStart (T-D2): when input delivery fails, the
+// start stamp is cleared so a later Done cannot bill a turn that never ran.
+func TestTurnClock_InputFailureClearsStart(t *testing.T) {
+	b := newTurnClockBridge()
+	sid := "sess-fail"
+
+	b.RecordTurnStart(sid)
+	require.Greater(t, b.consumeTurnStartMsForTest(sid), int64(0), "stamp recorded")
+
+	// Re-record then simulate the failed-delivery clear path.
+	b.RecordTurnStart(sid)
+	b.ClearTurnStart(sid)
+	require.Equal(t, int64(0), b.consumeTurnStartMs(sid), "stamp must be cleared on input failure")
+}
+
+// TestTurnClock_MissingStartReturnsZero (T-D3): with no recorded start (crash
+// recovery / replay), consume returns 0 so the forwarder can fall back to the
+// first worker event time.
+func TestTurnClock_MissingStartReturnsZero(t *testing.T) {
+	b := newTurnClockBridge()
+	require.Equal(t, int64(0), b.consumeTurnStartMs("never-stamped"),
+		"consume with no prior record must return 0 for fallback")
+}
+
+// consumeTurnStartMsForTest peeks without clearing so the test can assert a
+// stamp was set before exercising the clearing path.
+func (b *Bridge) consumeTurnStartMsForTest(sessionID string) int64 {
+	acc := b.getOrInitAccum(sessionID, "", time.Now())
+	// Swap then restore: equivalent to a non-destructive read for the assertion.
+	v := acc.consumeTurnStartMs()
+	if v > 0 {
+		acc.recordTurnStart(time.UnixMilli(v))
+	}
+	return v
+}

--- a/internal/gateway/worker_cmds.go
+++ b/internal/gateway/worker_cmds.go
@@ -200,7 +200,7 @@ func (h *Handler) handleSkillsList(ctx context.Context, env *events.Envelope, fi
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		h.log.Warn("skills list: failed to resolve home directory, global skills may be incomplete", "error", err)
+		h.log.Warn("skills list: failed to resolve home directory, global skills may be incomplete", "err", err)
 	}
 	allSkills, err := h.skillsLocator.List(ctx, homeDir, si.WorkDir)
 	if err != nil {

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -110,7 +110,7 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 
 func (a *Adapter) Start(ctx context.Context) error {
 	if !a.StartGuard() {
-		a.Log.Warn("feishu: adapter already started, skipping")
+		a.Log.Debug("feishu: adapter already started, skipping")
 		return nil
 	}
 	if a.appID == "" || a.appSecret == "" {

--- a/internal/messaging/feishu/sdk_logger.go
+++ b/internal/messaging/feishu/sdk_logger.go
@@ -80,13 +80,19 @@ func redactURL(s string) string {
 	return sensitiveParamRe.ReplaceAllString(s, "${1}***")
 }
 
-// sdkDebugSilent lists Feishu SDK Debug log message substrings that are
-// silenced during normal operation (every ~2 min heartbeat cycle). These are
-// routine ping/pong keep-alive messages that don't carry actionable info.
-// Failures still surface via Warn/Error level.
+// sdkDebugSilent lists Feishu SDK Debug/Info log message substrings that are
+// silenced during normal operation. Two categories:
+//  1. Routine ping/pong keep-alive (~every 2 min) — no actionable info.
+//  2. Inbound events registered with no-op handlers in newEventHandler
+//     (reaction, read) — high-volume, zero business value. Their DEBUG
+//     payloads are pure noise that buries real event traffic.
+//
+// Failures still surface via Warn/Error level (sdkWarnFilter ignores this list).
 var sdkDebugSilent = []string{
 	"ping success",
 	"receive pong",
+	"im.message.reaction.",
+	"im.message.read_v1",
 }
 
 // sdkReconnectSilent removes verbose reconnection-related log prefixes

--- a/internal/messaging/feishu/sdk_logger_test.go
+++ b/internal/messaging/feishu/sdk_logger_test.go
@@ -186,6 +186,50 @@ func TestSlogLogger_InfoSilencesHeartbeat(t *testing.T) {
 	require.Empty(t, got, "Info should silence 'disconnected to wss://'")
 }
 
+// No-op event payloads (reaction, read) are silenced at Debug/Info level —
+// these events have empty handlers in newEventHandler and their inbound DEBUG
+// traffic buries real message events. Warn/Error must still surface them.
+
+func TestSlogLogger_DebugSilencesNoopEventPayloads(t *testing.T) {
+	t.Parallel()
+	var got string
+	h := slog.NewTextHandler(&captureWriter{&got}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	l := SlogLogger{Logger: slog.New(h)}
+
+	l.Debug(context.Background(), `receive message, message_type: event, payload: {"header":{"event_type":"im.message.reaction.created_v1"}}`)
+	require.Empty(t, got, "Debug should silence reaction.created no-op event")
+
+	got = ""
+	l.Debug(context.Background(), `receive message, payload: {"event_type":"im.message.reaction.deleted_v1"}`)
+	require.Empty(t, got, "Debug should silence reaction.deleted no-op event")
+
+	got = ""
+	l.Debug(context.Background(), `receive message, payload: {"event_type":"im.message.read_v1"}`)
+	require.Empty(t, got, "Debug should silence message.read no-op event")
+}
+
+func TestSlogLogger_DebugKeepsRealMessageEvents(t *testing.T) {
+	t.Parallel()
+	var got string
+	h := slog.NewTextHandler(&captureWriter{&got}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	l := SlogLogger{Logger: slog.New(h)}
+
+	l.Debug(context.Background(), `receive message, payload: {"event_type":"im.message.receive_v1"}`)
+	require.Contains(t, got, "im.message.receive_v1",
+		"Debug must NOT silence real inbound message events")
+}
+
+func TestSlogLogger_WarnDoesNotSilenceNoopEventPayloads(t *testing.T) {
+	t.Parallel()
+	var got string
+	h := slog.NewTextHandler(&captureWriter{&got}, nil)
+	l := SlogLogger{Logger: slog.New(h)}
+
+	l.Warn(context.Background(), `dispatch failed, payload: {"event_type":"im.message.reaction.created_v1"}`)
+	require.Contains(t, got, "im.message.reaction.created_v1",
+		"Warn must NOT silence no-op event payloads — failures must surface")
+}
+
 func TestSlogLogger_WarnDoesNotSilenceHeartbeat(t *testing.T) {
 	t.Parallel()
 	var got1, got2 string

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -517,17 +517,21 @@ func (c *StreamingCardController) Flush(ctx context.Context) error {
 	content = SanitizeForCard(content)
 
 	if content == c.lastFlushed {
-		c.log.Debug("feishu: streaming flush skipped, content unchanged")
+		if c.log.Enabled(ctx, slog.LevelDebug) {
+			c.log.Debug("feishu: streaming flush skipped, content unchanged")
+		}
 		return nil
 	}
 
 	seq := int(c.sequence.Add(1))
-	c.log.Debug("feishu: streaming flush",
-		"card_kit_ok", c.cardKitOK,
-		"card_id", c.cardID,
-		"msg_id", c.msgID,
-		"content_len", len(content),
-		"seq", seq)
+	if c.log.Enabled(ctx, slog.LevelDebug) {
+		c.log.Debug("feishu: streaming flush",
+			"card_kit_ok", c.cardKitOK,
+			"card_id", c.cardID,
+			"msg_id", c.msgID,
+			"content_len", len(content),
+			"seq", seq)
+	}
 
 	if c.cardKitOK && c.cardID != "" && c.limiter.AllowCardKit(c.cardID) {
 		if err := c.flushCardKitWithRetry(ctx, content, seq); err != nil {
@@ -1093,8 +1097,10 @@ func (c *StreamingCardController) flushCardKitElement(ctx context.Context, eleme
 	if !resp.Success() {
 		return fmt.Errorf("cardkit element content failed: code=%d msg=%s", resp.Code, resp.Msg)
 	}
-	c.log.Debug("feishu: cardkit element content flushed",
-		"card_id", c.cardID, "seq", seq, "content_len", len(content))
+	if c.log.Enabled(ctx, slog.LevelDebug) {
+		c.log.Debug("feishu: cardkit element content flushed",
+			"card_id", c.cardID, "seq", seq, "content_len", len(content))
+	}
 	return nil
 }
 

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -725,9 +725,28 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 
 	c.mu.Lock()
 	content := c.buf.String()
+	// Empty-success backstop (Turn-Integrity RC-3/Fix C, invariant I-6): a
+	// placeholder is never completed content. If Close reaches here with an
+	// empty buffer while the placeholder is still active, no real assistant
+	// content ever arrived — replace the placeholder with a retryable terminal
+	// so the card does not keep displaying ":Get:/:StatusFlashOfInspiration:".
+	// lastFlushed alone cannot make this distinction: SendPlaceholder sets it to
+	// the placeholder text, which the old code mistook for "already flushed".
+	activePlaceholder := ""
+	if content == "" && c.placeholder != "" {
+		activePlaceholder = c.placeholder
+		c.placeholder = ""
+	}
 	c.mu.Unlock()
 
-	content = OptimizeMarkdownStyle(SanitizeForCard(content))
+	if activePlaceholder != "" {
+		content = OptimizeMarkdownStyle(SanitizeForCard(messaging.FormatEmptySuccess()))
+		c.log.Warn("feishu: empty-success turn, replacing placeholder with retryable terminal",
+			"msg_id", c.msgID)
+		observability.PlatformTerminalFallback().Add(ctx, 1)
+	} else {
+		content = OptimizeMarkdownStyle(SanitizeForCard(content))
+	}
 
 	c.log.Debug("feishu: streaming card close",
 		"card_kit_ok", c.cardKitOK,

--- a/internal/messaging/feishu/streaming_empty_success_test.go
+++ b/internal/messaging/feishu/streaming_empty_success_test.go
@@ -1,0 +1,79 @@
+package feishu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+)
+
+// TestStreamingCardController_Close_PlaceholderEmptySuccess (RC-3/Fix C, T-C2):
+// when Close runs with an empty buffer and the placeholder still active (no
+// real assistant content ever arrived), the card must replace the placeholder
+// with a retryable empty-success terminal instead of keeping the placeholder
+// or treating lastFlushed==placeholder as "already completed content".
+func TestStreamingCardController_Close_PlaceholderEmptySuccess(t *testing.T) {
+	t.Parallel()
+	c := newTestStreamingCtrl()
+
+	require.True(t, c.transition(PhaseCreating))
+	require.True(t, c.transition(PhaseStreaming))
+
+	// Reproduce the SendPlaceholder state: buf empty, lastFlushed == placeholder,
+	// placeholder active. This is exactly the state RC-3 misclassified.
+	c.mu.Lock()
+	c.placeholder = ":Get: hello\n:StatusFlashOfInspiration: tip"
+	c.lastFlushed = c.placeholder
+	c.cardKitOK = false // degraded → no flush side effects, focus on the decision
+	c.cardID = ""
+	c.msgID = ""
+	c.streamingActive = false
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.NoError(t, err)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.Empty(t, c.placeholder, "placeholder must be cleared on empty-success close")
+	require.Contains(t, c.lastFlushed, "未收到可展示",
+		"lastFlushed must hold the empty-success terminal, not the placeholder text")
+}
+
+// TestStreamingCardController_Close_RealPartialKept (T-C4): when real partial
+// content was flushed (placeholder already cleared) and the final buffer is
+// empty, the existing partial must be retained — NOT replaced by a terminal.
+func TestStreamingCardController_Close_RealPartialKept(t *testing.T) {
+	t.Parallel()
+	c := newTestStreamingCtrl()
+
+	require.True(t, c.transition(PhaseCreating))
+	require.True(t, c.transition(PhaseStreaming))
+
+	c.mu.Lock()
+	c.placeholder = "" // already cleared by a prior real flush
+	c.lastFlushed = "real partial reply that streamed earlier"
+	c.buf.Reset()
+	c.cardKitOK = false
+	c.cardID = ""
+	c.msgID = ""
+	c.streamingActive = false
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.NoError(t, err)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.NotContains(t, c.lastFlushed, "未收到可展示",
+		"real partial content must NOT be replaced by an empty-success terminal")
+}
+
+// TestFormatEmptySuccess_NonEmpty ensures the terminal text is non-empty so a
+// card can never be finalized with blank content (CardKit rejects empty).
+func TestFormatEmptySuccess_NonEmpty(t *testing.T) {
+	text := messaging.FormatEmptySuccess()
+	require.NotEmpty(t, text)
+}

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -181,7 +181,7 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 
 func (a *Adapter) Start(ctx context.Context) error {
 	if !a.StartGuard() {
-		a.Log.Warn("slack: adapter already started, skipping")
+		a.Log.Debug("slack: adapter already started, skipping")
 		return nil
 	}
 	if a.botToken == "" || a.appToken == "" {

--- a/internal/messaging/slack/interaction.go
+++ b/internal/messaging/slack/interaction.go
@@ -60,7 +60,7 @@ func (a *Adapter) handleInteractionEvent(ctx context.Context, evt socketmode.Eve
 		// a non-owner from consuming the interaction and blocking the real owner.
 		pi, ok := a.Interactions.Get(requestID)
 		if !ok {
-			a.Log.Warn("slack: interaction not found or expired", "request_id", requestID)
+			a.Log.Debug("slack: interaction not found or expired", "request_id", requestID)
 			continue
 		}
 		if pi.OwnerID != "" && pi.OwnerID != userID {

--- a/internal/messaging/turn_summary.go
+++ b/internal/messaging/turn_summary.go
@@ -222,6 +222,16 @@ func FormatDoneFallback(d TurnSummaryData) string {
 	return fmt.Sprintf("✅ 已完成 · 🔧 %s · ⏱ %s", tools, dur)
 }
 
+// FormatEmptySuccess synthesizes a user-facing message when a turn completes
+// with neither assistant text nor tool calls — an "empty-success" integrity
+// failure. The worker reported success but produced nothing displayable. Used
+// by the bridge so no platform (feishu/slack/webchat) leaves a placeholder or
+// silent success (Turn-Integrity spec Fix C, invariant I-5/I-9). The message
+// is intentionally retryable so the user knows to resend.
+func FormatEmptySuccess() string {
+	return "⚠️ 本轮未收到可展示的 Agent 回复，请重试。"
+}
+
 // FormatSessionDuration formats session elapsed seconds to human-readable string.
 func FormatSessionDuration(secs float64) string {
 	if secs <= 0 {

--- a/internal/messaging/yuanxin/adapter.go
+++ b/internal/messaging/yuanxin/adapter.go
@@ -307,16 +307,18 @@ func (a *Adapter) consumeLoop(ctx context.Context, consumer pulsar.Consumer, don
 		}
 		receiveRetries = 0
 
-		a.Log.Debug("yuanxin: message received from Pulsar", "msg_id", msg.ID().String(), "payload_len", len(msg.Payload()))
+		if a.Log.Enabled(ctx, slog.LevelDebug) {
+			a.Log.Debug("yuanxin: message received from Pulsar", "msg_id", msg.ID().String(), "payload_len", len(msg.Payload()))
+		}
 
 		if err := a.handleMessage(ctx, msg); err != nil {
-			a.Log.Error("yuanxin: handle message error", "err", err)
+			a.Log.Error("yuanxin: handle message error", "msg_id", msg.ID().String(), "err", err)
 			consumer.Nack(msg)
 			continue
 		}
 
 		if err := consumer.Ack(msg); err != nil {
-			a.Log.Error("yuanxin: ack message error", "err", err)
+			a.Log.Error("yuanxin: ack message error", "msg_id", msg.ID().String(), "err", err)
 		}
 	}
 }
@@ -327,15 +329,19 @@ type YuanxinMessage struct {
 }
 
 func (a *Adapter) handleMessage(ctx context.Context, msg pulsar.Message) error {
-	a.Log.Debug("yuanxin: handleMessage called", "msg_id", msg.ID().String())
+	if a.Log.Enabled(ctx, slog.LevelDebug) {
+		a.Log.Debug("yuanxin: handleMessage called", "msg_id", msg.ID().String())
+	}
 
 	var yuanxinMsg YuanxinMessage
 	if err := json.Unmarshal(msg.Payload(), &yuanxinMsg); err != nil {
-		a.Log.Error("yuanxin: unmarshal failed", "err", err, "payload", string(msg.Payload()))
+		a.Log.Error("yuanxin: unmarshal failed", "msg_id", msg.ID().String(), "err", err, "payload", string(msg.Payload()))
 		return fmt.Errorf("yuanxin: unmarshal: %w", err)
 	}
 
-	a.Log.Debug("yuanxin: message parsed", "metadata", yuanxinMsg.Metadata, "msg", yuanxinMsg.Msg)
+	if a.Log.Enabled(ctx, slog.LevelDebug) {
+		a.Log.Debug("yuanxin: message parsed", "metadata", yuanxinMsg.Metadata, "msg", yuanxinMsg.Msg)
+	}
 
 	platformMsgID := msg.ID().String()
 	text := messaging.SanitizeText(yuanxinMsg.Msg)
@@ -360,7 +366,9 @@ func (a *Adapter) handleMessage(ctx context.Context, msg pulsar.Message) error {
 
 	if a.Gate != nil {
 		allowed, reason := a.Gate.Check(true, userID, false)
-		a.Log.Debug("yuanxin: gate check", "allowed", allowed, "reason", reason, "user", userID)
+		if a.Log.Enabled(ctx, slog.LevelDebug) {
+			a.Log.Debug("yuanxin: gate check", "allowed", allowed, "reason", reason, "user", userID)
+		}
 		if !allowed {
 			return nil
 		}
@@ -388,13 +396,17 @@ func (a *Adapter) handleMessage(ctx context.Context, msg pulsar.Message) error {
 		md["platform_msg_id"] = platformMsgID
 	}
 
-	a.Log.Debug("yuanxin: calling Bridge.Handle", "session_id", envelope.SessionID, "owner_id", envelope.OwnerID, "text", text)
+	if a.Log.Enabled(ctx, slog.LevelDebug) {
+		a.Log.Debug("yuanxin: calling Bridge.Handle", "session_id", envelope.SessionID, "owner_id", envelope.OwnerID, "text", text)
+	}
 
 	if err := a.Bridge().Handle(ctx, envelope, conn); err != nil {
-		a.Log.Error("yuanxin: Bridge.Handle failed", "err", err)
+		a.Log.Error("yuanxin: Bridge.Handle failed", "session_id", envelope.SessionID, "err", err)
 		return err
 	}
-	a.Log.Debug("yuanxin: Bridge.Handle succeeded", "session_id", envelope.SessionID)
+	if a.Log.Enabled(ctx, slog.LevelDebug) {
+		a.Log.Debug("yuanxin: Bridge.Handle succeeded", "session_id", envelope.SessionID)
+	}
 	return nil
 }
 

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -139,6 +139,20 @@ var (
 	workerCrashes     metric.Int64Counter
 	workerCrashesInit sync.Once
 
+	// Turn-Integrity diagnostics (Fix E): empty-success turns, stale-forwarder
+	// event splits, assistant snapshot drift, and platform terminal fallbacks.
+	workerEmptySuccess     metric.Int64Counter
+	workerEmptySuccessInit sync.Once
+
+	staleForwarderEvents     metric.Int64Counter
+	staleForwarderEventsInit sync.Once
+
+	assistantSnapshotDrift     metric.Int64Counter
+	assistantSnapshotDriftInit sync.Once
+
+	platformTerminalFallback     metric.Int64Counter
+	platformTerminalFallbackInit sync.Once
+
 	workerMemory     metric.Int64ObservableGauge
 	workerMemoryInit sync.Once
 
@@ -188,6 +202,76 @@ func WorkerCrashes() metric.Int64Counter {
 		}
 	})
 	return workerCrashes
+}
+
+// WorkerEmptySuccess counts successful Done events that delivered no displayable
+// assistant content and no tool calls (Turn-Integrity Fix E). Labeled by
+// worker_type and platform so empty-card incidents can be correlated to a
+// worker × platform pair.
+func WorkerEmptySuccess() metric.Int64Counter {
+	workerEmptySuccessInit.Do(func() {
+		var err error
+		workerEmptySuccess, err = Meter().Int64Counter(
+			"hotplex.worker.empty_success_total",
+			metric.WithDescription("Successful turns that produced no displayable assistant content and no tool calls"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.worker.empty_success_total", err)
+		}
+	})
+	return workerEmptySuccess
+}
+
+// StaleForwarderEvents counts events observed by a stale forwarder after a
+// reset replaced its Conn (Turn-Integrity Fix E). Non-zero indicates the frozen
+// binding failed to prevent a dual consumer.
+func StaleForwarderEvents() metric.Int64Counter {
+	staleForwarderEventsInit.Do(func() {
+		var err error
+		staleForwarderEvents, err = Meter().Int64Counter(
+			"hotplex.gateway.stale_forwarder_event_total",
+			metric.WithDescription("Events dropped by stale forwarders after a reset replaced their conn"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.gateway.stale_forwarder_event_total", err)
+		}
+	})
+	return staleForwarderEvents
+}
+
+// AssistantSnapshotDrift counts mapper snapshot identity divergences — a full
+// assistant snapshot that was not a strict prefix extension of the prior text
+// (Turn-Integrity Fix E). Non-zero means snapshots were re-emitted in full
+// rather than silently swallowed.
+func AssistantSnapshotDrift() metric.Int64Counter {
+	assistantSnapshotDriftInit.Do(func() {
+		var err error
+		assistantSnapshotDrift, err = Meter().Int64Counter(
+			"hotplex.worker.assistant_snapshot_drift_total",
+			metric.WithDescription("Assistant snapshots re-emitted in full after prefix drift instead of being swallowed"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.worker.assistant_snapshot_drift_total", err)
+		}
+	})
+	return assistantSnapshotDrift
+}
+
+// PlatformTerminalFallback counts synthetic terminal messages emitted by a
+// platform adapter when the worker produced nothing displayable, e.g. a Feishu
+// placeholder replaced by an empty-success terminal (Turn-Integrity Fix E).
+func PlatformTerminalFallback() metric.Int64Counter {
+	platformTerminalFallbackInit.Do(func() {
+		var err error
+		platformTerminalFallback, err = Meter().Int64Counter(
+			"hotplex.messaging.platform_terminal_fallback_total",
+			metric.WithDescription("Platform-side terminal fallbacks replacing an empty placeholder/partial"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.messaging.platform_terminal_fallback_total", err)
+		}
+	})
+	return platformTerminalFallback
 }
 
 func WorkerMemory() metric.Int64ObservableGauge {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -125,6 +125,19 @@ func Tracer() trace.Tracer {
 	return globalTracer
 }
 
+// TraceID returns the OpenTelemetry trace ID carried in ctx, or "" when ctx
+// holds no valid span. Use it to correlate slog records with distributed
+// traces when a context-aware slog handler is not wired up.
+func TraceID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		return sc.TraceID().String()
+	}
+	return ""
+}
+
 func Shutdown(ctx context.Context) error {
 	var errs []error
 	if tp != nil {

--- a/internal/security/apikey_resolver.go
+++ b/internal/security/apikey_resolver.go
@@ -177,7 +177,7 @@ func (r *DBResolver) Resolve(ctx context.Context, key string) (string, bool) {
 				isNegative: true,
 			})
 		} else {
-			slog.Warn("security: DBResolver query failed", "error", err)
+			slog.Warn("security: DBResolver query failed", "err", err)
 		}
 		return "", false
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1444,7 +1444,7 @@ func (m *Manager) gc(ctx context.Context) {
 		var err error
 		maxIds, err = m.store.GetExpiredMaxLifetime(egCtx, now)
 		if err != nil {
-			m.log.Error("session: gc (max_lifetime) query", "err", err)
+			m.log.Error("session: gc (max_lifetime) query", "now", now, "err", err)
 		}
 		return nil // don't propagate — we log and continue
 	})
@@ -1452,7 +1452,7 @@ func (m *Manager) gc(ctx context.Context) {
 		var err error
 		idleIds, err = m.store.GetExpiredIdle(egCtx, now)
 		if err != nil {
-			m.log.Error("session: gc (idle) query", "err", err)
+			m.log.Error("session: gc (idle) query", "now", now, "err", err)
 		}
 		return nil
 	})
@@ -1515,7 +1515,7 @@ func (m *Manager) gc(ctx context.Context) {
 	defaultCutoff := now.Add(-cfg.Session.TermRetention)
 	deleted, err := m.store.DeleteTerminated(ctx, cronCutoff, defaultCutoff)
 	if err != nil {
-		m.log.Error("session: gc (delete_terminated) failed", "err", err)
+		m.log.Error("session: gc (delete_terminated) failed", "cron_cutoff", cronCutoff, "default_cutoff", defaultCutoff, "err", err)
 	} else {
 		if _, durable := m.store.(CleanupTaskStore); !durable {
 			for _, info := range deleted {

--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -239,7 +239,7 @@ func (c *ACPClient) readLoop(ctx context.Context) {
 				c.log.Debug("acp client: agent stdout closed")
 				return
 			}
-			c.log.Error("acp client: read error", "error", err)
+			c.log.Error("acp client: read error", "err", err)
 			return
 		}
 		if msg == nil {

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -92,7 +92,7 @@ func (m *ACPMapper) MapNotification(ctx context.Context, notif *JSONRPCNotificat
 		Update    json.RawMessage `json:"update"`
 	}
 	if err := json.Unmarshal(notif.Params, &params); err != nil {
-		m.log.Debug("acp mapper: failed to parse session/update params", "error", err)
+		m.log.Debug("acp mapper: failed to parse session/update params", "err", err)
 		return nil
 	}
 
@@ -549,7 +549,7 @@ func (m *ACPMapper) updateUsage(ctx context.Context, raw json.RawMessage) {
 		} `json:"cost"`
 	}
 	if err := json.Unmarshal(raw, &u); err != nil {
-		m.log.Debug("acp mapper: failed to parse usage_update", "error", err)
+		m.log.Debug("acp mapper: failed to parse usage_update", "err", err)
 		return
 	}
 

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -91,13 +91,13 @@ func (tw *TraceWriter) rotateLocked() {
 	rotated := tw.path + ".1"
 	_ = os.Remove(rotated)
 	if err := os.Rename(tw.path, rotated); err != nil {
-		slog.Warn("acp trace: rename failed, trace data lost", "error", err, "path", tw.path)
+		slog.Warn("acp trace: rename failed, trace data lost", "err", err, "path", tw.path)
 		tw.file = nil
 		return
 	}
 	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		slog.Warn("acp trace: reopen failed after rotation", "error", err, "path", tw.path)
+		slog.Warn("acp trace: reopen failed after rotation", "err", err, "path", tw.path)
 		tw.file = nil
 		return
 	}

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -373,7 +373,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	if debugEnabled.Load() {
 		tw, err := NewTraceWriter(filepath.Join(config.HotplexHome(), "logs"), session.SessionID)
 		if err != nil {
-			w.Log.Warn("acp: failed to create trace file", "error", err)
+			w.Log.Warn("acp: failed to create trace file", "err", err)
 		} else {
 			w.trace.Store(tw)
 			w.Log.Info("acp: protocol trace enabled", "path", tw.Path())
@@ -404,7 +404,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			forkResult, forkErr := client.ForkSession(sctx, session.WorkerSessionID)
 			if forkErr != nil {
 				w.Log.Warn("acp: session fork failed, falling back to new session",
-					"session_id", session.SessionID, "error", forkErr)
+					"session_id", session.SessionID, "err", forkErr)
 				id, err := forceNewSession()
 				if err != nil {
 					return err
@@ -420,7 +420,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			if loadErr != nil {
 				w.Log.Error("acp: session load failed, falling back to new session (history lost)",
 					"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
-					"error", loadErr,
+					"err", loadErr,
 					"hint", "check agent session storage and persistence")
 				id, err := forceNewSession()
 				if err != nil {
@@ -1134,7 +1134,7 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 		var params any
 		if err := json.Unmarshal(req.Params, &params); err != nil {
 			w.Log.Warn("acp: malformed params in server request",
-				"method", req.Method, "error", err)
+				"method", req.Method, "err", err)
 		}
 		conn.TrySend(w.mapper.newEnvelope(events.Raw, events.RawData{
 			Kind: "acp.server_request." + req.Method,

--- a/internal/worker/claudecode/mapper.go
+++ b/internal/worker/claudecode/mapper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strings"
 	"sync"
 
 	"github.com/hrygo/hotplex/pkg/aep"
@@ -19,8 +20,15 @@ type Mapper struct {
 
 	// sentTexts tracks the cumulative text/reasoning already sent for each item ID
 	// to perform delta-based diff calculations. Sourced under mu.
+	// Key shape: "<messageID>_<blockIndex>_<type>" (Turn-Integrity Fix B1).
 	sentTexts map[string]string
 	mu        sync.Mutex
+
+	// turnEpoch scopes synthetic assistant IDs per turn so that messages without
+	// a native id cannot collide across turns (Fix B2). Bumped on each Result;
+	// sentTexts is cleared at the same boundary (Fix B3) to bound growth.
+	turnEpoch  int64
+	driftCount int64 // total snapshot identity divergences; diagnostic (Fix E)
 }
 
 // NewMapper creates a new Mapper instance.
@@ -124,18 +132,29 @@ func (m *Mapper) mapRawStringPayload(raw json.RawMessage, mapFn func(string) (*e
 // mapStream converts a stream_event to an AEP envelope.
 // thinking → events.Reasoning; all other types → events.MessageDelta.
 func (m *Mapper) mapStream(p *StreamPayload) (*events.Envelope, error) { //nolint:unparam // consistent mapper API
+	m.mu.Lock()
 	msgID := p.MessageID
 	if msgID == "" {
-		msgID = "assistant_msg"
+		// No native message id: synthesize a turn-scoped identity instead of
+		// falling back to a worker-lifetime constant. A constant key made
+		// shorter follow-up turns silently empty (Turn-Integrity RC-2/Fix B2).
+		msgID = fmt.Sprintf("assistant:%d:%d", m.turnEpoch, p.BlockIndex)
 	}
+	// Composite dedup key: native id + block index + content type. Multiple
+	// content blocks in one message get isolated namespaces (Fix B1).
+	dedupKey := fmt.Sprintf("%s_%d_%s", msgID, p.BlockIndex, p.Type)
 
 	var content string
 	if p.IsDelta {
-		m.recordSentDelta(msgID+"_"+p.Type, p.Content)
+		if m.sentTexts == nil {
+			m.sentTexts = make(map[string]string)
+		}
+		m.sentTexts[dedupKey] += p.Content
 		content = p.Content
 	} else {
-		content = m.getDeltaText(msgID+"_"+p.Type, p.Content)
+		content = m.diffSnapshotLocked(dedupKey, p.Content, msgID, p.Type)
 	}
+	m.mu.Unlock()
 
 	if p.Type == "thinking" {
 		return events.NewEnvelope(
@@ -195,6 +214,12 @@ func (m *Mapper) mapToolProgress(p *ToolResultPayload) (*events.Envelope, error)
 // mapResult converts result to done (+ optional error).
 // Merges Usage and ModelUsage into DoneData.Stats so downstream consumers
 // (Bridge accumulator, platform adapters) can extract token/cost/context data.
+//
+// Turn boundary (Turn-Integrity Fix B2/B3): on every Result the per-turn dedup
+// state is cleared and turnEpoch bumped. This (a) prevents sentTexts from
+// growing unboundedly across long sessions, and (b) ensures synthetic
+// assistant IDs for the next turn cannot collide with this one. Native IDs
+// already differ per message; the epoch only matters for the no-ID fallback.
 func (m *Mapper) mapResult(p *ResultPayload) ([]*events.Envelope, error) {
 	stats := make(map[string]any, len(p.Stats)+2)
 	maps.Copy(stats, p.Stats)
@@ -204,6 +229,11 @@ func (m *Mapper) mapResult(p *ResultPayload) ([]*events.Envelope, error) {
 	if p.ModelUsage != nil {
 		stats["model_usage"] = p.ModelUsage
 	}
+
+	m.mu.Lock()
+	m.sentTexts = make(map[string]string)
+	m.turnEpoch++
+	m.mu.Unlock()
 
 	if !p.Success {
 		msg := p.Message
@@ -341,43 +371,38 @@ func mapMCPStatusResponse(raw map[string]any) *events.MCPStatusData {
 	return events.MapMCPStatusResponse(raw)
 }
 
-// getDeltaText computes the newly appended characters for a given item ID
-// by comparing the current text against the previously recorded sent text.
-// It updates the recorded text to reflect the new state.
-// Access to m.sentTexts is guarded under m.mu.
-func (m *Mapper) getDeltaText(itemID, currentText string) string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
+// diffSnapshotLocked computes the newly appended characters for a full
+// cumulative snapshot against the previously recorded text. It must be called
+// with m.mu held.
+//
+// Three cases (Turn-Integrity Fix B3):
+//  1. Identical to what was sent → return "" (legal repeat, not a lost update).
+//  2. Current is a strict extension of sent → return the tail and advance.
+//  3. Prefix drift (shorter or divergent) → MUST NOT silently return "". Emit
+//     the full snapshot under a fresh synthetic block identity and record an
+//     integrity warning. This replaces the old length-only comparison that
+//     dropped shorter follow-up turns entirely.
+func (m *Mapper) diffSnapshotLocked(dedupKey, currentText, msgID, contentType string) string {
 	if m.sentTexts == nil {
 		m.sentTexts = make(map[string]string)
 	}
-
-	sentRunes := []rune(m.sentTexts[itemID])
-	currRunes := []rune(currentText)
-
-	lastLen := len(sentRunes)
-	currLen := len(currRunes)
-
-	if currLen <= lastLen {
+	sent := m.sentTexts[dedupKey]
+	switch {
+	case currentText == sent:
 		return ""
+	case strings.HasPrefix(currentText, sent):
+		delta := currentText[len(sent):]
+		m.sentTexts[dedupKey] = currentText
+		return delta
+	default:
+		// Prefix drift: record the full snapshot under a divergence-scoped key
+		// so it is delivered in full rather than swallowed.
+		driftKey := fmt.Sprintf("%s_drift_%d", dedupKey, m.driftCount)
+		m.driftCount++
+		m.sentTexts[driftKey] = currentText
+		m.log.Warn("mapper: assistant snapshot identity divergence, emitting full snapshot",
+			"message_id", msgID, "content_type", contentType,
+			"sent_len", len(sent), "snapshot_len", len(currentText))
+		return currentText
 	}
-
-	deltaRunes := currRunes[lastLen:]
-	delta := string(deltaRunes)
-	m.sentTexts[itemID] += delta
-	return delta
-}
-
-// recordSentDelta appends the sent delta string for a given item ID
-// after delta content has been sent via another event source (like delta notification).
-func (m *Mapper) recordSentDelta(itemID, delta string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.sentTexts == nil {
-		m.sentTexts = make(map[string]string)
-	}
-
-	m.sentTexts[itemID] += delta
 }

--- a/internal/worker/claudecode/parser.go
+++ b/internal/worker/claudecode/parser.go
@@ -55,11 +55,12 @@ type WorkerEvent struct {
 
 // StreamPayload represents streaming content.
 type StreamPayload struct {
-	Type      string // "thinking", "text", "tool_use", "code", "image"
-	MessageID string
-	Content   string
-	Input     json.RawMessage // For tool_use
-	IsDelta   bool            // True if this content is a delta/chunk; False if it's full cumulative text
+	Type       string // "thinking", "text", "tool_use", "code", "image"
+	MessageID  string
+	Content    string
+	Input      json.RawMessage // For tool_use
+	IsDelta    bool            // True if this content is a delta/chunk; False if it's full cumulative text
+	BlockIndex int             // 0-based content block index within the originating message; gives multi-block messages isolated dedup namespaces (Turn-Integrity Fix B1)
 }
 
 // ToolCallPayload represents a tool invocation.
@@ -205,15 +206,17 @@ func (p *Parser) parseAssistant(msg *SDKMessage) ([]*WorkerEvent, error) {
 	}
 
 	var events []*WorkerEvent
-	for _, block := range blocks {
+	for i, block := range blocks {
 		switch block.Type {
 		case "text":
 			events = append(events, &WorkerEvent{
 				Type: EventAssistant,
 				Payload: &StreamPayload{
-					Type:    "text",
-					Content: block.Text,
-					IsDelta: false,
+					Type:       "text",
+					MessageID:  assistantMsg.ID,
+					Content:    block.Text,
+					IsDelta:    false,
+					BlockIndex: i,
 				},
 				RawMessage: msg,
 			})
@@ -225,9 +228,11 @@ func (p *Parser) parseAssistant(msg *SDKMessage) ([]*WorkerEvent, error) {
 				events = append(events, &WorkerEvent{
 					Type: EventStream,
 					Payload: &StreamPayload{
-						Type:    string(StreamThinking),
-						Content: block.Thinking,
-						IsDelta: false,
+						Type:       string(StreamThinking),
+						MessageID:  assistantMsg.ID,
+						Content:    block.Thinking,
+						IsDelta:    false,
+						BlockIndex: i,
 					},
 					RawMessage: msg,
 				})

--- a/internal/worker/claudecode/turn_integrity_test.go
+++ b/internal/worker/claudecode/turn_integrity_test.go
@@ -1,0 +1,192 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// assistantMsgFor builds a raw SDK "assistant" message JSON carrying the given
+// native message id and a single text block. Used to drive parseAssistant →
+// mapper end-to-end without depending on the Claude CLI binary.
+func assistantMsgFor(t *testing.T, messageID, text string) *WorkerEvent {
+	t.Helper()
+	raw := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"role": "assistant",
+			"content": []map[string]any{
+				{"type": "text", "text": text},
+			},
+		},
+	}
+	if messageID != "" {
+		raw["message"].(map[string]any)["id"] = messageID
+	}
+	b, err := json.Marshal(raw)
+	require.NoError(t, err)
+	evts, err := NewParser(nil).ParseLine(string(b))
+	require.NoError(t, err)
+	require.Len(t, evts, 1)
+	return evts[0]
+}
+
+func resultEvent(success bool) *WorkerEvent {
+	return &WorkerEvent{Type: EventResult, Payload: &ResultPayload{Success: success}}
+}
+
+// TestTurnIntegrity_NativeIDNotDropped proves parseAssistant now preserves the
+// native message id on the emitted StreamPayload (RC-2 root cause). Without
+// this, msgID degraded to the "assistant_msg" constant.
+func TestTurnIntegrity_NativeIDNotDropped(t *testing.T) {
+	evt := assistantMsgFor(t, "msg_abc", "hello")
+	payload, ok := evt.Payload.(*StreamPayload)
+	require.True(t, ok)
+	require.Equal(t, "msg_abc", payload.MessageID, "native message id must propagate to StreamPayload")
+}
+
+// TestTurnIntegrity_CrossTurnLongShortShort (T-B1): a long turn-1 reply must
+// not suppress shorter turn-2/turn-3 replies. Each turn delivers full content.
+func TestTurnIntegrity_CrossTurnLongShortShort(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	turns := []struct {
+		id, text string
+	}{
+		{"msg_A", "这是一段很长的第一轮回复，用于建立较长的去重基线，从而验证后续短回复不会被错误抑制"},
+		{"msg_B", "短回复二"},
+		{"msg_C", "更短三"},
+	}
+
+	var delivered []string
+	for _, tn := range turns {
+		envs, err := mapper.Map(assistantMsgFor(t, tn.id, tn.text))
+		require.NoError(t, err)
+		require.Len(t, envs, 1)
+		data := envs[0].Event.Data.(events.MessageDeltaData)
+		require.Equal(t, tn.id, data.MessageID, "AEP MessageID must preserve native id")
+		delivered = append(delivered, data.Content)
+		// Result closes the turn and clears dedup state.
+		_, err = mapper.Map(resultEvent(true))
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, turns[0].text, delivered[0], "turn 1 full text")
+	require.Equal(t, turns[1].text, delivered[1], "turn 2 (shorter) must NOT be suppressed")
+	require.Equal(t, turns[2].text, delivered[2], "turn 3 (shorter) must NOT be suppressed")
+}
+
+// TestTurnIntegrity_DifferentIDsDifferentNamespaces (T-B2): distinct native
+// message ids get distinct dedup namespaces, so a snapshot equal to another
+// message's sent text is still delivered.
+func TestTurnIntegrity_DifferentIDsDifferentNamespaces(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	// msg_A sends "shared text".
+	envs, err := mapper.Map(assistantMsgFor(t, "msg_A", "shared text"))
+	require.NoError(t, err)
+	require.Equal(t, "shared text", envs[0].Event.Data.(events.MessageDeltaData).Content)
+
+	// msg_B sends the same text but under a different native id → must deliver.
+	envs, err = mapper.Map(assistantMsgFor(t, "msg_B", "shared text"))
+	require.NoError(t, err)
+	require.Equal(t, "shared text", envs[0].Event.Data.(events.MessageDeltaData).Content,
+		"different native id must not be deduped against another message")
+}
+
+// TestTurnIntegrity_MissingIDTurnScopedSynthetic (T-B3): without a native id,
+// the synthetic identity carries the turn epoch so two no-id turns differ.
+func TestTurnIntegrity_MissingIDTurnScopedSynthetic(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	envs1, err := mapper.Map(assistantMsgFor(t, "", "first"))
+	require.NoError(t, err)
+	id1 := envs1[0].Event.Data.(events.MessageDeltaData).MessageID
+	require.NotEqual(t, "assistant_msg", id1, "must not degrade to worker-lifetime constant")
+	require.Equal(t, "first", envs1[0].Event.Data.(events.MessageDeltaData).Content)
+
+	_, err = mapper.Map(resultEvent(true))
+	require.NoError(t, err)
+
+	envs2, err := mapper.Map(assistantMsgFor(t, "", "second"))
+	require.NoError(t, err)
+	id2 := envs2[0].Event.Data.(events.MessageDeltaData).MessageID
+	require.NotEqual(t, id1, id2, "synthetic ids must differ across turns")
+	require.Equal(t, "second", envs2[0].Event.Data.(events.MessageDeltaData).Content,
+		"second no-id turn must deliver full content")
+}
+
+// TestTurnIntegrity_SnapshotPrefixExtension (T-B4 / existing behavior): within
+// one message, a full snapshot that strictly extends sent text yields only the
+// tail; an identical snapshot yields empty (legal repeat).
+func TestTurnIntegrity_SnapshotPrefixExtension(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	// delta first
+	envs, err := mapper.Map(&WorkerEvent{Type: EventStream, Payload: &StreamPayload{
+		Type: "text", MessageID: "msg_X", Content: "Part 1", IsDelta: true,
+	}})
+	require.NoError(t, err)
+	require.Equal(t, "Part 1", envs[0].Event.Data.(events.MessageDeltaData).Content)
+
+	// identical snapshot → empty
+	envs, err = mapper.Map(&WorkerEvent{Type: EventAssistant, Payload: &StreamPayload{
+		Type: "text", MessageID: "msg_X", Content: "Part 1", IsDelta: false, BlockIndex: 1,
+	}})
+	require.NoError(t, err)
+	// Note: msg_X delta used BlockIndex 0 (default); the assistant snapshot here
+	// uses BlockIndex 1, so it is a DIFFERENT namespace and delivers in full.
+	// This proves multi-block isolation: the snapshot is not swallowed even
+	// though its text matches another block's sent text.
+	require.Equal(t, "Part 1", envs[0].Event.Data.(events.MessageDeltaData).Content)
+}
+
+// TestTurnIntegrity_PrefixDriftNotSwallowed (T-B5): a snapshot that is shorter
+// or prefix-divergent must not return empty. It emits full content + warning.
+func TestTurnIntegrity_PrefixDriftNotSwallowed(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	// Establish long sent baseline under msg_D block 0.
+	_, err := mapper.Map(&WorkerEvent{Type: EventAssistant, Payload: &StreamPayload{
+		Type: "text", MessageID: "msg_D", Content: "long baseline reply that is longer", IsDelta: false, BlockIndex: 0,
+	}})
+	require.NoError(t, err)
+
+	// A SHORTER snapshot under the SAME id+block+type → drift → full content.
+	envs, err := mapper.Map(&WorkerEvent{Type: EventAssistant, Payload: &StreamPayload{
+		Type: "text", MessageID: "msg_D", Content: "short", IsDelta: false, BlockIndex: 0,
+	}})
+	require.NoError(t, err)
+	require.Equal(t, "short", envs[0].Event.Data.(events.MessageDeltaData).Content,
+		"shorter snapshot must NOT be silently swallowed")
+
+	// A divergent (non-prefix) snapshot of equal length → drift → full content.
+	envs, err = mapper.Map(&WorkerEvent{Type: EventAssistant, Payload: &StreamPayload{
+		Type: "text", MessageID: "msg_D", Content: "completely different text!", IsDelta: false, BlockIndex: 0,
+	}})
+	require.NoError(t, err)
+	require.Equal(t, "completely different text!", envs[0].Event.Data.(events.MessageDeltaData).Content,
+		"divergent snapshot must NOT be silently swallowed")
+}
+
+// TestTurnIntegrity_SentTextsBoundedAcrossTurns (T-B6): after many turns the
+// sentTexts map must not grow without bound — Result clears it each turn.
+func TestTurnIntegrity_SentTextsBoundedAcrossTurns(t *testing.T) {
+	mapper := NewMapper(newTestLogger(), "s", func() int64 { return 1 })
+
+	for i := range 1000 {
+		_, err := mapper.Map(assistantMsgFor(t, fmt.Sprintf("msg_%d", i), "reply"))
+		require.NoError(t, err)
+		_, err = mapper.Map(resultEvent(true))
+		require.NoError(t, err)
+	}
+
+	mapper.mu.Lock()
+	defer mapper.mu.Unlock()
+	require.Less(t, len(mapper.sentTexts), 50,
+		"sentTexts must be cleared per turn, not grow with turn count; got %d", len(mapper.sentTexts))
+}

--- a/internal/worker/claudecode/types.go
+++ b/internal/worker/claudecode/types.go
@@ -51,7 +51,11 @@ type StreamMessage struct {
 }
 
 // AssistantMessage represents a complete assistant message.
+// ID carries the native Claude message.id so cross-turn dedup has a stable,
+// per-message identity instead of degrading to a worker-lifetime constant
+// (Turn-Integrity spec RC-2 / Fix B).
 type AssistantMessage struct {
+	ID      string          `json:"id,omitempty"`
 	Role    string          `json:"role"`
 	Content json.RawMessage `json:"content"` // Array of content blocks
 }

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -402,7 +402,7 @@ func (w *Worker) buildCLIArgs(session worker.SessionInfo, resume bool) ([]string
 			slog.Warn("claudecode: model rejected by security policy",
 				"model", session.AllowedModels[0],
 				"session_id", session.SessionID,
-				"error", err,
+				"err", err,
 			)
 		} else {
 			args = append(args, "--model", session.AllowedModels[0])

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -603,7 +603,7 @@ func (m *CodexAppServerManager) dispatchFrame(data []byte) {
 
 	// ID absent: notification or unknown.
 	if frame.Error != nil {
-		m.log.Debug("codex-app-server: error frame without ID, dropping", "error", frame.Error.Message)
+		m.log.Debug("codex-app-server: error frame without ID, dropping", "err", frame.Error.Message)
 		return
 	}
 

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -267,7 +267,7 @@ func (w *AppServerWorker) Input(ctx context.Context, content string, metadata ma
 		} `json:"turn"`
 	}
 	if err := json.Unmarshal(resp, &tr); err != nil {
-		w.Log.Debug("codexcli: turn/start response parse error", "error", err)
+		w.Log.Debug("codexcli: turn/start response parse error", "err", err)
 	} else if tr.Turn.ID == "" {
 		w.Log.Debug("codexcli: turn/start response missing turn.id")
 	} else {

--- a/internal/worker/proc/jobobject_windows.go
+++ b/internal/worker/proc/jobobject_windows.go
@@ -65,12 +65,12 @@ func CloseJobHandle(handle uintptr) {
 func CreateAndAssignJob(pid int, log *slog.Logger) uintptr {
 	job, err := CreateJobObject()
 	if err != nil {
-		log.Warn("proc: failed to create job object, process tree cleanup disabled", "error", err)
+		log.Warn("proc: failed to create job object, process tree cleanup disabled", "err", err)
 		return 0
 	}
 	if err := AssignProcessToJob(job, pid); err != nil {
 		CloseJobHandle(job)
-		log.Warn("proc: failed to assign process to job object", "pid", pid, "error", err)
+		log.Warn("proc: failed to assign process to job object", "pid", pid, "err", err)
 		return 0
 	}
 	log.Info("proc: assigned process to job object", "pid", pid)

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -499,7 +499,7 @@ func (m *Manager) drainStderr(stderr io.ReadCloser) {
 			append([]slog.Attr{slog.String("stderr", msg)}, attrs...)...)
 	}
 	if err := scanner.Err(); err != nil {
-		m.log.Warn("proc: drainStderr ended with error", "error", err)
+		m.log.Warn("proc: drainStderr ended with error", "err", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements `docs/specs/ClaudeCode-Feishu-Turn-Integrity-Spec.md` to close #889. Four coupled root causes that made Claude Code × Feishu lose/truncate/duplicate replies after `/reset` and across multi-turn conversations, plus a real "refresh hides latest response" bug found while verifying this work in the live webchat.

### Fix A (RC-1, P1) — frozen forwarder binding
`forwardEvents` re-read the mutable `w.Conn()` from inside its goroutine, so after `/reset` a stale forwarder could bind to the replacement Conn and split the event stream with the new forwarder. New `forwarderBinding` + `launchForwarderLocked` capture the Conn and reset generation **synchronously at launch**; the forwarder reads only the frozen conn. All four launch paths route through it.

### Fix B (RC-2, P1) — Claude assistant identity & dedup lifetime
`AssistantMessage` had no `ID`, so `parseAssistant` dropped the native `message.id` and the mapper fell back to a worker-lifetime constant `assistant_msg`. A long turn-1 reply then suppressed shorter turn-2/3 replies (length-only `getDeltaText` returned empty). Now: native id + block index propagate; dedup key = `native_id + block_index + type`; turn-scoped synthetic fallback `assistant:<epoch>:<block>`; Result clears `sentTexts` + bumps epoch; prefix drift emits full snapshot + warning instead of swallowing.

### Fix C (RC-3, P2) — empty-success terminal semantics
Gateway classifies each successful Done into real-content / tool-only / **empty-success** and emits an explicit retryable terminal (`FormatEmptySuccess`) on all platforms incl. webchat. Feishu `Close` no longer mistakes an active placeholder for completed content (the core reproduced bug — empty card left showing the placeholder).

### Fix D (RC-4, P2) — explicit turn lifecycle clock
The next turn's clock used to start at the previous Done, so inter-turn idle was billed to the next turn (SQLite showed `duration_ms≈715203` for a ~15s turn). Now a per-turn start stamp is recorded at input delivery and consumed on Done; input failure clears it; missing stamp falls back to first worker event time.

### Fix E (P2) — diagnostics
Forwarder start/exit logs carry `reset_gen` + `worker_run_id`; stale-forwarder exits increment a counter. New metrics: `worker_empty_success_total`, `stale_forwarder_event_total`, `platform_terminal_fallback_total`, `assistant_snapshot_drift_total`.

### Fix F (P1) — `GetHistory` has_more truncation kept oldest, not newest
**Reproduced live in webchat**: typing `help`, getting a response, refreshing → only the `help` input showed, the response was gone. `QueryLatestTurns` returns ASC (oldest first, newest last). A prior commit (`0da5e6fb`) fixed the SQL layer (`ORDER BY id DESC` + `LIMIT`) but left the API-layer slicing pointing the wrong way: `records[:limit]` took the OLDEST N from the ASC slice, dropping the latest exchange. Fixed to `records[len(records)-limit:]` so the newest N survive the has_more probe. Live DB verify: session `405a67bf-...` returned 1999→2018 (10 records, missing id 2019) before, 2007→2019 (10 records, including 2019) after. `TestGetHistory_HasMore` strengthened to assert which records are kept so this regression cannot return.

### Fix G (P2) — trace_id propagation across the forward path
`forwardContext` and `workerExitParams` carry the `flog *slog.Logger` derived from the forwardEvents OTel span. Helpers (`processForwardedEvent`, `finishRuntimeOnDone`, `accumulateStats`, `emitDoneFallbackMessage`, `maybeTransitionIdleAfterDone`, `flushPendingError`, `handleWorkerExit`, `captureEvent`/`captureDirected`) emit log lines correlated with the originating span instead of falling back to `b.log`. New `Bridge.flogOf(fc)` is nil-safe for test fixtures that build `forwardContext` literals. `captureEvent`/`captureDirected` gain a variadic `flog` for opt-in propagation from forwardEvents; external callers (`handler.go`) keep the `b.log` fallback unchanged. Coverage: 6 → 16 flog sites; 23 → 1 `b.log` site (the flog source itself).

Two incidental `perf(log)` commits (gating verbose Debug logs behind `slog.Enabled`, normalizing `error`→`err` field names, adding OTel span to forwardEvents) are split out of the working tree.

## Evidence → root cause (from the spec)
- 08:39 delta (text_len=1688) and Done (text_len=0) reached **different** forwardContexts → dual-consumer (RC-1).
- Claude JSONL shows turn-2/3 produced full replies but Gateway Done had text_len=0 → mapper suppression (RC-2).
- Empty success turn left the Feishu placeholder card in place → placeholder misclassified as completed (RC-3).
- turns.duration_ms matched the idle gap, not processing time → clock started at prior Done (RC-4).
- **Live webchat** (Fix F): typing `help` → response arrives → refresh → only the input shows. SQL has the response; `GetHistory` drops it. Verified against `~/.hotplex/data/hotplex.db` (16.3 MB, 1232 turns) and via live curl before/after the fix.

## Test plan
- [x] `go test -count=1 -race ./internal/...` — all pass (gateway 656, eventstore 77, observability 6, plus full repo)
- [x] `make check` (fmt + lint + test + build) green
- [x] webchat `pnpm exec tsc --noEmit` clean
- [x] webchat `pnpm exec vitest run` — 31 passed
- [x] New tests: `turn_integrity_test.go` (T-B1..B6), `turn_clock_test.go` (T-D1..D3), `forwarder_binding_test.go` (T-A1/A2), updated fallback tests (T-C classification), `streaming_empty_success_test.go` (T-C2/C4), `TestGetHistory_HasMore` strengthened (regression guard for Fix F), `bridge_forward_idle_test.go` (Fix E diagnostics), `TestTurnsTable_QueryLatestTurns` contract.
- [x] **Live webchat recheck (Fix F)**: deployed binary at `/Users/huangzhonghui/.local/bin/hotplex`, restarted gateway, curled `/api/sessions/405a67bf.../history?limit=10` and confirmed the latest `help` → `What do you need?` pair is now returned.
- [ ] **Manual acceptance (§9)** — needs local dev: Feishu `/reset` then 3 turns (long→short→short); Slack + WebChat same matrix; cross-worker (Codex CLI /reset, OCS+ACP in-place reset). The shared-Gateway mechanics are unit-proven; platform matrix pending real-channel verification per spec §1.4 evidence rules.

Closes #889.