### PR TITLE
fix: 修复 OCS 崩溃恢复与 Turn Summary Token 展示

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -88,6 +88,12 @@ histogram_quantile(0.95, rate(hotplex_worker_execution_duration_bucket[5m]))
 sum by (worker_type) (hotplex_worker_memory_bytes)
 ```
 
+## Gateway Forwarder 指标
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.gateway.forwarder.panics` | Counter | Worker 事件转发 goroutine 已恢复的 panic 数，label: `worker_type` |
+
 ## Turn TTFT 指标
 
 | 指标 | 类型 | 说明 |

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -85,15 +85,19 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	}
 	ctx, span := observability.Tracer().Start(parent, "bridge.forward_events")
 	defer span.End()
+	w := fb.worker
+	workerType := w.Type()
 	flog := b.log.With("trace_id", observability.TraceID(ctx))
 	defer func() {
 		if r := recover(); r != nil {
-			flog.Error("bridge: panic in forwardEvents", "session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
+			observability.GatewayForwarderPanics().Add(context.Background(), 1,
+				metric.WithAttributes(attribute.String("worker_type", string(workerType))))
+			flog.Error("bridge: panic in forwardEvents", "session_id", sessionID,
+				"worker_type", workerType, "worker_run_id", opts.workerRunID,
+				"panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
-	w := fb.worker
-	workerType := w.Type()
 	flog.Debug("bridge: forwardEvents goroutine started", "session_id", sessionID,
 		"worker_type", workerType, "resumed", opts.resumed,
 		"has_frozen_conn", fb.conn != nil, "forwarder_reset_gen", fb.resetGen,
@@ -196,6 +200,12 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	for env := range recvCh {
 		b.processForwardedEvent(env, w, opts, fc)
 	}
+	// Wait() can release the live Worker.Conn. Read from the connection that
+	// supplied this forwarder's events before that cleanup so crash recovery
+	// re-delivers the correct turn input and never observes a replacement/reset
+	// connection. In the defensive nil-frozen-Conn path this also preserves the
+	// input from the live fallback that actually supplied the event stream.
+	lastInput := snapshotLastInput(recvSource)
 	if !fc.doneReceived {
 		b.finishTurnTTFT(sessionID, "worker_exit")
 	}
@@ -233,8 +243,17 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		sessPlatform:   fc.sessPlatform,
 		sessOwner:      fc.sessOwner,
 		resetGen:       myResetGen,
+		lastInput:      lastInput,
 		flog:           flog,
 	})
+}
+
+func snapshotLastInput(conn worker.SessionConn) string {
+	ir, ok := conn.(worker.InputRecoverer)
+	if !ok {
+		return ""
+	}
+	return sanitizeLastInput(ir.LastInput())
 }
 
 // processForwardedEvent handles a single worker event in the forwarding loop.
@@ -749,6 +768,9 @@ type workerExitParams struct {
 	// flog carries trace_id from the originating forwardEvents span so exit-path
 	// logs stay correlatable with the run that produced them.
 	flog *slog.Logger
+	// lastInput was captured from the frozen forwarder connection before Wait()
+	// releases the worker's mutable live connection.
+	lastInput string
 }
 
 // handleWorkerExit processes worker exit after the recv channel closes.
@@ -828,12 +850,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		p.opts.retryDepth = 1
 	}
 	if fallbackAttempted {
-		var lastInput string
-		if conn := w.Conn(); conn != nil {
-			if ir, ok := conn.(worker.InputRecoverer); ok {
-				lastInput = sanitizeLastInput(ir.LastInput())
-			}
-		}
+		lastInput := p.lastInput
 		if lastInput == "" {
 			lastInput = p.opts.lastInput
 		}

--- a/internal/gateway/bridge_forward_snapshot_test.go
+++ b/internal/gateway/bridge_forward_snapshot_test.go
@@ -1,0 +1,31 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestSnapshotLastInput_UsesFrozenConnection(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeWorkerConn{
+		ch:        make(chan *events.Envelope),
+		lastInput: "resume this turn",
+	}
+
+	require.Equal(t, "resume this turn", snapshotLastInput(conn))
+}
+
+func TestSnapshotLastInput_SanitizesControlCommand(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeWorkerConn{
+		ch:        make(chan *events.Envelope),
+		lastInput: "$reset",
+	}
+
+	require.Empty(t, snapshotLastInput(conn))
+}

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -1083,7 +1083,8 @@ func TestBridge_NewBridge(t *testing.T) {
 
 // fakeWorkerConn implements worker.SessionConn with a fake channel.
 type fakeWorkerConn struct {
-	ch chan *events.Envelope
+	ch        chan *events.Envelope
+	lastInput string
 }
 
 func (f *fakeWorkerConn) Send(ctx context.Context, msg *events.Envelope) error { return nil }
@@ -1091,8 +1092,10 @@ func (f *fakeWorkerConn) Recv() <-chan *events.Envelope                        {
 func (f *fakeWorkerConn) Close() error                                         { return nil }
 func (f *fakeWorkerConn) UserID() string                                       { return "test_user" }
 func (f *fakeWorkerConn) SessionID() string                                    { return "test_session" }
+func (f *fakeWorkerConn) LastInput() string                                    { return f.lastInput }
 
 var _ worker.SessionConn = (*fakeWorkerConn)(nil)
+var _ worker.InputRecoverer = (*fakeWorkerConn)(nil)
 
 // fakeWorker is a minimal worker.Worker implementation for Bridge tests.
 type fakeWorker struct {

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -59,70 +59,86 @@ func (a *sessionAccumulator) mergePerTurnStats(data events.DoneData) {
 	if data.Stats == nil {
 		return
 	}
+	modelUsage := mapValue(data.Stats, "model_usage", "modelUsage")
 
 	// Claude Code format: input_tokens, cache_creation_input_tokens, and
 	// cache_read_input_tokens are separate additive fields (Anthropic API).
 	// Total input = input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
 	if usage, ok := data.Stats["usage"].(map[string]any); ok {
-		inputTokens := events.ToInt64(usage["input_tokens"])
-		if inputTokens == 0 {
-			inputTokens = events.ToInt64(usage["inputTokens"])
-		}
-		cacheWrite := events.ToInt64(usage["cache_creation_input_tokens"])
-		if cacheWrite == 0 {
-			cacheWrite = events.ToInt64(usage["cacheCreationInputTokens"])
-		}
-		cacheRead := events.ToInt64(usage["cache_read_input_tokens"])
-		if cacheRead == 0 {
-			cacheRead = events.ToInt64(usage["cacheReadInputTokens"])
-		}
-		outputTokens := events.ToInt64(usage["output_tokens"])
-		if outputTokens == 0 {
-			outputTokens = events.ToInt64(usage["outputTokens"])
-		}
-
-		a.TotalInput += inputTokens + cacheWrite + cacheRead
-		a.TotalOutput += outputTokens
-		a.TotalCacheWrite += cacheWrite
-		a.TotalCacheRead += cacheRead
+		a.mergeClaudeUsage(usage)
 	} else if tokens, ok := data.Stats["tokens"].(map[string]any); ok {
 		// OpenCode format: input/cache_read/cache_write are separate additive fields.
-		input := events.ToInt64(tokens["input"])
-		output := events.ToInt64(tokens["output"])
-		cacheRead := events.ToInt64(tokens["cache_read"])
-		if cacheRead == 0 {
-			cacheRead = events.ToInt64(tokens["cacheRead"])
+		a.mergeOpenCodeTokens(tokens)
+	} else {
+		// Some Claude Code responses only include per-model camelCase usage.
+		// Use it only as a fallback so a complete usage map is never double-counted.
+		for _, value := range modelUsage {
+			if usage, ok := value.(map[string]any); ok {
+				a.mergeClaudeUsage(usage)
+			}
 		}
-		cacheWrite := events.ToInt64(tokens["cache_write"])
-		if cacheWrite == 0 {
-			cacheWrite = events.ToInt64(tokens["cacheWrite"])
-		}
-
-		a.TotalInput += input + cacheRead + cacheWrite
-		a.TotalOutput += output
-		a.TotalCacheWrite += cacheWrite
-		a.TotalCacheRead += cacheRead
 	}
 
 	// Claude Code modelUsage: extract model name + contextWindow
-	if modelUsage, ok := data.Stats["model_usage"].(map[string]any); ok {
-		for modelName, v := range modelUsage {
-			mu, ok := v.(map[string]any)
-			if !ok {
-				continue
-			}
-			if a.ModelName == "" {
-				a.ModelName = shortModelName(modelName)
-			}
-			if cw := events.ToInt64(mu["contextWindow"]); cw > 0 {
-				a.ContextWindow = cw
-			}
+	for modelName, v := range modelUsage {
+		mu, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if a.ModelName == "" {
+			a.ModelName = shortModelName(modelName)
+		}
+		if cw := events.ToInt64(mu["contextWindow"]); cw > 0 {
+			a.ContextWindow = cw
 		}
 	}
 
 	// Cost: Claude Code uses "total_cost_usd", OpenCode uses "cost"
 	a.TotalCostUSD += events.ToFloat64(data.Stats["total_cost_usd"])
 	a.TotalCostUSD += events.ToFloat64(data.Stats["cost"])
+}
+
+func mapValue(values map[string]any, keys ...string) map[string]any {
+	for _, key := range keys {
+		if value, ok := values[key].(map[string]any); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func tokenValue(values map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		value := events.ToInt64(values[key])
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func (a *sessionAccumulator) mergeClaudeUsage(usage map[string]any) {
+	inputTokens := tokenValue(usage, "input_tokens", "inputTokens")
+	cacheWrite := tokenValue(usage, "cache_creation_input_tokens", "cacheCreationInputTokens")
+	cacheRead := tokenValue(usage, "cache_read_input_tokens", "cacheReadInputTokens")
+	outputTokens := tokenValue(usage, "output_tokens", "outputTokens")
+
+	a.TotalInput += inputTokens + cacheWrite + cacheRead
+	a.TotalOutput += outputTokens
+	a.TotalCacheWrite += cacheWrite
+	a.TotalCacheRead += cacheRead
+}
+
+func (a *sessionAccumulator) mergeOpenCodeTokens(tokens map[string]any) {
+	input := tokenValue(tokens, "input", "input_tokens", "inputTokens")
+	output := tokenValue(tokens, "output", "output_tokens", "outputTokens")
+	cacheRead := tokenValue(tokens, "cache_read", "cacheRead", "cacheReadTokens")
+	cacheWrite := tokenValue(tokens, "cache_write", "cacheWrite", "cacheWriteTokens")
+
+	a.TotalInput += input + cacheRead + cacheWrite
+	a.TotalOutput += output
+	a.TotalCacheWrite += cacheWrite
+	a.TotalCacheRead += cacheRead
 }
 
 // Workers report cumulative totals, so deltas are derived by subtracting

--- a/internal/gateway/session_stats_test.go
+++ b/internal/gateway/session_stats_test.go
@@ -58,6 +58,44 @@ func TestSessionAccumulator_MergePerTurnStats(t *testing.T) {
 		require.InDelta(t, 0.0234, acc.TotalCostUSD, 0.0001)
 	})
 
+	t.Run("model usage camelCase fallback", func(t *testing.T) {
+		acc := &sessionAccumulator{StartedAt: time.Now()}
+		acc.mergePerTurnStats(events.DoneData{
+			Stats: map[string]any{
+				"modelUsage": map[string]any{
+					"claude-sonnet-4-6": map[string]any{
+						"inputTokens":              float64(1200),
+						"outputTokens":             float64(300),
+						"cacheCreationInputTokens": float64(200),
+						"cacheReadInputTokens":     float64(100),
+						"contextWindow":            float64(200000),
+					},
+				},
+			},
+		})
+
+		require.Equal(t, int64(1500), acc.TotalInput)
+		require.Equal(t, int64(300), acc.TotalOutput)
+		require.Equal(t, int64(200000), acc.ContextWindow)
+	})
+
+	t.Run("opencode camelCase token fields", func(t *testing.T) {
+		acc := &sessionAccumulator{StartedAt: time.Now()}
+		acc.mergePerTurnStats(events.DoneData{
+			Stats: map[string]any{
+				"tokens": map[string]any{
+					"inputTokens":  float64(800),
+					"outputTokens": float64(160),
+					"cacheRead":    float64(120),
+					"cacheWrite":   float64(80),
+				},
+			},
+		})
+
+		require.Equal(t, int64(1000), acc.TotalInput)
+		require.Equal(t, int64(160), acc.TotalOutput)
+	})
+
 	t.Run("nil stats", func(t *testing.T) {
 		acc := &sessionAccumulator{StartedAt: time.Now()}
 		acc.mergePerTurnStats(events.DoneData{})

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -338,6 +338,9 @@ var (
 	gatewayErrors     metric.Int64Counter
 	gatewayErrorsInit sync.Once
 
+	gatewayForwarderPanics     metric.Int64Counter
+	gatewayForwarderPanicsInit sync.Once
+
 	gatewayInitHandshakeDuration     metric.Float64Histogram
 	gatewayInitHandshakeDurationInit sync.Once
 
@@ -513,6 +516,22 @@ func GatewayErrors() metric.Int64Counter {
 		}
 	})
 	return gatewayErrors
+}
+
+// GatewayForwarderPanics counts recovered panics in the per-session worker
+// event forwarder. The worker_type label is a bounded worker enum.
+func GatewayForwarderPanics() metric.Int64Counter {
+	gatewayForwarderPanicsInit.Do(func() {
+		var err error
+		gatewayForwarderPanics, err = Meter().Int64Counter(
+			"hotplex.gateway.forwarder.panics",
+			metric.WithDescription("Recovered panics in worker event forwarders"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.gateway.forwarder.panics", err)
+		}
+	})
+	return gatewayForwarderPanics
 }
 
 func GatewayInitHandshakeDuration() metric.Float64Histogram {

--- a/internal/worker/opencodeserver/sse_test.go
+++ b/internal/worker/opencodeserver/sse_test.go
@@ -940,6 +940,13 @@ func TestConn_LastInput_EmptyOnNoSend(t *testing.T) {
 	require.Empty(t, c.LastInput())
 }
 
+func TestConn_LastInput_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var c *conn
+	require.Empty(t, c.LastInput())
+}
+
 // ─── Error Classification Tests ───────────────────────────────────────────────
 
 func TestConn_Send_ServerDown(t *testing.T) {

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -426,6 +426,9 @@ func (w *Worker) Wait() (int, error) {
 func (w *Worker) Conn() worker.SessionConn {
 	w.Mu.Lock()
 	defer w.Mu.Unlock()
+	if w.httpConn == nil {
+		return nil
+	}
 	return w.httpConn
 }
 
@@ -1064,6 +1067,9 @@ type ocsModelRef struct {
 var _ worker.InputRecoverer = (*conn)(nil)
 
 func (c *conn) LastInput() string {
+	if c == nil {
+		return ""
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.lastInput

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -64,7 +64,9 @@ func TestOpenCodeServerWorker_EnvBlocklist(t *testing.T) {
 func TestOpenCodeServerWorker_ConnBeforeStart(t *testing.T) {
 	t.Parallel()
 	w := New()
-	require.Nil(t, w.Conn())
+	// require.Nil uses reflection and treats a typed nil as nil. Production
+	// callers compare the interface value directly, so preserve that contract.
+	require.True(t, w.Conn() == nil)
 }
 
 func TestOpenCodeServerWorker_HealthBeforeStart(t *testing.T) {

--- a/webchat/components/assistant-ui/AssistantMessage.tsx
+++ b/webchat/components/assistant-ui/AssistantMessage.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { PermissionApprovalCard } from "@/components/assistant-ui/tools/PermissionApprovalCard";
 import { QuestionResponseCard } from "@/components/assistant-ui/tools/QuestionResponseCard";
 import { ElicitationFormCard } from "@/components/assistant-ui/tools/ElicitationFormCard";
+import { shouldSkipAssistantMessageRender } from "./assistant-message-memo";
 
 // ToolCallPart is isolated so that a streaming sibling (growing text/reasoning)
 // does not re-render completed tool parts. Its memo comparator compares the
@@ -307,45 +308,6 @@ const AssistantMessage = memo(function AssistantMessage({ message, onInteraction
       </div>
     </motion.div>
   );
-}, (prev, next) => {
-  if (prev.message.id !== next.message.id) return false;
-  // A status transition must always re-render: the streaming cursor and part
-  // status chips depend on ext.status, not just content. The previous check
-  // only forced re-render while next is 'running', missing the running→complete
-  // transition where text is unchanged but the cursor must disappear.
-  const prevRunning = getExt(prev.message).status?.type === 'running';
-  const nextRunning = getExt(next.message).status?.type === 'running';
-  if (prevRunning || nextRunning) return false;
-  if (prev.onInteractionRespond !== next.onInteractionRespond) return false;
-  // Shallow-compare the content array element-wise. The previous check
-  // (`prev.message.content === next.message.content`) compared array
-  // references, but convertToThreadMessage rebuilds the array on every render,
-  // so the reference always differs and the memo was effectively disabled —
-  // every delta flush re-rendered every assistant message. Compare by value
-  // instead, covering the fields each part type actually mutates:
-  //  - text / reasoning: text
-  //  - tool-call: toolName + args + toolCallId + result + status
-  // Without args/toolName, a tool-call whose args are patched post-stream
-  // (e.g. reconcile) wouldn't re-render. Without reasoning text, a reconcile
-  // that rewrites completed reasoning content wouldn't update either.
-  const pc = getExt(prev.message).content || [];
-  const nc = getExt(next.message).content || [];
-  if (pc.length !== nc.length) return false;
-  for (let i = 0; i < pc.length; i++) {
-    const a = pc[i] as Record<string, unknown>;
-    const b = nc[i] as Record<string, unknown>;
-    if (a?.type !== b?.type) return false;
-    if (a?.type === 'text' || a?.type === 'reasoning') {
-      if (a.text !== b.text) return false;
-    } else if (a?.type === 'tool-call') {
-      if (a.toolName !== b.toolName) return false;
-      if (a.args !== b.args) return false;
-      if (a.toolCallId !== b.toolCallId) return false;
-      if (a.result !== b.result) return false;
-      if (a.status !== b.status) return false;
-    }
-  }
-  return true;
-});
+}, shouldSkipAssistantMessageRender);
 
 export { AssistantMessage };

--- a/webchat/components/assistant-ui/assistant-message-memo.ts
+++ b/webchat/components/assistant-ui/assistant-message-memo.ts
@@ -1,0 +1,52 @@
+import { getExt } from "./thread-helpers";
+
+type AssistantMessageProps = {
+  message: unknown;
+  onInteractionRespond?: unknown;
+};
+
+// shouldSkipAssistantMessageRender is the memo comparator for AssistantMessage.
+// Summary and context cards are carried in metadata rather than content, so
+// they must participate in equality checks after a message reaches complete.
+export function shouldSkipAssistantMessageRender(
+  prev: AssistantMessageProps,
+  next: AssistantMessageProps,
+): boolean {
+  if ((prev.message as { id?: unknown })?.id !== (next.message as { id?: unknown })?.id) return false;
+
+  const prevExt = getExt(prev.message);
+  const nextExt = getExt(next.message);
+  const prevRunning = prevExt.status?.type === "running";
+  const nextRunning = nextExt.status?.type === "running";
+  if (prevRunning || nextRunning) return false;
+  if (prev.onInteractionRespond !== next.onInteractionRespond) return false;
+
+  const prevCustom = prevExt.metadata?.custom;
+  const nextCustom = nextExt.metadata?.custom;
+  if (
+    prevCustom?.contextUsage !== nextCustom?.contextUsage ||
+    prevCustom?.turnSummary !== nextCustom?.turnSummary ||
+    prevCustom?.progress !== nextCustom?.progress
+  ) {
+    return false;
+  }
+
+  const prevContent = prevExt.content || [];
+  const nextContent = nextExt.content || [];
+  if (prevContent.length !== nextContent.length) return false;
+  for (let i = 0; i < prevContent.length; i += 1) {
+    const a = prevContent[i] as Record<string, unknown>;
+    const b = nextContent[i] as Record<string, unknown>;
+    if (a?.type !== b?.type) return false;
+    if (a?.type === "text" || a?.type === "reasoning") {
+      if (a.text !== b.text) return false;
+    } else if (a?.type === "tool-call") {
+      if (a.toolName !== b.toolName) return false;
+      if (a.args !== b.args) return false;
+      if (a.toolCallId !== b.toolCallId) return false;
+      if (a.result !== b.result) return false;
+      if (a.status !== b.status) return false;
+    }
+  }
+  return true;
+}

--- a/webchat/lib/adapters/assistant-message-memo.test.ts
+++ b/webchat/lib/adapters/assistant-message-memo.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipAssistantMessageRender } from "@/components/assistant-ui/assistant-message-memo";
+
+const message = (turnSummary?: Record<string, unknown>) => ({
+  id: "assistant-1",
+  content: [{ type: "text", text: "done" }],
+  metadata: { custom: turnSummary ? { turnSummary } : {} },
+  status: { type: "complete" },
+});
+
+describe("shouldSkipAssistantMessageRender", () => {
+  it("re-renders when done adds a Turn Summary to an already complete message", () => {
+    const summary = {
+      turn_input_tok: 1200,
+      turn_output_tok: 300,
+    };
+
+    expect(
+      shouldSkipAssistantMessageRender(
+        { message: message() },
+        { message: message(summary) },
+      ),
+    ).toBe(false);
+  });
+
+  it("skips equal completed messages", () => {
+    const summary = {
+      turn_input_tok: 1200,
+      turn_output_tok: 300,
+    };
+    const stable = message(summary);
+
+    expect(
+      shouldSkipAssistantMessageRender(
+        { message: stable },
+        { message: stable },
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

- 修复 #899：OpenCode Server 单例异常退出时，Worker 的连接清理会返回 typed-nil 接口，导致 Gateway 转发协程在读取恢复输入时 panic，既不执行崩溃恢复，也不向用户反馈错误。
- 修复 v1.35.1 后仍存在的 WebChat Turn Summary Token 展示回归：后端兼容 camelCase / `modelUsage` token 字段，前端在消息已完成后也会响应 Turn Summary 元数据更新。

## 根因与修复

### OpenCode Server 异常退出

- `Conn()` 在未连接或已释放时返回真正的 nil interface；`LastInput()` 追加 nil receiver 防护。
- Gateway 在 `Wait()` 释放连接前，从当前 forwarder 的事件源快照并净化最后输入；崩溃恢复不再重新读取可变的 Worker 连接。
- 转发器 panic 会记录可观测性指标 `hotplex.gateway.forwarder.panics`，用于后续诊断。

### Turn Summary Token

- token 聚合支持 `model_usage` / `modelUsage`，并兼容 Claude 与 OpenCode Server 的 snake_case、camelCase 及 `tokens` 字段形式，且避免同一轮重复累计。
- AssistantMessage memo 比较器纳入 `turnSummary`、`contextUsage` 和 `progress` 元数据；完成态消息收到摘要后会重新渲染。

## 验证

- `go test ./internal/gateway ./internal/worker/opencodeserver ./internal/observability -count=1 -race`（965 tests）
- `make check`
- `make test-short`
- `webchat: vitest run`
- `webchat: tsc --noEmit -p tsconfig.json`
- 独立代码审查：无 P0/P1；已纳入审查提出的防御性路径修正。

Closes #899