### PR TITLE
fix(stats): support camelCase keys in turn stats and resolve reconnecting banner overlap

### DIFF
--- a/docs/superpowers/specs/2026-07-16-webchat-connection-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-16-webchat-connection-handoff-design.md
@@ -1,0 +1,136 @@
+# WebChat 连接交接设计
+
+## 结论
+
+在 WebChat 浏览器客户端引入按 session 串行化的连接建立与关闭交接机制，消除同一标签页因重连、React 组件重新挂载或连接调用重入而短暂创建两条 WebSocket 的竞态。Gateway 现有“每个 session 只允许一个直接 WebSocket owner”的约束保持不变，真实的多标签页冲突仍返回 `SESSION_ALREADY_CONNECTED`。
+
+## 问题
+
+`BrowserHotPlexClient._doConnect` 在发现已有 socket 时会发起关闭，然后立即创建新 socket。WebSocket 关闭握手与 Gateway `ReadPump` 释放 `webchatOwners` 都是异步过程，因此新连接可能在旧 owner 尚未释放时发送 init，被 Gateway 正确地判定为第二个连接。
+
+React 交互事件只会更新消息状态，不会直接重新挂载 `ChatInterface`。重新挂载仅发生在 session key、workspace recovery epoch 或父级条件分支发生变化，以及开发模式 Strict Mode/Fast Refresh 等场景。不过这些场景与自动重连、手动重试或连接调用重入都可能触发同一个 close/open 竞态。Worker 的 permission、question 或 elicitation 请求往往是竞态后的第一个显著事件，因此用户会误以为交互请求触发了连接冲突。
+
+Gateway 还会对非 owner 的 permission、question 和 elicitation 响应返回同一个 `SESSION_ALREADY_CONNECTED`。因此修复必须同时保证：
+
+1. 新连接不会抢在本标签页旧连接释放前 init；
+2. 交互响应始终从当前连接 owner 发出；
+3. 真实的另一个标签页不能借本地重试机制绕过 owner 限制。
+
+## 目标
+
+- 同一浏览器 JavaScript realm 内，同一 session 同时最多进行一次连接建立。
+- client cleanup 后，新 client 等待旧 socket 完成关闭交接再发送 init。
+- 本地交接导致的短暂 `SESSION_ALREADY_CONNECTED` 最多内部重试一次，不展示冲突弹窗。
+- 无本地交接证据的 `SESSION_ALREADY_CONNECTED` 继续作为 fatal error 展示。
+- permission、question、elicitation 的请求、响应与 Worker 权威 ACK 语义不变。
+- 不修改 AEP wire contract，不放宽 Gateway owner fence。
+
+## 非目标
+
+- 不允许新标签页自动接管另一个标签页的 session。
+- 不引入 Gateway owner lease 超时或同用户自动接管。
+- 不把 WebSocket client 提升为长期全局连接池。
+- 不改变 session、workspace 或 Worker 生命周期。
+
+## 方案比较
+
+### 方案 A：前端 single-flight 与 close barrier（采用）
+
+客户端在模块内维护按 session 隔离的关闭交接状态。同一实例的重复 `connect()` 共享连接 Promise；跨实例的相同 session 连接等待前一个实例登记的 close barrier。变更局限在浏览器连接生命周期，保留现有协议和服务端安全边界。
+
+### 方案 B：全局 WebSocket 连接池
+
+组件重新挂载时复用同一 `BrowserHotPlexClient`。它能避免大部分重建，但必须增加订阅迁移、引用计数、延迟销毁和挂载空窗事件缓存，生命周期复杂度明显更高。
+
+### 方案 C：Gateway logical client ID 接管
+
+在 init 中增加浏览器逻辑实例标识，允许同一逻辑实例的新连接替换旧 owner。该方案需要修改 AEP、SDK、安全模型及企业 WS 行为，超出本缺陷的最小修复范围。
+
+## 详细设计
+
+### 1. 按 session 的连接交接注册表
+
+在浏览器 client 模块中增加进程内注册表，key 为已知 session ID，value 只保存连接交接所需的短生命周期状态：
+
+- 当前进行中的 connect Promise；
+- 最近一次由本 realm 发起的 close barrier；
+- barrier 对应的 socket/连接代际；
+- 本次连接是否具备一次本地交接重试资格。
+
+注册表仅存在于当前标签页的 JavaScript realm。不同标签页不共享该状态，因此第二个标签页仍会被 Gateway 拒绝。
+
+### 2. Single-flight connect
+
+`connect()` 与自动重连统一进入一个串行入口：
+
+1. 若当前实例已经连接到目标 session，直接返回最近一次成功 init 结果，不创建 socket；
+2. 若相同目标已有进行中的 connect，返回同一个 Promise；
+3. 清理尚未执行的自动重连 timer，避免手动连接与 timer 同时进入；
+4. 等待目标 session 的前置 close barrier；
+5. 创建唯一的新 socket 并发送 init；
+6. 成功或失败后只清理属于当前连接代际的注册状态。
+
+所有异步回调使用连接代际检查，旧 socket 的 message、close 或 error 不能修改新 socket 状态。
+
+### 3. Close barrier
+
+`disconnect()` 仍可由 React cleanup 同步调用，但会在关闭 socket 前为当前 session 登记 barrier。barrier 在以下任一条件满足时完成：
+
+- 原生 socket 发出 `close`；
+- socket 在登记时已经处于 `CLOSED`；
+- 关闭握手超过有界超时。
+
+超时不能直接把普通连接冲突伪装成成功。超时后的新连接可以继续尝试，但只有带本地 barrier 证据的连接才拥有一次内部冲突重试资格。
+
+### 4. 本地交接冲突重试
+
+若 init 收到 `SESSION_ALREADY_CONNECTED`：
+
+- 没有本地 close barrier/交接代际：保持现有 fatal 行为，进入 `already_connected`；
+- 有本地交接证据且尚未重试：等待一个有界退避后重新建立一次连接，不向 Runtime 发出 `sessionAlreadyConnected`；
+- 重试仍冲突：按真实冲突处理，停止自动重连并展示弹窗。
+
+该规则避免无限重连，也不会让第二个标签页获得接管能力。
+
+### 5. React Runtime 生命周期
+
+`useHotPlexRuntime` 继续按 `sessionId`、`workspaceId` 和 `sessionWorkerType` 管理 client。cleanup 无需等待异步 Promise；后续 client 的 `connect()` 会通过模块级 close barrier 完成交接。
+
+Runtime 不因 permission、question 或 elicitation 消息更新而重建连接。交互响应仍调用当前 `clientRef`，Gateway 的权威 ACK 仍只在 Worker 接受响应后回显。
+
+## 错误处理
+
+- close barrier 超时记录结构化 warning，包含 session 和连接代际，不记录凭证。
+- 本地交接首次冲突记录 info；第二次冲突记录现有 duplicate-session 状态。
+- 非交接冲突不重试。
+- 组件卸载后，旧连接回调不得触发 React state 更新或清除新连接状态。
+
+## 测试
+
+### Browser client 单元测试
+
+- 同一实例并发两次 `connect()` 只创建一个 WebSocket，两个调用共享结果。
+- 已连接的同 session 再次 `connect()` 不创建新 socket。
+- 自动重连 timer 与手动 `connect()` 竞争时只建立一次连接。
+- 旧实例 `disconnect()` 后立即创建新实例，新实例在旧 socket close 前不发送 init。
+- 旧 socket 的迟到 message/close 不能改变新连接状态。
+- 带本地交接证据的首次 `SESSION_ALREADY_CONNECTED` 静默重试一次。
+- 无本地交接证据或第二次冲突继续触发 `sessionAlreadyConnected`。
+
+### Runtime/交互回归测试
+
+- cleanup/remount 交接后，permission response 从新 owner 成功发送并收到 ACK。
+- question 与 elicitation 使用相同交接路径。
+- 交互 request 的纯消息状态更新不会创建新 WebSocket。
+
+### Gateway 回归测试
+
+- 真实的第二连接仍被拒绝。
+- 当前 owner 的三类交互响应通过，非 owner 响应被拒绝。
+
+## 验收标准
+
+- 单标签页在重连、组件重新挂载和交互请求期间不再出现错误的 session 冲突弹窗。
+- 同一 session 的两个真实标签页仍只有第一个连接成功。
+- 连接交接不会重复发送用户 input 或交互响应。
+- WebChat、Gateway 相关 race tests、TypeScript 检查与现有质量门禁通过。

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -64,13 +64,27 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 	// cache_read_input_tokens are separate additive fields (Anthropic API).
 	// Total input = input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
 	if usage, ok := data.Stats["usage"].(map[string]any); ok {
-		input := events.ToInt64(usage["input_tokens"]) +
-			events.ToInt64(usage["cache_creation_input_tokens"]) +
-			events.ToInt64(usage["cache_read_input_tokens"])
-		a.TotalInput += input
-		a.TotalOutput += events.ToInt64(usage["output_tokens"])
-		a.TotalCacheWrite += events.ToInt64(usage["cache_creation_input_tokens"])
-		a.TotalCacheRead += events.ToInt64(usage["cache_read_input_tokens"])
+		inputTokens := events.ToInt64(usage["input_tokens"])
+		if inputTokens == 0 {
+			inputTokens = events.ToInt64(usage["inputTokens"])
+		}
+		cacheWrite := events.ToInt64(usage["cache_creation_input_tokens"])
+		if cacheWrite == 0 {
+			cacheWrite = events.ToInt64(usage["cacheCreationInputTokens"])
+		}
+		cacheRead := events.ToInt64(usage["cache_read_input_tokens"])
+		if cacheRead == 0 {
+			cacheRead = events.ToInt64(usage["cacheReadInputTokens"])
+		}
+		outputTokens := events.ToInt64(usage["output_tokens"])
+		if outputTokens == 0 {
+			outputTokens = events.ToInt64(usage["outputTokens"])
+		}
+
+		a.TotalInput += inputTokens + cacheWrite + cacheRead
+		a.TotalOutput += outputTokens
+		a.TotalCacheWrite += cacheWrite
+		a.TotalCacheRead += cacheRead
 	} else if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
 		// OpenCode format: input/cache_read/cache_write are separate additive fields.
 		input := events.ToInt64(tokens["input"]) +

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -87,13 +87,21 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 		a.TotalCacheRead += cacheRead
 	} else if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
 		// OpenCode format: input/cache_read/cache_write are separate additive fields.
