### PR TITLE
perf(webchat): 消除首 token 前黑洞并建立 TTFT 可观测性

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -88,6 +88,40 @@ histogram_quantile(0.95, rate(hotplex_worker_execution_duration_bucket[5m]))
 sum by (worker_type) (hotplex_worker_memory_bytes)
 ```
 
+## Turn TTFT 指标
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.turn.ttft` | Histogram | Gateway 收到输入至首个可见 Worker 输出的耗时，label: `worker_type`, `first_output`（`reasoning` / `text`） |
+| `hotplex.turn.first_text_latency` | Histogram | Gateway 收到输入至首个文本 delta 的耗时，label: `worker_type` |
+| `hotplex.turn.stage_duration` | Histogram | admission、dispatch、first_output 三个阶段耗时，label: `worker_type`, `stage` |
+| `hotplex.turn.without_output` | Counter | 未产生可见输出即终止的 turn，label: `worker_type`, `terminal_status` |
+
+TTFT 仅使用 Gateway 侧时间戳；浏览器绘制时间属于独立客户端遥测，不能与本指标混合。所有标签均为有限枚举，严禁添加 session、execution、user、workspace、提示词或原始错误等高基数字段。Worker 尚未绑定即终止的 turn 使用固定的 `worker_type="unknown"`。
+
+阶段边界依次为 Gateway 收到输入、持久化接受完成、`Worker.Input` 成功（包括 Worker 的 `turn/start` 接受）以及首个可见输出；`first_output` 仅统计最后一段至首输出的耗时。
+
+### 常用查询与评审阈值
+
+```promql
+# 按 Worker 类型查看 p50 / p95 / p99 TTFT
+histogram_quantile(0.50, sum by (le, worker_type) (rate(hotplex_turn_ttft_bucket[15m])))
+histogram_quantile(0.95, sum by (le, worker_type) (rate(hotplex_turn_ttft_bucket[15m])))
+histogram_quantile(0.99, sum by (le, worker_type) (rate(hotplex_turn_ttft_bucket[15m])))
+
+# p95 的首个输出前阶段拆分
+histogram_quantile(0.95, sum by (le, stage, worker_type) (
+  rate(hotplex_turn_stage_duration_bucket{stage=~"admission|dispatch|first_output"}[15m])
+))
+
+# 无输出终止占比
+sum(rate(hotplex_turn_without_output_total[15m])) by (terminal_status, worker_type)
+/
+sum(rate(hotplex_turn_ttft_count[15m])) by (worker_type)
+```
+
+以同一 Worker 类型、相同流量窗口的基线为准：p95 TTFT 连续 30 分钟高于基线 20%，或 p99 连续 15 分钟超过 30 秒时必须评审；先用阶段指标定位 admission、dispatch 或 provider/Worker 首输出，再决定是否投入冷路径优化。
+
 ## Gateway 指标
 
 ### 连接与消息