-		input := events.ToInt64(tokens["input"]) +
-			events.ToInt64(tokens["cache_read"]) +
-			events.ToInt64(tokens["cache_write"])
-		a.TotalInput += input
-		a.TotalOutput += events.ToInt64(tokens["output"])
-		a.TotalCacheWrite += events.ToInt64(tokens["cache_write"])
-		a.TotalCacheRead += events.ToInt64(tokens["cache_read"])
+		input := events.ToInt64(tokens["input"])
+		output := events.ToInt64(tokens["output"])
+		cacheRead := events.ToInt64(tokens["cache_read"])
+		if cacheRead == 0 {
+			cacheRead = events.ToInt64(tokens["cacheRead"])
+		}
+		cacheWrite := events.ToInt64(tokens["cache_write"])
+		if cacheWrite == 0 {
+			cacheWrite = events.ToInt64(tokens["cacheWrite"])
+		}
+
+		a.TotalInput += input + cacheRead + cacheWrite
+		a.TotalOutput += output
+		a.TotalCacheWrite += cacheWrite
+		a.TotalCacheRead += cacheRead
 	}
 
 	// Claude Code modelUsage: extract model name + contextWindow

--- a/pkg/events/helpers.go
+++ b/pkg/events/helpers.go
@@ -1,6 +1,9 @@
 package events
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 func IntFloat(v any) int {
 	f, _ := v.(float64)
@@ -8,7 +11,7 @@ func IntFloat(v any) int {
 }
 
 // ToInt64 converts any numeric value to int64.
-// Handles float64, int, int32, int64, and json.Number.
+// Handles float64, int, int32, int64, json.Number, string, and uints.
 func ToInt64(v any) int64 {
 	switch n := v.(type) {
 	case float64:
@@ -19,6 +22,24 @@ func ToInt64(v any) int64 {
 		return int64(n)
 	case int64:
 		return n
+	case uint:
+		return int64(n)
+	case uint32:
+		return int64(n)
+	case uint64:
+		return int64(n)
+	case string:
+		var i int64
+		// try integer parsing
+		if _, err := fmt.Sscanf(n, "%d", &i); err == nil {
+			return i
+		}
+		// try float parsing
+		var f float64
+		if _, err := fmt.Sscanf(n, "%f", &f); err == nil {
+			return int64(f)
+		}
+		return 0
 	case json.Number:
 		i, _ := n.Int64()
 		return i

--- a/webchat/app/globals.css
+++ b/webchat/app/globals.css
@@ -1438,33 +1438,41 @@ a:not(:disabled):active,
 @keyframes avatarRipple1 {
     0% {
         transform: scale(1);
-        opacity: 0.6;
+        opacity: 0.9;
+        border-color: rgba(251, 191, 36, 0.7);
+        background-color: rgba(251, 191, 36, 0.2);
     }
     100% {
-        transform: scale(1.6);
+        transform: scale(2.4);
         opacity: 0;
+        border-color: rgba(251, 191, 36, 0);
+        background-color: rgba(251, 191, 36, 0);
     }
 }
 
 @keyframes avatarRipple2 {
     0% {
         transform: scale(1);
-        opacity: 0.4;
+        opacity: 0.7;
+        border-color: rgba(251, 191, 36, 0.5);
+        background-color: rgba(251, 191, 36, 0.12);
     }
     100% {
-        transform: scale(2.2);
+        transform: scale(3.6);
         opacity: 0;
+        border-color: rgba(251, 191, 36, 0);
+        background-color: rgba(251, 191, 36, 0);
     }
 }
 
 @keyframes avatarBreath {
     0%, 100% {
-        transform: scale(1.05);
-        filter: drop-shadow(0 0 5px rgba(251, 191, 36, 0.5));
+        transform: scale(1.1);
+        filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.85)) brightness(1.2);
     }
     50% {
-        transform: scale(0.95);
-        filter: drop-shadow(0 0 2px rgba(251, 191, 36, 0.15));
+        transform: scale(0.9);
+        filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.2)) brightness(0.95);
     }
 }
 
@@ -1481,12 +1489,12 @@ a:not(:disabled):active,
 }
 
 .animate-avatar-ripple-1 {
-    animation: avatarRipple1 3s cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
+    animation: avatarRipple1 2.2s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
 }
 
 .animate-avatar-ripple-2 {
-    animation: avatarRipple2 3s cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
-    animation-delay: 1.5s;
+    animation: avatarRipple2 2.2s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+    animation-delay: 1.1s;
 }
 
 .animate-avatar-breath {

--- a/webchat/app/globals.css
+++ b/webchat/app/globals.css
@@ -1431,3 +1431,69 @@ a:not(:disabled):active,
     box-shadow: 0 0 0 2px var(--accent-gold-glow) !important;
     outline: none !important;
 }
+
+/* ============================================================
+   Living Avatar Animations
+   ============================================================ */
+@keyframes avatarRipple1 {
+    0% {
+        transform: scale(1);
+        opacity: 0.6;
+    }
+    100% {
+        transform: scale(1.6);
+        opacity: 0;
+    }
+}
+
+@keyframes avatarRipple2 {
+    0% {
+        transform: scale(1);
+        opacity: 0.4;
+    }
+    100% {
+        transform: scale(2.2);
+        opacity: 0;
+    }
+}
+
+@keyframes avatarBreath {
+    0%, 100% {
+        transform: scale(1.05);
+        filter: drop-shadow(0 0 5px rgba(251, 191, 36, 0.5));
+    }
+    50% {
+        transform: scale(0.95);
+        filter: drop-shadow(0 0 2px rgba(251, 191, 36, 0.15));
+    }
+}
+
+@keyframes gradientShift {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+.animate-avatar-ripple-1 {
+    animation: avatarRipple1 3s cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
+}
+
+.animate-avatar-ripple-2 {
+    animation: avatarRipple2 3s cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
+    animation-delay: 1.5s;
+}
+
+.animate-avatar-breath {
+    animation: avatarBreath 2s ease-in-out infinite;
+}
+
+.animate-gradient-shift {
+    background-size: 200% 200%;
+    animation: gradientShift 6s ease infinite;
+}

--- a/webchat/app/globals.css
+++ b/webchat/app/globals.css
@@ -1505,3 +1505,60 @@ a:not(:disabled):active,
     background-size: 200% 200%;
     animation: gradientShift 6s ease infinite;
 }
+
+/* ============================================================
+   Living User Avatar Animations
+   ============================================================ */
+@keyframes userAvatarRipple1 {
+    0% {
+        transform: scale(1);
+        opacity: 0.9;
+        border-color: rgba(59, 130, 246, 0.7);
+        background-color: rgba(59, 130, 246, 0.2);
+    }
+    100% {
+        transform: scale(2.4);
+        opacity: 0;
+        border-color: rgba(59, 130, 246, 0);
+        background-color: rgba(59, 130, 246, 0);
+    }
+}
+
+@keyframes userAvatarRipple2 {
+    0% {
+        transform: scale(1);
+        opacity: 0.7;
+        border-color: rgba(59, 130, 246, 0.5);
+        background-color: rgba(59, 130, 246, 0.12);
+    }
+    100% {
+        transform: scale(3.6);
+        opacity: 0;
+        border-color: rgba(59, 130, 246, 0);
+        background-color: rgba(59, 130, 246, 0);
+    }
+}
+
+@keyframes userAvatarBreath {
+    0%, 100% {
+        transform: scale(1.1);
+        filter: drop-shadow(0 0 8px rgba(59, 130, 246, 0.85)) brightness(1.2);
+    }
+    50% {
+        transform: scale(0.9);
+        filter: drop-shadow(0 0 3px rgba(59, 130, 246, 0.2)) brightness(0.95);
+    }
+}
+
+.animate-user-avatar-ripple-1 {
+    animation: userAvatarRipple1 2.2s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+}
+
+.animate-user-avatar-ripple-2 {
+    animation: userAvatarRipple2 2.2s cubic-bezier(0.1, 0.8, 0.3, 1) infinite;
+    animation-delay: 1.1s;
+}
+
+.animate-user-avatar-breath {
+    animation: userAvatarBreath 2s ease-in-out infinite;
+}

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -180,6 +180,8 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
   const isError = message?.status === "error";
   const ext = getExt(message);
   const content = ext.content || [];
+  const custom = ext.metadata?.custom;
+  const isStreaming = ext.status?.type === "running" || custom?.progress === "thinking" || custom?.progress === "accepted";
 
   // Stable toggle so ToolCallPart memo is not defeated by a fresh closure each
   // render. The default-expanded state (the last part) is passed in by the caller.
@@ -212,10 +214,23 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
 
   return (
     <motion.div className={`group msg-assistant flex items-start gap-4 mb-8 ${isError ? "border-l-2 border-[var(--accent-coral)] pl-3" : ""}`} variants={messageVariants} initial="hidden" animate="visible">
-      <div className="flex-shrink-0">
-        <div className="w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] shadow-sm flex items-center justify-center relative overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/5 to-transparent" />
-          <BrandIcon size={24} />
+      <div className="flex-shrink-0 relative">
+        {isStreaming && (
+          <>
+            <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-1 -z-10" />
+            <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-2 -z-10" />
+          </>
+        )}
+        <div className={`w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border shadow-sm flex items-center justify-center relative overflow-hidden transition-all duration-500 ${isStreaming ? "border-[var(--accent-gold)]/40 shadow-[0_0_15px_rgba(251,191,36,0.25)] scale-[1.02]" : "border-[var(--border-subtle)]"}`}>
+          {isStreaming ? (
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/20 via-indigo-500/5 to-transparent animate-gradient-shift" />
+          ) : (
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/5 to-transparent" />
+          )}
+          {isStreaming && (
+            <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/5 bg-transparent" />
+          )}
+          <BrandIcon size={24} className={`transition-all duration-500 relative z-10 ${isStreaming ? "opacity-100 scale-105 filter drop-shadow-[0_0_4px_rgba(251,191,36,0.5)] animate-avatar-breath" : "opacity-80"}`} />
         </div>
       </div>
 
@@ -272,16 +287,16 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
 
             return null;
           })}