--- a/docs/superpowers/specs/2026-07-15-webchat-ttft-observability-design.md
+++ b/docs/superpowers/specs/2026-07-15-webchat-ttft-observability-design.md
@@ -1,0 +1,80 @@
+# WebChat staged feedback and TTFT observability
+
+## Goal
+
+Remove the apparent "black hole" between a WebChat send action and the first
+worker event, while collecting server-authoritative time-to-first-token (TTFT)
+data that can guide later latency work. This implements GitHub issue #894.
+
+## Scope
+
+- Create one local assistant placeholder synchronously for every submitted
+  input, then move it through localized `thinking`, `accepted`, and output
+  states without changing its message ID.
+- Reuse the existing `input.ack` protocol: a delivered acknowledgement changes
+  the placeholder to accepted; an unknown acknowledgement never claims
+  success.
+- Record one TTFT sample per Gateway turn, separately identifying the first
+  reasoning and first text output and retaining bounded stage data.
+- Document dashboard queries and review thresholds.
+
+Cold-start acceleration and new AEP progress events are explicitly out of
+scope. The existing input acknowledgement contract remains unchanged.
+
+## Frontend design
+
+The runtime adapter will hold the pending placeholder identity and its input
+correlation key. `onNew` appends the user message and the streaming assistant
+placeholder in the same synchronous update. The placeholder has no content;
+the presentation layer renders the localized stage text from metadata rather
+than putting a visible status string into model content.
+
+`input.ack`, `message.start`, reasoning, and text-delta handlers locate that
+placeholder and update it in place. The first worker-originated output moves
+the placeholder into output state. Acknowledgements remain idempotent by
+client-message/execution identity and cannot regress an output state.
+
+`done`, an error, an unknown delivery outcome, and terminal reconnect paths
+end or remove the placeholder so it cannot remain streaming indefinitely.
+Output that arrives before its acknowledgement owns the visible state; a late
+acknowledgement does not create another message.
+
+Both locale trees receive identical keys for the `thinking` and `accepted`
+states.
+
+## Server observability design
+
+Gateway maintains a short-lived per-turn record keyed by execution ID. It
+captures timestamps at input receipt, durable acceptance, Worker.Input
+success, first reasoning, first text, and terminal completion. The bridge
+forwarder supplies first-output timestamps; the input handler supplies ingress
+and dispatch timestamps.
+
+The primary `hotplex.turn.ttft` histogram measures Gateway receipt to the
+first user-visible worker output. Its bounded dimensions distinguish output
+kind (`reasoning` or `text`), worker type, and cold/warm classification. A
+separate bounded stage metric or structured trace records the durations for
+admission, dispatch, and first output. Completed turns without output increase
+a separate counter by terminal class and never write a successful TTFT sample.
+
+No session ID, execution ID, user ID, workspace ID, prompt, metadata value, or
+raw worker error appears as a metric label.
+
+## Error handling and lifecycle
+
+The tracker records only the first event of each phase, making multiple deltas
+and reconnect replays harmless. Terminal handling removes the record after
+emitting its single applicable result. If the record is absent, normal event
+forwarding continues and no synthetic sample is emitted.
+
+## Testing and documentation
+
+Frontend tests cover delta-first, message-start-first, reasoning-first,
+delivered/unknown/duplicate acknowledgements, output-before-ack, error, and
+reconnect behavior. Gateway tests cover a single sample across repeated deltas,
+reasoning-before-text, error/completion before output, and bounded attributes.
+
+`docs/reference/metrics.md` documents the metrics, sample PromQL for p50/p95/
+p99 TTFT, and review thresholds. A p95 regression or sustained p99 breach is
+an investigation trigger; cold-path optimization is deferred until production
+stage data identifies it as material.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -97,6 +97,7 @@ type Bridge struct {
 	executionStore execution.Store     // durable ingress runtime correlation; nil = disabled
 	repairer       *execution.Repairer // terminal-state repair retry; nil-safe
 	workerRuns     sync.Map            // sessionID -> workerRunBinding; updated on each successful attach
+	turnTTFT       *turnTTFTTracker
 }
 
 type workerRunBinding struct {
@@ -139,6 +140,7 @@ func NewBridge(deps BridgeDeps) *Bridge {
 		shutdownCancel:     shutdownCancel,
 		executionStore:     deps.ExecutionStore,
 		repairer:           deps.Repairer,
+		turnTTFT:           newTurnTTFTTracker(),
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
 	b.defaultPermissionMode.Store(worker.NormalizePermissionMode(deps.DefaultPermissionMode))

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -196,6 +196,9 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	for env := range recvCh {
 		b.processForwardedEvent(env, w, opts, fc)
 	}
+	if !fc.doneReceived {
+		b.finishTurnTTFT(sessionID, "worker_exit")
+	}
 
 	// Flush buffered error that never reached a retry decision point.
 	if fc.pendingError != nil {
@@ -335,6 +338,12 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	}
 
 	deltaContent, reasoningContent := b.extractTurnContent(env, fc)
+	if env.Event.Type == events.Reasoning && reasoningContent != "" {
+		b.recordTurnFirstOutput(sessionID, false)
+	}
+	if (env.Event.Type == events.MessageDelta || env.Event.Type == events.Message) && extractMessageContent(env) != "" {
+		b.recordTurnFirstOutput(sessionID, true)
+	}
 
 	// Stats accumulation.
 	b.accumulateStats(env, w, opts, fc)
@@ -345,6 +354,11 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		b.resetCrashLoop(sessionID)
 		b.maybeTransitionIdleAfterDone(sessionID, fc)
 		b.finishRuntimeOnDone(sessionID, fc, env)
+		terminalStatus := "completed"
+		if done, ok := asDoneData(env.Event.Data); ok && !done.Success {
+			terminalStatus = "failed"
+		}
+		b.finishTurnTTFT(sessionID, terminalStatus)
 	}
 
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -348,17 +348,17 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	// Stats accumulation.
 	b.accumulateStats(env, w, opts, fc)
 
+	terminalStatus := ""
 	// Done processing: mark received.
 	if env.Event.Type == events.Done {
 		fc.doneReceived = true
 		b.resetCrashLoop(sessionID)
 		b.maybeTransitionIdleAfterDone(sessionID, fc)
 		b.finishRuntimeOnDone(sessionID, fc, env)
-		terminalStatus := "completed"
+		terminalStatus = "completed"
 		if done, ok := asDoneData(env.Event.Data); ok && !done.Success {
 			terminalStatus = "failed"
 		}
-		b.finishTurnTTFT(sessionID, terminalStatus)
 	}
 
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {
@@ -400,6 +400,9 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	}
 
 	if env.Event.Type == events.Done {
+		// A retry continues the same accepted input, so only finish TTFT after
+		// the retry decision confirms this is the terminal worker attempt.
+		b.finishTurnTTFT(sessionID, terminalStatus)
 		fc.turnText.Reset()
 		// Do NOT reset fc.turnStartTime here. The previous code did
 		// `fc.turnStartTime = time.Now()` at Done, which started the NEXT turn's

--- a/internal/gateway/bridge_forward_ttft_test.go
+++ b/internal/gateway/bridge_forward_ttft_test.go
@@ -1,0 +1,50 @@
+package gateway
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/aep"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestProcessForwardedEvent_RetryPreservesTTFTUntilFinalDone(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sessionID   = "session-1"
+		executionID = "execution-1"
+	)
+	start := time.Unix(100, 0)
+	retryCtrl := NewLLMRetryController(config.AutoRetryConfig{
+		Enabled:    true,
+		MaxRetries: 1,
+		BaseDelay:  time.Hour,
+		MaxDelay:   time.Hour,
+		RetryInput: "continue",
+	}, slog.Default())
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: newTestHub(t), RetryCtrl: retryCtrl})
+	b.shutdownCancel()
+
+	b.turnTTFT.begin(sessionID, executionID, worker.TypeCodexCLI, start)
+	_, ok := b.turnTTFT.durableAccepted(sessionID, executionID, start.Add(100*time.Millisecond))
+	require.True(t, ok)
+	_, _, ok = b.turnTTFT.workerAccepted(sessionID, executionID, start.Add(200*time.Millisecond))
+	require.True(t, ok)
+
+	fc := &forwardContext{sessionID: sessionID, workerType: worker.TypeCodexCLI}
+	fw := &mockBridgeWorker{workerType: worker.TypeCodexCLI}
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), "", 0, events.Error,
+		events.ErrorData{Message: "rate limit exceeded"}), fw, forwardOpts{}, fc)
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), "", 0, events.Done,
+		events.DoneData{Success: false}), fw, forwardOpts{}, fc)
+
+	outputs := b.turnTTFT.firstOutput(sessionID, true, start.Add(time.Second))
+	require.NotNil(t, outputs.ttft, "retry must preserve the TTFT record for the next worker output")
+	require.NotNil(t, outputs.firstText)
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -292,6 +292,7 @@ func (h *Handler) tryCommandDispatch(ctx context.Context, env *events.Envelope, 
 // deliverToWorker validates session state, handles IDLE→RUNNING transition,
 // and delivers user input to the worker process.
 func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, content string) error {
+	inputReceivedAt := time.Now()
 	_, err := h.sm.Get(ctx, env.SessionID)
 	if err != nil {
 		h.log.Warn("gateway: handleInput session not found", "session_id", env.SessionID, "err", err)
@@ -331,6 +332,10 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 	finalized := execRecord == nil
 	if !finalized {
 		observability.ExecutionAccept().Add(ctx, 1)
+		if h.bridge != nil {
+			h.bridge.beginTurnTTFT(env.SessionID, execRecord.ExecutionID, worker.WorkerType("unknown"), inputReceivedAt)
+			h.bridge.markTurnDurablyAccepted(env.SessionID, execRecord.ExecutionID)
+		}
 	}
 	defer func() {
 		if finalized {
@@ -357,6 +362,9 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		// not overwrite the intended outcome with a generic unknown.
 		finalized = true
 		h.sendInputAck(ctx, env, execRecord, false)
+		if h.bridge != nil && status == execution.StatusFailed {
+			h.bridge.finishTurnTTFT(env.SessionID, string(status))
+		}
 	}
 	// Fence recovery may have replaced the Worker and transitioned a TERMINATED
 	// session back to RUNNING while accepting this input. Re-read state so the
@@ -418,6 +426,9 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 		finishOutcome(execution.StatusFailed, events.ErrCodeSessionNotFound)
 		return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "no worker attached to session")
+	}
+	if h.bridge != nil && execRecord != nil {
+		h.bridge.setTurnTTFTWorkerType(env.SessionID, execRecord.ExecutionID, w.Type())
 	}
 
 	if si.State == events.StateIdle {
@@ -484,6 +495,9 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		}
 		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 		return h.sendErrorf(ctx, env, code, "worker input failed: %v", err)
+	}
+	if h.bridge != nil && execRecord != nil {
+		h.bridge.markTurnWorkerAccepted(env.SessionID, execRecord.ExecutionID)
 	}
 	if err := h.finishInputExecution(ctx, execRecord, execution.StatusDelivered, ""); err != nil {
 		h.log.Error("gateway: persist delivered input status failed", "err", err,

--- a/internal/gateway/turn_ttft.go
+++ b/internal/gateway/turn_ttft.go
@@ -1,0 +1,235 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/observability"
+	"github.com/hrygo/hotplex/internal/worker"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// turnTTFTTracker correlates one accepted input with its first worker output.
+// It is process-local by design: identifiers correlate events only and are
+// never exported as metric attributes or persisted with input content.
+type turnTTFTTracker struct {
+	mu        sync.Mutex
+	bySession map[string]*turnTTFTRecord
+}
+
+type turnTTFTRecord struct {
+	executionID       string
+	workerType        worker.WorkerType
+	receivedAt        time.Time
+	durableAcceptedAt time.Time
+	workerAcceptedAt  time.Time
+	firstOutputAt     time.Time
+	firstOutputText   bool
+	firstTextAt       time.Time
+	ttftEmitted       bool
+	firstTextEmitted  bool
+}
+
+type turnTTFTSample struct {
+	workerType worker.WorkerType
+	duration   time.Duration
+}
+
+func newTurnTTFTTracker() *turnTTFTTracker {
+	return &turnTTFTTracker{bySession: make(map[string]*turnTTFTRecord)}
+}
+
+func (t *turnTTFTTracker) begin(sessionID, executionID string, workerType worker.WorkerType, receivedAt time.Time) {
+	if sessionID == "" || executionID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.bySession[sessionID] = &turnTTFTRecord{
+		executionID: executionID,
+		workerType:  workerType,
+		receivedAt:  receivedAt,
+	}
+}
+
+func (t *turnTTFTTracker) durableAccepted(sessionID, executionID string, at time.Time) (turnTTFTSample, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	record := t.bySession[sessionID]
+	if record == nil || record.executionID != executionID || !record.durableAcceptedAt.IsZero() {
+		return turnTTFTSample{}, false
+	}
+	record.durableAcceptedAt = at
+	return turnTTFTSample{workerType: record.workerType, duration: at.Sub(record.receivedAt)}, true
+}
+
+func (t *turnTTFTTracker) setWorkerType(sessionID, executionID string, workerType worker.WorkerType) (turnTTFTSample, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	record := t.bySession[sessionID]
+	if record != nil && record.executionID == executionID {
+		record.workerType = workerType
+		if !record.durableAcceptedAt.IsZero() {
+			return turnTTFTSample{workerType: workerType, duration: record.durableAcceptedAt.Sub(record.receivedAt)}, true
+		}
+	}
+	return turnTTFTSample{}, false
+}
+
+func (t *turnTTFTTracker) workerAccepted(sessionID, executionID string, at time.Time) (turnTTFTSample, turnTTFTOutputs, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	record := t.bySession[sessionID]
+	if record == nil || record.executionID != executionID || !record.workerAcceptedAt.IsZero() {
+		return turnTTFTSample{}, turnTTFTOutputs{}, false
+	}
+	record.workerAcceptedAt = at
+	start := record.durableAcceptedAt
+	if start.IsZero() {
+		start = record.receivedAt
+	}
+	return turnTTFTSample{workerType: record.workerType, duration: at.Sub(start)}, t.readyOutputs(record), true
+}
+
+type turnTTFTOutputs struct {
+	ttft             *turnTTFTSample
+	firstText        *turnTTFTSample
+	firstOutputStage *turnTTFTSample
+	firstOutputText  bool
+}
+
+func (t *turnTTFTTracker) readyOutputs(record *turnTTFTRecord) turnTTFTOutputs {
+	if record.workerAcceptedAt.IsZero() {
+		return turnTTFTOutputs{}
+	}
+	outputs := turnTTFTOutputs{}
+	if !record.firstOutputAt.IsZero() && !record.ttftEmitted {
+		ttft := turnTTFTSample{workerType: record.workerType, duration: record.firstOutputAt.Sub(record.receivedAt)}
+		stage := turnTTFTSample{workerType: record.workerType, duration: record.firstOutputAt.Sub(record.workerAcceptedAt)}
+		record.ttftEmitted = true
+		outputs.ttft = &ttft
+		outputs.firstOutputStage = &stage
+		outputs.firstOutputText = record.firstOutputText
+	}
+	if !record.firstTextAt.IsZero() && !record.firstTextEmitted {
+		firstText := turnTTFTSample{workerType: record.workerType, duration: record.firstTextAt.Sub(record.receivedAt)}
+		record.firstTextEmitted = true
+		outputs.firstText = &firstText
+	}
+	return outputs
+}
+
+func (t *turnTTFTTracker) firstOutput(sessionID string, text bool, at time.Time) turnTTFTOutputs {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	record := t.bySession[sessionID]
+	if record == nil {
+		return turnTTFTOutputs{}
+	}
+	if record.firstOutputAt.IsZero() {
+		record.firstOutputAt = at
+		record.firstOutputText = text
+	}
+	if text && record.firstTextAt.IsZero() {
+		record.firstTextAt = at
+	}
+	return t.readyOutputs(record)
+}
+
+func (t *turnTTFTTracker) finish(sessionID string) (worker.WorkerType, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	record := t.bySession[sessionID]
+	if record == nil {
+		return "", false
+	}
+	delete(t.bySession, sessionID)
+	return record.workerType, record.firstOutputAt.IsZero()
+}
+
+func (b *Bridge) beginTurnTTFT(sessionID, executionID string, workerType worker.WorkerType, receivedAt time.Time) {
+	if b.turnTTFT != nil {
+		b.turnTTFT.begin(sessionID, executionID, workerType, receivedAt)
+	}
+}
+
+func (b *Bridge) markTurnDurablyAccepted(sessionID, executionID string) {
+	if b.turnTTFT == nil {
+		return
+	}
+	_, _ = b.turnTTFT.durableAccepted(sessionID, executionID, time.Now())
+}
+
+func (b *Bridge) setTurnTTFTWorkerType(sessionID, executionID string, workerType worker.WorkerType) {
+	if b.turnTTFT == nil {
+		return
+	}
+	if sample, ok := b.turnTTFT.setWorkerType(sessionID, executionID, workerType); ok {
+		observability.TurnStageDuration().Record(context.Background(), sample.duration.Seconds(),
+			metric.WithAttributes(
+				attribute.String("worker_type", string(sample.workerType)),
+				attribute.String("stage", "admission"),
+			))
+	}
+}
+
+func (b *Bridge) markTurnWorkerAccepted(sessionID, executionID string) {
+	if b.turnTTFT == nil {
+		return
+	}
+	if sample, outputs, ok := b.turnTTFT.workerAccepted(sessionID, executionID, time.Now()); ok {
+		observability.TurnStageDuration().Record(context.Background(), sample.duration.Seconds(),
+			metric.WithAttributes(
+				attribute.String("worker_type", string(sample.workerType)),
+				attribute.String("stage", "dispatch"),
+			))
+		b.recordTurnTTFTOutputs(outputs)
+	}
+}
+
+func (b *Bridge) recordTurnFirstOutput(sessionID string, text bool) {
+	if b.turnTTFT == nil {
+		return
+	}
+	b.recordTurnTTFTOutputs(b.turnTTFT.firstOutput(sessionID, text, time.Now()))
+}
+
+func (b *Bridge) recordTurnTTFTOutputs(outputs turnTTFTOutputs) {
+	if outputs.ttft != nil {
+		outputKind := "reasoning"
+		if outputs.firstOutputText {
+			outputKind = "text"
+		}
+		observability.TurnTTFT().Record(context.Background(), outputs.ttft.duration.Seconds(),
+			metric.WithAttributes(
+				attribute.String("worker_type", string(outputs.ttft.workerType)),
+				attribute.String("first_output", outputKind),
+			))
+		observability.TurnStageDuration().Record(context.Background(), outputs.firstOutputStage.duration.Seconds(),
+			metric.WithAttributes(
+				attribute.String("worker_type", string(outputs.firstOutputStage.workerType)),
+				attribute.String("stage", "first_output"),
+			))
+	}
+	if outputs.firstText != nil {
+		observability.TurnFirstTextLatency().Record(context.Background(), outputs.firstText.duration.Seconds(),
+			metric.WithAttributes(attribute.String("worker_type", string(outputs.firstText.workerType))))
+	}
+}
+
+func (b *Bridge) finishTurnTTFT(sessionID, terminalStatus string) {
+	if b.turnTTFT == nil {
+		return
+	}
+	workerType, withoutOutput := b.turnTTFT.finish(sessionID)
+	if withoutOutput {
+		observability.TurnWithoutOutput().Add(context.Background(), 1,
+			metric.WithAttributes(
+				attribute.String("worker_type", string(workerType)),
+				attribute.String("terminal_status", terminalStatus),
+			))
+	}
+}

--- a/internal/gateway/turn_ttft_test.go
+++ b/internal/gateway/turn_ttft_test.go
@@ -1,0 +1,59 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+func TestTurnTTFTTracker_RecordsEarlyFirstOutputOnceAndFirstTextSeparately(t *testing.T) {
+	t.Parallel()
+	tracker := newTurnTTFTTracker()
+	start := time.Unix(100, 0)
+
+	tracker.begin("session-1", "execution-1", worker.TypeCodexCLI, start)
+	admission, ok := tracker.durableAccepted("session-1", "execution-1", start.Add(100*time.Millisecond))
+	require.True(t, ok)
+	require.Equal(t, 100*time.Millisecond, admission.duration)
+
+	outputs := tracker.firstOutput("session-1", false, start.Add(time.Second))
+	require.Nil(t, outputs.ttft, "output may arrive before Worker.Input returns")
+
+	dispatch, outputs, ok := tracker.workerAccepted("session-1", "execution-1", start.Add(250*time.Millisecond))
+	require.True(t, ok)
+	require.Equal(t, 150*time.Millisecond, dispatch.duration)
+	require.NotNil(t, outputs.ttft)
+	require.Equal(t, time.Second, outputs.ttft.duration)
+	require.NotNil(t, outputs.firstOutputStage)
+	require.Equal(t, 750*time.Millisecond, outputs.firstOutputStage.duration)
+	require.Nil(t, outputs.firstText, "reasoning must not count as first text")
+
+	outputs = tracker.firstOutput("session-1", true, start.Add(1500*time.Millisecond))
+	require.Nil(t, outputs.ttft, "multiple worker events must not create a second TTFT sample")
+	require.NotNil(t, outputs.firstText)
+	require.Equal(t, 1500*time.Millisecond, outputs.firstText.duration)
+
+	outputs = tracker.firstOutput("session-1", true, start.Add(2*time.Second))
+	require.Nil(t, outputs.ttft)
+	require.Nil(t, outputs.firstText, "multiple text deltas must not create a second first-text sample")
+
+	workerType, withoutOutput := tracker.finish("session-1")
+	require.Equal(t, worker.TypeCodexCLI, workerType)
+	require.False(t, withoutOutput)
+}
+
+func TestTurnTTFTTracker_ClassifiesTerminalTurnWithoutOutput(t *testing.T) {
+	t.Parallel()
+	tracker := newTurnTTFTTracker()
+	tracker.begin("session-1", "execution-1", worker.TypeCodexCLI, time.Now())
+
+	workerType, withoutOutput := tracker.finish("session-1")
+	require.Equal(t, worker.TypeCodexCLI, workerType)
+	require.True(t, withoutOutput)
+
+	_, withoutOutput = tracker.finish("session-1")
+	require.False(t, withoutOutput, "terminal handling must be idempotent")
+}

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -1027,6 +1027,18 @@ var (
 	executionRuntimeDuration     metric.Float64Histogram
 	executionRuntimeDurationInit sync.Once
 
+	turnTTFT     metric.Float64Histogram
+	turnTTFTInit sync.Once
+
+	turnFirstTextLatency     metric.Float64Histogram
+	turnFirstTextLatencyInit sync.Once
+
+	turnStageDuration     metric.Float64Histogram
+	turnStageDurationInit sync.Once
+
+	turnWithoutOutput     metric.Int64Counter
+	turnWithoutOutputInit sync.Once
+
 	leaseRenewFailure     metric.Int64Counter
 	leaseRenewFailureInit sync.Once
 
@@ -1160,6 +1172,74 @@ func ExecutionRuntimeDuration() metric.Float64Histogram {
 		}
 	})
 	return executionRuntimeDuration
+}
+
+// TurnTTFT records gateway input receipt to first user-visible worker output.
+// Labels are bounded to worker_type and first_output (reasoning/text).
+func TurnTTFT() metric.Float64Histogram {
+	turnTTFTInit.Do(func() {
+		var err error
+		turnTTFT, err = Meter().Float64Histogram(
+			"hotplex.turn.ttft",
+			metric.WithDescription("Gateway receipt to first user-visible worker output in seconds. Labels: worker_type, first_output"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60),
+		)
+		if err != nil {
+			warnInstrument("hotplex.turn.ttft", err)
+		}
+	})
+	return turnTTFT
+}
+
+// TurnFirstTextLatency records gateway input receipt to the first text delta.
+// It remains distinct from TTFT when a reasoning event is visible first.
+func TurnFirstTextLatency() metric.Float64Histogram {
+	turnFirstTextLatencyInit.Do(func() {
+		var err error
+		turnFirstTextLatency, err = Meter().Float64Histogram(
+			"hotplex.turn.first_text_latency",
+			metric.WithDescription("Gateway receipt to first text delta in seconds. Labels: worker_type"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60),
+		)
+		if err != nil {
+			warnInstrument("hotplex.turn.first_text_latency", err)
+		}
+	})
+	return turnFirstTextLatency
+}
+
+// TurnStageDuration records bounded admission, dispatch, and first-output stages.
+func TurnStageDuration() metric.Float64Histogram {
+	turnStageDurationInit.Do(func() {
+		var err error
+		turnStageDuration, err = Meter().Float64Histogram(
+			"hotplex.turn.stage_duration",
+			metric.WithDescription("Turn stage duration in seconds. Labels: worker_type, stage"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60),
+		)
+		if err != nil {
+			warnInstrument("hotplex.turn.stage_duration", err)
+		}
+	})
+	return turnStageDuration
+}
+
+// TurnWithoutOutput counts terminal turns that did not emit user-visible output.
+func TurnWithoutOutput() metric.Int64Counter {
+	turnWithoutOutputInit.Do(func() {
+		var err error
+		turnWithoutOutput, err = Meter().Int64Counter(
+			"hotplex.turn.without_output",
+			metric.WithDescription("Completed worker turns without visible output. Labels: worker_type, terminal_status"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.turn.without_output", err)
+		}
+	})
+	return turnWithoutOutput
 }
 
 func LeaseRenewFailure() metric.Int64Counter {

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -278,6 +278,12 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
           {ext.metadata?.turnSummary && (
             <TurnSummaryCard data={ext.metadata.turnSummary} />
           )}
+          {ext.metadata?.progress && (
+            <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+              <span className="w-2 h-2 rounded-full bg-[var(--accent-gold)] animate-pulse" />
+              <span>{t(`status.${ext.metadata.progress}`)}</span>
+            </div>
+          )}
         </div>
         <MessageActions message={message} />
         {isError && (

--- a/webchat/components/assistant-ui/thread-helpers.ts
+++ b/webchat/components/assistant-ui/thread-helpers.ts
@@ -7,6 +7,7 @@ export interface ThreadMessageExtension {
   metadata?: {
     contextUsage?: ContextUsageData;
     turnSummary?: TurnSessionStats;
+    progress?: 'thinking' | 'accepted';
   };
   content: unknown[];
 }

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -67,6 +67,13 @@ import {
     appendReasoningDelta,
     concatTextParts,
 } from "@/lib/adapters/merge-parts";
+import {
+    completeStreamingAssistant,
+    createPendingAssistantMessage,
+    matchesActiveInput,
+    removePendingAssistant,
+    updatePendingAssistant,
+} from "@/lib/adapters/pending-assistant";
 
 // Re-export for consumers
 export type { HotPlexMessage };
@@ -179,6 +186,7 @@ function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
                 ? { contextUsage: contextUsagePart.data }
                 : {}),
             ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
+            ...(message.progress ? { progress: message.progress } : {}),
         } satisfies Record<string, unknown>,
     } as ThreadMessageLike & {
         status?: { type: "running" } | { type: "complete"; reason: string };
@@ -289,6 +297,9 @@ export function useHotPlexRuntime({
         }
     }, []);
     const clientRef = useRef<BrowserHotPlexClient | null>(null);
+    const pendingAssistantIdRef = useRef<string | null>(null);
+    const activeAssistantIdRef = useRef<string | null>(null);
+    const activeInputMessageIdRef = useRef<string | null>(null);
     const historyLoadingRef = useRef(false);
     const sessionIdRef = useRef(sessionId);
     const sessionAlreadyConnectedRef = useRef(false);
@@ -469,6 +480,19 @@ export function useHotPlexRuntime({
         // Append delta content to the last text part of the last assistant message
         const appendDelta = (content: string) => {
             setMessages((prev) => {
+                const pending = updatePendingAssistant(
+                    prev,
+                    pendingAssistantIdRef.current,
+                    (message) => ({
+                        ...message,
+                        progress: undefined,
+                        parts: appendTextDelta(message.parts, content),
+                    }),
+                );
+                if (pending !== prev) {
+                    pendingAssistantIdRef.current = null;
+                    return pending;
+                }
                 const lastMessage = prev[prev.length - 1];
                 if (
                     lastMessage?.role === "assistant" &&
@@ -507,6 +531,19 @@ export function useHotPlexRuntime({
             if (!data) return;
 
             setMessages((prev) => {
+                const pending = updatePendingAssistant(
+                    prev,
+                    pendingAssistantIdRef.current,
+                    (message) => ({
+                        ...message,
+                        progress: undefined,
+                        parts: appendReasoningDelta(message.parts, data.content || ""),
+                    }),
+                );
+                if (pending !== prev) {
+                    pendingAssistantIdRef.current = null;
+                    return pending;
+                }
                 const lastMessage = prev[prev.length - 1];
                 if (
                     lastMessage?.role === "assistant" &&
@@ -553,6 +590,21 @@ export function useHotPlexRuntime({
             // Always use env.id for consistency with handleMessageStart
             const msgId = env.id;
             setMessages((prev) => {
+                const pending = updatePendingAssistant(
+                    prev,
+                    pendingAssistantIdRef.current,
+                    (message) => ({
+                        ...message,
+                        role,
+                        progress: undefined,
+                        parts: [{ type: "text", text: data?.content || "" }],
+                        status: "complete",
+                    }),
+                );
+                if (pending !== prev) {
+                    pendingAssistantIdRef.current = null;
+                    return pending;
+                }
                 let existingIdx = prev.findIndex((m) => m.id === msgId);
 
                 // Fallback: adopt streaming message with fallback ID instead of creating duplicate (#331).
@@ -657,6 +709,10 @@ export function useHotPlexRuntime({
 
         const handleDone = (data: DoneData, _env: Envelope) => {
             streamingFallbackId = null;
+            const pendingAssistantID = pendingAssistantIdRef.current;
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
 
             if (data?.stats) {
                 recordTurn(data.stats);
@@ -665,6 +721,10 @@ export function useHotPlexRuntime({
             }
 
             setMessages((prev) => {
+                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                if (withoutPending !== prev) {
+                    return withoutPending;
+                }
                 const lastMessage = prev[prev.length - 1];
                 if (lastMessage?.role === "assistant") {
                     const parts = [...lastMessage.parts];
@@ -905,7 +965,20 @@ export function useHotPlexRuntime({
             // Don't pollute the chat with error messages; just mark the run as stopped.
             if (isTerminated) {
                 setIsRunning(false);
+                const pendingAssistantID = pendingAssistantIdRef.current;
+                const activeAssistantID = activeAssistantIdRef.current;
+                pendingAssistantIdRef.current = null;
+                activeAssistantIdRef.current = null;
+                activeInputMessageIdRef.current = null;
                 setMessages((prev) => {
+                    const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                    if (withoutPending !== prev) {
+                        return withoutPending;
+                    }
+                    const completed = completeStreamingAssistant(prev, activeAssistantID);
+                    if (completed !== prev) {
+                        return completed;
+                    }
                     const lastMessage = prev[prev.length - 1];
                     if (
                         lastMessage?.role === "assistant" &&
@@ -999,8 +1072,21 @@ export function useHotPlexRuntime({
             // If it's a fatal error, stop the run and complete the streaming message
             if (!isResumeRetry) {
                 setIsRunning(false);
+                const pendingAssistantID = pendingAssistantIdRef.current;
+                const activeAssistantID = activeAssistantIdRef.current;
+                pendingAssistantIdRef.current = null;
+                activeAssistantIdRef.current = null;
+                activeInputMessageIdRef.current = null;
 
                 setMessages((prev) => {
+                    const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                    if (withoutPending !== prev) {
+                        return withoutPending;
+                    }
+                    const completed = completeStreamingAssistant(prev, activeAssistantID);
+                    if (completed !== prev) {
+                        return completed;
+                    }
                     const lastMessage = prev[prev.length - 1];
                     if (
                         lastMessage?.role === "assistant" &&
@@ -1093,6 +1179,17 @@ export function useHotPlexRuntime({
                 );
             }
             setIsRunning(false);
+            const pendingAssistantID = pendingAssistantIdRef.current;
+            const activeAssistantID = activeAssistantIdRef.current;
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
+            setMessages((prev) => {
+                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                return withoutPending !== prev
+                    ? withoutPending
+                    : completeStreamingAssistant(prev, activeAssistantID);
+            });
             if (!sessionAlreadyConnectedRef.current) {
                 setConnectionState("disconnected");
             }
@@ -1112,6 +1209,17 @@ export function useHotPlexRuntime({
         const handleReconnectFailed = (attempt: number) => {
             logger.warn("RuntimeAdapter", "Reconnect attempts exhausted", { attempt });
             setIsRunning(false);
+            const pendingAssistantID = pendingAssistantIdRef.current;
+            const activeAssistantID = activeAssistantIdRef.current;
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
+            setMessages((prev) => {
+                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                return withoutPending !== prev
+                    ? withoutPending
+                    : completeStreamingAssistant(prev, activeAssistantID);
+            });
             setConnectionState("disconnected");
         };
 
@@ -1121,6 +1229,19 @@ export function useHotPlexRuntime({
         const handleMessageStart = (data: MessageStartData, env: Envelope) => {
             if (!data) return;
             setMessages((prev) => {
+                const pending = updatePendingAssistant(
+                    prev,
+                    pendingAssistantIdRef.current,
+                    (message) => ({
+                        ...message,
+                        progress: undefined,
+                        status: "streaming",
+                    }),
+                );
+                if (pending !== prev) {
+                    pendingAssistantIdRef.current = null;
+                    return pending;
+                }
                 // Reasoning events may arrive before messageStart, creating env.id early.
                 const existingIdx = prev.findIndex((m) => m.id === env.id);
                 if (existingIdx !== -1) {
@@ -1159,27 +1280,51 @@ export function useHotPlexRuntime({
         // / restart), so without this handler the UI would spin forever on a
         // turn whose outcome is ambiguous.
         const handleInputAck = (data: InputAckData) => {
-            if (data.status !== "unknown") {
+            if (!matchesActiveInput(activeInputMessageIdRef.current, data.client_message_id)) {
                 return;
             }
+            if (data.status === "delivered") {
+                setMessages((prev) =>
+                    updatePendingAssistant(
+                        prev,
+                        pendingAssistantIdRef.current,
+                        (message) => ({ ...message, progress: "accepted" }),
+                    ),
+                );
+                return;
+            }
+            if (data.status !== "unknown") return;
             logger.warn("RuntimeAdapter", "Input outcome unknown", {
                 client_message_id: data.client_message_id,
                 execution_id: data.execution_id,
                 error_code: data.error_code,
             });
             setIsRunning(false);
-            setMessages((prev) => [
-                ...prev,
-                {
-                    id: `input-unknown-${Date.now()}`,
-                    role: "assistant" as const,
-                    parts: [
-                        { type: "text" as const, text: i18n.t("chat:error.input_unknown") },
-                    ],
-                    createdAt: new Date(),
-                    status: "complete" as const,
-                },
-            ]);
+            const pendingAssistantID = pendingAssistantIdRef.current;
+            const activeAssistantID = activeAssistantIdRef.current;
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
+            setMessages((prev) => {
+                const pending = updatePendingAssistant(
+                    prev,
+                    pendingAssistantID,
+                    (message) => ({
+                        ...message,
+                        progress: undefined,
+                        parts: [
+                            {
+                                type: "text" as const,
+                                text: i18n.t("chat:error.input_unknown"),
+                            },
+                        ],
+                        status: "complete",
+                    }),
+                );
+                return pending !== prev
+                    ? pending
+                    : completeStreamingAssistant(prev, activeAssistantID);
+            });
         };
 
         // Subscribe to events
@@ -1561,18 +1706,37 @@ export function useHotPlexRuntime({
             createdAt: new Date(),
             status: "complete",
         };
+        const assistantID = `assistant-local-${Date.now()}`;
+        const pendingAssistant = createPendingAssistantMessage(
+            assistantID,
+            new Date(),
+        );
 
-        setMessages((prev) => [...prev, userMessage]);
+        // The user message and local assistant placeholder must enter state in
+        // one update so the first frame always shows that the turn is pending.
+        pendingAssistantIdRef.current = assistantID;
+        activeAssistantIdRef.current = assistantID;
+        activeInputMessageIdRef.current = null;
+        setMessages((prev) => [...prev, userMessage, pendingAssistant]);
         setIsRunning(true);
         startTurn(); // Begin timing for metrics
 
         // Send to HotPlex gateway with error handling
         try {
-            client.sendInput(textContent);
+            activeInputMessageIdRef.current = client.sendInput(textContent);
         } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);
             // The optimistically-added user message did not go out — remove it.
-            setMessages((prev) => prev.slice(0, -1));
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
+            setMessages((prev) =>
+                prev.filter(
+                    (message) =>
+                        message.id !== userMessage.id &&
+                        message.id !== assistantID,
+                ),
+            );
             if (errMsg === "Input already pending") {
                 // A previous turn is still in flight (often an unknown-outcome
                 // tombstone). This is not a connection fault.

--- a/webchat/lib/adapters/pending-assistant.test.ts
+++ b/webchat/lib/adapters/pending-assistant.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { HotPlexMessage } from "@/lib/types/message";
+import {
+    completeStreamingAssistant,
+    createPendingAssistantMessage,
+    matchesActiveInput,
+    removePendingAssistant,
+    updatePendingAssistant,
+} from "./pending-assistant";
+
+const pending = () => createPendingAssistantMessage("assistant-local-1", new Date(0));
+
+describe("pending assistant state", () => {
+    it("creates one local streaming placeholder in the thinking stage", () => {
+        const message = pending();
+
+        expect(message).toMatchObject({
+            id: "assistant-local-1",
+            role: "assistant",
+            parts: [],
+            status: "streaming",
+            progress: "thinking",
+        });
+    });
+
+    it("adopts the placeholder without changing its ID for delta-first output", () => {
+        const messages = updatePendingAssistant([pending()], "assistant-local-1", (message) => ({
+            ...message,
+            progress: undefined,
+            parts: [{ type: "text", text: "hello" }],
+        }));
+
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toMatchObject({
+            id: "assistant-local-1",
+            status: "streaming",
+            progress: undefined,
+            parts: [{ type: "text", text: "hello" }],
+        });
+    });
+
+    it("transitions a delivered acknowledgement and ignores output-before-ack", () => {
+        const accepted = updatePendingAssistant([pending()], "assistant-local-1", (message) => ({
+            ...message,
+            progress: "accepted",
+        }));
+        const output: HotPlexMessage[] = [{
+            ...accepted[0],
+            progress: undefined,
+            parts: [{ type: "reasoning", text: "working" }],
+        }];
+        const lateAck = updatePendingAssistant(output, null, (message) => ({
+            ...message,
+            progress: "accepted",
+        }));
+
+        expect(accepted[0].progress).toBe("accepted");
+        expect(lateAck[0].progress).toBeUndefined();
+        expect(lateAck[0].parts).toEqual([{ type: "reasoning", text: "working" }]);
+    });
+
+    it("accepts only acknowledgements for the active client message", () => {
+        expect(matchesActiveInput("evt-current", "evt-current")).toBe(true);
+        expect(matchesActiveInput("evt-current", "evt-replayed")).toBe(false);
+        expect(matchesActiveInput(null, "evt-current")).toBe(false);
+    });
+
+    it("clears the placeholder on reconnect or unknown delivery", () => {
+        expect(removePendingAssistant([pending()], "assistant-local-1")).toEqual([]);
+    });
+
+    it("finalizes an adopted streaming message on a terminal transport outcome", () => {
+        const adopted: HotPlexMessage = {
+            ...pending(),
+            progress: undefined,
+            parts: [{ type: "text", text: "partial response" }],
+        };
+
+        expect(completeStreamingAssistant([adopted], adopted.id)).toMatchObject([
+            { id: adopted.id, status: "complete", progress: undefined },
+        ]);
+    });
+});

--- a/webchat/lib/adapters/pending-assistant.ts
+++ b/webchat/lib/adapters/pending-assistant.ts
@@ -1,0 +1,77 @@
+import type { HotPlexMessage } from "@/lib/types/message";
+
+export function createPendingAssistantMessage(
+    id: string,
+    createdAt: Date,
+): HotPlexMessage {
+    return {
+        id,
+        role: "assistant",
+        parts: [],
+        createdAt,
+        status: "streaming",
+        progress: "thinking",
+    };
+}
+
+export function matchesActiveInput(
+    activeClientMessageID: string | null,
+    acknowledgedClientMessageID: string,
+): boolean {
+    return activeClientMessageID !== null &&
+        activeClientMessageID === acknowledgedClientMessageID;
+}
+
+export function updatePendingAssistant(
+    messages: HotPlexMessage[],
+    id: string | null,
+    update: (message: HotPlexMessage) => HotPlexMessage,
+): HotPlexMessage[] {
+    if (!id) return messages;
+    const index = messages.findIndex(
+        (message) =>
+            message.id === id &&
+            message.role === "assistant" &&
+            message.status === "streaming",
+    );
+    if (index === -1) return messages;
+    const next = [...messages];
+    next[index] = update(next[index]);
+    return next;
+}
+
+export function removePendingAssistant(
+    messages: HotPlexMessage[],
+    id: string | null,
+): HotPlexMessage[] {
+    if (!id) return messages;
+    return messages.filter(
+        (message) =>
+            !(
+                message.id === id &&
+                message.role === "assistant" &&
+                message.status === "streaming"
+            ),
+    );
+}
+
+export function completeStreamingAssistant(
+    messages: HotPlexMessage[],
+    id: string | null,
+): HotPlexMessage[] {
+    if (!id) return messages;
+    const index = messages.findIndex(
+        (message) =>
+            message.id === id &&
+            message.role === "assistant" &&
+            message.status === "streaming",
+    );
+    if (index === -1) return messages;
+    const next = [...messages];
+    next[index] = {
+        ...next[index],
+        progress: undefined,
+        status: "complete",
+    };
+    return next;
+}

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -126,8 +126,9 @@ describe("BrowserHotPlexClient input retry identity", () => {
         internal.ws = { readyState: 1 };
         const send = vi.spyOn(internal, "_send").mockImplementation(() => undefined);
 
-        client.sendInput("hello");
+        const submittedID = client.sendInput("hello");
         const firstId = send.mock.calls[0][0].id;
+        expect(submittedID).toBe(firstId);
         internal._reconnecting = true;
 
         internal._handleMessage(

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -570,7 +570,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     this.ws.send(serializeEnvelope(env));
   }
 
-  sendInput(content: string): void {
+  sendInput(content: string): string {
     if (this.pendingInput) {
       throw new Error('Input already pending');
     }
@@ -593,6 +593,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       }
       throw err;
     }
+    return pending.clientMessageId;
   }
 
   async sendInputAsync(content: string): Promise<void> {

--- a/webchat/lib/types/message.ts
+++ b/webchat/lib/types/message.ts
@@ -14,4 +14,9 @@ export interface HotPlexMessage<P extends MessagePart = MessagePart> {
   parts: P[];
   createdAt: Date;
   status?: 'streaming' | 'complete' | 'error';
+  /**
+   * Local-only staged feedback shown before the worker emits visible output.
+   * It is deliberately not persisted or sent over AEP.
+   */
+  progress?: 'thinking' | 'accepted';
 }

--- a/webchat/locales/en/chat.json
+++ b/webchat/locales/en/chat.json
@@ -67,6 +67,8 @@
     "preparing": "PREPARING",
     "error": "ERROR",
     "active": "ACTIVE",
+    "thinking": "Thinking",
+    "accepted": "Agent accepted the request",
     "session_expired_settings": "Session expired — please re-login to access Settings",
     "starting_session": "Starting new session...",
     "loading_workers": "Loading worker engines...",

--- a/webchat/locales/zh-CN/chat.json
+++ b/webchat/locales/zh-CN/chat.json
@@ -67,6 +67,8 @@
     "preparing": "准备中",
     "error": "错误",
     "active": "激活",
+    "thinking": "正在思考",
+    "accepted": "Agent 已接单",
     "session_expired_settings": "会话已过期 — 请重新登录以访问设置",
     "starting_session": "正在开启新会话...",
     "loading_workers": "正在加载 Worker 引擎...",


### PR DESCRIPTION
## 结论

本 PR 完整实现 #894：WebChat 在发送后立即展示可本地采纳的 assistant 占位状态，并以既有 `input.ack` 提供可信的 Worker 接单反馈；Gateway 新增服务端 TTFT 与阶段指标，用于区分 admission、dispatch 和首个可见输出的耗时。

Closes #894

## 变更内容

- WebChat
  - 在用户消息与本地 assistant placeholder 的同一状态更新中创建 `thinking` 状态。
  - `input.ack(status=delivered)` 仅在匹配当前 `client_message_id` 时更新为“Agent 已接单”；重放或迟到 ack 不影响新 turn。
  - reasoning、`message.start`、delta 与完整 `message` 原地采纳占位消息，保留稳定 message ID。
  - unknown、错误、断线与重连失败都会清理或完成占位/已采纳的流式消息，避免遗留 streaming 条目。
  - 同步新增中英文 i18n 文案。

- Gateway / observability
  - 以 execution ID 关联 Gateway 接收、持久化接受、`Worker.Input` 成功、首个 reasoning / text 输出与终态。
  - `hotplex.turn.ttft` 一 turn 仅记录一次；首个 reasoning 与首个 text 分别可观测。
  - 处理首个 Worker 事件早于 `Worker.Input` 返回的并发顺序，并覆盖非流式 `message`；空输出不会产生成功 TTFT 样本。
  - 新增无可见输出终态计数和 bounded-label 阶段直方图，避免 session/execution/user/prompt 等高基数标签。
  - 补充指标参考、PromQL 查询与 p50/p95/p99 评审阈值。

## 验证

- `make check`
- `go test -race ./internal/gateway ./internal/observability`
- `npm test`（WebChat：5 个文件、42 项）
- `npm run build`（WebChat）
- pre-push：fmt、vet、mod verify、lint、build、test-short

## 设计说明

- `docs/superpowers/specs/2026-07-15-webchat-ttft-observability-design.md`