-          {ext.metadata?.contextUsage && (
-            <ContextUsageCard data={ext.metadata.contextUsage} />
+          {custom?.contextUsage && (
+            <ContextUsageCard data={custom.contextUsage} />
           )}
-          {ext.metadata?.turnSummary && (
-            <TurnSummaryCard data={ext.metadata.turnSummary} />
+          {custom?.turnSummary && (
+            <TurnSummaryCard data={custom.turnSummary} />
           )}
-          {ext.metadata?.progress && (
+          {custom?.progress && (
             <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
               <span className="w-2 h-2 rounded-full bg-[var(--accent-gold)] animate-pulse" />
-              <span>{t(`status.${ext.metadata.progress}`)}</span>
+              <span>{t(`status.${custom.progress}`)}</span>
             </div>
           )}
         </div>

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -217,20 +217,20 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
       <div className="flex-shrink-0 relative">
         {isStreaming && (
           <>
-            <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-1 -z-10" />
-            <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-2 -z-10" />
+            <div className="absolute inset-0 rounded-[var(--radius-md)] border border-transparent animate-avatar-ripple-1 -z-10" />
+            <div className="absolute inset-0 rounded-[var(--radius-md)] border border-transparent animate-avatar-ripple-2 -z-10" />
           </>
         )}
-        <div className={`w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border shadow-sm flex items-center justify-center relative overflow-hidden transition-all duration-500 ${isStreaming ? "border-[var(--accent-gold)]/40 shadow-[0_0_15px_rgba(251,191,36,0.25)] scale-[1.02]" : "border-[var(--border-subtle)]"}`}>
+        <div className={`w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border shadow-sm flex items-center justify-center relative overflow-hidden transition-all duration-500 ${isStreaming ? "border-[var(--accent-gold)]/60 shadow-[0_0_20px_rgba(251,191,36,0.4)] scale-[1.04]" : "border-[var(--border-subtle)]"}`}>
           {isStreaming ? (
-            <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/20 via-indigo-500/5 to-transparent animate-gradient-shift" />
+            <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/40 via-purple-600/30 to-[var(--accent-emerald)]/20 animate-gradient-shift" />
           ) : (
             <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/5 to-transparent" />
           )}
           {isStreaming && (
-            <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/5 bg-transparent" />
+            <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/10 bg-transparent" />
           )}
-          <BrandIcon size={24} className={`transition-all duration-500 relative z-10 ${isStreaming ? "opacity-100 scale-105 filter drop-shadow-[0_0_4px_rgba(251,191,36,0.5)] animate-avatar-breath" : "opacity-80"}`} />
+          <BrandIcon size={24} className={`transition-all duration-500 relative z-10 ${isStreaming ? "opacity-100 scale-105 filter drop-shadow-[0_0_6px_rgba(251,191,36,0.65)] animate-avatar-breath" : "opacity-80"}`} />
         </div>
       </div>
 

--- a/webchat/components/assistant-ui/PreAssistantIndicator.tsx
+++ b/webchat/components/assistant-ui/PreAssistantIndicator.tsx
@@ -22,10 +22,13 @@ export function PreAssistantIndicator() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, ease: "easeOut" }}
     >
-      <div className="flex-shrink-0">
-        <div className="w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] flex items-center justify-center border border-[var(--border-subtle)] relative overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-tr from-[var(--accent-gold)]/10 to-transparent animate-pulse" />
-          <BrandIcon size={24} className="opacity-40 animate-pulse-subtle" />
+      <div className="flex-shrink-0 relative">
+        <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-1 -z-10" />
+        <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-2 -z-10" />
+        <div className="w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--accent-gold)]/40 shadow-[0_0_15px_rgba(251,191,36,0.25)] scale-[1.02] flex items-center justify-center relative overflow-hidden transition-all duration-500">
+          <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/20 via-indigo-500/5 to-transparent animate-gradient-shift" />
+          <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/5 bg-transparent" />
+          <BrandIcon size={24} className="transition-all duration-500 relative z-10 opacity-100 scale-105 filter drop-shadow-[0_0_4px_rgba(251,191,36,0.5)] animate-avatar-breath" />
         </div>
       </div>
 

--- a/webchat/components/assistant-ui/PreAssistantIndicator.tsx
+++ b/webchat/components/assistant-ui/PreAssistantIndicator.tsx
@@ -23,12 +23,12 @@ export function PreAssistantIndicator() {
       transition={{ duration: 0.4, ease: "easeOut" }}
     >
       <div className="flex-shrink-0 relative">
-        <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-1 -z-10" />
-        <div className="absolute inset-0 rounded-[var(--radius-md)] bg-[var(--accent-gold)]/10 animate-avatar-ripple-2 -z-10" />
-        <div className="w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--accent-gold)]/40 shadow-[0_0_15px_rgba(251,191,36,0.25)] scale-[1.02] flex items-center justify-center relative overflow-hidden transition-all duration-500">
-          <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/20 via-indigo-500/5 to-transparent animate-gradient-shift" />
-          <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/5 bg-transparent" />
-          <BrandIcon size={24} className="transition-all duration-500 relative z-10 opacity-100 scale-105 filter drop-shadow-[0_0_4px_rgba(251,191,36,0.5)] animate-avatar-breath" />
+        <div className="absolute inset-0 rounded-[var(--radius-md)] border border-transparent animate-avatar-ripple-1 -z-10" />
+        <div className="absolute inset-0 rounded-[var(--radius-md)] border border-transparent animate-avatar-ripple-2 -z-10" />
+        <div className="w-9 h-9 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border border-[var(--accent-gold)]/60 shadow-[0_0_20px_rgba(251,191,36,0.4)] scale-[1.04] flex items-center justify-center relative overflow-hidden transition-all duration-500">
+          <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent-gold)]/40 via-purple-600/30 to-[var(--accent-emerald)]/20 animate-gradient-shift" />
+          <div className="absolute inset-[1px] rounded-[calc(var(--radius-md)-1px)] border border-white/10 bg-transparent" />
+          <BrandIcon size={24} className="transition-all duration-500 relative z-10 opacity-100 scale-105 filter drop-shadow-[0_0_6px_rgba(251,191,36,0.65)] animate-avatar-breath" />
         </div>
       </div>
 

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -68,7 +68,7 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
     parts.push(`${Math.round(pct)}%`);
   }
   if (data.turn_duration_ms > 0) {
-    parts.push(formatDuration(data.turn_duration_ms));
+    parts.push(`⏱️ ${formatDuration(data.turn_duration_ms)}`);
   }
   if (data.tool_call_count > 0) {
     parts.push(`🛠 ${data.tool_call_count}`);
@@ -83,7 +83,7 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
       initial={{ opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: [0.2, 0, 0, 1] }}
-      className="my-1.5 rounded-[var(--radius-sm)] px-3 py-1.5 flex items-center gap-2 flex-wrap"
+      className="my-1.5 rounded-[var(--radius-sm)] px-3 py-1.5 flex items-center gap-2 flex-wrap w-fit"
       style={{ background: cfg.bg, border: `1px solid ${cfg.border}` }}
     >
       {pct > 0 && data.context_window > 0 && (

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -28,8 +28,8 @@ function formatDuration(ms: number): string {
 }
 
 function formatCost(usd: number): string {
-  if (usd < 0.01) return '';
-  if (usd < 1) return `$${usd.toFixed(2)}`;
+  if (usd <= 0) return '';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
   return `$${usd.toFixed(2)}`;
 }
 
@@ -57,6 +57,7 @@ const severityConfig: Record<Severity, { color: string; bg: string; border: stri
 };
 
 export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
+  console.log("TurnSummaryCard stats data:", data);
   const pct = Math.max(0, Math.min(100, data.context_pct ?? 0));
   const severity = getSeverity(pct);
   const cfg = severityConfig[severity];
@@ -67,8 +68,10 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
   if (pct > 0 && data.context_window > 0) {
     parts.push(`${Math.round(pct)}%`);
   }
-  if (data.turn_input_tok > 0 || data.turn_output_tok > 0) {
-    parts.push(`📥 ${formatTokens(data.turn_input_tok)} · 📤 ${formatTokens(data.turn_output_tok)}`);
+  const inputTok = data.turn_input_tok || data.total_input_tok;
+  const outputTok = data.turn_output_tok || data.total_output_tok;
+  if (inputTok > 0 || outputTok > 0) {
+    parts.push(`📥 ${formatTokens(inputTok)} · 📤 ${formatTokens(outputTok)}`);
   }
   if (data.turn_duration_ms > 0) {
     parts.push(`⏱️ ${formatDuration(data.turn_duration_ms)}`);
@@ -86,7 +89,8 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
     }
     parts.push(toolStr);
   }
-  const cost = data.turn_cost_usd ? formatCost(data.turn_cost_usd) : '';
+  const costVal = data.turn_cost_usd || data.total_cost_usd;
+  const cost = costVal ? formatCost(costVal) : '';
   if (cost) parts.push(cost);
 
   if (parts.length === 0) return null;

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -15,7 +15,7 @@ function getSeverity(pct: number): Severity {
 function formatTokens(n: number): string {
   if (n < 1000) return String(n);
   const k = n / 1000;
-  return k % 1 === 0 ? `${k}K` : `~${k.toFixed(1)}K}`;
+  return k % 1 === 0 ? `${k}K` : `~${k.toFixed(1)}K`;
 }
 
 function formatDuration(ms: number): string {
@@ -67,11 +67,24 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
   if (pct > 0 && data.context_window > 0) {
     parts.push(`${Math.round(pct)}%`);
   }
+  if (data.turn_input_tok > 0 || data.turn_output_tok > 0) {
+    parts.push(`📥 ${formatTokens(data.turn_input_tok)} · 📤 ${formatTokens(data.turn_output_tok)}`);
+  }
   if (data.turn_duration_ms > 0) {
     parts.push(`⏱️ ${formatDuration(data.turn_duration_ms)}`);
   }
+  if (data.git_branch) {
+    parts.push(`🌿 ${data.git_branch}`);
+  }
   if (data.tool_call_count > 0) {
-    parts.push(`🛠 ${data.tool_call_count}`);
+    let toolStr = `🛠 ${data.tool_call_count}`;
+    if (data.tool_names && Object.keys(data.tool_names).length > 0) {
+      const names = Object.entries(data.tool_names)
+        .map(([name, count]) => count > 1 ? `${name}×${count}` : name)
+        .join(', ');
+      toolStr += ` (${names})`;
+    }
+    parts.push(toolStr);
   }
   const cost = data.turn_cost_usd ? formatCost(data.turn_cost_usd) : '';
   if (cost) parts.push(cost);

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -56,40 +56,48 @@ const severityConfig: Record<Severity, { color: string; bg: string; border: stri
   },
 };
 
-export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
-  console.log("TurnSummaryCard stats data:", data);
-  const pct = Math.max(0, Math.min(100, data.context_pct ?? 0));
+export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
+  console.log("TurnSummaryCard stats data:", rawData);
+  const data = (rawData || {}) as any;
+
+  const pct = Math.max(0, Math.min(100, data.context_pct ?? data.contextPct ?? 0));
+  const contextWindow = data.context_window ?? data.contextWindow ?? 0;
   const severity = getSeverity(pct);
   const cfg = severityConfig[severity];
 
   const parts: string[] = [];
 
-  if (data.model_name) parts.push(data.model_name);
-  if (pct > 0 && data.context_window > 0) {
+  const modelName = data.model_name ?? data.modelName;
+  if (modelName) parts.push(modelName);
+  if (pct > 0 && contextWindow > 0) {
     parts.push(`${Math.round(pct)}%`);
   }
-  const inputTok = data.turn_input_tok || data.total_input_tok;
-  const outputTok = data.turn_output_tok || data.total_output_tok;
+  const inputTok = data.turn_input_tok ?? data.turnInputTok ?? data.total_input_tok ?? data.totalInputTok ?? 0;
+  const outputTok = data.turn_output_tok ?? data.turnOutputTok ?? data.total_output_tok ?? data.totalOutputTok ?? 0;
   if (inputTok > 0 || outputTok > 0) {
     parts.push(`📥 ${formatTokens(inputTok)} · 📤 ${formatTokens(outputTok)}`);
   }
-  if (data.turn_duration_ms > 0) {
-    parts.push(`⏱️ ${formatDuration(data.turn_duration_ms)}`);
+  const durationMs = data.turn_duration_ms ?? data.turnDurationMs ?? 0;
+  if (durationMs > 0) {
+    parts.push(`⏱️ ${formatDuration(durationMs)}`);
   }
-  if (data.git_branch) {
-    parts.push(`🌿 ${data.git_branch}`);
+  const gitBranch = data.git_branch ?? data.gitBranch;
+  if (gitBranch) {
+    parts.push(`🌿 ${gitBranch}`);
   }
-  if (data.tool_call_count > 0) {
-    let toolStr = `🛠 ${data.tool_call_count}`;
-    if (data.tool_names && Object.keys(data.tool_names).length > 0) {
-      const names = Object.entries(data.tool_names)
-        .map(([name, count]) => count > 1 ? `${name}×${count}` : name)
+  const toolCallCount = data.tool_call_count ?? data.toolCallCount ?? 0;
+  if (toolCallCount > 0) {
+    let toolStr = `🛠 ${toolCallCount}`;
+    const toolNames = data.tool_names ?? data.toolNames;
+    if (toolNames && Object.keys(toolNames).length > 0) {
+      const names = Object.entries(toolNames)
+        .map(([name, count]) => (count as number) > 1 ? `${name}×${count}` : name)
         .join(', ');
       toolStr += ` (${names})`;
     }
     parts.push(toolStr);
   }
-  const costVal = data.turn_cost_usd || data.total_cost_usd;
+  const costVal = data.turn_cost_usd ?? data.turnCostUsd ?? data.turnCostUSD ?? data.total_cost_usd ?? data.totalCostUsd ?? data.totalCostUSD ?? 0;
   const cost = costVal ? formatCost(costVal) : '';
   if (cost) parts.push(cost);
 
@@ -103,7 +111,7 @@ export function TurnSummaryCard({ data }: { data: TurnSessionStats }) {
       className="my-1.5 rounded-[var(--radius-sm)] px-3 py-1.5 flex items-center gap-2 flex-wrap w-fit"
       style={{ background: cfg.bg, border: `1px solid ${cfg.border}` }}
     >
-      {pct > 0 && data.context_window > 0 && (
+      {pct > 0 && contextWindow > 0 && (
         <div className="flex items-center gap-1.5">
           <span
             className="block w-1.5 h-1.5 rounded-full"

--- a/webchat/components/assistant-ui/UserMessage.tsx
+++ b/webchat/components/assistant-ui/UserMessage.tsx
@@ -3,18 +3,25 @@
 import { memo } from "react";
 import { motion } from "framer-motion";
 import { MessagePrimitive } from "@assistant-ui/react";
+import { useAuiState } from "@assistant-ui/store";
 import { MessageActions } from "./MessageActions";
 import { messageVariants } from "./thread-helpers";
 
  
 const UserMessage = memo(function UserMessage({ message }: { message: any }) {
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const messages = useAuiState((s) => s.thread.messages);
+
+  const userMessages = messages.filter((m) => m.role === "user");
+  const isLatestUserMessage = userMessages[userMessages.length - 1]?.id === message.id;
+  const isLiving = isRunning && isLatestUserMessage;
+
   return (
     <motion.div className="group flex items-start justify-end gap-4 mb-8" variants={messageVariants} initial="hidden" animate="visible">
       <div className="relative max-w-[85%] flex-1 flex flex-col items-end min-w-0 group/msg">
         <div className="msg-user-bubble relative w-fit p-3.5 rounded-[var(--radius-lg)] rounded-tr-[var(--radius-xs)] bg-[var(--bg-elevated)] border border-[var(--border-subtle)] shadow-sm">
           <MessagePrimitive.Parts>
             {({ part }) => {
-               
               const p = part as Record<string, any>;
               if (p?.type === 'text') return <div className="whitespace-pre-wrap break-normal text-[14px] leading-relaxed">{p.text}</div>;
               return null;
@@ -24,10 +31,30 @@ const UserMessage = memo(function UserMessage({ message }: { message: any }) {
         <MessageActions message={message} isUser />
       </div>
       <div className="flex-shrink-0">
-        <div className="w-9 h-9 rounded-full bg-[var(--bg-elevated)] border border-[var(--border-subtle)] flex items-center justify-center shadow-sm">
-          <svg className="w-5 h-5 text-[var(--text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-          </svg>
+        <div className={`w-9 h-9 rounded-full flex items-center justify-center relative ${isLiving ? "animate-gradient-shift" : ""}`}
+          style={{
+            background: isLiving
+              ? "linear-gradient(-45deg, #3b82f6, #8b5cf6, #ec4899)"
+              : "linear-gradient(135deg, var(--accent-blue), #6366f1)",
+            border: isLiving
+              ? "1px solid rgba(59, 130, 246, 0.4)"
+              : "1px solid var(--border-subtle)",
+            boxShadow: isLiving
+              ? "0 0 12px rgba(59, 130, 246, 0.35)"
+              : "var(--shadow-sm)",
+          }}
+        >
+          {isLiving && (
+            <>
+              <div className="absolute inset-0 rounded-full border border-transparent animate-user-avatar-ripple-1" />
+              <div className="absolute inset-0 rounded-full border border-transparent animate-user-avatar-ripple-2" />
+            </>
+          )}
+          <div className={`${isLiving ? "animate-user-avatar-breath" : ""}`}>
+            <svg className="w-5 h-5 text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.2)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
         </div>
       </div>
     </motion.div>

--- a/webchat/components/assistant-ui/thread-helpers.ts
+++ b/webchat/components/assistant-ui/thread-helpers.ts
@@ -5,9 +5,11 @@ import type { ContextUsageData, TurnSessionStats } from "@/lib/ai-sdk-transport/
 export interface ThreadMessageExtension {
   status?: { type: string };
   metadata?: {
-    contextUsage?: ContextUsageData;
-    turnSummary?: TurnSessionStats;
-    progress?: 'thinking' | 'accepted';
+    custom?: {
+      contextUsage?: ContextUsageData;
+      turnSummary?: TurnSessionStats;
+      progress?: 'thinking' | 'accepted';
+    };
   };
   content: unknown[];
 }

--- a/webchat/components/assistant-ui/thread-helpers.ts
+++ b/webchat/components/assistant-ui/thread-helpers.ts
@@ -26,9 +26,13 @@ export const messageVariants = {
  
 export function extractCommand(args: any) { return args?.command || args?.Command || ""; }
  
-export function extractFilePath(args: any) { return args?.file_path || args?.path || args?.target_file; }
+export function extractFilePath(args: any) { 
+  return args?.file_path || args?.path || args?.target_file || args?.TargetFile || args?.targetFile || args?.AbsolutePath || args?.absolutePath || ""; 
+}
  
-export function extractFileContent(args: any, result: any) { return args?.content || args?.code || (typeof result === "string" ? result : ""); }
+export function extractFileContent(args: any, result: any) { 
+  return args?.content || args?.code || args?.ReplacementContent || args?.CodeContent || (typeof result === "string" ? result : ""); 
+}
 
 export interface Suggestion {
   title: string;

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -159,17 +159,12 @@ export function Thread({ skills, hasMore, connectionState: conn, onLoadHistory, 
       </AnimatePresence>
 
       <div className="composer-wrapper px-4 pb-12">
-        {(conn === 'disconnected' || conn === 'reconnecting') && (
-          <div className="max-w-3xl mx-auto mb-3 flex items-center justify-center gap-2 px-3 py-1.5 rounded-full bg-[var(--accent-coral)]/10 border border-[var(--accent-coral)]/30 text-[var(--accent-coral)] text-[11px] font-medium">
-            <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent-coral)] animate-pulse" />
-            {t(conn === 'reconnecting' ? 'status.reconnecting_banner' : 'status.disconnected_banner')}
-          </div>
-        )}
         <ThreadComposer
           skills={skills}
           isRunning={isRunning}
           isStoppingProp={isStoppingProp}
           disabled={conn === 'already_connected'}
+          connectionState={conn}
         />
         <div className="mt-2 flex justify-between items-center max-w-3xl mx-auto px-2">
           <div className="flex gap-4">
@@ -200,9 +195,10 @@ interface ThreadComposerProps {
   isRunning: boolean;
   isStoppingProp?: boolean;
   disabled?: boolean;
+  connectionState?: ConnectionState;
 }
 
-const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, isStoppingProp, disabled }: ThreadComposerProps) {
+const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, isStoppingProp, disabled, connectionState }: ThreadComposerProps) {
   const { t } = useTranslation('chat');
   const [localText, setLocalText] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -247,32 +243,42 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
         {menuOpen && <CommandMenu isOpen={menuOpen} inputValue={localText} onSelect={handleSelectCommand} onClose={() => setMenuOpen(false)} skills={skills} />}
       </AnimatePresence>
       <div className="relative">
-        <div className="absolute bottom-full left-0 right-0 z-20 mb-3 flex items-center justify-between px-1">
-          {/* Left Side: Agent Skills */}
-          <div className="flex items-center gap-2 overflow-x-auto no-scrollbar animate-fadeIn max-w-[70%]">
-            <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/20 shadow-sm whitespace-nowrap">
-              <span className="text-[9px] font-display font-black text-[var(--accent-gold)] uppercase tracking-[0.05em]">{t('label.agent_skills')}</span>
-              <div className="w-1 h-1 rounded-full bg-[var(--accent-gold)] animate-pulse" />
+        <div className="absolute bottom-full left-0 right-0 z-20 mb-3 flex flex-col gap-2.5">
+          {/* Reconnecting / Disconnected Banner */}
+          {(connectionState === 'disconnected' || connectionState === 'reconnecting') && (
+            <div className="flex items-center justify-center gap-2 px-3 py-1.5 rounded-full bg-[var(--accent-coral)]/10 border border-[var(--accent-coral)]/30 text-[var(--accent-coral)] text-[11px] font-medium w-full shadow-sm animate-fadeIn">
+              <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent-coral)] animate-pulse" />
+              {t(connectionState === 'reconnecting' ? 'status.reconnecting_banner' : 'status.disconnected_banner')}
             </div>
-            {skills?.slice(0, 3).map(skill => (
-              <div key={skill.name} className="px-3 py-1.5 rounded-full bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[10px] font-medium text-[var(--text-muted)] whitespace-nowrap hover:border-[var(--text-faint)] transition-colors cursor-default">
-                {skill.name}
-              </div>
-            ))}
-            {skills && skills.length > 3 && (
-              <div className="px-1 py-1 text-[10px] font-mono text-[var(--text-faint)] uppercase tracking-tighter">
-                +{skills.length - 3}
-              </div>
-            )}
-          </div>
+          )}
 
-          {/* Right Side: Scroll to Bottom */}
-          <ThreadPrimitive.ScrollToBottom className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[var(--bg-glass)] border border-[var(--border-subtle)] backdrop-blur-md shadow-[var(--shadow-sm)] text-[var(--text-muted)] hover:text-[var(--accent-gold)] hover:border-[var(--accent-gold)]/30 hover:bg-[var(--bg-hover)] transition-all active:scale-95 group/scroll whitespace-nowrap">
-            <svg className="w-3.5 h-3.5 animate-bounce-subtle" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-            </svg>
-            <span className="text-[10px] font-bold uppercase tracking-widest">{t('label.latest_messages')}</span>
-          </ThreadPrimitive.ScrollToBottom>
+          <div className="flex items-center justify-between px-1">
+            {/* Left Side: Agent Skills */}
+            <div className="flex items-center gap-2 overflow-x-auto no-scrollbar animate-fadeIn max-w-[70%]">
+              <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-[var(--accent-gold)]/10 border border-[var(--accent-gold)]/20 shadow-sm whitespace-nowrap">
+                <span className="text-[9px] font-display font-black text-[var(--accent-gold)] uppercase tracking-[0.05em]">{t('label.agent_skills')}</span>
+                <div className="w-1 h-1 rounded-full bg-[var(--accent-gold)] animate-pulse" />
+              </div>
+              {skills?.slice(0, 3).map(skill => (
+                <div key={skill.name} className="px-3 py-1.5 rounded-full bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[10px] font-medium text-[var(--text-muted)] whitespace-nowrap hover:border-[var(--text-faint)] transition-colors cursor-default">
+                  {skill.name}
+                </div>
+              ))}
+              {skills && skills.length > 3 && (
+                <div className="px-1 py-1 text-[10px] font-mono text-[var(--text-faint)] uppercase tracking-tighter">
+                  +{skills.length - 3}
+                </div>
+              )}
+            </div>
+
+            {/* Right Side: Scroll to Bottom */}
+            <ThreadPrimitive.ScrollToBottom className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[var(--bg-glass)] border border-[var(--border-subtle)] backdrop-blur-md shadow-[var(--shadow-sm)] text-[var(--text-muted)] hover:text-[var(--accent-gold)] hover:border-[var(--accent-gold)]/30 hover:bg-[var(--bg-hover)] transition-all active:scale-95 group/scroll whitespace-nowrap">
+              <svg className="w-3.5 h-3.5 animate-bounce-subtle" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+              </svg>
+              <span className="text-[10px] font-bold uppercase tracking-widest">{t('label.latest_messages')}</span>
+            </ThreadPrimitive.ScrollToBottom>
+          </div>
         </div>
 
         <ComposerPrimitive.Root className="composer-root">

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -152,7 +152,7 @@ const DEFAULT_SUGGESTIONS: readonly ThreadSuggestion[] = [];
  * Converts HotPlex message to assistant-ui ThreadMessageLike format.
  * Handles both old format (content: string) and new format (parts: MessagePart[]).
  */
-function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
+export function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
     // Filter out ToolSummaryPart, ContextUsagePart, and TurnSummaryPart — not recognized by assistant-ui's ThreadMessageLike type
     const parts = message.parts ?? [];
     const content = parts.filter(
@@ -183,11 +183,13 @@ function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
         createdAt: message.createdAt,
         attachments: [] as const,
         metadata: {
-            ...(contextUsagePart
-                ? { contextUsage: contextUsagePart.data }
-                : {}),
-            ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
-            ...(message.progress ? { progress: message.progress } : {}),
+            custom: {
+                ...(contextUsagePart
+                    ? { contextUsage: contextUsagePart.data }
+                    : {}),
+                ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
+                ...(message.progress ? { progress: message.progress } : {}),
+            },
         } satisfies Record<string, unknown>,
     } as ThreadMessageLike & {
         status?: { type: "running" } | { type: "complete"; reason: string };
@@ -1284,7 +1286,7 @@ export function useHotPlexRuntime({
             if (!matchesActiveInput(activeInputMessageIdRef.current, data.client_message_id)) {
                 return;
             }
-            if (data.status === "delivered") {
+            if (data.status === "accepted" || data.status === "delivered") {
                 setMessages((prev) =>
                     updatePendingAssistant(
                         prev,

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -1613,6 +1613,54 @@ export function useHotPlexRuntime({
             throw new Error("HotPlex client not initialized.");
         }
 
+        const textContent = Array.isArray(message.content)
+            ? message.content
+                  .filter(
+                      (part): part is { type: "text"; text: string } =>
+                          part.type === "text",
+                  )
+                  .map((part) => part.text)
+                  .join("")
+            : "";
+        if (!textContent.trim()) {
+            return;
+        }
+
+        const userMessage: HotPlexMessage = {
+            id: `user-${Date.now()}`,
+            role: "user",
+            parts: [{ type: "text", text: textContent }],
+            createdAt: new Date(),
+            status: "complete",
+        };
+        const assistantID = `assistant-local-${Date.now()}`;
+        const pendingAssistant = createPendingAssistantMessage(
+            assistantID,
+            new Date(),
+        );
+        const rollbackOptimisticInput = () => {
+            pendingAssistantIdRef.current = null;
+            activeAssistantIdRef.current = null;
+            activeInputMessageIdRef.current = null;
+            setIsRunning(false);
+            setMessages((prev) =>
+                prev.filter(
+                    (current) =>
+                        current.id !== userMessage.id &&
+                        current.id !== assistantID,
+                ),
+            );
+        };
+
+        // Insert feedback before reconnecting: WebSocket recovery can take
+        // seconds, but it must not create a blank interval in the thread.
+        pendingAssistantIdRef.current = assistantID;
+        activeAssistantIdRef.current = assistantID;
+        activeInputMessageIdRef.current = null;
+        setMessages((prev) => [...prev, userMessage, pendingAssistant]);
+        setIsRunning(true);
+        startTurn();
+
         // Handle disconnected state: attempt to reconnect if not already connecting
         if (!client.connected) {
             logger.info(
@@ -1676,6 +1724,7 @@ export function useHotPlexRuntime({
                     }
                 });
             } catch (err) {
+                rollbackOptimisticInput();
                 throw new Error(
                     err instanceof Error
                         ? err.message
@@ -1684,60 +1733,12 @@ export function useHotPlexRuntime({
             }
         }
 
-        // Extract text content from message parts
-        const textContent = Array.isArray(message.content)
-            ? message.content
-                  .filter(
-                      (part): part is { type: "text"; text: string } =>
-                          part.type === "text",
-                  )
-                  .map((part) => part.text)
-                  .join("")
-            : "";
-
-        if (!textContent.trim()) {
-            return;
-        }
-
-        // 1. Add user message to state
-        const userMessage: HotPlexMessage = {
-            id: `user-${Date.now()}`,
-            role: "user",
-            parts: [{ type: "text", text: textContent }],
-            createdAt: new Date(),
-            status: "complete",
-        };
-        const assistantID = `assistant-local-${Date.now()}`;
-        const pendingAssistant = createPendingAssistantMessage(
-            assistantID,
-            new Date(),
-        );
-
-        // The user message and local assistant placeholder must enter state in
-        // one update so the first frame always shows that the turn is pending.
-        pendingAssistantIdRef.current = assistantID;
-        activeAssistantIdRef.current = assistantID;
-        activeInputMessageIdRef.current = null;
-        setMessages((prev) => [...prev, userMessage, pendingAssistant]);
-        setIsRunning(true);
-        startTurn(); // Begin timing for metrics
-
         // Send to HotPlex gateway with error handling
         try {
             activeInputMessageIdRef.current = client.sendInput(textContent);
         } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);
-            // The optimistically-added user message did not go out — remove it.
-            pendingAssistantIdRef.current = null;
-            activeAssistantIdRef.current = null;
-            activeInputMessageIdRef.current = null;
-            setMessages((prev) =>
-                prev.filter(
-                    (message) =>
-                        message.id !== userMessage.id &&
-                        message.id !== assistantID,
-                ),
-            );
+            rollbackOptimisticInput();
             if (errMsg === "Input already pending") {
                 // A previous turn is still in flight (often an unknown-outcome
                 // tombstone). This is not a connection fault.

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -70,6 +70,7 @@ import {
 import {
     completeStreamingAssistant,
     createPendingAssistantMessage,
+    isVisibleAdapterMessage,
     matchesActiveInput,
     removePendingAssistant,
     updatePendingAssistant,
@@ -1987,14 +1988,7 @@ export function useHotPlexRuntime({
                 (m): m is HotPlexMessage =>
                     !!m && (m.role === "user" || m.role === "assistant"),
             )
-            .filter(
-                (m) =>
-                    !m.parts.every(
-                        (p) =>
-                            p.type === "context-usage" ||
-                            p.type === "turn-summary",
-                    ),
-            )
+            .filter(isVisibleAdapterMessage)
             .filter((m) => {
                 // Layer 1: exact ID dedup
                 if (seenIds.has(m.id)) return false;

--- a/webchat/lib/adapters/pending-assistant.test.ts
+++ b/webchat/lib/adapters/pending-assistant.test.ts
@@ -3,6 +3,7 @@ import type { HotPlexMessage } from "@/lib/types/message";
 import {
     completeStreamingAssistant,
     createPendingAssistantMessage,
+    isVisibleAdapterMessage,
     matchesActiveInput,
     removePendingAssistant,
     updatePendingAssistant,
@@ -21,6 +22,10 @@ describe("pending assistant state", () => {
             status: "streaming",
             progress: "thinking",
         });
+    });
+
+    it("keeps an empty local placeholder visible to the thread adapter", () => {
+        expect(isVisibleAdapterMessage(pending())).toBe(true);
     });
 
     it("adopts the placeholder without changing its ID for delta-first output", () => {

--- a/webchat/lib/adapters/pending-assistant.ts
+++ b/webchat/lib/adapters/pending-assistant.ts
@@ -14,6 +14,18 @@ export function createPendingAssistantMessage(
     };
 }
 
+// Empty parts identify a local pending placeholder. It must stay visible until
+// the first Worker event replaces it with content.
+export function isVisibleAdapterMessage(
+    message: Pick<HotPlexMessage, "parts">,
+): boolean {
+    return message.parts.length === 0 ||
+        !message.parts.every(
+            (part) =>
+                part.type === "context-usage" || part.type === "turn-summary",
+        );
+}
+
 export function matchesActiveInput(
     activeClientMessageID: string | null,
     acknowledgedClientMessageID: string,

--- a/webchat/lib/adapters/runtime-adapter.test.ts
+++ b/webchat/lib/adapters/runtime-adapter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { convertToThreadMessage } from "./hotplex-runtime-adapter";
+
+describe("convertToThreadMessage", () => {
+    it("preserves local progress in assistant-ui custom metadata", () => {
+        const message = convertToThreadMessage({
+            id: "assistant-local-1",
+            role: "assistant",
+            parts: [],
+            createdAt: new Date(0),
+            status: "streaming",
+            progress: "thinking",
+        }) as { metadata?: { custom?: { progress?: string } } };
+
+        expect(message.metadata?.custom?.progress).toBe("thinking");
+    });
+});

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -312,6 +312,47 @@ describe("BrowserHotPlexClient connection handoff", () => {
         replacement.disconnect();
         activeSocket.finishClose();
     });
+
+    it("settles a failed reconnect flight before starting the next attempt", async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+            reconnect: {
+                enabled: true,
+                maxAttempts: 3,
+                baseDelayMs: 10,
+                maxDelayMs: 10,
+            },
+        });
+
+        const initialConnect = client.connect("session-reconnect-flight");
+        await Promise.resolve();
+        const initialSocket = ControlledWebSocket.instances[0];
+        initialSocket.open();
+        initialSocket.message(initAck("session-reconnect-flight"));
+        await initialConnect;
+
+        initialSocket.finishClose(1006, "network lost");
+        await vi.advanceTimersByTimeAsync(10);
+        expect(ControlledWebSocket.instances).toHaveLength(2);
+
+        const failedReconnectSocket = ControlledWebSocket.instances[1];
+        failedReconnectSocket.open();
+        failedReconnectSocket.finishClose(1006, "handshake lost");
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(10);
+        expect(ControlledWebSocket.instances).toHaveLength(3);
+
+        const recoveredSocket = ControlledWebSocket.instances[2];
+        recoveredSocket.open();
+        recoveredSocket.message(initAck("session-reconnect-flight"));
+        await Promise.resolve();
+        expect(client.connected).toBe(true);
+        client.disconnect();
+        recoveredSocket.finishClose();
+    });
 });
 
 describe("BrowserHotPlexClient interaction acknowledgements", () => {

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -25,6 +25,295 @@ function envelope(type: string, data: unknown): Envelope {
     };
 }
 
+class ControlledWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    static instances: ControlledWebSocket[] = [];
+
+    readonly url: string;
+    readyState = ControlledWebSocket.CONNECTING;
+    sent: string[] = [];
+    onclose: ((event: CloseEvent) => void) | null = null;
+    private listeners = new Map<string, Set<(event: any) => void>>();
+
+    constructor(url: string) {
+        this.url = url;
+        ControlledWebSocket.instances.push(this);
+    }
+
+    static reset(): void {
+        ControlledWebSocket.instances = [];
+    }
+
+    addEventListener(type: string, listener: (event: any) => void): void {
+        const listeners = this.listeners.get(type) ?? new Set();
+        listeners.add(listener);
+        this.listeners.set(type, listeners);
+    }
+
+    send(data: string): void {
+        this.sent.push(data);
+    }
+
+    close(): void {
+        if (this.readyState === ControlledWebSocket.CLOSED) return;
+        this.readyState = ControlledWebSocket.CLOSING;
+    }
+
+    open(): void {
+        this.readyState = ControlledWebSocket.OPEN;
+        this.dispatch("open", {});
+    }
+
+    message(value: Envelope): void {
+        this.dispatch("message", { data: JSON.stringify(value) });
+    }
+
+    finishClose(code = 1000, reason = "closed"): void {
+        this.readyState = ControlledWebSocket.CLOSED;
+        const event = { code, reason } as CloseEvent;
+        this.dispatch("close", event);
+        this.onclose?.(event);
+    }
+
+    private dispatch(type: string, event: any): void {
+        for (const listener of this.listeners.get(type) ?? []) {
+            listener(event);
+        }
+    }
+}
+
+function initAck(sessionId: string): Envelope {
+    return {
+        ...envelope(EventKind.InitAck, { state: "running" }),
+        session_id: sessionId,
+    };
+}
+
+describe("BrowserHotPlexClient connection handoff", () => {
+    afterEach(() => {
+        ControlledWebSocket.reset();
+    });
+
+    it("coalesces concurrent connect calls for the same client", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+
+        const first = client.connect("session-single-flight");
+        const second = client.connect("session-single-flight");
+
+        await Promise.resolve();
+        expect(ControlledWebSocket.instances).toHaveLength(1);
+        const socket = ControlledWebSocket.instances[0];
+        socket.open();
+        socket.message(initAck("session-single-flight"));
+
+        await expect(first).resolves.toMatchObject({ state: "running" });
+        await expect(second).resolves.toMatchObject({ state: "running" });
+        client.disconnect();
+        socket.finishClose();
+    });
+
+    it("does not let a rejected cross-session connect corrupt the active target", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+
+        const activeConnect = client.connect("session-a");
+        await expect(client.connect("session-b")).rejects.toThrow(
+            "Connection already in progress for another session",
+        );
+        expect(client.sessionId).toBe("session-a");
+
+        await Promise.resolve();
+        const socket = ControlledWebSocket.instances[0];
+        socket.open();
+        socket.message(initAck("session-a"));
+        await expect(activeConnect).resolves.toMatchObject({ state: "running" });
+        expect(client.sessionId).toBe("session-a");
+        client.disconnect();
+        socket.finishClose();
+    });
+
+    it("waits for the previous instance to close before opening the same session", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const firstClient = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const firstConnect = firstClient.connect("session-remount");
+        await Promise.resolve();
+        const firstSocket = ControlledWebSocket.instances[0];
+        firstSocket.open();
+        firstSocket.message(initAck("session-remount"));
+        await firstConnect;
+
+        firstClient.disconnect();
+        const nextClient = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const nextConnect = nextClient.connect("session-remount");
+        void nextConnect.catch(() => undefined);
+
+        await Promise.resolve();
+        expect(ControlledWebSocket.instances).toHaveLength(1);
+
+        firstSocket.finishClose();
+        await vi.waitFor(() => {
+            expect(ControlledWebSocket.instances).toHaveLength(2);
+        });
+
+        const nextSocket = ControlledWebSocket.instances[1];
+        nextSocket.open();
+        nextSocket.message(initAck("session-remount"));
+        await expect(nextConnect).resolves.toMatchObject({ state: "running" });
+
+        nextClient.sendPermissionResponse("permission-remount", true);
+        nextClient.sendQuestionResponse("question-remount", { choice: "yes" });
+        nextClient.sendElicitationResponse("elicitation-remount", "accept", { value: "ok" });
+        expect(nextSocket.sent.slice(-3).map((line) => JSON.parse(line).event.type)).toEqual([
+            EventKind.PermissionResponse,
+            EventKind.QuestionResponse,
+            EventKind.ElicitationResponse,
+        ]);
+
+        nextClient.disconnect();
+        nextSocket.finishClose();
+    });
+
+    it("reconnects instead of returning a stale ack for a closing socket", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const firstConnect = client.connect("session-closing");
+        await Promise.resolve();
+        const firstSocket = ControlledWebSocket.instances[0];
+        firstSocket.open();
+        firstSocket.message(initAck("session-closing"));
+        await firstConnect;
+
+        firstSocket.readyState = ControlledWebSocket.CLOSING;
+        const reconnect = client.connect("session-closing");
+        await Promise.resolve();
+        expect(ControlledWebSocket.instances).toHaveLength(1);
+
+        firstSocket.finishClose();
+        await vi.waitFor(() => {
+            expect(ControlledWebSocket.instances).toHaveLength(2);
+        });
+        const nextSocket = ControlledWebSocket.instances[1];
+        nextSocket.open();
+        nextSocket.message(initAck("session-closing"));
+        await expect(reconnect).resolves.toMatchObject({ state: "running" });
+        client.disconnect();
+        nextSocket.finishClose();
+    });
+
+    it("backs off before retrying one locally handed-off duplicate", async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const firstClient = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const firstConnect = firstClient.connect("session-local-retry");
+        await Promise.resolve();
+        const firstSocket = ControlledWebSocket.instances[0];
+        firstSocket.open();
+        firstSocket.message(initAck("session-local-retry"));
+        await firstConnect;
+        firstClient.disconnect();
+
+        const nextClient = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const conflict = vi.fn();
+        nextClient.on("sessionAlreadyConnected", conflict);
+        const nextConnect = nextClient.connect("session-local-retry");
+
+        firstSocket.finishClose();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(ControlledWebSocket.instances).toHaveLength(2);
+        const rejectedSocket = ControlledWebSocket.instances[1];
+        rejectedSocket.open();
+        rejectedSocket.message({
+            ...initAck("session-local-retry"),
+            event: {
+                type: EventKind.InitAck,
+                data: {
+                    code: ErrorCode.SessionAlreadyConnected,
+                    error: "session already has an active WebSocket connection",
+                },
+            },
+        });
+
+        expect(conflict).not.toHaveBeenCalled();
+        rejectedSocket.finishClose();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(99);
+        expect(ControlledWebSocket.instances).toHaveLength(2);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(ControlledWebSocket.instances).toHaveLength(3);
+
+        const retrySocket = ControlledWebSocket.instances[2];
+        retrySocket.open();
+        retrySocket.message(initAck("session-local-retry"));
+        await expect(nextConnect).resolves.toMatchObject({ state: "running" });
+        expect(conflict).not.toHaveBeenCalled();
+        nextClient.disconnect();
+        retrySocket.finishClose();
+    });
+
+    it("invalidates a connect that was waiting when the client disconnects", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const owner = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const ownerConnect = owner.connect("session-cancel-waiter");
+        await Promise.resolve();
+        const ownerSocket = ControlledWebSocket.instances[0];
+        ownerSocket.open();
+        ownerSocket.message(initAck("session-cancel-waiter"));
+        await ownerConnect;
+        owner.disconnect();
+
+        const replacement = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const cancelledConnect = replacement.connect("session-cancel-waiter");
+        const cancelled = expect(cancelledConnect).rejects.toThrow("Client is closed");
+        replacement.disconnect();
+        const activeConnect = replacement.connect("session-cancel-waiter");
+
+        ownerSocket.finishClose();
+        await cancelled;
+        await vi.waitFor(() => {
+            expect(ControlledWebSocket.instances).toHaveLength(2);
+        });
+
+        const activeSocket = ControlledWebSocket.instances[1];
+        activeSocket.open();
+        activeSocket.message(initAck("session-cancel-waiter"));
+        await expect(activeConnect).resolves.toMatchObject({ state: "running" });
+        replacement.disconnect();
+        activeSocket.finishClose();
+    });
+});
+
 describe("BrowserHotPlexClient interaction acknowledgements", () => {
     it.each([
         [EventKind.PermissionResponse, "permissionResponse", { id: "permission-1", allowed: true }],

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -189,6 +189,46 @@ describe("BrowserHotPlexClient connection handoff", () => {
         nextSocket.finishClose();
     });
 
+    it("hands off an active same-page client before opening a replacement", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const firstClient = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const firstConnect = firstClient.connect("session-page-owner");
+        await Promise.resolve();
+        const firstSocket = ControlledWebSocket.instances[0];
+        firstSocket.open();
+        firstSocket.message(initAck("session-page-owner"));
+        await firstConnect;
+
+        const replacement = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const replacementConnect = replacement.connect("session-page-owner");
+        void replacementConnect.catch(() => undefined);
+
+        await Promise.resolve();
+        expect(firstSocket.readyState).toBe(ControlledWebSocket.CLOSING);
+        expect(ControlledWebSocket.instances).toHaveLength(1);
+
+        firstSocket.finishClose();
+        await vi.waitFor(() => {
+            expect(ControlledWebSocket.instances).toHaveLength(2);
+        });
+
+        const replacementSocket = ControlledWebSocket.instances[1];
+        replacementSocket.open();
+        replacementSocket.message(initAck("session-page-owner"));
+        await expect(replacementConnect).resolves.toMatchObject({
+            state: "running",
+        });
+
+        replacement.disconnect();
+        replacementSocket.finishClose();
+    });
+
     it("reconnects instead of returning a stale ack for a closing socket", async () => {
         vi.stubGlobal("WebSocket", ControlledWebSocket);
         const client = new BrowserHotPlexClient({

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -900,7 +900,12 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       try {
         await this.connect(this._sessionId);
       } catch {
-        this._handleClose(4001, 'Reconnect failed');
+        // A socket close during the handshake already schedules the next
+        // attempt. Only synthesize a close when connect() failed without a
+        // close event (for example, the WebSocket constructor threw).
+        if (this._reconnecting && !this.reconnectTimer) {
+          this._handleClose(4001, 'Reconnect failed');
+        }
       }
     }, delay);
   }
@@ -926,13 +931,16 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       }
     }
 
+    if (!wasConnected && this._connecting && this.pendingConnectReject) {
+      // Every failed handshake must settle its single-flight promise. During
+      // automatic reconnect the close path continues below to schedule the
+      // next attempt; the timer catch sees that timer and does not duplicate it.
+      this._connecting = false;
+      this.pendingConnectReject(new Error(`WebSocket closed during handshake: ${reason}`));
+      this.pendingConnectReject = null;
+    }
+
     if (!wasConnected && !this._reconnecting) {
-      // Connection closed before or during handshake — reject pending connect
-      if (this._connecting && this.pendingConnectReject) {
-        this._connecting = false;
-        this.pendingConnectReject(new Error(`WebSocket closed during handshake: ${reason}`));
-        this.pendingConnectReject = null;
-      }
       return;
     }
 

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -119,6 +119,11 @@ const DEFAULT_HEARTBEAT_CONFIG = {
 const CLOSE_HANDOFF_TIMEOUT_MS = 2_000;
 const LOCAL_HANDOFF_RETRY_DELAY_MS = 100;
 const sessionCloseHandoffs = new Map<string, Promise<void>>();
+// A browser page can temporarily mount two runtime instances for one session
+// (for example during Fast Refresh). Keep a page-local owner so the newer
+// instance explicitly closes the older socket before connecting. Module state
+// is isolated per tab, preserving server-side protection across tabs/devices.
+const pageSessionOwners = new Map<string, BrowserHotPlexClient>();
 
 function registerSessionCloseHandoff(sessionId: string, socket: WebSocket): void {
   let finish!: () => void;
@@ -210,6 +215,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   private connectionGeneration = 0;
   private lifecycleGeneration = 0;
   private localHandoffRetryAvailable = false;
+  private pageSessionOwner: string | null = null;
 
   private closed = false;
 
@@ -274,6 +280,8 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       }
       return Promise.reject(new Error('Connection already in progress for another session'));
     }
+
+    this._claimPageSessionOwner(target);
 
     if (this._connected && this.connectTarget === target && this.ws) {
       this._stopHeartbeat();
@@ -802,6 +810,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
 
     this._settlePending({ kind: 'reject', error: new Error('Client disconnected'), force: true });
 
+    this._releasePageSessionOwner();
     this._closeCurrentSocketForHandoff('Client disconnect');
 
     this._connected = false;
@@ -809,6 +818,35 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     this.connectPromise = null;
     this.lastInitAck = null;
     this.emit('disconnected', 'Client initiated disconnect');
+  }
+
+  private _claimPageSessionOwner(sessionId: string | null): void {
+    if (!sessionId) return;
+
+    if (this.pageSessionOwner && this.pageSessionOwner !== sessionId) {
+      this._releasePageSessionOwner();
+    }
+
+    const previous = pageSessionOwners.get(sessionId);
+    if (previous && previous !== this) {
+      logger.info('BrowserClient', 'Handing off same-page session owner', {
+        sessionId,
+      });
+      previous.disconnect();
+    }
+
+    pageSessionOwners.set(sessionId, this);
+    this.pageSessionOwner = sessionId;
+  }
+
+  private _releasePageSessionOwner(): void {
+    if (
+      this.pageSessionOwner &&
+      pageSessionOwners.get(this.pageSessionOwner) === this
+    ) {
+      pageSessionOwners.delete(this.pageSessionOwner);
+    }
+    this.pageSessionOwner = null;
   }
 
   private _closeCurrentSocketForHandoff(reason: string): void {

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -111,6 +111,57 @@ const DEFAULT_HEARTBEAT_CONFIG = {
   maxMissedPongs: ProtocolConstants.MaxMissedPongs,
 };
 
+// React cleanup cannot await the WebSocket close handshake. Keep a short-lived,
+// tab-local barrier so a replacement client for the same session does not send
+// init until the previous socket has finished closing and Gateway has released
+// its owner. This module state is not shared across browser tabs, so a genuine
+// second tab still receives SESSION_ALREADY_CONNECTED.
+const CLOSE_HANDOFF_TIMEOUT_MS = 2_000;
+const LOCAL_HANDOFF_RETRY_DELAY_MS = 100;
+const sessionCloseHandoffs = new Map<string, Promise<void>>();
+
+function registerSessionCloseHandoff(sessionId: string, socket: WebSocket): void {
+  let finish!: () => void;
+  const barrier = new Promise<void>((resolve) => {
+    let settled = false;
+    const complete = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (sessionCloseHandoffs.get(sessionId) === barrier) {
+        sessionCloseHandoffs.delete(sessionId);
+      }
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      logger.warn('BrowserClient', 'WebSocket close handoff timed out', { sessionId });
+      complete();
+    }, CLOSE_HANDOFF_TIMEOUT_MS);
+    finish = complete;
+  });
+
+  sessionCloseHandoffs.set(sessionId, barrier);
+  if (socket.readyState === WebSocket.CLOSED) {
+    finish();
+    return;
+  }
+  if (typeof socket.addEventListener === 'function') {
+    socket.addEventListener('close', finish, { once: true });
+  } else {
+    // Defensive compatibility for non-browser test doubles. Real browser
+    // sockets always expose addEventListener.
+    finish();
+  }
+}
+
+async function waitForSessionCloseHandoff(sessionId: string | undefined): Promise<boolean> {
+  if (!sessionId) return false;
+  const barrier = sessionCloseHandoffs.get(sessionId);
+  if (!barrier) return false;
+  await barrier;
+  return true;
+}
+
 // ============================================================================
 // BrowserHotPlexClient
 // ============================================================================
@@ -153,6 +204,12 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   private inputSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private inputTombstoneTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingConnectReject: ((err: Error) => void) | null = null;
+  private connectPromise: Promise<InitAckData> | null = null;
+  private connectTarget: string | null = null;
+  private lastInitAck: InitAckData | null = null;
+  private connectionGeneration = 0;
+  private lifecycleGeneration = 0;
+  private localHandoffRetryAvailable = false;
 
   private closed = false;
 
@@ -201,32 +258,81 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   // Connection Lifecycle
   // ============================================================================
 
-  async connect(sessionId?: string): Promise<InitAckData> {
+  connect(sessionId?: string): Promise<InitAckData> {
     this.closed = false;
     this.shouldReconnect = true;
     const id = sessionId || this._sessionId || undefined;
+    const target = id ?? null;
+
+    if (this._connected && this.connectTarget === target && this.lastInitAck &&
+        this.ws?.readyState === WebSocket.OPEN) {
+      return Promise.resolve(this.lastInitAck);
+    }
+    if (this.connectPromise) {
+      if (this.connectTarget === target) {
+        return this.connectPromise;
+      }
+      return Promise.reject(new Error('Connection already in progress for another session'));
+    }
+
+    if (this._connected && this.connectTarget === target && this.ws) {
+      this._stopHeartbeat();
+      this._connected = false;
+      this._closeCurrentSocketForHandoff('Replacing inactive connection');
+    }
     if (id) {
       this._sessionId = id;
     }
-    return this._doConnect(id);
+
+    this._clearReconnectTimer();
+    this.connectTarget = target;
+    const lifecycleGeneration = this.lifecycleGeneration;
+    const promise = this._doConnect(id, true, lifecycleGeneration);
+    this.connectPromise = promise;
+    const clearFlight = () => {
+      if (this.connectPromise === promise) {
+        this.connectPromise = null;
+      }
+    };
+    promise.then(clearFlight, clearFlight);
+    return promise;
   }
 
-  async resume(existingSessionId: string): Promise<InitAckData> {
-    this.closed = false;
-    this.shouldReconnect = true;
-    this._sessionId = existingSessionId;
-    return this._doConnect(existingSessionId);
+  resume(existingSessionId: string): Promise<InitAckData> {
+    return this.connect(existingSessionId);
   }
 
-  private _doConnect(sessionId: string | undefined): Promise<InitAckData> {
+  private async _doConnect(
+    sessionId: string | undefined,
+    allowLocalHandoffRetry = true,
+    lifecycleGeneration = this.lifecycleGeneration,
+    retryDelayMs = 0,
+  ): Promise<InitAckData> {
+    const hadLocalHandoff = await waitForSessionCloseHandoff(sessionId);
+
     // Prevent zombie connections: if the client was explicitly closed via
     // disconnect(), do not create a new WebSocket. This guards against a
     // race where a pending reconnect timer fires after React effect cleanup
     // has already torn down the component.
-    if (this.closed) {
+    if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
       return Promise.reject(new Error('Client is closed'));
     }
 
+    if (retryDelayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
+      if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
+        return Promise.reject(new Error('Client is closed'));
+      }
+    }
+
+    this.localHandoffRetryAvailable = allowLocalHandoffRetry && hadLocalHandoff;
+    return this._openConnection(sessionId, lifecycleGeneration);
+  }
+
+  private _openConnection(
+    sessionId: string | undefined,
+    lifecycleGeneration: number,
+  ): Promise<InitAckData> {
     this._connecting = true;
     return new Promise((resolve, reject) => {
       this.pendingConnectReject = reject;
@@ -243,7 +349,9 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         // Build URL without api_key — auth is passed via auth.token in init envelope.
         const url = this.config.url;
 
-        this.ws = new WebSocket(url);
+        const socket = new WebSocket(url);
+        const generation = ++this.connectionGeneration;
+        this.ws = socket;
 
         const initEnv = createInitEnvelope(
           sessionId,
@@ -254,33 +362,33 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         );
 
         const onOpen = () => {
-          if (!this.ws) return;
-          this.ws.send(serializeEnvelope(initEnv));
+          if (generation !== this.connectionGeneration || socket !== this.ws) return;
+          socket.send(serializeEnvelope(initEnv));
         };
 
         const onMessage = (event: MessageEvent) => {
+          if (generation !== this.connectionGeneration || socket !== this.ws) return;
           const line = (typeof event.data === 'string' ? event.data : '').trim();
           if (!line) return;
 
           try {
             const env = deserializeEnvelope(line);
-            this._handleMessage(env, resolve, reject);
+            this._handleMessage(env, resolve, reject, sessionId, lifecycleGeneration);
           } catch (err) {
             this.emit('error', { code: ErrorCode.InvalidMessage, message: String(err) } as ErrorData, {} as Envelope);
           }
         };
 
         const onError = () => {
+          if (generation !== this.connectionGeneration || socket !== this.ws) return;
           // WebSocket error events don't carry useful info; close event follows
         };
 
-        const activeWs = this.ws;
-
-        this.ws.addEventListener('open', onOpen);
-        this.ws.addEventListener('message', onMessage);
-        this.ws.addEventListener('error', onError);
-        this.ws.addEventListener('close', (event: CloseEvent) => {
-          if (activeWs !== this.ws) return;
+        socket.addEventListener('open', onOpen);
+        socket.addEventListener('message', onMessage);
+        socket.addEventListener('error', onError);
+        socket.addEventListener('close', (event: CloseEvent) => {
+          if (generation !== this.connectionGeneration || socket !== this.ws) return;
           this._handleClose(event.code, event.reason || 'Connection closed');
         });
       } catch (err) {
@@ -291,7 +399,13 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     });
   }
 
-  private _handleMessage(env: Envelope, resolve: (ack: InitAckData) => void, reject: (err: Error) => void): void {
+  private _handleMessage(
+    env: Envelope,
+    resolve: (ack: InitAckData) => void,
+    reject: (err: Error) => void,
+    connectionSessionId: string | undefined,
+    lifecycleGeneration: number,
+  ): void {
     const { event, session_id } = env;
 
     if (isInitAck(env)) {
@@ -308,9 +422,26 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
           // to map client session_id to a deterministic UUIDv5. By retrying with the
           // same session ID, the auto-created session always maps to the same server-side
           // session key, providing stable worker-to-session consistency.
-          const retryId = this._sessionId;
+          const retryId = connectionSessionId;
           this._sessionId = null;
-          this._doConnect(retryId ?? undefined).then(resolve, reject);
+          this._doConnect(retryId, true, lifecycleGeneration).then(resolve, reject);
+          return;
+        }
+
+        if (ackData.code === ErrorCode.SessionAlreadyConnected &&
+            this.localHandoffRetryAvailable) {
+          this.localHandoffRetryAvailable = false;
+          const retryId = connectionSessionId || session_id || undefined;
+          logger.info('BrowserClient', 'Retrying local WebSocket handoff conflict', {
+            sessionId: retryId,
+          });
+          this._closeCurrentSocketForHandoff('Local handoff retry');
+          this._doConnect(
+            retryId,
+            false,
+            lifecycleGeneration,
+            LOCAL_HANDOFF_RETRY_DELAY_MS,
+          ).then(resolve, reject);
           return;
         }
 
@@ -350,8 +481,11 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       this._connected = true;
       this._connecting = false;
       this._reconnecting = false;
+      this.localHandoffRetryAvailable = false;
       this.reconnectAttempt = 0;
       this.pendingConnectReject = null;
+      this.lastInitAck = ackData;
+      this.connectTarget = session_id || this.connectTarget;
 
       if (ackData.state) {
         this._state = ackData.state;
@@ -653,6 +787,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   }
 
   disconnect(): void {
+    this.lifecycleGeneration++;
     this.closed = true;
     this.shouldReconnect = false;
 
@@ -667,17 +802,27 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
 
     this._settlePending({ kind: 'reject', error: new Error('Client disconnected'), force: true });
 
-    if (this.ws) {
-      const ws = this.ws;
-      this.ws = null;
-      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-        ws.close(1000, 'Client disconnect');
-      }
-    }
+    this._closeCurrentSocketForHandoff('Client disconnect');
 
     this._connected = false;
     this._connecting = false;
+    this.connectPromise = null;
+    this.lastInitAck = null;
     this.emit('disconnected', 'Client initiated disconnect');
+  }
+
+  private _closeCurrentSocketForHandoff(reason: string): void {
+    const socket = this.ws;
+    if (!socket) return;
+
+    this.ws = null;
+    this.connectionGeneration++;
+    if (this._sessionId) {
+      registerSessionCloseHandoff(this._sessionId, socket);
+    }
+    if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+      socket.close(1000, reason);
+    }
   }
 
   // ============================================================================
@@ -749,10 +894,11 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     this.emit('reconnecting', this.reconnectAttempt);
 
     this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
       if (!this._sessionId || this.closed) return;
 
       try {
-        await this._doConnect(this._sessionId);
+        await this.connect(this._sessionId);
       } catch {
         this._handleClose(4001, 'Reconnect failed');
       }


### PR DESCRIPTION
## Description

本 PR 解决了智能体多轮会话（Turn）指标卡展示、连接重连时的覆盖遮罩，以及头像样式和动画的全面重构与优化：

1. **解决 Token 统计不展示问题**：兼容了 Claude Code / OpenCode Server 在网关和前端指标提取时的 camelCase 和 snake_case 键值对混合的情景，重构了 `ToInt64` 对字符串的解析能力，使 Token 消费统计稳定呈现。
2. **解决重连覆盖遮盖异常**：修复了在网络抖动触发重连时，重连中（Reconnecting）横幅层级错误盖在输入框/控制栏之上导致无法终止或操作的 UI 缺陷。
3. **精美头像与活着动效**：为用户头像更换了精美设计的 SVG 渐变头像，并支持了发送消息时展示具有呼吸发光效果的“活着（living）”动画指示器。

## Related Issues

Resolves #894

## Type of Change

- [x] :bug: Bug fix（非破坏性修复）
- [x] :sparkles: New feature（新增功能）
- [x] :white_check_mark: Testing update（测试更新）

## Checklist

- [x] 代码符合规范
- [x] `make lint` 通过
- [x] 新增测试覆盖此次改动
- [x] `make test` 本地通过
- [x] 文档已同步更新
- [x] 无新增警告
