### PR TITLE
feat(webchat): 添加可编辑后续消息队列

### DIFF
--- a/docs/superpowers/plans/2026-07-16-webchat-follow-up-queue.md
+++ b/docs/superpowers/plans/2026-07-16-webchat-follow-up-queue.md
@@ -1,0 +1,156 @@
+# Issue #902 实施计划
+
+设计依据：`docs/superpowers/specs/2026-07-16-webchat-follow-up-queue-design.md`
+
+## 交付原则
+
+- 先写失败测试，再实现最小正确行为。
+- 保持一个 active execution；队列项只在 `delivered` ACK 后移除。
+- `unknown`、断线和 ambiguous outcome 不自动重投。
+- 未发送 prompt 仅存在页面内存，不进入存储、日志或指标。
+- #902 与 `handler.go` 防空输入分别形成原子 commit。
+
+## Task 1：页面级队列存储
+
+文件：
+
+- 新建 `webchat/lib/adapters/follow-up-queue.ts`
+- 新建 `webchat/lib/adapters/follow-up-queue.test.ts`
+
+步骤：
+
+1. 为 enqueue/FIFO、编辑、删除、move-to-front、状态转换、session 隔离、20 条上限和 clearSession 编写失败测试。
+2. 实现 `FollowUpQueueStore`、不可变快照和 subscribe/getSnapshot。
+3. 增加 `queued | sending | failed`、结构化失败原因与显式 retry。
+4. 验证该模块不读取 browser persistence API、不记录 prompt。
+
+验证：
+
+```bash
+cd webchat && pnpm vitest run lib/adapters/follow-up-queue.test.ts
+```
+
+## Task 2：Browser client stop terminal waiter
+
+文件：
+
+- 修改 `webchat/lib/ai-sdk-transport/client/browser-client.ts`
+- 修改 `webchat/lib/ai-sdk-transport/client/browser-client.test.ts`
+
+步骤：
+
+1. 将旧的“send stop 立即清 pending”测试改为“stop 不提前释放 pending”。
+2. 增加 stop single-flight、自然 done/`stopped_by_user`、重复 done、timeout、disconnect 测试。
+3. 实现 `stopCurrentTurn()`；连续调用复用 Promise，只有 terminal 才 resolve。
+4. 将 done/error/disconnect 的 stop waiter 结算集中到单一方法，避免竞态双结算。
+
+验证：
+
+```bash
+cd webchat && pnpm vitest run lib/ai-sdk-transport/client/browser-client.test.ts
+```
+
+## Task 3：Runtime queue 与 single-flight drain
+
+文件：
+
+- 修改 `webchat/lib/adapters/hotplex-runtime-adapter.ts`
+- 扩展 `webchat/lib/adapters/runtime-adapter.test.ts`，必要时新建纯状态机测试文件
+- 修改 `webchat/app/components/chat/ChatContainer.assistant-ui.tsx`
+
+步骤：
+
+1. `ChatContainer` 创建稳定的页面级 store，并传给 keyed `ChatInterface`。
+2. 提取公共 `dispatchInput(text, queueItemId?)`，让普通发送和队列发送共享 optimistic/rollback 逻辑。
+3. 维护 running/stopping/connection refs、active queue item 与 drain single-flight。
+4. 将 delivered ACK、failed/unknown ACK、done、fatal error、disconnect、reconnect、state idle 连接到幂等队列转换。
+5. 实现 enqueue/edit/delete/retry/send-now/clear 操作并通过 adapter `extras` 暴露。
+6. session 删除时在 `removeSession` wrapper 中清理对应队列。
+
+验证重点：
+
+- done 后一次只发送队首。
+- delivered 移除可见项，但下一项等 terminal。
+- unknown/断线保留原文并转 failed。
+- 重复 ACK、terminal 与 send-now 点击不会重复发送。
+
+## Task 4：队列面板与 composer 交互
+
+文件：
+
+- 新建 `webchat/components/assistant-ui/FollowUpQueue.tsx`
+- 修改 `webchat/components/assistant-ui/thread.tsx`
+- 修改 `webchat/locales/zh-CN/chat.json`
+- 修改 `webchat/locales/en/chat.json`
+
+步骤：
+
+1. 在消息与 composer 之间渲染编号 FIFO 面板。
+2. 实现展开/收起、编辑、保存、取消、删除、立即发送和失败重试。
+3. `sending` 禁止重复操作；失败提示不只依赖颜色。
+4. running/stopping 时由 composer 直接 enqueue；成功才清草稿，溢出保留草稿。
+5. 支持 Enter 提交、Shift+Enter 换行、Escape 取消编辑、aria-label 与 focus ring。
+6. 校验中英文 JSON key 完全一致。
+
+验证：
+
+```bash
+cd webchat && pnpm lint && pnpm test && pnpm build
+```
+
+## Task 5：Gateway 空白 input 防御
+
+文件：
+
+- 将当前主工作区 `internal/gateway/handler.go` 的 4 行修改复制到 feature worktree
+- 修改最合适的 `internal/gateway/*_test.go`
+
+步骤：
+
+1. 增加表驱动测试，覆盖空串、空格、tab、换行和非空输入。
+2. 证明纯空白输入不调用命令路由、session transition 或 Worker input。
+3. 保持非空 input 原语义不变。
+4. 独立提交并在 commit body 说明防御目的。
+
+验证：
+
+```bash
+go test -race -count=1 ./internal/gateway
+```
+
+## Task 6：E2E 与完整门禁
+
+文件：
+
+- 修改 `webchat/e2e/chat.spec.ts` 或新增专用 queue spec
+
+步骤：
+
+1. 使用可控 WebSocket stub 覆盖连续发送、可见队列、编辑后 dispatch、立即发送 stop→done→input 和 aria/键盘。
+2. 运行 WebChat unit、production build 与 Chromium Playwright。
+3. 运行 Gateway race 测试和仓库 `make check`。
+4. 检查 `git diff --check`、翻译 key 对齐、无持久化/日志泄漏路径。
+
+验证：
+
+```bash
+cd webchat && pnpm test && pnpm build && pnpm test:e2e
+go test -race -count=1 ./internal/gateway
+make check
+```
+
+## Task 7：提交、审查与 PR
+
+提交顺序：
+
+1. `docs(webchat): design follow-up queue for #902`
+2. `feat(webchat): add editable follow-up queue`
+3. `fix(gateway): ignore blank input payloads`
+4. 后续测试或审查修复仅在逻辑独立时拆分，否则归入对应实现提交前完成。
+
+交付：
+
+1. 自审全部 diff，重点检查竞态、隐私、session 隔离与 a11y。
+2. 推送 feature 分支并创建中文 PR，正文逐项映射 #902 验收标准，使用 `Closes #902`。
+3. 检查 PR checks 与当前 HEAD review；一次性修复 P0/P1 和有价值的 P2。
+4. 仅在 checks 通过、无未处理高优先级 review、PR mergeable 且验收审计有直接证据时完成交付。

--- a/docs/superpowers/specs/2026-07-16-webchat-follow-up-queue-design.md
+++ b/docs/superpowers/specs/2026-07-16-webchat-follow-up-queue-design.md
@@ -1,0 +1,100 @@
+# WebChat 可编辑后续消息队列设计
+
+## 背景与目标
+
+WebChat 目前将 composer 提交直接交给 `BrowserHotPlexClient.sendInput()`。当一个 turn 尚未结束时，assistant-ui external-store runtime 会禁用发送，同时 Browser client 只允许一个 `pendingInput`，Gateway 也用 active gate 保证同一 session 只有一个 active execution。
+
+本设计在不修改 AEP wire contract、不并发调用 `Worker.Input`、不持久化未发送 prompt 的前提下，为每个 WebChat session 增加页面生命周期内的可编辑 FIFO 队列，并提供“立即发送”的 stop-and-send 语义。
+
+## 方案选择
+
+### 采用：页面级队列存储 + runtime 单航班消费
+
+- `ChatContainer` 创建一个页面级 `FollowUpQueueStore`，其生命周期覆盖 session 切换，但不跨页面刷新。
+- `useHotPlexRuntime` 订阅当前 session 的队列快照，负责 dispatch、ACK、terminal、重连和 stop 编排。
+- `Thread` 只渲染队列并调用明确的 enqueue/edit/delete/retry/send-now 操作。
+- Browser client 提供可等待 terminal 的 single-flight stop 操作，不再在发送 stop frame 时提前清除 `pendingInput`。
+
+这一方案保持产品状态、传输状态和展示层各自独立，且所有竞态均可由纯队列状态测试和 Browser client 时序测试覆盖。
+
+### 未采用：assistant-ui 内置 queue
+
+当前使用的 external-store runtime 将 `capabilities.queue` 固定为 `false`。启用它需要升级或 fork 上游，并且仍不能表达 HotPlex 的 `delivered`、`unknown`、stop terminal 与 durable execution 语义。
+
+### 未采用：Gateway durable queue
+
+服务端队列会扩大到协议、调度、隐私与持久化工程，并可能保存尚未发送的 prompt，与本需求“页面生命周期内存队列”的边界冲突。
+
+## 组件边界
+
+### `FollowUpQueueStore`
+
+新建纯 TypeScript 队列存储，按 `session_id` 隔离数据并提供订阅接口。`ChatContainer` 持有其实例，session 删除成功或乐观删除时显式清理相应队列。
+
+队列项包含：
+
+- `id`：页面本地唯一 ID。
+- `text`：最终待 dispatch 的文本。
+- `createdAt`：创建时间。
+- `status`：`queued | sending | failed`。
+- `errorKind` / `errorMessage`：失败原因；`unknown` 使用独立类型。
+- `clientMessageId`：仅在真正 dispatch 后设置。
+
+队列最大 20 条。达到上限时 enqueue 返回结构化错误，调用方不清空 composer。存储不访问 `localStorage`、网络、日志或指标。
+
+`failed` 项保留原文并阻塞 FIFO。只有用户点击“重试”后才转回 `queued`，因此 `unknown`、断线或 ambiguous delivery 不会自动重投。
+
+### Runtime drain 状态机
+
+runtime 为当前 session 维护一个 single-flight drain 和一个 active queue item 关联：
+
+1. 仅在 client 已连接、session 非 running/stopping、没有 active queue item、队首为 `queued` 时开始 dispatch。
+2. dispatch 前原子地把队首改为 `sending`，随后才创建 `client_message_id` 和 optimistic user/assistant 消息。
+3. `input.ack=delivered` 后从可见队列移除该项，但 active 关联保留到 turn terminal，防止下一项过早发送。
+4. `done` 清除 active 关联，并仅触发一次下一轮 drain。
+5. `failed`、`unknown`、发送异常或断线会把尚未确认 delivered 的 active 项改为 `failed`，保留原文；不会自动 drain 越过它。
+6. 重复 ACK、重复 terminal、重连事件和 React effect 重建均通过 queue item ID、client message ID 与 single-flight guard 幂等处理。
+
+普通 composer 提交在 session 空闲时沿用直接 dispatch；running 或 stopping 时只 enqueue，不创建 optimistic message。只有真正 dispatch 时消息才进入 thread。
+
+### “立即发送”
+
+点击任意未发送项时：
+
+1. 把该项移到队首，其余项保持相对顺序。
+2. 若当前 turn 正在运行，调用 Browser client 的 `stopCurrentTurn()`。
+3. `stopCurrentTurn()` 对连续调用复用同一 Promise，并等待 `done`；自然完成与 `stopped_by_user` 都是合法 terminal。
+4. terminal 到达后由统一 drain 发送队首，不在按钮回调中直接发送，避免双 dispatch。
+5. stop 超时、断线或失败时不发送队首，项目保留并显示可重试错误。
+
+普通停止按钮也使用同一 stop waiter，但不改变队列顺序。发送 stop frame 不再提前清除 Browser client 的 `pendingInput`；它由 `done`、明确 error 或 disconnect 统一结算。
+
+## UI 与可访问性
+
+队列面板位于消息列表与 composer 之间，保持 HotPlex 现有工业化、紧凑的视觉语言：编号体现 FIFO，金色表示排队，珊瑚色强调“立即发送”，失败态使用可辨识的边框与文字而不只依赖颜色。
+
+每项支持展开/收起、编辑、保存、取消、删除、立即发送；失败项额外显示“重试”。`sending` 项禁用所有破坏性操作。编辑器支持 Escape 取消、明确的 label、focus ring 与屏幕阅读器状态。所有新增文案和 aria-label 同步加入中英文 `chat.json`，并保持 key 完全一致。
+
+running/stopping 时 Enter 或发送按钮调用 enqueue；达到 20 条时 composer 草稿保持不变并显示双语错误。Shift+Enter 仍插入换行。
+
+## Handler 防御性变更
+
+同一 PR 按用户要求纳入 `internal/gateway/handler.go` 的空白 input 防御：在命令分发与 Worker 投递前忽略纯空白内容，并添加表驱动回归测试。该变更作为独立原子 commit，避免与 #902 的前端实现混在同一提交中。
+
+## 测试策略
+
+- 队列存储 Vitest：FIFO、编辑/取消、删除、session 隔离、20 条上限、move-to-front、状态 CAS、failed 明确重试、session 清理。
+- Runtime Vitest：正常 done 后逐条 drain、delivered 前失败回滚、unknown 不重投、重复 ACK/terminal、重连与 stop/done 竞态。
+- Browser client Vitest：stop single-flight、自然 done、`stopped_by_user`、超时/断线、stop 不提前释放 pending input、terminal 后可发送下一条。
+- 组件/E2E：运行中连续提交、队列可视化、编辑后发送、立即发送、键盘与 aria、溢出保留草稿。
+- Gateway Go 测试：空白 input 不触发命令或 Worker 投递，非空输入行为不变，并运行相关 `-race`。
+- 最终门禁：WebChat `pnpm test`、`pnpm build`、相关 Playwright、Go 相关测试与仓库 `make check`。
+
+## 非目标与不变量
+
+- 不跨刷新、设备或 Gateway 实例保存队列。
+- 不向 execution store、eventstore、日志或指标写入排队 prompt。
+- 不允许同一 session 同时存在两个 active execution。
+- 不引入 Worker 原生 mid-turn steering。
+- 不修改 Slack、飞书、Cron 入站行为。
+- 不实现拖拽排序、优先级调度或批量编辑。

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -182,6 +182,41 @@ func TestHandleInput_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHandleInput_BlankContentIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: ""},
+		{name: "spaces", content: "   "},
+		{name: "tabs", content: "\t\t"},
+		{name: "newlines", content: "\n\r\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, mgr, _, _ := newHandlerWithRealStore(t)
+			sid := "sess_blank_" + tt.name
+			_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+			require.NoError(t, err)
+
+			w := new(mockWorkerForHandler)
+			w.On("Terminate", mock.Anything).Return(nil).Maybe()
+			require.NoError(t, mgr.AttachWorker(context.Background(), sid, w))
+
+			require.NoError(t, handler.handleInput(context.Background(), inputEnvelope(sid, tt.content)))
+			w.AssertNotCalled(t, "Input", mock.Anything, mock.Anything, mock.Anything)
+
+			info, err := mgr.Get(context.Background(), sid)
+			require.NoError(t, err)
+			require.Equal(t, events.StateCreated, info.State)
+		})
+	}
+}
+
 func TestHandleInput_SessionNotFound(t *testing.T) {
 	t.Parallel()
 	store := new(mockStore)

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -150,6 +151,9 @@ func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {
 	}
 
 	content, _ := data["content"].(string)
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
 	if handled, err := h.tryCommandDispatch(ctx, env, content); handled {
 		return err
 	}

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -35,6 +35,10 @@ import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import type { WorkerType } from "@/lib/ai-sdk-transport/client/constants";
 import { selectRecoveryWorkspace } from "@/lib/workspace-recovery";
+import {
+    FollowUpQueueStore,
+    type FollowUpQueueControls,
+} from "@/lib/adapters/follow-up-queue";
 
 // Clear all hotplex workspace/session selection state from localStorage.
 // Called on logout so a different account logging into the same browser does
@@ -60,6 +64,7 @@ function ChatInterface({
     onSessionStateChange,
     workspaceId,
     onWorkspaceError,
+    followUpQueueStore,
 }: {
     sessionId: string | null;
     workerType?: WorkerType;
@@ -67,6 +72,7 @@ function ChatInterface({
     onSessionStateChange?: (state: string) => void;
     workspaceId?: string;
     onWorkspaceError?: (workspaceId?: string) => void;
+    followUpQueueStore: FollowUpQueueStore;
 }) {
     const { skills, mergeSkills } = useSkillsCache(sessionId);
     const adapter = useHotPlexRuntime({
@@ -80,6 +86,7 @@ function ChatInterface({
             onWorkspaceError && workspaceId
                 ? () => onWorkspaceError(workspaceId)
                 : undefined,
+        followUpQueueStore,
     });
 
     const runtime = useExternalStoreRuntime(adapter);
@@ -91,6 +98,7 @@ function ChatInterface({
         onInteractionRespond?: (toolCallId: string, allowed: boolean) => void;
         isStopping?: boolean;
         onRetryConnection?: () => void;
+        followUpQueue?: FollowUpQueueControls;
     };
     const extras = adapter.extras as AdapterExtras | undefined;
     const hasMore = extras?.hasMore ?? false;
@@ -99,6 +107,7 @@ function ChatInterface({
     const onInteractionRespond = extras?.onInteractionRespond;
     const isStopping = extras?.isStopping ?? false;
     const onRetryConnection = extras?.onRetryConnection;
+    const followUpQueue = extras?.followUpQueue;
     const suggestions = adapter.suggestions as
         readonly { title: string; label: string; prompt: string }[] | undefined;
 
@@ -113,6 +122,7 @@ function ChatInterface({
                 suggestions={suggestions}
                 isStopping={isStopping}
                 onRetryConnection={onRetryConnection}
+                followUpQueue={followUpQueue}
             />
         </AssistantRuntimeProvider>
     );
@@ -121,6 +131,7 @@ function ChatInterface({
 export default function ChatContainer() {
     const router = useRouter();
     const { t } = useTranslation(['chat', 'common']);
+    const [followUpQueueStore] = useState(() => new FollowUpQueueStore());
     const [sidebarOpen, setSidebarOpen] = useState(true);
     // Reactive mobile detection: the mobile drawer (fixed overlay) needs a11y
     // behaviors (ESC / focus trap / scroll lock / aria-modal) that the desktop
@@ -384,6 +395,11 @@ export default function ChatContainer() {
         loadedWorkspaceId === activeWorkspace?.id
             ? activeSession?.id || null
             : null;
+
+    const handleDeleteSession = useCallback(async (id: string) => {
+        followUpQueueStore.clearSession(id);
+        await removeSession(id);
+    }, [followUpQueueStore, removeSession]);
 
     // Handle NewSessionModal confirm
     const handleModalConfirm = useCallback(
@@ -687,7 +703,7 @@ export default function ChatContainer() {
                         isLoading={sessionsLoading}
                         onSelect={selectSession}
                         onCreate={handleCreateNew}
-                        onDelete={removeSession}
+                        onDelete={handleDeleteSession}
                         currentUserRole={currentUser?.role}
                     />
                 </aside>
@@ -761,6 +777,7 @@ export default function ChatContainer() {
                                 }
                                 workspaceId={activeWorkspace?.id}
                                 onWorkspaceError={handleWorkspaceError}
+                                followUpQueueStore={followUpQueueStore}
                             />
                         )}
                     </div>

--- a/webchat/components/assistant-ui/FollowUpQueue.tsx
+++ b/webchat/components/assistant-ui/FollowUpQueue.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+import type {
+  FollowUpQueueControls,
+  FollowUpQueueErrorKind,
+  FollowUpQueueItem,
+} from "@/lib/adapters/follow-up-queue";
+
+interface FollowUpQueueProps {
+  queue: FollowUpQueueControls;
+  isStopping?: boolean;
+}
+
+const errorKey = {
+  unknown: "follow_up.error.unknown",
+  connection: "follow_up.error.connection",
+  busy: "follow_up.error.busy",
+  send: "follow_up.error.send",
+  stop: "follow_up.error.stop",
+} as const satisfies Record<FollowUpQueueErrorKind, string>;
+
+function QueueItem({
+  item,
+  index,
+  queue,
+  isStopping,
+}: {
+  item: FollowUpQueueItem;
+  index: number;
+  queue: FollowUpQueueControls;
+  isStopping?: boolean;
+}) {
+  const { t } = useTranslation("chat");
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(item.text);
+  const sending = item.status === "sending";
+
+  const cancelEdit = useCallback(() => {
+    setDraft(item.text);
+    setEditing(false);
+  }, [item.text]);
+
+  const saveEdit = useCallback(() => {
+    if (!draft.trim() || !queue.updateText(item.id, draft)) return;
+    setEditing(false);
+  }, [draft, item.id, queue]);
+
+  return (
+    <motion.li
+      layout
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, x: 16 }}
+      className={`rounded-xl border bg-[var(--bg-elevated)]/95 px-3 py-2.5 shadow-sm ${
+        item.status === "failed"
+          ? "border-[var(--accent-coral)]/55"
+          : sending
+            ? "border-[var(--accent-gold)]/55"
+            : "border-[var(--border-subtle)]"
+      }`}
+      aria-busy={sending}
+    >
+      <div className="flex items-start gap-2.5">
+        <span
+          className="mt-0.5 flex h-6 min-w-6 items-center justify-center rounded-full border border-[var(--accent-gold)]/30 bg-[var(--accent-gold)]/10 px-1 font-mono text-[10px] font-bold text-[var(--accent-gold)]"
+          aria-label={t("follow_up.aria.position", { position: index + 1 })}
+        >
+          {String(index + 1).padStart(2, "0")}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className="font-mono text-[9px] font-bold uppercase tracking-[0.14em] text-[var(--text-faint)]">
+              {t(`follow_up.status.${item.status}`)}
+            </span>
+            {!editing && (
+              <button
+                type="button"
+                onClick={() => setExpanded((value) => !value)}
+                className="rounded px-1.5 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-gold)]/50"
+                aria-expanded={expanded}
+                aria-label={t(
+                  expanded
+                    ? "follow_up.aria.collapse"
+                    : "follow_up.aria.expand",
+                  { position: index + 1 },
+                )}
+              >
+                {t(expanded ? "follow_up.action.collapse" : "follow_up.action.expand")}
+              </button>
+            )}
+          </div>
+
+          {editing ? (
+            <div className="space-y-2">
+              <textarea
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") cancelEdit();
+                }}
+                rows={3}
+                autoFocus
+                className="w-full resize-y rounded-lg border border-[var(--accent-gold)]/40 bg-[var(--bg-base)] px-3 py-2 text-xs leading-relaxed text-[var(--text-primary)] outline-none focus:ring-2 focus:ring-[var(--accent-gold)]/25"
+                aria-label={t("follow_up.aria.edit_input", { position: index + 1 })}
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelEdit}
+                  className="rounded-md px-2.5 py-1 text-[10px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-gold)]/50"
+                >
+                  {t("follow_up.action.cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={saveEdit}
+                  disabled={!draft.trim()}
+                  className="rounded-md bg-[var(--accent-gold)] px-2.5 py-1 text-[10px] font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-[var(--accent-gold)]/40"
+                >
+                  {t("follow_up.action.save")}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p
+              className={`whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--text-primary)] ${
+                expanded ? "" : "line-clamp-2"
+              }`}
+            >
+              {item.text}
+            </p>
+          )}
+
+          {item.status === "failed" && item.errorKind && (
+            <p
+              role="alert"
+              className="mt-2 flex items-center gap-1.5 text-[10px] leading-relaxed text-[var(--accent-coral)]"
+            >
+              <span aria-hidden="true">!</span>
+              {t(errorKey[item.errorKind])}
+            </p>
+          )}
+
+          {!editing && (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => {
+                  setDraft(item.text);
+                  setEditing(true);
+                }}
+                disabled={sending}
+                className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[10px] text-[var(--text-muted)] hover:border-[var(--text-faint)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-1 focus:ring-[var(--accent-gold)]/50"
+                aria-label={t("follow_up.aria.edit", { position: index + 1 })}
+              >
+                {t("follow_up.action.edit")}
+              </button>
+              <button
+                type="button"
+                onClick={() => queue.remove(item.id)}
+                disabled={sending}
+                className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[10px] text-[var(--text-muted)] hover:border-[var(--accent-coral)]/40 hover:text-[var(--accent-coral)] disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-1 focus:ring-[var(--accent-coral)]/50"
+                aria-label={t("follow_up.aria.delete", { position: index + 1 })}
+              >
+                {t("follow_up.action.delete")}
+              </button>
+              {item.status === "failed" && (
+                <button
+                  type="button"
+                  onClick={() => queue.retry(item.id)}
+                  className="rounded-md border border-[var(--accent-gold)]/35 bg-[var(--accent-gold)]/10 px-2 py-1 text-[10px] font-semibold text-[var(--accent-gold)] hover:bg-[var(--accent-gold)]/15 focus:outline-none focus:ring-1 focus:ring-[var(--accent-gold)]/50"
+                  aria-label={t("follow_up.aria.retry", { position: index + 1 })}
+                >
+                  {t("follow_up.action.retry")}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void queue.sendNow(item.id)}
+                disabled={sending || isStopping}
+                className="ml-auto rounded-md bg-[var(--accent-coral)]/12 px-2 py-1 text-[10px] font-semibold text-[var(--accent-coral)] hover:bg-[var(--accent-coral)]/20 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-1 focus:ring-[var(--accent-coral)]/50"
+                aria-label={t("follow_up.aria.send_now", { position: index + 1 })}
+              >
+                {t("follow_up.action.send_now")}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.li>
+  );
+}
+
+export function FollowUpQueue({ queue, isStopping }: FollowUpQueueProps) {
+  const { t } = useTranslation("chat");
+  if (queue.items.length === 0) return null;
+
+  return (
+    <section
+      className="pointer-events-auto mx-auto mb-3 w-full max-w-3xl overflow-hidden rounded-2xl border border-[var(--accent-gold)]/20 bg-[var(--bg-glass)] shadow-[var(--shadow-sm)] backdrop-blur-xl"
+      aria-label={t("follow_up.aria.panel")}
+    >
+      <header className="flex items-center justify-between border-b border-[var(--border-subtle)] px-3.5 py-2">
+        <div className="flex items-center gap-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent-gold)] shadow-[0_0_10px_var(--accent-gold)]" />
+          <h2 className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+            {t("follow_up.title")}
+          </h2>
+        </div>
+        <span
+          className="rounded-full border border-[var(--border-subtle)] bg-[var(--bg-elevated)] px-2 py-0.5 font-mono text-[9px] text-[var(--text-faint)]"
+          aria-live="polite"
+        >
+          {t("follow_up.count", { count: queue.items.length })}
+        </span>
+      </header>
+      <ol className="max-h-64 space-y-2 overflow-y-auto p-2.5">
+        <AnimatePresence initial={false} mode="popLayout">
+          {queue.items.map((item, index) => (
+            <QueueItem
+              key={item.id}
+              item={item}
+              index={index}
+              queue={queue}
+              isStopping={isStopping}
+            />
+          ))}
+        </AnimatePresence>
+      </ol>
+    </section>
+  );
+}

--- a/webchat/components/assistant-ui/thread.tsx
+++ b/webchat/components/assistant-ui/thread.tsx
@@ -16,6 +16,8 @@ import { UserMessage } from "./UserMessage";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { PreAssistantIndicator } from "./PreAssistantIndicator";
 import { useTranslation } from "react-i18next";
+import { FollowUpQueue } from "./FollowUpQueue";
+import type { FollowUpQueueControls } from "@/lib/adapters/follow-up-queue";
 
 interface ThreadProps {
   skills?: SkillEntry[];
@@ -26,6 +28,7 @@ interface ThreadProps {
   suggestions?: readonly { title: string; label: string; prompt: string }[];
   isStopping?: boolean;
   onRetryConnection?: () => void;
+  followUpQueue?: FollowUpQueueControls;
 }
 
 const connLabelKey = {
@@ -44,7 +47,7 @@ const connDot: Record<ConnectionState, string> = {
   already_connected: 'bg-[var(--accent-coral)]',
 };
 
-export function Thread({ skills, hasMore, connectionState: conn, onLoadHistory, onInteractionRespond, suggestions, isStopping: isStoppingProp, onRetryConnection }: ThreadProps) {
+export function Thread({ skills, hasMore, connectionState: conn, onLoadHistory, onInteractionRespond, suggestions, isStopping: isStoppingProp, onRetryConnection, followUpQueue }: ThreadProps) {
   const { t } = useTranslation('chat');
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [historyHasMore, setHistoryHasMore] = useState(hasMore);
@@ -159,12 +162,16 @@ export function Thread({ skills, hasMore, connectionState: conn, onLoadHistory, 
       </AnimatePresence>
 
       <div className="composer-wrapper px-4 pb-12">
+        {followUpQueue && (
+          <FollowUpQueue queue={followUpQueue} isStopping={isStoppingProp} />
+        )}
         <ThreadComposer
           skills={skills}
           isRunning={isRunning}
           isStoppingProp={isStoppingProp}
           disabled={conn === 'already_connected'}
           connectionState={conn}
+          followUpQueue={followUpQueue}
         />
         <div className="mt-2 flex justify-between items-center max-w-3xl mx-auto px-2">
           <div className="flex gap-4">
@@ -196,12 +203,14 @@ interface ThreadComposerProps {
   isStoppingProp?: boolean;
   disabled?: boolean;
   connectionState?: ConnectionState;
+  followUpQueue?: FollowUpQueueControls;
 }
 
-const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, isStoppingProp, disabled, connectionState }: ThreadComposerProps) {
+const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, isStoppingProp, disabled, connectionState, followUpQueue }: ThreadComposerProps) {
   const { t } = useTranslation('chat');
   const [localText, setLocalText] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
+  const [queueError, setQueueError] = useState<string | null>(null);
   const aui = useAui();
   const text = useAuiState((s) => s.composer.text);
   const composingRef = useRef(false);
@@ -228,6 +237,7 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
     const val = e.target.value;
     setLocalText(val);
     setMenuOpen(val.startsWith("/"));
+    setQueueError(null);
     if (!composingRef.current) aui.composer().setText(val);
   }, [aui]);
 
@@ -237,13 +247,47 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
     setMenuOpen(false);
   }, [aui]);
 
+  const handleQueueSubmit = useCallback(() => {
+    if (!followUpQueue || !localText.trim()) return;
+    const result = followUpQueue.enqueue(localText);
+    if (!result.ok) {
+      setQueueError(t(
+        result.reason === "limit"
+          ? "follow_up.error.limit"
+          : "follow_up.error.blank",
+      ));
+      return;
+    }
+    setQueueError(null);
+    setLocalText("");
+    setMenuOpen(false);
+    aui.composer().setText("");
+  }, [aui, followUpQueue, localText, t]);
+
+  const queueing =
+    isRunning ||
+    !!isStoppingProp ||
+    (followUpQueue?.items.length ?? 0) > 0;
+  const handleComposerKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      !queueing ||
+      event.key !== "Enter" ||
+      event.shiftKey ||
+      event.nativeEvent.isComposing
+    ) {
+      return;
+    }
+    event.preventDefault();
+    handleQueueSubmit();
+  }, [handleQueueSubmit, queueing]);
+
   return (
     <div className="composer-container relative max-w-3xl mx-auto">
       <AnimatePresence>
         {menuOpen && <CommandMenu isOpen={menuOpen} inputValue={localText} onSelect={handleSelectCommand} onClose={() => setMenuOpen(false)} skills={skills} />}
       </AnimatePresence>
       <div className="relative">
-        <div className="absolute bottom-full left-0 right-0 z-20 mb-3 flex flex-col gap-2.5">
+        <div className="pointer-events-none absolute bottom-full left-0 right-0 z-20 mb-3 flex flex-col gap-2.5">
           {/* Reconnecting / Disconnected Banner */}
           {(connectionState === 'disconnected' || connectionState === 'reconnecting') && (
             <div className="flex items-center justify-center gap-2 px-3 py-1.5 rounded-full bg-[var(--accent-coral)]/10 border border-[var(--accent-coral)]/30 text-[var(--accent-coral)] text-[11px] font-medium w-full shadow-sm animate-fadeIn">
@@ -272,7 +316,7 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
             </div>
 
             {/* Right Side: Scroll to Bottom */}
-            <ThreadPrimitive.ScrollToBottom className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[var(--bg-glass)] border border-[var(--border-subtle)] backdrop-blur-md shadow-[var(--shadow-sm)] text-[var(--text-muted)] hover:text-[var(--accent-gold)] hover:border-[var(--accent-gold)]/30 hover:bg-[var(--bg-hover)] transition-all active:scale-95 group/scroll whitespace-nowrap">
+            <ThreadPrimitive.ScrollToBottom className="pointer-events-auto flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[var(--bg-glass)] border border-[var(--border-subtle)] backdrop-blur-md shadow-[var(--shadow-sm)] text-[var(--text-muted)] hover:text-[var(--accent-gold)] hover:border-[var(--accent-gold)]/30 hover:bg-[var(--bg-hover)] transition-all active:scale-95 group/scroll whitespace-nowrap">
               <svg className="w-3.5 h-3.5 animate-bounce-subtle" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
               </svg>
@@ -281,7 +325,14 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
           </div>
         </div>
 
-        <ComposerPrimitive.Root className="composer-root">
+        <ComposerPrimitive.Root
+          className="composer-root"
+          onSubmit={(event) => {
+            if (!queueing) return;
+            event.preventDefault();
+            handleQueueSubmit();
+          }}
+        >
           <div className="composer-input-row">
             <ComposerPrimitive.Input
               className="composer-input"
@@ -294,7 +345,16 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
               onChange={handleChange}
               onCompositionStart={handleCompositionStart}
               onCompositionEnd={handleCompositionEnd}
+              onKeyDown={handleComposerKeyDown}
             />
+            {queueError && (
+              <p
+                role="alert"
+                className="absolute bottom-full left-3 right-3 mb-2 rounded-lg border border-[var(--accent-coral)]/35 bg-[var(--bg-elevated)] px-3 py-2 text-[10px] text-[var(--accent-coral)] shadow-sm"
+              >
+                {queueError}
+              </p>
+            )}
             <div className="flex items-center gap-2">
               {(isRunning || isStoppingProp) && (
                 <ComposerPrimitive.Cancel className={`btn-icon ${isStoppingProp ? 'btn-stop-stopping' : 'btn-stop'}`} disabled={disabled || isStoppingProp} aria-label={t(isStoppingProp ? 'aria.stopping' : 'aria.stop')}>
@@ -308,7 +368,19 @@ const ThreadComposer = React.memo(function ThreadComposer({ skills, isRunning, i
                   )}
                 </ComposerPrimitive.Cancel>
               )}
-              <ComposerPrimitive.Send className="btn-icon btn-primary" disabled={disabled} aria-label={t('aria.send')}><svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 12h14M12 5l7 7-7 7" /></svg></ComposerPrimitive.Send>
+              {queueing ? (
+                <button
+                  type="button"
+                  onClick={handleQueueSubmit}
+                  className="btn-icon btn-primary"
+                  disabled={disabled || !followUpQueue || !localText.trim()}
+                  aria-label={t('follow_up.aria.enqueue')}
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 12h14M12 5l7 7-7 7" /></svg>
+                </button>
+              ) : (
+                <ComposerPrimitive.Send className="btn-icon btn-primary" disabled={disabled} aria-label={t('aria.send')}><svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 12h14M12 5l7 7-7 7" /></svg></ComposerPrimitive.Send>
+              )}
             </div>
           </div>
         </ComposerPrimitive.Root>

--- a/webchat/e2e/chat.spec.ts
+++ b/webchat/e2e/chat.spec.ts
@@ -1,91 +1,757 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from "@playwright/test";
 
-// Locators (single source of truth) --------------------------------------
+const COMPOSER_PLACEHOLDER = "输入消息，或输入 '/' 使用命令...";
 
-const COMPOSER_PLACEHOLDER = '输入消息，Shift+Enter 换行...';
+type SentEnvelope = {
+    id: string;
+    event: { type: string; data: Record<string, unknown> };
+};
 
-/** Wait for assistant-ui to hydrate (dynamic import + WS handshake). */
+async function installMockGateway(page: Page) {
+    await page.addInitScript(() => {
+        type Envelope = {
+            version: string;
+            id: string;
+            seq: number;
+            session_id: string;
+            timestamp: number;
+            event: { type: string; data: Record<string, unknown> };
+        };
+        type TestWindow = typeof window & {
+            __aepEvents: Envelope[];
+            __mockAEP: {
+                emit(
+                    type: string,
+                    data: Record<string, unknown>,
+                    id?: string,
+                ): void;
+                disconnect(): void;
+                pauseNextConnect(): void;
+                setNextInitState(state: "idle" | "running"): void;
+                setNextInputOutcome(
+                    outcome: "delivered" | "unknown" | "failed",
+                ): void;
+            };
+        };
+
+        const testWindow = window as TestWindow;
+        const NativeWebSocket = window.WebSocket;
+        testWindow.__aepEvents = [];
+        let serverSequence = 0;
+        let activeSocket: MockWebSocket | null = null;
+        let nextInitState: "idle" | "running" = "idle";
+        let nextInputOutcome: "delivered" | "unknown" | "failed" = "delivered";
+        let pauseNextSocketOpen = false;
+
+        class MockWebSocket extends EventTarget {
+            static readonly CONNECTING = 0;
+            static readonly OPEN = 1;
+            static readonly CLOSING = 2;
+            static readonly CLOSED = 3;
+
+            readonly url: string;
+            readyState = MockWebSocket.CONNECTING;
+            onopen: ((event: Event) => void) | null = null;
+            onmessage: ((event: MessageEvent) => void) | null = null;
+            onerror: ((event: Event) => void) | null = null;
+            onclose: ((event: CloseEvent) => void) | null = null;
+
+            constructor(url: string | URL) {
+                super();
+                this.url = String(url);
+                activeSocket = this;
+                queueMicrotask(() => {
+                    if (pauseNextSocketOpen) {
+                        pauseNextSocketOpen = false;
+                        return;
+                    }
+                    this.readyState = MockWebSocket.OPEN;
+                    const event = new Event("open");
+                    this.dispatchEvent(event);
+                    this.onopen?.(event);
+                });
+            }
+
+            send(payload: string) {
+                const envelope = JSON.parse(payload) as Envelope;
+                testWindow.__aepEvents.push(envelope);
+                if (envelope.event.type === "init") {
+                    this.emit("init_ack", { state: nextInitState });
+                    return;
+                }
+                if (envelope.event.type === "input") {
+                    const outcome = nextInputOutcome;
+                    nextInputOutcome = "delivered";
+                    queueMicrotask(() => {
+                        this.emit("input.ack", {
+                            client_message_id: envelope.id,
+                            execution_id: `execution-${envelope.id}`,
+                            status: "accepted",
+                        });
+                        this.emit("input.ack", {
+                            client_message_id: envelope.id,
+                            execution_id: `execution-${envelope.id}`,
+                            status: outcome,
+                            ...(outcome === "delivered"
+                                ? {}
+                                : {
+                                      error_code: `TEST_${outcome.toUpperCase()}`,
+                                  }),
+                        });
+                    });
+                    return;
+                }
+                if (envelope.event.type === "ping") {
+                    this.emit("pong", {});
+                }
+            }
+
+            close(code = 1000, reason = "mock closed") {
+                if (this.readyState === MockWebSocket.CLOSED) return;
+                this.readyState = MockWebSocket.CLOSED;
+                if (activeSocket === this) activeSocket = null;
+                const event = new CloseEvent("close", { code, reason });
+                this.dispatchEvent(event);
+                this.onclose?.(event);
+            }
+
+            emit(type: string, data: Record<string, unknown>, id?: string) {
+                serverSequence += 1;
+                const envelope: Envelope = {
+                    version: "aep/v1",
+                    id: id ?? `server-${serverSequence}`,
+                    seq: serverSequence,
+                    session_id: "session-e2e",
+                    timestamp: Date.now(),
+                    event: { type, data },
+                };
+                const event = new MessageEvent("message", {
+                    data: JSON.stringify(envelope),
+                });
+                this.dispatchEvent(event);
+                this.onmessage?.(event);
+            }
+        }
+
+        testWindow.__mockAEP = {
+            emit(type, data, id) {
+                activeSocket?.emit(type, data, id);
+            },
+            disconnect() {
+                activeSocket?.close(1012, "mock reconnect");
+            },
+            pauseNextConnect() {
+                pauseNextSocketOpen = true;
+            },
+            setNextInitState(state) {
+                nextInitState = state;
+            },
+            setNextInputOutcome(outcome) {
+                nextInputOutcome = outcome;
+            },
+        };
+        const RoutedWebSocket = new Proxy(NativeWebSocket, {
+            construct(Target, args) {
+                const [rawUrl] = args as [string | URL];
+                const url = new URL(String(rawUrl), window.location.href);
+                if (url.pathname !== "/ws") {
+                    return Reflect.construct(Target, args);
+                }
+                return new MockWebSocket(rawUrl);
+            },
+        });
+        Object.defineProperty(window, "WebSocket", {
+            configurable: true,
+            writable: true,
+            value: RoutedWebSocket,
+        });
+    });
+
+    await page.route("**/api/**", async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        const json = (body: unknown, status = 200) =>
+            route.fulfill({
+                status,
+                contentType: "application/json",
+                body: JSON.stringify(body),
+            });
+
+        if (url.pathname === "/api/auth/me") {
+            await json({
+                id: "user-e2e",
+                username: "e2e",
+                display_name: "E2E User",
+                role: "admin",
+                status: "active",
+                created_at: 1,
+                updated_at: 1,
+            });
+            return;
+        }
+        if (url.pathname === "/api/workspaces" && request.method() === "GET") {
+            await json({
+                workspaces: [
+                    {
+                        id: "workspace-e2e",
+                        name: "E2E Workspace",
+                        work_dir: "/tmp/e2e",
+                        owner_user_id: "user-e2e",
+                        worker_preference: "codex_cli",
+                        permission_mode: "workspace",
+                        agent_config_overrides: "{}",
+                        status: "active",
+                        created_at: 1,
+                        updated_at: 1,
+                    },
+                ],
+                limit: 100,
+                offset: 0,
+            });
+            return;
+        }
+        if (url.pathname === "/api/sessions" && request.method() === "GET") {
+            await json({
+                sessions: [
+                    {
+                        id: "session-e2e",
+                        user_id: "user-e2e",
+                        worker_type: "codex_cli",
+                        state: "idle",
+                        title: "Queue E2E",
+                        work_dir: "/tmp/e2e",
+                        created_at: new Date(1).toISOString(),
+                        updated_at: new Date(2).toISOString(),
+                    },
+                ],
+                limit: 20,
+                offset: 0,
+            });
+            return;
+        }
+        if (url.pathname === "/api/sessions/session-e2e/history") {
+            await json({ records: [], has_more: false });
+            return;
+        }
+        if (url.pathname === "/api/workers") {
+            await json([{ type: "codex_cli", installed: true }]);
+            return;
+        }
+        if (request.method() === "DELETE") {
+            await route.fulfill({ status: 204 });
+            return;
+        }
+        await json({});
+    });
+}
+
 async function waitForChatReady(page: Page) {
-  await page.getByPlaceholder(COMPOSER_PLACEHOLDER).waitFor({ state: 'visible', timeout: 20_000 });
+    await page.getByPlaceholder(COMPOSER_PLACEHOLDER).waitFor({
+        state: "visible",
+        timeout: 20_000,
+    });
 }
 
-/** Get the composer textarea. */
 function composerInput(page: Page) {
-  return page.getByPlaceholder(COMPOSER_PLACEHOLDER);
+    return page.getByPlaceholder(COMPOSER_PLACEHOLDER);
 }
 
-/** Get the send button (inside the composer form, next to textarea). */
 function sendButton(page: Page) {
-  return page.locator('form button[type="button"]');
+    return page.getByRole("button", { name: "发送消息" });
 }
 
-// Tests ------------------------------------------------------------------
+async function sentInputs(page: Page): Promise<SentEnvelope[]> {
+    return page.evaluate(() =>
+        (
+            (window as typeof window & { __aepEvents: SentEnvelope[] })
+                .__aepEvents ?? []
+        ).filter((event) => event.event.type === "input"),
+    );
+}
 
-test.describe('Chat Page', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-    await waitForChatReady(page);
-  });
+async function sentEvents(page: Page): Promise<SentEnvelope[]> {
+    return page.evaluate(
+        () =>
+            (window as typeof window & { __aepEvents: SentEnvelope[] })
+                .__aepEvents ?? [],
+    );
+}
 
-  test('displays header with correct title and subtitle', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'HotPlex AI' })).toBeVisible();
-    await expect(page.getByText(/AEP v1/)).toBeVisible();
-  });
+async function emitDone(page: Page, id: string, reason = "completed") {
+    await page.evaluate(
+        ({ eventId, doneReason }) => {
+            (
+                window as typeof window & {
+                    __mockAEP: {
+                        emit(
+                            type: string,
+                            data: Record<string, unknown>,
+                            id?: string,
+                        ): void;
+                    };
+                }
+            ).__mockAEP.emit(
+                "done",
+                { success: true, reason: doneReason },
+                eventId,
+            );
+        },
+        { eventId: id, doneReason: reason },
+    );
+}
 
-  test('shows composer when no messages', async ({ page }) => {
-    const input = composerInput(page);
-    await expect(input).toBeVisible();
-    await expect(input).toBeEditable();
-  });
+async function emitGatewayEvent(
+    page: Page,
+    type: string,
+    data: Record<string, unknown>,
+    id?: string,
+) {
+    await page.evaluate(
+        ({ eventType, eventData, eventId }) => {
+            (
+                window as typeof window & {
+                    __mockAEP: {
+                        emit(
+                            type: string,
+                            data: Record<string, unknown>,
+                            id?: string,
+                        ): void;
+                    };
+                }
+            ).__mockAEP.emit(eventType, eventData, eventId);
+        },
+        { eventType: type, eventData: data, eventId: id },
+    );
+}
 
-  test('send button becomes enabled when text is entered', async ({ page }) => {
-    const sendBtn = sendButton(page);
-    await expect(sendBtn).toBeDisabled();
+async function setNextInputOutcome(
+    page: Page,
+    outcome: "delivered" | "unknown" | "failed",
+) {
+    await page.evaluate((nextOutcome) => {
+        (
+            window as typeof window & {
+                __mockAEP: {
+                    setNextInputOutcome(value: typeof nextOutcome): void;
+                };
+            }
+        ).__mockAEP.setNextInputOutcome(nextOutcome);
+    }, outcome);
+}
 
-    await composerInput(page).fill('Hello');
-    await expect(sendBtn).toBeEnabled();
-  });
+async function disconnectGateway(
+    page: Page,
+    reconnectState: "idle" | "running",
+    pauseReconnect = false,
+) {
+    await page.evaluate(
+        ({ state, pause }) => {
+            const mock = (
+                window as typeof window & {
+                    __mockAEP: {
+                        setNextInitState(value: typeof state): void;
+                        pauseNextConnect(): void;
+                        disconnect(): void;
+                    };
+                }
+            ).__mockAEP;
+            mock.setNextInitState(state);
+            if (pause) mock.pauseNextConnect();
+            mock.disconnect();
+        },
+        { state: reconnectState, pause: pauseReconnect },
+    );
+}
 
-  test('Enter key submits and clears the input', async ({ page }) => {
-    const input = composerInput(page);
+test.describe("Chat Page", () => {
+    test.beforeEach(async ({ page }) => {
+        await installMockGateway(page);
+        await page.goto("/");
+        await waitForChatReady(page);
+    });
 
-    await input.fill('Hello world');
-    await input.press('Enter');
+    test("renders an authenticated chat with a usable composer", async ({
+        page,
+    }) => {
+        await expect(
+            page.getByRole("heading", { name: "HotPlex" }),
+        ).toBeVisible();
+        await expect(composerInput(page)).toBeEditable();
+        await expect(sendButton(page)).toBeDisabled();
 
-    await expect(input).toHaveValue('');
-  });
+        await composerInput(page).fill("Hello");
+        await expect(sendButton(page)).toBeEnabled();
+        await composerInput(page).press("Shift+Enter");
+        await composerInput(page).pressSequentially("world");
+        await expect(composerInput(page)).toHaveValue(/Hello\nworld/);
+    });
 
-  test('Shift+Enter creates a new line without sending', async ({ page }) => {
-    const input = composerInput(page);
+    test("queues follow-ups FIFO and dispatches one per terminal turn", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(1);
 
-    await input.fill('line one');
-    await input.press('Shift+Enter');
-    await input.pressSequentially('line two');
+        await input.fill("second");
+        await input.press("Enter");
+        await input.fill("third");
+        await page.getByRole("button", { name: "将消息加入后续队列" }).click();
 
-    const value = await input.inputValue();
-    expect(value).toContain('line two');
-  });
+        const panel = page.getByRole("region", { name: "后续消息队列" });
+        await expect(panel).toContainText("second");
+        await expect(panel).toContainText("third");
+        expect(await sentInputs(page)).toHaveLength(1);
 
-  test('empty input cannot be sent', async ({ page }) => {
-    const sendBtn = sendButton(page);
-    await expect(sendBtn).toBeDisabled();
+        await emitDone(page, "done-first");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        expect((await sentInputs(page))[1]?.event.data.content).toBe("second");
+        await expect(panel).toContainText("third");
 
-    await composerInput(page).fill('   ');
-    await expect(sendBtn).toBeDisabled();
-  });
+        // A duplicate terminal envelope must not advance or fail the new turn.
+        await emitDone(page, "done-first");
+        await page.waitForTimeout(50);
+        expect(await sentInputs(page)).toHaveLength(2);
 
-  test('opens and closes the session panel', async ({ page }) => {
-    const sessionBtn = page.getByRole('button', { name: /会话/ });
-    await expect(sessionBtn).toBeVisible();
+        await emitDone(page, "done-second");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(3);
+        expect((await sentInputs(page))[2]?.event.data.content).toBe("third");
+    });
 
-    await sessionBtn.click();
+    test("resumes FIFO after a delivered turn finishes while disconnected", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("delivered before disconnect");
+        await input.press("Enter");
+        await input.fill("must drain after idle reconnect");
+        await input.press("Enter");
 
-    const panel = page.getByRole('dialog', { name: '会话列表' });
-    await expect(panel).toBeVisible();
+        await emitDone(page, "done-before-disconnect");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        await disconnectGateway(page, "idle");
 
-    const closeBtn = panel.getByRole('button', { name: '关闭' });
-    await closeBtn.click();
+        await expect
+            .poll(async () => (await sentInputs(page)).length, {
+                timeout: 10_000,
+            })
+            .toBe(3);
+        expect((await sentInputs(page))[2]?.event.data.content).toBe(
+            "must drain after idle reconnect",
+        );
+    });
 
-    await expect(panel).not.toBeVisible();
-  });
+    test("keeps unknown delivery blocked until an explicit retry", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("ambiguous follow-up");
+        await input.press("Enter");
+
+        await setNextInputOutcome(page, "unknown");
+        await emitDone(page, "done-before-unknown");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+
+        const panel = page.getByRole("region", { name: "后续消息队列" });
+        await expect(panel).toContainText("需要处理");
+        await page.waitForTimeout(100);
+        expect(await sentInputs(page)).toHaveLength(2);
+
+        await input.fill("must stay behind failed head");
+        await input.press("Enter");
+        await expect(panel).toContainText("must stay behind failed head");
+        expect(await sentInputs(page)).toHaveLength(2);
+
+        await panel.getByRole("button", { name: /重试队列第/ }).click();
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(3);
+        expect((await sentInputs(page))[2]?.event.data.content).toBe(
+            "ambiguous follow-up",
+        );
+        await expect(
+            page.getByText("ambiguous follow-up", { exact: true }),
+        ).toHaveCount(1);
+        await emitDone(page, "done-after-explicit-retry");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(4);
+        expect((await sentInputs(page))[3]?.event.data.content).toBe(
+            "must stay behind failed head",
+        );
+    });
+
+    test("removes the preserved unknown turn when explicitly deleted", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("unknown prompt to remove");
+        await input.press("Enter");
+
+        await setNextInputOutcome(page, "unknown");
+        await emitDone(page, "done-before-unknown-remove");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+
+        const panel = page.getByRole("region", { name: "后续消息队列" });
+        await expect(panel).toContainText("需要处理");
+        await panel.getByRole("button", { name: /删除队列第/ }).click();
+
+        await expect(panel).toHaveCount(0);
+        await expect(
+            page.getByText("unknown prompt to remove", { exact: true }),
+        ).toHaveCount(0);
+        expect(await sentInputs(page)).toHaveLength(2);
+    });
+
+    test("converges unknown delivery when the original turn finishes late", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("late terminal follow-up");
+        await input.press("Enter");
+
+        await setNextInputOutcome(page, "unknown");
+        await emitDone(page, "done-before-late-terminal");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        const panel = page.getByRole("region", { name: "后续消息队列" });
+        await expect(panel).toContainText("需要处理");
+
+        await emitGatewayEvent(
+            page,
+            "message.start",
+            { id: "late-assistant", role: "assistant", content_type: "text" },
+            "late-message-start",
+        );
+        await emitGatewayEvent(page, "message.delta", {
+            message_id: "late-assistant",
+            content: "late response content",
+        });
+        await emitGatewayEvent(
+            page,
+            "done",
+            {
+                success: true,
+                reason: "late-terminal-for-unknown",
+                stats: {
+                    _session: {
+                        model_name: "late-convergence-model",
+                        turn_count: 2,
+                        tool_call_count: 0,
+                        duration: "1s",
+                        duration_seconds: 1,
+                        total_input_tok: 10,
+                        total_output_tok: 5,
+                        context_fill: 10,
+                        context_window: 100,
+                        context_pct: 10,
+                        total_cost_usd: 0,
+                        turn_duration_ms: 1000,
+                        turn_input_tok: 6,
+                        turn_output_tok: 5,
+                        turn_cost_usd: 0,
+                        tool_names: null,
+                        work_dir: "/tmp/hotplex-e2e",
+                    },
+                },
+            },
+            "late-terminal-for-unknown",
+        );
+        await expect(panel).toHaveCount(0);
+        await expect(
+            page.getByText("late terminal follow-up", { exact: true }),
+        ).toHaveCount(1);
+        const lateResponse = page.getByText("late response content", {
+            exact: true,
+        });
+        await expect(lateResponse).toBeVisible();
+        const lateResponseBody = lateResponse.locator(
+            "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' msg-assistant-body ')][1]",
+        );
+        await expect(lateResponseBody).toContainText("late-convergence-model");
+        await expect(lateResponseBody.locator(".streaming-cursor")).toHaveCount(
+            0,
+        );
+        await page.waitForTimeout(100);
+        expect(await sentInputs(page)).toHaveLength(2);
+        await expect(
+            page.getByRole("button", { name: /重试队列第/ }),
+        ).toHaveCount(0);
+    });
+
+    test("converges unknown delivery when its delivered ACK arrives late", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("late acknowledgement follow-up");
+        await input.press("Enter");
+
+        await setNextInputOutcome(page, "unknown");
+        await emitDone(page, "done-before-late-ack");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        const originalDispatch = (await sentInputs(page))[1];
+        const panel = page.getByRole("region", { name: "后续消息队列" });
+        await expect(panel).toContainText("需要处理");
+
+        await emitGatewayEvent(page, "input.ack", {
+            client_message_id: originalDispatch.id,
+            execution_id: `execution-${originalDispatch.id}`,
+            status: "delivered",
+        });
+        await expect(panel).toHaveCount(0);
+        expect(await sentInputs(page)).toHaveLength(2);
+    });
+
+    test("reports send-now failure instead of silently degrading while reconnecting", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("urgent while reconnecting");
+        await input.press("Enter");
+
+        await disconnectGateway(page, "running", true);
+        const urgent = page
+            .getByRole("listitem")
+            .filter({ hasText: "urgent while reconnecting" });
+        await urgent
+            .getByRole("button", {
+                name: /停止当前轮次并立即发送队列第/,
+            })
+            .click();
+
+        await expect(urgent).toContainText("需要处理");
+        await expect(urgent).toContainText("连接中断");
+        expect(
+            (await sentEvents(page)).filter(
+                (event) => event.event.type === "control",
+            ),
+        ).toHaveLength(0);
+    });
+
+    test("edits and deletes queued prompts before their only dispatch", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("draft prompt");
+        await input.press("Enter");
+        await input.fill("remove me");
+        await input.press("Enter");
+
+        const draftItem = page
+            .getByRole("listitem")
+            .filter({ hasText: "draft prompt" });
+        await draftItem.getByRole("button", { name: /编辑队列第/ }).click();
+        const editInput = draftItem.getByRole("textbox", {
+            name: /编辑队列第/,
+        });
+        await editInput.fill("final prompt");
+        await page.getByRole("button", { name: "保存" }).click();
+
+        const removedItem = page
+            .getByRole("listitem")
+            .filter({ hasText: "remove me" });
+        await removedItem.getByRole("button", { name: /删除队列第/ }).click();
+        await expect(page.getByText("remove me")).toHaveCount(0);
+
+        await emitDone(page, "done-edit");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        const inputs = await sentInputs(page);
+        expect(inputs[1]?.event.data.content).toBe("final prompt");
+        expect(
+            inputs.some((event) => event.event.data.content === "draft prompt"),
+        ).toBe(false);
+        expect(
+            inputs.some((event) => event.event.data.content === "remove me"),
+        ).toBe(false);
+    });
+
+    test("send now stops the current turn and promotes the selected item", async ({
+        page,
+    }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+        await input.fill("normal follow-up");
+        await input.press("Enter");
+        await input.fill("urgent follow-up");
+        await input.press("Enter");
+
+        const urgent = page
+            .getByRole("listitem")
+            .filter({ hasText: "urgent follow-up" });
+        await urgent
+            .getByRole("button", {
+                name: /停止当前轮次并立即发送队列第/,
+            })
+            .click();
+
+        await expect
+            .poll(
+                async () =>
+                    (await sentEvents(page)).filter(
+                        (event) => event.event.type === "control",
+                    ).length,
+            )
+            .toBe(1);
+        expect(await sentInputs(page)).toHaveLength(1);
+
+        await emitDone(page, "done-stopped", "stopped_by_user");
+        await expect.poll(async () => (await sentInputs(page)).length).toBe(2);
+        expect((await sentInputs(page))[1]?.event.data.content).toBe(
+            "urgent follow-up",
+        );
+        await expect(
+            page.getByRole("region", { name: "后续消息队列" }),
+        ).toContainText("normal follow-up");
+    });
+
+    test("keeps the draft when the 20-item queue is full", async ({ page }) => {
+        const input = composerInput(page);
+        await input.fill("first");
+        await input.press("Enter");
+
+        for (let index = 1; index <= 20; index += 1) {
+            await input.fill(`queued-${index}`);
+            await input.press("Enter");
+        }
+        await expect(page.getByRole("listitem")).toHaveCount(20);
+
+        await emitGatewayEvent(
+            page,
+            "message",
+            {
+                role: "assistant",
+                content: "final answer before terminal done",
+            },
+            "message-before-done",
+        );
+        await input.fill("overflow draft");
+        await input.press("Enter");
+        await expect(input).toHaveValue("overflow draft");
+        await expect(
+            page.getByText("队列最多容纳 20 条消息", { exact: false }),
+        ).toBeVisible();
+        await expect(page.getByRole("listitem")).toHaveCount(20);
+    });
+
+    test("collapses and restores the desktop session sidebar", async ({
+        page,
+    }) => {
+        const collapse = page.getByRole("button", { name: "折叠侧边栏" });
+        await collapse.click();
+        const expand = page.getByRole("button", { name: "展开侧边栏" });
+        await expect(expand).toBeVisible();
+        await expand.click();
+        await expect(page.getByText("Queue E2E")).toBeVisible();
+    });
 });

--- a/webchat/lib/adapters/follow-up-queue.test.ts
+++ b/webchat/lib/adapters/follow-up-queue.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    FOLLOW_UP_QUEUE_LIMIT,
+    FollowUpQueueStore,
+} from "./follow-up-queue";
+
+function createStore(limit = FOLLOW_UP_QUEUE_LIMIT) {
+    let sequence = 0;
+    return new FollowUpQueueStore({
+        limit,
+        createId: () => `queue-${++sequence}`,
+        now: () => 1_700_000_000_000 + sequence,
+    });
+}
+
+describe("FollowUpQueueStore", () => {
+    it("keeps FIFO order and isolates queues by session", () => {
+        const store = createStore();
+
+        expect(store.enqueue("session-a", "first")).toMatchObject({ ok: true });
+        expect(store.enqueue("session-b", "other")).toMatchObject({ ok: true });
+        expect(store.enqueue("session-a", "second")).toMatchObject({ ok: true });
+
+        expect(store.getSnapshot("session-a").map((item) => item.text)).toEqual([
+            "first",
+            "second",
+        ]);
+        expect(store.getSnapshot("session-b").map((item) => item.text)).toEqual([
+            "other",
+        ]);
+    });
+
+    it("preserves the submitted text and rejects blank items", () => {
+        const store = createStore();
+
+        expect(store.enqueue("session-a", "  keep spacing  ")).toMatchObject({
+            ok: true,
+        });
+        expect(store.getSnapshot("session-a")[0]?.text).toBe("  keep spacing  ");
+        expect(store.enqueue("session-a", " \n\t ")).toEqual({
+            ok: false,
+            reason: "blank",
+        });
+    });
+
+    it("enforces the configured limit without mutating the queue", () => {
+        const store = createStore(2);
+        store.enqueue("session-a", "first");
+        store.enqueue("session-a", "second");
+
+        expect(store.enqueue("session-a", "third")).toEqual({
+            ok: false,
+            reason: "limit",
+        });
+        expect(store.getSnapshot("session-a").map((item) => item.text)).toEqual([
+            "first",
+            "second",
+        ]);
+    });
+
+    it("edits queued items but never mutates a sending item", () => {
+        const store = createStore();
+        const result = store.enqueue("session-a", "draft");
+        if (!result.ok) throw new Error("enqueue failed");
+
+        expect(store.updateText("session-a", result.item.id, "final text")).toBe(
+            true,
+        );
+        expect(store.getSnapshot("session-a")[0]?.text).toBe("final text");
+        expect(store.markSending("session-a", result.item.id)).toBe(true);
+        expect(store.updateText("session-a", result.item.id, "too late")).toBe(
+            false,
+        );
+        expect(store.remove("session-a", result.item.id)).toBe(false);
+    });
+
+    it("moves an arbitrary item to the front without reordering the others", () => {
+        const store = createStore();
+        store.enqueue("session-a", "first");
+        store.enqueue("session-a", "second");
+        const third = store.enqueue("session-a", "third");
+        if (!third.ok) throw new Error("enqueue failed");
+
+        expect(store.prepareSendNow("session-a", third.item.id)).toBe(true);
+        expect(store.getSnapshot("session-a").map((item) => item.text)).toEqual([
+            "third",
+            "first",
+            "second",
+        ]);
+    });
+
+    it("removes an item only after its delivered acknowledgement", () => {
+        const store = createStore();
+        const result = store.enqueue("session-a", "first");
+        if (!result.ok) throw new Error("enqueue failed");
+
+        store.markSending("session-a", result.item.id);
+        store.attachClientMessageId("session-a", result.item.id, "client-1");
+
+        expect(store.markDelivered("session-a", "different-client")).toBeNull();
+        expect(store.getSnapshot("session-a")).toHaveLength(1);
+        expect(store.markDelivered("session-a", "client-1")?.id).toBe(
+            result.item.id,
+        );
+        expect(store.getSnapshot("session-a")).toHaveLength(0);
+    });
+
+    it("requires an explicit retry after unknown or failed delivery", () => {
+        const store = createStore();
+        const result = store.enqueue("session-a", "first");
+        if (!result.ok) throw new Error("enqueue failed");
+
+        store.markSending("session-a", result.item.id);
+        store.markFailed("session-a", result.item.id, "unknown", "Outcome unknown");
+
+        expect(store.getSnapshot("session-a")[0]).toMatchObject({
+            status: "failed",
+            errorKind: "unknown",
+            errorMessage: "Outcome unknown",
+        });
+        expect(store.peekDispatchable("session-a")).toBeNull();
+        expect(store.retry("session-a", result.item.id)).toBe(true);
+        expect(store.peekDispatchable("session-a")).toMatchObject({
+            id: result.item.id,
+            status: "queued",
+        });
+    });
+
+    it("converges an unknown item when its original delivery is confirmed late", () => {
+        const store = createStore();
+        const result = store.enqueue("session-a", "first");
+        if (!result.ok) throw new Error("enqueue failed");
+
+        store.markSending("session-a", result.item.id);
+        store.attachClientMessageId("session-a", result.item.id, "client-1");
+        store.markFailed("session-a", result.item.id, "unknown", "Outcome unknown");
+
+        expect(store.getSnapshot("session-a")[0]?.clientMessageId).toBe("client-1");
+        expect(store.markDelivered("session-a", "client-1")?.id).toBe(
+            result.item.id,
+        );
+        expect(store.getSnapshot("session-a")).toHaveLength(0);
+    });
+
+    it("turns a failed item into an explicit send-now retry", () => {
+        const store = createStore();
+        const first = store.enqueue("session-a", "first");
+        store.enqueue("session-a", "second");
+        if (!first.ok) throw new Error("enqueue failed");
+        store.markFailed("session-a", first.item.id, "connection", "offline");
+
+        expect(store.prepareSendNow("session-a", first.item.id)).toBe(true);
+        expect(store.getSnapshot("session-a")[0]).toMatchObject({
+            id: first.item.id,
+            status: "queued",
+            errorKind: undefined,
+            errorMessage: undefined,
+        });
+    });
+
+    it("notifies subscribers only for real changes and clears a deleted session", () => {
+        const store = createStore();
+        const listener = vi.fn();
+        const unsubscribe = store.subscribe(listener);
+
+        store.enqueue("session-a", "first");
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(store.remove("session-a", "missing")).toBe(false);
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        store.clearSession("session-a");
+        expect(listener).toHaveBeenCalledTimes(2);
+        expect(store.getSnapshot("session-a")).toEqual([]);
+
+        unsubscribe();
+        store.enqueue("session-a", "after unsubscribe");
+        expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns a stable snapshot until that session changes", () => {
+        const store = createStore();
+        const empty = store.getSnapshot("session-a");
+        expect(store.getSnapshot("session-a")).toBe(empty);
+
+        store.enqueue("session-b", "other");
+        expect(store.getSnapshot("session-a")).toBe(empty);
+
+        store.enqueue("session-a", "first");
+        expect(store.getSnapshot("session-a")).not.toBe(empty);
+    });
+});

--- a/webchat/lib/adapters/follow-up-queue.ts
+++ b/webchat/lib/adapters/follow-up-queue.ts
@@ -1,0 +1,267 @@
+export const FOLLOW_UP_QUEUE_LIMIT = 20;
+
+export type FollowUpQueueStatus = "queued" | "sending" | "failed";
+
+export type FollowUpQueueErrorKind =
+    | "unknown"
+    | "connection"
+    | "busy"
+    | "send"
+    | "stop";
+
+export interface FollowUpQueueItem {
+    readonly id: string;
+    readonly text: string;
+    readonly createdAt: number;
+    readonly sequence: number;
+    readonly status: FollowUpQueueStatus;
+    readonly clientMessageId?: string;
+    readonly errorKind?: FollowUpQueueErrorKind;
+    readonly errorMessage?: string;
+}
+
+export type FollowUpQueueEnqueueResult =
+    | { readonly ok: true; readonly item: FollowUpQueueItem }
+    | { readonly ok: false; readonly reason: "blank" | "limit" };
+
+export interface FollowUpQueueControls {
+    readonly items: readonly FollowUpQueueItem[];
+    enqueue(text: string): FollowUpQueueEnqueueResult;
+    updateText(itemId: string, text: string): boolean;
+    remove(itemId: string): boolean;
+    retry(itemId: string): boolean;
+    sendNow(itemId: string): Promise<void>;
+}
+
+interface FollowUpQueueStoreOptions {
+    readonly limit?: number;
+    readonly createId?: () => string;
+    readonly now?: () => number;
+}
+
+const EMPTY_QUEUE: readonly FollowUpQueueItem[] = Object.freeze([]);
+let fallbackIdSequence = 0;
+
+function defaultCreateId(): string {
+    if (typeof globalThis.crypto?.randomUUID === "function") {
+        return globalThis.crypto.randomUUID();
+    }
+    fallbackIdSequence += 1;
+    return `queue-${Date.now()}-${fallbackIdSequence}`;
+}
+
+/**
+ * Page-local, session-isolated storage for prompts that have not been
+ * dispatched to the Gateway yet. The store deliberately has no persistence,
+ * logging, or transport dependencies.
+ */
+export class FollowUpQueueStore {
+    private readonly queues = new Map<
+        string,
+        readonly FollowUpQueueItem[]
+    >();
+    private readonly listeners = new Set<() => void>();
+    private readonly limit: number;
+    private readonly createId: () => string;
+    private readonly now: () => number;
+    private nextSequence = 0;
+
+    constructor(options: FollowUpQueueStoreOptions = {}) {
+        this.limit = options.limit ?? FOLLOW_UP_QUEUE_LIMIT;
+        this.createId = options.createId ?? defaultCreateId;
+        this.now = options.now ?? Date.now;
+    }
+
+    subscribe = (listener: () => void): (() => void) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    getSnapshot(sessionId: string | undefined): readonly FollowUpQueueItem[] {
+        if (!sessionId) return EMPTY_QUEUE;
+        return this.queues.get(sessionId) ?? EMPTY_QUEUE;
+    }
+
+    enqueue(sessionId: string, text: string): FollowUpQueueEnqueueResult {
+        if (!text.trim()) return { ok: false, reason: "blank" };
+        const queue = this.getSnapshot(sessionId);
+        if (queue.length >= this.limit) {
+            return { ok: false, reason: "limit" };
+        }
+
+        this.nextSequence += 1;
+        const item: FollowUpQueueItem = {
+            id: this.createId(),
+            text,
+            createdAt: this.now(),
+            sequence: this.nextSequence,
+            status: "queued",
+        };
+        this.setQueue(sessionId, [...queue, item]);
+        return { ok: true, item };
+    }
+
+    updateText(sessionId: string, itemId: string, text: string): boolean {
+        if (!text.trim()) return false;
+        return this.updateItem(sessionId, itemId, (item) => {
+            if (item.status === "sending" || item.text === text) return null;
+            return { ...item, text };
+        });
+    }
+
+    remove(sessionId: string, itemId: string): boolean {
+        const queue = this.getSnapshot(sessionId);
+        const index = queue.findIndex((item) => item.id === itemId);
+        if (index === -1 || queue[index]?.status === "sending") return false;
+        this.setQueue(sessionId, [
+            ...queue.slice(0, index),
+            ...queue.slice(index + 1),
+        ]);
+        return true;
+    }
+
+    prepareSendNow(sessionId: string, itemId: string): boolean {
+        const queue = this.getSnapshot(sessionId);
+        const index = queue.findIndex((item) => item.id === itemId);
+        const item = queue[index];
+        if (!item || item.status === "sending") return false;
+
+        const prepared: FollowUpQueueItem = {
+            ...item,
+            status: "queued",
+            clientMessageId: undefined,
+            errorKind: undefined,
+            errorMessage: undefined,
+        };
+        const rest = queue.filter((current) => current.id !== itemId);
+        const next = [prepared, ...rest];
+        const changed =
+            index !== 0 ||
+            item.status !== "queued" ||
+            item.clientMessageId !== undefined ||
+            item.errorKind !== undefined ||
+            item.errorMessage !== undefined;
+        if (changed) this.setQueue(sessionId, next);
+        return true;
+    }
+
+    peekDispatchable(sessionId: string): FollowUpQueueItem | null {
+        const head = this.getSnapshot(sessionId)[0];
+        return head?.status === "queued" ? head : null;
+    }
+
+    markSending(sessionId: string, itemId: string): boolean {
+        const head = this.getSnapshot(sessionId)[0];
+        if (!head || head.id !== itemId || head.status !== "queued") {
+            return false;
+        }
+        return this.updateItem(sessionId, itemId, (item) => ({
+            ...item,
+            status: "sending",
+            clientMessageId: undefined,
+            errorKind: undefined,
+            errorMessage: undefined,
+        }));
+    }
+
+    attachClientMessageId(
+        sessionId: string,
+        itemId: string,
+        clientMessageId: string,
+    ): boolean {
+        return this.updateItem(sessionId, itemId, (item) => {
+            if (item.status !== "sending") return null;
+            return { ...item, clientMessageId };
+        });
+    }
+
+    markDelivered(
+        sessionId: string,
+        clientMessageId: string,
+    ): FollowUpQueueItem | null {
+        const queue = this.getSnapshot(sessionId);
+        const index = queue.findIndex(
+            (item) =>
+                (item.status === "sending" ||
+                    (item.status === "failed" && item.errorKind === "unknown")) &&
+                item.clientMessageId === clientMessageId,
+        );
+        if (index === -1) return null;
+        const delivered = queue[index] ?? null;
+        this.setQueue(sessionId, [
+            ...queue.slice(0, index),
+            ...queue.slice(index + 1),
+        ]);
+        return delivered;
+    }
+
+    markFailed(
+        sessionId: string,
+        itemId: string,
+        errorKind: FollowUpQueueErrorKind,
+        errorMessage: string,
+    ): boolean {
+        return this.updateItem(sessionId, itemId, (item) => ({
+            ...item,
+            status: "failed",
+            clientMessageId:
+                errorKind === "unknown" ? item.clientMessageId : undefined,
+            errorKind,
+            errorMessage,
+        }));
+    }
+
+    retry(sessionId: string, itemId: string): boolean {
+        return this.updateItem(sessionId, itemId, (item) => {
+            if (item.status !== "failed") return null;
+            return {
+                ...item,
+                status: "queued",
+                clientMessageId: undefined,
+                errorKind: undefined,
+                errorMessage: undefined,
+            };
+        });
+    }
+
+    clearSession(sessionId: string): void {
+        if (!this.queues.has(sessionId)) return;
+        this.queues.delete(sessionId);
+        this.emitChange();
+    }
+
+    private updateItem(
+        sessionId: string,
+        itemId: string,
+        update: (
+            item: FollowUpQueueItem,
+        ) => FollowUpQueueItem | null,
+    ): boolean {
+        const queue = this.getSnapshot(sessionId);
+        const index = queue.findIndex((item) => item.id === itemId);
+        const item = queue[index];
+        if (!item) return false;
+        const nextItem = update(item);
+        if (!nextItem) return false;
+        const next = [...queue];
+        next[index] = nextItem;
+        this.setQueue(sessionId, next);
+        return true;
+    }
+
+    private setQueue(
+        sessionId: string,
+        queue: readonly FollowUpQueueItem[],
+    ): void {
+        if (queue.length === 0) {
+            this.queues.delete(sessionId);
+        } else {
+            this.queues.set(sessionId, Object.freeze(queue));
+        }
+        this.emitChange();
+    }
+
+    private emitChange(): void {
+        for (const listener of this.listeners) listener();
+    }
+}

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -5,7 +5,14 @@
  * This is the core integration layer that bridges the two systems.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from "react";
 import type {
     ExternalStoreAdapter,
     ThreadMessageLike,
@@ -65,8 +72,11 @@ import type { HotPlexMessage } from "@/lib/types/message";
 import {
     appendTextDelta,
     appendReasoningDelta,
-    concatTextParts,
 } from "@/lib/adapters/merge-parts";
+import {
+    patchAuthoritativeAssistantContent,
+    selectAuthoritativeAssistantContent,
+} from "@/lib/adapters/reconcile-turn";
 import {
     completeStreamingAssistant,
     createPendingAssistantMessage,
@@ -75,6 +85,11 @@ import {
     removePendingAssistant,
     updatePendingAssistant,
 } from "@/lib/adapters/pending-assistant";
+import {
+    FollowUpQueueStore,
+    type FollowUpQueueControls,
+    type FollowUpQueueErrorKind,
+} from "@/lib/adapters/follow-up-queue";
 
 // Re-export for consumers
 export type { HotPlexMessage };
@@ -93,21 +108,21 @@ type ThreadSuggestion = { title: string; label: string; prompt: string };
 
 export type InteractionKind = "permission" | "question" | "elicitation";
 export type InteractionStatus =
-  | "pending"
-  | "submitting"
-  | "resolved"
-  | "rejected"
-  | "expired"
-  | "failed";
+    | "pending"
+    | "submitting"
+    | "resolved"
+    | "rejected"
+    | "expired"
+    | "failed";
 
 export interface InteractionState {
-  kind: InteractionKind;
-  requestId: string;
-  status: InteractionStatus;
-  createdAt: number;
-  expiresAt?: number;
-  response?: any;
-  error?: string;
+    kind: InteractionKind;
+    requestId: string;
+    status: InteractionStatus;
+    createdAt: number;
+    expiresAt?: number;
+    response?: any;
+    error?: string;
 }
 
 // ============================================================================
@@ -137,6 +152,8 @@ export interface UseHotPlexRuntimeConfig {
     onSessionStateChange?: (state: string) => void;
     /** Custom welcome suggestions shown when thread is empty. */
     suggestions?: readonly ThreadSuggestion[];
+    /** Page-scoped queue store that survives keyed session runtime remounts. */
+    followUpQueueStore?: FollowUpQueueStore;
 }
 
 // Content-signature prefix length for dedup — covers most short/medium responses.
@@ -152,7 +169,9 @@ const DEFAULT_SUGGESTIONS: readonly ThreadSuggestion[] = [];
  * Converts HotPlex message to assistant-ui ThreadMessageLike format.
  * Handles both old format (content: string) and new format (parts: MessagePart[]).
  */
-export function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLike {
+export function convertToThreadMessage(
+    message: HotPlexMessage,
+): ThreadMessageLike {
     // Filter out ToolSummaryPart, ContextUsagePart, and TurnSummaryPart — not recognized by assistant-ui's ThreadMessageLike type
     const parts = message.parts ?? [];
     const content = parts.filter(
@@ -187,7 +206,9 @@ export function convertToThreadMessage(message: HotPlexMessage): ThreadMessageLi
                 ...(contextUsagePart
                     ? { contextUsage: contextUsagePart.data }
                     : {}),
-                ...(turnSummaryPart ? { turnSummary: turnSummaryPart.data } : {}),
+                ...(turnSummaryPart
+                    ? { turnSummary: turnSummaryPart.data }
+                    : {}),
                 ...(message.progress ? { progress: message.progress } : {}),
             },
         } satisfies Record<string, unknown>,
@@ -278,6 +299,7 @@ export function useHotPlexRuntime({
     onSkillsChange,
     onSessionStateChange,
     suggestions: configSuggestions,
+    followUpQueueStore,
 }: UseHotPlexRuntimeConfig = {}): ExternalStoreAdapter<HotPlexMessage> {
     // State
     const [messages, setMessages] = useState<HotPlexMessage[]>([]);
@@ -285,6 +307,20 @@ export function useHotPlexRuntime({
     const [historyHasMore, setHistoryHasMore] = useState(true);
     const [connectionState, setConnectionState] =
         useState<ConnectionState>("disconnected");
+    const ownedQueueStoreRef = useRef<FollowUpQueueStore | null>(null);
+    if (!ownedQueueStoreRef.current) {
+        ownedQueueStoreRef.current = new FollowUpQueueStore();
+    }
+    const queueStore = followUpQueueStore ?? ownedQueueStoreRef.current;
+    const getQueueSnapshot = useCallback(
+        () => queueStore.getSnapshot(sessionId),
+        [queueStore, sessionId],
+    );
+    const queuedItems = useSyncExternalStore(
+        queueStore.subscribe,
+        getQueueSnapshot,
+        getQueueSnapshot,
+    );
 
     // One-time cleanup of orphaned localStorage keys from removed message cache
     useEffect(() => {
@@ -306,6 +342,48 @@ export function useHotPlexRuntime({
     const historyLoadingRef = useRef(false);
     const sessionIdRef = useRef(sessionId);
     const sessionAlreadyConnectedRef = useRef(false);
+    const turnActiveRef = useRef(false);
+    const drainInFlightRef = useRef(false);
+    const scheduleQueueDrainRef = useRef<() => void>(() => undefined);
+    const activeQueueDispatchRef = useRef<{
+        sessionId: string;
+        itemId: string;
+        userMessageId: string;
+        assistantMessageId: string;
+        clientMessageId?: string;
+        delivered: boolean;
+        outcomeUnknown?: boolean;
+        text: string;
+    } | null>(null);
+    const failActiveQueueDispatchRef = useRef<
+        (kind: FollowUpQueueErrorKind, message: string) => boolean
+    >(() => false);
+
+    failActiveQueueDispatchRef.current = (kind, message) => {
+        const active = activeQueueDispatchRef.current;
+        if (!active || active.delivered) return false;
+        queueStore.markFailed(active.sessionId, active.itemId, kind, message);
+        if (kind === "unknown") {
+            active.outcomeUnknown = true;
+            turnActiveRef.current = false;
+            setIsRunning(false);
+            return true;
+        }
+        activeQueueDispatchRef.current = null;
+        turnActiveRef.current = false;
+        pendingAssistantIdRef.current = null;
+        activeAssistantIdRef.current = null;
+        activeInputMessageIdRef.current = null;
+        setIsRunning(false);
+        setMessages((previous) =>
+            previous.filter(
+                (messageItem) =>
+                    messageItem.id !== active.userMessageId &&
+                    messageItem.id !== active.assistantMessageId,
+            ),
+        );
+        return true;
+    };
 
     // Welcome suggestions — shown when thread is empty (use prop or default list)
     const suggestions: readonly ThreadSuggestion[] =
@@ -330,9 +408,9 @@ export function useHotPlexRuntime({
     const interactionMapRef = useRef<
         Map<string, { type: "permission" | "question" | "elicitation" }>
     >(new Map());
-    const interactionAckTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
-        new Map(),
-    );
+    const interactionAckTimersRef = useRef<
+        Map<string, ReturnType<typeof setTimeout>>
+    >(new Map());
 
     // Cache min turn ID for cursor-based pagination (avoid O(n) scan on each load)
     const minIdRef = useRef<number>(0);
@@ -429,7 +507,6 @@ export function useHotPlexRuntime({
                 ]);
             });
         return () => controller.abort();
-         
     }, [sessionId]);
 
     // Initialize WebSocket client
@@ -479,6 +556,7 @@ export function useHotPlexRuntime({
         // Track the streaming fallback message ID (created by delta/reasoning before messageStart).
         // Used by handleMessage to adopt the fallback instead of creating a duplicate (#331).
         let streamingFallbackId: string | null = null;
+        const processedDoneEventIds = new Set<string>();
 
         // Append delta content to the last text part of the last assistant message
         const appendDelta = (content: string) => {
@@ -532,6 +610,7 @@ export function useHotPlexRuntime({
         // Handle reasoning/thinking content (appends to last reasoning part or creates one)
         const handleReasoning = (data: ReasoningData, _env: Envelope) => {
             if (!data) return;
+            turnActiveRef.current = true;
 
             setMessages((prev) => {
                 const pending = updatePendingAssistant(
@@ -540,7 +619,10 @@ export function useHotPlexRuntime({
                     (message) => ({
                         ...message,
                         progress: undefined,
-                        parts: appendReasoningDelta(message.parts, data.content || ""),
+                        parts: appendReasoningDelta(
+                            message.parts,
+                            data.content || "",
+                        ),
                     }),
                 );
                 if (pending !== prev) {
@@ -578,6 +660,7 @@ export function useHotPlexRuntime({
 
         const handleDelta = (data: MessageDeltaData, _env: Envelope) => {
             if (!data) return;
+            turnActiveRef.current = true;
             // Synchronous commit — no RAF batching (see note above appendDelta).
             appendDelta(data.content || "");
         };
@@ -647,7 +730,6 @@ export function useHotPlexRuntime({
                     },
                 ];
             });
-            setIsRunning(false);
         };
 
         const handleToolCall = (data: ToolCallData, _env: Envelope) => {
@@ -710,9 +792,36 @@ export function useHotPlexRuntime({
             });
         };
 
-        const handleDone = (data: DoneData, _env: Envelope) => {
+        const handleDone = (data: DoneData, env: Envelope) => {
+            if (processedDoneEventIds.has(env.id)) return;
+            processedDoneEventIds.add(env.id);
+            if (processedDoneEventIds.size > 256) {
+                const oldest = processedDoneEventIds.values().next().value;
+                if (oldest) processedDoneEventIds.delete(oldest);
+            }
             streamingFallbackId = null;
+            turnActiveRef.current = false;
+            const queuedDispatch = activeQueueDispatchRef.current;
+            const convergedUnknown = queuedDispatch?.outcomeUnknown === true;
+            if (queuedDispatch?.outcomeUnknown) {
+                queueStore.remove(
+                    queuedDispatch.sessionId,
+                    queuedDispatch.itemId,
+                );
+                activeQueueDispatchRef.current = null;
+            } else if (queuedDispatch && !queuedDispatch.delivered) {
+                failActiveQueueDispatchRef.current(
+                    "unknown",
+                    "Turn completed before delivery was confirmed",
+                );
+            } else {
+                activeQueueDispatchRef.current = null;
+            }
             const pendingAssistantID = pendingAssistantIdRef.current;
+            const reconciliationTargetID =
+                queuedDispatch?.assistantMessageId ??
+                pendingAssistantID ??
+                activeAssistantIdRef.current;
             pendingAssistantIdRef.current = null;
             activeAssistantIdRef.current = null;
             activeInputMessageIdRef.current = null;
@@ -724,7 +833,44 @@ export function useHotPlexRuntime({
             }
 
             setMessages((prev) => {
-                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                if (convergedUnknown) {
+                    const convergenceAssistantID =
+                        queuedDispatch?.assistantMessageId;
+                    const assistantIndex = prev.findIndex(
+                        (message) =>
+                            message.id === convergenceAssistantID &&
+                            message.role === "assistant",
+                    );
+                    if (assistantIndex === -1) return prev;
+                    const message = prev[assistantIndex];
+                    const parts = message.parts.map((part) =>
+                        part.type === "tool-call" &&
+                        (!part.status || part.status.type === "running")
+                            ? {
+                                  ...part,
+                                  status: { type: "complete" as const },
+                              }
+                            : part,
+                    );
+                    if (data?.stats?._session) {
+                        parts.push({
+                            type: "turn-summary" as const,
+                            data: data.stats._session,
+                        });
+                    }
+                    const next = [...prev];
+                    next[assistantIndex] = {
+                        ...message,
+                        status: "complete" as const,
+                        progress: undefined,
+                        parts,
+                    };
+                    return next;
+                }
+                const withoutPending = removePendingAssistant(
+                    prev,
+                    pendingAssistantID,
+                );
                 if (withoutPending !== prev) {
                     return withoutPending;
                 }
@@ -758,17 +904,17 @@ export function useHotPlexRuntime({
                 return prev;
             });
 
-            if (cancelTimeoutRef.current) {
-                clearTimeout(cancelTimeoutRef.current);
-                cancelTimeoutRef.current = null;
-            }
             setIsRunning(false);
             setIsStopping(false);
             stoppingRef.current = false;
+            queueMicrotask(() => scheduleQueueDrainRef.current());
 
             // Fetch skills after the first turn completes (worker conversation is now active)
             // Skip if the turn was stopped by the user, since the worker is detached.
-            if (!skillsFetchedRef.current && data?.reason !== "stopped_by_user") {
+            if (
+                !skillsFetchedRef.current &&
+                data?.reason !== "stopped_by_user"
+            ) {
                 skillsFetchedRef.current = true;
                 try {
                     client.sendWorkerCommand(WorkerStdioCommand.Skills);
@@ -784,7 +930,10 @@ export function useHotPlexRuntime({
             // one cheap REST call). reconcileTurnContent has prefix + length
             // guards that make it a no-op when streaming was complete, so an
             // unconditional trigger is safe and correct.
-            void reconcileTurnContent();
+            void reconcileTurnContent({
+                targetAssistantId: reconciliationTargetID,
+                terminalSeq: env.seq,
+            });
         };
 
         // Re-fetch the authoritative content for the just-completed turn and
@@ -795,21 +944,29 @@ export function useHotPlexRuntime({
         // The trade-off is write latency: captureAssistantTurn enqueues the
         // record on done, but the collector flushes async (~1s batch interval),
         // so the first fetch may miss it. We retry once after a short delay.
-        const reconcileTurnContent = async () => {
+        const reconcileTurnContent = async ({
+            targetAssistantId,
+            terminalSeq,
+            inputContent,
+        }: {
+            targetAssistantId: string | null;
+            terminalSeq?: number;
+            inputContent?: string;
+        }) => {
             const sid = sessionIdRef.current;
-            if (!sid) return;
-            const fetchLastAssistantContent = async (): Promise<string | null> => {
-                // history returns ASC by id; the latest assistant turn (if any)
-                // is the last assistant record in the page. A small limit is
-                // enough — we only need the most recent turn.
-                const res = await getSessionHistory(sid, { limit: 5 });
-                for (let i = res.records.length - 1; i >= 0; i--) {
-                    const rec = res.records[i];
-                    if (rec.role === "assistant" && rec.content) {
-                        return rec.content;
-                    }
+            if (!sid || !targetAssistantId) return;
+            const fetchLastAssistantContent = async (): Promise<
+                string | null
+            > => {
+                const res = await getSessionHistory(sid, { limit: 20 });
+                if (terminalSeq !== undefined) {
+                    return selectAuthoritativeAssistantContent(res.records, {
+                        terminalSeq,
+                    });
                 }
-                return null;
+                return selectAuthoritativeAssistantContent(res.records, {
+                    inputContent: inputContent ?? "",
+                });
             };
             try {
                 let fullText = await fetchLastAssistantContent();
@@ -823,42 +980,17 @@ export function useHotPlexRuntime({
                 }
                 if (!fullText || cancelled) return;
                 const full = fullText; // const for closure narrowing (no `!` needed)
-                setMessages((prev) => {
-                    const last = prev[prev.length - 1];
-                    if (last?.role !== "assistant") return prev;
-                    const currentText = concatTextParts(last.parts);
-                    // The streamed text must be a prefix of the authoritative
-                    // text — deltas are appended sequentially, so a dropped tail
-                    // means the authoritative version is the streamed prefix +
-                    // the missing suffix. If the prefix doesn't match, the
-                    // fetched record belongs to a DIFFERENT turn (collector
-                    // latency exceeded the retry, returning the previous turn's
-                    // record) — refuse to patch rather than overwrite with
-                    // wrong-turn content.
-                    if (currentText.length > 0 && !full.startsWith(currentText)) {
-                        return prev;
-                    }
-                    // Only patch if authoritative is longer (deltas really lost).
-                    if (full.length <= currentText.length) return prev;
-                    // Replace ALL text parts with the single authoritative text,
-                    // keeping the position of the first text part. A streaming
-                    // message can have interleaved [text, tool-call, text] parts
-                    // (text before and after a tool call). Patching only the
-                    // first text part would leave the trailing partial text part
-                    // in place, duplicating content. Collapse all text into one.
-                    const firstTextIdx = last.parts.findIndex((p) => p.type === "text");
-                    const nonTextParts: MessagePart[] = last.parts.filter((p) => p.type !== "text");
-                    const insertIdx = firstTextIdx === -1 ? 0 : firstTextIdx;
-                    const parts = [...nonTextParts];
-                    parts.splice(insertIdx, 0, { type: "text", text: full });
-                    return [...prev.slice(0, -1), { ...last, parts }];
-                });
-            } catch (err) {
-                logger.warn(
-                    "RuntimeAdapter",
-                    "Reconcile turn content failed",
-                    { error: String(err) },
+                setMessages((previous) =>
+                    patchAuthoritativeAssistantContent(
+                        previous,
+                        targetAssistantId,
+                        full,
+                    ),
                 );
+            } catch (err) {
+                logger.warn("RuntimeAdapter", "Reconcile turn content failed", {
+                    error: String(err),
+                });
             }
         };
 
@@ -874,38 +1006,51 @@ export function useHotPlexRuntime({
                 clearTimeout(timer);
                 interactionAckTimersRef.current.delete(requestId);
             }
-            setMessages((prev) => prev.map((msg) => {
-                if (msg.role !== "assistant") return msg;
-                let found = false;
-                const parts = msg.parts.map((part) => {
-                    if (part.type !== "tool-call" || part.toolCallId !== requestId) {
-                        return part;
-                    }
-                    const interaction = part.args?.interaction;
-                    if (!interaction || (onlySubmitting && interaction.status !== "submitting")) {
-                        return part;
-                    }
-                    found = true;
-                    return {
-                        ...part,
-                        args: {
-                            ...part.args,
-                            interaction: {
-                                ...interaction,
-                                status,
-                                response,
-                                error,
+            setMessages((prev) =>
+                prev.map((msg) => {
+                    if (msg.role !== "assistant") return msg;
+                    let found = false;
+                    const parts = msg.parts.map((part) => {
+                        if (
+                            part.type !== "tool-call" ||
+                            part.toolCallId !== requestId
+                        ) {
+                            return part;
+                        }
+                        const interaction = part.args?.interaction;
+                        if (
+                            !interaction ||
+                            (onlySubmitting &&
+                                interaction.status !== "submitting")
+                        ) {
+                            return part;
+                        }
+                        found = true;
+                        return {
+                            ...part,
+                            args: {
+                                ...part.args,
+                                interaction: {
+                                    ...interaction,
+                                    status,
+                                    response,
+                                    error,
+                                },
                             },
-                        },
-                    };
-                });
-                return found ? { ...msg, parts } : msg;
-            }));
+                        };
+                    });
+                    return found ? { ...msg, parts } : msg;
+                }),
+            );
         };
 
         const handlePermissionResponse = (data: PermissionResponseData) => {
             if (!data?.id) return;
-            updateInteractionState(data.id, data.allowed ? "resolved" : "rejected", data);
+            updateInteractionState(
+                data.id,
+                data.allowed ? "resolved" : "rejected",
+                data,
+            );
             interactionMapRef.current.delete(data.id);
         };
 
@@ -917,7 +1062,11 @@ export function useHotPlexRuntime({
 
         const handleElicitationResponse = (data: ElicitationResponseData) => {
             if (!data?.id) return;
-            updateInteractionState(data.id, data.action === "accept" ? "resolved" : "rejected", data);
+            updateInteractionState(
+                data.id,
+                data.action === "accept" ? "resolved" : "rejected",
+                data,
+            );
             interactionMapRef.current.delete(data.id);
         };
 
@@ -934,8 +1083,9 @@ export function useHotPlexRuntime({
             }
 
             // Mark any submitting interaction as failed if this is an interaction error
-            const isInteractionError = (data?.message || "").includes("worker response failed") || 
-                                       (data?.message || "").includes("invalid response data");
+            const isInteractionError =
+                (data?.message || "").includes("worker response failed") ||
+                (data?.message || "").includes("invalid response data");
             if (isInteractionError) {
                 const reqId = env?.metadata?.interaction_error?.request_id;
                 if (reqId) {
@@ -948,6 +1098,23 @@ export function useHotPlexRuntime({
                 }
             }
 
+            const queuedDispatch = activeQueueDispatchRef.current;
+            if (
+                !isInteractionError &&
+                queuedDispatch &&
+                !queuedDispatch.delivered
+            ) {
+                logger.warn("RuntimeAdapter", "Queued input delivery failed", {
+                    code: data?.code || "unknown",
+                    eventId: env?.id,
+                });
+                failActiveQueueDispatchRef.current(
+                    isBusy ? "busy" : "send",
+                    data?.code || data?.message || "Input delivery failed",
+                );
+                return;
+            }
+
             const isResumeRetry = (data?.code as string) === "RESUME_RETRY";
             const isShutdown = (data?.message || "").includes(
                 "during shutdown",
@@ -956,8 +1123,7 @@ export function useHotPlexRuntime({
                 (data?.code as string) === "SESSION_TERMINATED";
             // CONFIG_INVALID is a user-command rejection (e.g. /cd on a
             // workspace-bound session), not a runtime fault — warn, don't error.
-            const isConfigInvalid =
-                (data?.code as string) === "CONFIG_INVALID";
+            const isConfigInvalid = (data?.code as string) === "CONFIG_INVALID";
 
             // SESSION_BUSY is a transient state handled internally by auto-retry, so do not show it to the user and don't log as error.
             if (isBusy) {
@@ -967,6 +1133,8 @@ export function useHotPlexRuntime({
             // SESSION_TERMINATED is a normal lifecycle event (user cancelled or server stopped).
             // Don't pollute the chat with error messages; just mark the run as stopped.
             if (isTerminated) {
+                turnActiveRef.current = false;
+                activeQueueDispatchRef.current = null;
                 setIsRunning(false);
                 const pendingAssistantID = pendingAssistantIdRef.current;
                 const activeAssistantID = activeAssistantIdRef.current;
@@ -974,11 +1142,17 @@ export function useHotPlexRuntime({
                 activeAssistantIdRef.current = null;
                 activeInputMessageIdRef.current = null;
                 setMessages((prev) => {
-                    const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                    const withoutPending = removePendingAssistant(
+                        prev,
+                        pendingAssistantID,
+                    );
                     if (withoutPending !== prev) {
                         return withoutPending;
                     }
-                    const completed = completeStreamingAssistant(prev, activeAssistantID);
+                    const completed = completeStreamingAssistant(
+                        prev,
+                        activeAssistantID,
+                    );
                     if (completed !== prev) {
                         return completed;
                     }
@@ -1011,6 +1185,7 @@ export function useHotPlexRuntime({
                 logger.info("RuntimeAdapter", "Session terminated", {
                     reason: data?.message,
                 });
+                queueMicrotask(() => scheduleQueueDrainRef.current());
                 return;
             }
 
@@ -1074,6 +1249,8 @@ export function useHotPlexRuntime({
 
             // If it's a fatal error, stop the run and complete the streaming message
             if (!isResumeRetry) {
+                turnActiveRef.current = false;
+                activeQueueDispatchRef.current = null;
                 setIsRunning(false);
                 const pendingAssistantID = pendingAssistantIdRef.current;
                 const activeAssistantID = activeAssistantIdRef.current;
@@ -1082,11 +1259,17 @@ export function useHotPlexRuntime({
                 activeInputMessageIdRef.current = null;
 
                 setMessages((prev) => {
-                    const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                    const withoutPending = removePendingAssistant(
+                        prev,
+                        pendingAssistantID,
+                    );
                     if (withoutPending !== prev) {
                         return withoutPending;
                     }
-                    const completed = completeStreamingAssistant(prev, activeAssistantID);
+                    const completed = completeStreamingAssistant(
+                        prev,
+                        activeAssistantID,
+                    );
                     if (completed !== prev) {
                         return completed;
                     }
@@ -1116,6 +1299,7 @@ export function useHotPlexRuntime({
                     }
                     return prev;
                 });
+                queueMicrotask(() => scheduleQueueDrainRef.current());
             }
 
             let errorMessage = data?.message;
@@ -1172,6 +1356,10 @@ export function useHotPlexRuntime({
 
         const handleDisconnected = (reason: string) => {
             logger.info("RuntimeAdapter", "Disconnected", { reason });
+            failActiveQueueDispatchRef.current(
+                "connection",
+                reason || "Disconnected",
+            );
             for (const requestId of interactionMapRef.current.keys()) {
                 updateInteractionState(
                     requestId,
@@ -1188,7 +1376,10 @@ export function useHotPlexRuntime({
             activeAssistantIdRef.current = null;
             activeInputMessageIdRef.current = null;
             setMessages((prev) => {
-                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                const withoutPending = removePendingAssistant(
+                    prev,
+                    pendingAssistantID,
+                );
                 return withoutPending !== prev
                     ? withoutPending
                     : completeStreamingAssistant(prev, activeAssistantID);
@@ -1200,6 +1391,10 @@ export function useHotPlexRuntime({
 
         const handleSessionAlreadyConnected = () => {
             sessionAlreadyConnectedRef.current = true;
+            failActiveQueueDispatchRef.current(
+                "connection",
+                "Session is connected elsewhere",
+            );
             setIsRunning(false);
             setConnectionState("already_connected");
         };
@@ -1210,7 +1405,13 @@ export function useHotPlexRuntime({
         };
 
         const handleReconnectFailed = (attempt: number) => {
-            logger.warn("RuntimeAdapter", "Reconnect attempts exhausted", { attempt });
+            logger.warn("RuntimeAdapter", "Reconnect attempts exhausted", {
+                attempt,
+            });
+            failActiveQueueDispatchRef.current(
+                "connection",
+                "Reconnect attempts exhausted",
+            );
             setIsRunning(false);
             const pendingAssistantID = pendingAssistantIdRef.current;
             const activeAssistantID = activeAssistantIdRef.current;
@@ -1218,7 +1419,10 @@ export function useHotPlexRuntime({
             activeAssistantIdRef.current = null;
             activeInputMessageIdRef.current = null;
             setMessages((prev) => {
-                const withoutPending = removePendingAssistant(prev, pendingAssistantID);
+                const withoutPending = removePendingAssistant(
+                    prev,
+                    pendingAssistantID,
+                );
                 return withoutPending !== prev
                     ? withoutPending
                     : completeStreamingAssistant(prev, activeAssistantID);
@@ -1231,6 +1435,7 @@ export function useHotPlexRuntime({
         // causes assistant-ui MessageRepository orphaned-node crash (#331).
         const handleMessageStart = (data: MessageStartData, env: Envelope) => {
             if (!data) return;
+            turnActiveRef.current = true;
             setMessages((prev) => {
                 const pending = updatePendingAssistant(
                     prev,
@@ -1283,8 +1488,46 @@ export function useHotPlexRuntime({
         // / restart), so without this handler the UI would spin forever on a
         // turn whose outcome is ambiguous.
         const handleInputAck = (data: InputAckData) => {
-            if (!matchesActiveInput(activeInputMessageIdRef.current, data.client_message_id)) {
+            const queuedDispatch = activeQueueDispatchRef.current;
+            const matchesQueuedDispatch =
+                queuedDispatch?.clientMessageId === data.client_message_id;
+            if (
+                !matchesActiveInput(
+                    activeInputMessageIdRef.current,
+                    data.client_message_id,
+                ) &&
+                !matchesQueuedDispatch
+            ) {
                 return;
+            }
+            if (queuedDispatch && matchesQueuedDispatch) {
+                if (data.status === "delivered") {
+                    const wasUnknown = queuedDispatch.outcomeUnknown === true;
+                    const deliveredItem = queueStore.markDelivered(
+                        queuedDispatch.sessionId,
+                        data.client_message_id,
+                    );
+                    if (deliveredItem) {
+                        queuedDispatch.delivered = true;
+                        queuedDispatch.outcomeUnknown = false;
+                        if (wasUnknown) {
+                            turnActiveRef.current = true;
+                            setIsRunning(true);
+                        }
+                    }
+                } else if (data.status === "unknown") {
+                    failActiveQueueDispatchRef.current(
+                        "unknown",
+                        data.error_code || "Input outcome is unknown",
+                    );
+                    return;
+                } else if (data.status === "failed") {
+                    failActiveQueueDispatchRef.current(
+                        "send",
+                        data.error_code || "Input delivery failed",
+                    );
+                    return;
+                }
             }
             if (data.status === "accepted" || data.status === "delivered") {
                 setMessages((prev) =>
@@ -1331,6 +1574,53 @@ export function useHotPlexRuntime({
         };
 
         // Subscribe to events
+        const handleConnected = (ack: { state?: string }) => {
+            sessionAlreadyConnectedRef.current = false;
+            setConnectionState("connected");
+            const turnIsRunning = ack.state === "running";
+            turnActiveRef.current = turnIsRunning;
+            setIsRunning(turnIsRunning);
+            if (!turnIsRunning) {
+                let drainDeferredForReconcile = false;
+                // A reconnect can miss the terminal Done after the queued input
+                // was already acknowledged as delivered. The init ACK is the
+                // authoritative session state, so idle completes that local
+                // association and allows the next FIFO item to drain.
+                const deliveredDispatch = activeQueueDispatchRef.current;
+                if (deliveredDispatch?.delivered) {
+                    const pendingAssistantID = pendingAssistantIdRef.current;
+                    const activeAssistantID = activeAssistantIdRef.current;
+                    activeQueueDispatchRef.current = null;
+                    pendingAssistantIdRef.current = null;
+                    activeAssistantIdRef.current = null;
+                    activeInputMessageIdRef.current = null;
+                    setMessages((previous) => {
+                        const completedPending = completeStreamingAssistant(
+                            previous,
+                            pendingAssistantID,
+                        );
+                        return completedPending !== previous
+                            ? completedPending
+                            : completeStreamingAssistant(
+                                  previous,
+                                  activeAssistantID,
+                              );
+                    });
+                    drainDeferredForReconcile = true;
+                    void reconcileTurnContent({
+                        targetAssistantId: deliveredDispatch.assistantMessageId,
+                        inputContent: deliveredDispatch.text,
+                    }).finally(() => scheduleQueueDrainRef.current());
+                }
+                setIsStopping(false);
+                stoppingRef.current = false;
+                if (!drainDeferredForReconcile) {
+                    queueMicrotask(() => scheduleQueueDrainRef.current());
+                }
+            }
+        };
+
+        client.on("connected", handleConnected);
         client.on("delta", handleDelta);
         client.on("message", handleMessage);
         client.on("inputAck", handleInputAck);
@@ -1344,9 +1634,11 @@ export function useHotPlexRuntime({
         client.on("messageStart", handleMessageStart);
         client.on("toolCall", handleToolCall);
         client.on("toolResult", handleToolResult);
-        client.on("state", (data: { state: string }) => {
+        const handleState = (data: { state: string }) => {
             onSessionStateChangeRef.current?.(data.state);
-        });
+            if (data.state === "running") turnActiveRef.current = true;
+        };
+        client.on("state", handleState);
 
         const handleContextUsage = (data: ContextUsageData) => {
             const names = data?.skills?.names ?? [];
@@ -1414,7 +1706,8 @@ export function useHotPlexRuntime({
                                             requestId: data.id,
                                             status: "pending",
                                             createdAt: Date.now(),
-                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                            expiresAt:
+                                                Date.now() + 5 * 60 * 1000,
                                         },
                                     },
                                     toolCallId: data.id,
@@ -1457,7 +1750,8 @@ export function useHotPlexRuntime({
                                             requestId: data.id,
                                             status: "pending",
                                             createdAt: Date.now(),
-                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                            expiresAt:
+                                                Date.now() + 5 * 60 * 1000,
                                         },
                                     },
                                     toolCallId: data.id,
@@ -1499,7 +1793,8 @@ export function useHotPlexRuntime({
                                             requestId: data.id,
                                             status: "pending",
                                             createdAt: Date.now(),
-                                            expiresAt: Date.now() + 5 * 60 * 1000,
+                                            expiresAt:
+                                                Date.now() + 5 * 60 * 1000,
                                         },
                                     },
                                     toolCallId: data.id,
@@ -1518,10 +1813,7 @@ export function useHotPlexRuntime({
         setConnectionState("connecting");
         client
             .connect(sessionId)
-            .then(() => {
-                sessionAlreadyConnectedRef.current = false;
-                setConnectionState("connected");
-            })
+            .then(() => undefined)
             .catch((err) => {
                 if (sessionAlreadyConnectedRef.current) {
                     logger.info("RuntimeAdapter", "Session already connected", {
@@ -1554,12 +1846,25 @@ export function useHotPlexRuntime({
             // Mark this effect instance as torn down so async paths
             // (reconcileTurnContent) skip their setMessages after unmount.
             cancelled = true;
+            const activeQueueDispatch = activeQueueDispatchRef.current;
+            if (activeQueueDispatch && !activeQueueDispatch.delivered) {
+                failActiveQueueDispatchRef.current(
+                    "connection",
+                    "Session connection was replaced",
+                );
+            }
+            activeQueueDispatchRef.current = null;
+            turnActiveRef.current = false;
+            client.off("connected", handleConnected);
             client.off("delta", handleDelta);
             client.off("message", handleMessage);
             client.off("inputAck", handleInputAck);
             client.off("done", handleDone);
             client.off("error", handleError);
-            client.off("sessionAlreadyConnected", handleSessionAlreadyConnected);
+            client.off(
+                "sessionAlreadyConnected",
+                handleSessionAlreadyConnected,
+            );
             client.off("disconnected", handleDisconnected);
             client.off("reconnecting", handleReconnecting);
             client.off("reconnect_failed", handleReconnectFailed);
@@ -1567,6 +1872,7 @@ export function useHotPlexRuntime({
             client.off("messageStart", handleMessageStart);
             client.off("toolCall", handleToolCall);
             client.off("toolResult", handleToolResult);
+            client.off("state", handleState);
             client.off("contextUsage", handleContextUsage);
             client.off("skillsList", handleSkillsList);
             client.off("permissionRequest", handlePermissionRequest);
@@ -1607,176 +1913,404 @@ export function useHotPlexRuntime({
         };
     }, []);
 
-    // Handler for new messages (from assistant-ui Composer)
-    // NOTE: reads client.connected directly from ref to avoid stale closure with isConnected state
-    const handleNew = useCallback(async (message: AppendMessage) => {
-        const client = clientRef.current;
-        if (!client) {
-            throw new Error("HotPlex client not initialized.");
-        }
-
-        const textContent = Array.isArray(message.content)
-            ? message.content
-                  .filter(
-                      (part): part is { type: "text"; text: string } =>
-                          part.type === "text",
-                  )
-                  .map((part) => part.text)
-                  .join("")
-            : "";
-        if (!textContent.trim()) {
-            return;
-        }
-
-        const userMessage: HotPlexMessage = {
-            id: `user-${Date.now()}`,
-            role: "user",
-            parts: [{ type: "text", text: textContent }],
-            createdAt: new Date(),
-            status: "complete",
-        };
-        const assistantID = `assistant-local-${Date.now()}`;
-        const pendingAssistant = createPendingAssistantMessage(
-            assistantID,
-            new Date(),
-        );
-        const rollbackOptimisticInput = () => {
-            pendingAssistantIdRef.current = null;
-            activeAssistantIdRef.current = null;
-            activeInputMessageIdRef.current = null;
-            setIsRunning(false);
-            setMessages((prev) =>
-                prev.filter(
-                    (current) =>
-                        current.id !== userMessage.id &&
-                        current.id !== assistantID,
-                ),
+    const dispatchInput = useCallback(
+        async (textContent: string, queueItemId?: string): Promise<string> => {
+            const client = clientRef.current;
+            if (!client) {
+                throw new Error("HotPlex client not initialized.");
+            }
+            const localId =
+                queueItemId ??
+                `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            const userMessage: HotPlexMessage = {
+                id: `user-${localId}`,
+                role: "user",
+                parts: [{ type: "text", text: textContent }],
+                createdAt: new Date(),
+                status: "complete",
+            };
+            const assistantID = `assistant-local-${localId}`;
+            const pendingAssistant = createPendingAssistantMessage(
+                assistantID,
+                new Date(),
             );
-        };
-
-        // Insert feedback before reconnecting: WebSocket recovery can take
-        // seconds, but it must not create a blank interval in the thread.
-        pendingAssistantIdRef.current = assistantID;
-        activeAssistantIdRef.current = assistantID;
-        activeInputMessageIdRef.current = null;
-        setMessages((prev) => [...prev, userMessage, pendingAssistant]);
-        setIsRunning(true);
-        startTurn();
-
-        // Handle disconnected state: attempt to reconnect if not already connecting
-        if (!client.connected) {
-            logger.info(
-                "RuntimeAdapter",
-                "Client not connected, attempting reconnect",
-            );
-            try {
-                if (!client.connecting) {
-                    // Don't pass sessionId here — the client internally tracks the latest session ID,
-                    // which may have been updated by a SessionNotFound retry in BrowserHotPlexClient.
-                    client.connect().catch((err) => {
-                        logger.error("RuntimeAdapter", "Auto-connect failed", {
-                            error: String(err),
-                        });
-                    });
+            const rollbackOptimisticInput = () => {
+                if (activeQueueDispatchRef.current?.itemId === queueItemId) {
+                    activeQueueDispatchRef.current = null;
                 }
+                pendingAssistantIdRef.current = null;
+                activeAssistantIdRef.current = null;
+                activeInputMessageIdRef.current = null;
+                turnActiveRef.current = false;
+                setIsRunning(false);
+                setMessages((prev) =>
+                    prev.filter(
+                        (current) =>
+                            current.id !== userMessage.id &&
+                            current.id !== assistantID,
+                    ),
+                );
+            };
 
-                // Wait for connection (up to 30s)
-                await new Promise<void>((resolve, reject) => {
-                    let settled = false;
-                    const settle = (fn: () => void) => {
-                        if (settled) return;
-                        settled = true;
-                        clearTimeout(timeout);
-                        client.off("connected", onConnected);
-                        client.off("disconnected", onDisconnected);
-                        connectionWaitRef.current = null;
-                        fn();
-                    };
+            // Insert feedback before reconnecting: WebSocket recovery can take
+            // seconds, but it must not create a blank interval in the thread.
+            pendingAssistantIdRef.current = assistantID;
+            activeAssistantIdRef.current = assistantID;
+            activeInputMessageIdRef.current = null;
+            turnActiveRef.current = true;
+            if (queueItemId && sessionIdRef.current) {
+                activeQueueDispatchRef.current = {
+                    sessionId: sessionIdRef.current,
+                    itemId: queueItemId,
+                    userMessageId: userMessage.id,
+                    assistantMessageId: assistantID,
+                    delivered: false,
+                    text: textContent,
+                };
+            }
+            setMessages((prev) => [...prev, userMessage, pendingAssistant]);
+            setIsRunning(true);
+            startTurn();
 
-                    const timeout = setTimeout(() => {
-                        settle(() =>
-                            reject(
-                                new Error(
-                                    "Connection timeout. Please check your network.",
-                                ),
-                            ),
-                        );
-                    }, 30000);
-
-                    const onConnected = () => {
-                        settle(() => resolve());
-                    };
-                    const onDisconnected = (reason: string) => {
-                        settle(() =>
-                            reject(new Error(`Connection failed: ${reason}`)),
-                        );
-                    };
-
-                    connectionWaitRef.current = {
-                        timeout,
-                        onConnected,
-                        onDisconnected,
-                    };
-                    client.on("connected", onConnected);
-                    client.on("disconnected", onDisconnected);
-
-                    // Check if it connected while we were setting up listeners
-                    if (client.connected) {
-                        settle(() => resolve());
+            // Handle disconnected state: attempt to reconnect if not already connecting
+            if (!client.connected) {
+                logger.info(
+                    "RuntimeAdapter",
+                    "Client not connected, attempting reconnect",
+                );
+                try {
+                    if (!client.connecting) {
+                        // Don't pass sessionId here — the client internally tracks the latest session ID,
+                        // which may have been updated by a SessionNotFound retry in BrowserHotPlexClient.
+                        client.connect().catch((err) => {
+                            logger.error(
+                                "RuntimeAdapter",
+                                "Auto-connect failed",
+                                {
+                                    error: String(err),
+                                },
+                            );
+                        });
                     }
-                });
+
+                    // Wait for connection (up to 30s)
+                    await new Promise<void>((resolve, reject) => {
+                        let settled = false;
+                        const settle = (fn: () => void) => {
+                            if (settled) return;
+                            settled = true;
+                            clearTimeout(timeout);
+                            client.off("connected", onConnected);
+                            client.off("disconnected", onDisconnected);
+                            connectionWaitRef.current = null;
+                            fn();
+                        };
+
+                        const timeout = setTimeout(() => {
+                            settle(() =>
+                                reject(
+                                    new Error(
+                                        "Connection timeout. Please check your network.",
+                                    ),
+                                ),
+                            );
+                        }, 30000);
+
+                        const onConnected = () => {
+                            settle(() => resolve());
+                        };
+                        const onDisconnected = (reason: string) => {
+                            settle(() =>
+                                reject(
+                                    new Error(`Connection failed: ${reason}`),
+                                ),
+                            );
+                        };
+
+                        connectionWaitRef.current = {
+                            timeout,
+                            onConnected,
+                            onDisconnected,
+                        };
+                        client.on("connected", onConnected);
+                        client.on("disconnected", onDisconnected);
+
+                        // Check if it connected while we were setting up listeners
+                        if (client.connected) {
+                            settle(() => resolve());
+                        }
+                    });
+                } catch (err) {
+                    rollbackOptimisticInput();
+                    throw new Error(
+                        err instanceof Error
+                            ? err.message
+                            : "HotPlex client not connected. Please check your network.",
+                    );
+                }
+            }
+
+            // Send to HotPlex gateway with error handling
+            try {
+                const clientMessageId = client.sendInput(textContent);
+                activeInputMessageIdRef.current = clientMessageId;
+                const activeQueueDispatch = activeQueueDispatchRef.current;
+                if (
+                    queueItemId &&
+                    activeQueueDispatch?.itemId === queueItemId &&
+                    activeQueueDispatch.sessionId === sessionIdRef.current
+                ) {
+                    activeQueueDispatch.clientMessageId = clientMessageId;
+                    if (
+                        !queueStore.attachClientMessageId(
+                            activeQueueDispatch.sessionId,
+                            queueItemId,
+                            clientMessageId,
+                        )
+                    ) {
+                        failActiveQueueDispatchRef.current(
+                            "unknown",
+                            "Queue dispatch correlation was lost",
+                        );
+                        throw new Error("Queue dispatch correlation was lost");
+                    }
+                }
+                return clientMessageId;
             } catch (err) {
                 rollbackOptimisticInput();
-                throw new Error(
-                    err instanceof Error
-                        ? err.message
-                        : "HotPlex client not connected. Please check your network.",
-                );
+                throw err;
             }
-        }
+        },
+        [queueStore, startTurn],
+    );
 
-        // Send to HotPlex gateway with error handling
-        try {
-            activeInputMessageIdRef.current = client.sendInput(textContent);
-        } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
-            rollbackOptimisticInput();
-            if (errMsg === "Input already pending") {
-                // A previous turn is still in flight (often an unknown-outcome
-                // tombstone). This is not a connection fault.
-                logger.warn("RuntimeAdapter", "sendInput blocked: input already pending");
-                throw new Error(i18n.t("chat:error.input_still_processing"));
-            }
-            logger.error("RuntimeAdapter", "sendInput failed", {
-                error: errMsg,
-            });
-            throw new Error(i18n.t("chat:error.send_failed_connection"));
+    const drainQueue = useCallback(async () => {
+        if (drainInFlightRef.current) return;
+        const sid = sessionIdRef.current;
+        const client = clientRef.current;
+        if (
+            !sid ||
+            !client?.connected ||
+            turnActiveRef.current ||
+            stoppingRef.current ||
+            activeQueueDispatchRef.current
+        ) {
+            return;
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- stable send action; startTurn is a stable callback
+        const item = queueStore.peekDispatchable(sid);
+        if (!item || !queueStore.markSending(sid, item.id)) return;
+
+        drainInFlightRef.current = true;
+        try {
+            await dispatchInput(item.text, item.id);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!failActiveQueueDispatchRef.current("send", message)) {
+                queueStore.markFailed(sid, item.id, "send", message);
+            }
+        } finally {
+            drainInFlightRef.current = false;
+        }
+    }, [dispatchInput, queueStore]);
+
+    scheduleQueueDrainRef.current = () => {
+        queueMicrotask(() => void drainQueue());
+    };
+
+    const enqueueFollowUp = useCallback(
+        (text: string) => {
+            const sid = sessionIdRef.current;
+            if (!sid) return { ok: false, reason: "blank" } as const;
+            const result = queueStore.enqueue(sid, text);
+            if (result.ok && !turnActiveRef.current && !stoppingRef.current) {
+                scheduleQueueDrainRef.current();
+            }
+            return result;
+        },
+        [queueStore],
+    );
+
+    const updateFollowUp = useCallback(
+        (itemId: string, text: string) => {
+            const sid = sessionIdRef.current;
+            return sid ? queueStore.updateText(sid, itemId, text) : false;
+        },
+        [queueStore],
+    );
+
+    const releaseUnknownQueueDispatch = useCallback((itemId: string) => {
+        const active = activeQueueDispatchRef.current;
+        if (active?.itemId === itemId && active.outcomeUnknown) {
+            activeQueueDispatchRef.current = null;
+            if (pendingAssistantIdRef.current === active.assistantMessageId) {
+                pendingAssistantIdRef.current = null;
+            }
+            if (activeAssistantIdRef.current === active.assistantMessageId) {
+                activeAssistantIdRef.current = null;
+            }
+            activeInputMessageIdRef.current = null;
+            setMessages((previous) =>
+                previous.filter(
+                    (message) =>
+                        message.id !== active.userMessageId &&
+                        message.id !== active.assistantMessageId,
+                ),
+            );
+            clientRef.current?.acknowledgeUnknownInputForRetry();
+        }
     }, []);
+
+    const removeFollowUp = useCallback(
+        (itemId: string) => {
+            const sid = sessionIdRef.current;
+            if (!sid || !queueStore.remove(sid, itemId)) return false;
+            releaseUnknownQueueDispatch(itemId);
+            if (!turnActiveRef.current && !stoppingRef.current) {
+                scheduleQueueDrainRef.current();
+            }
+            return true;
+        },
+        [queueStore, releaseUnknownQueueDispatch],
+    );
+
+    const retryFollowUp = useCallback(
+        (itemId: string) => {
+            const sid = sessionIdRef.current;
+            if (!sid) return false;
+            const item = queueStore
+                .getSnapshot(sid)
+                .find((current) => current.id === itemId);
+            if (!item || item.status !== "failed") return false;
+            if (item.errorKind === "unknown") {
+                releaseUnknownQueueDispatch(itemId);
+            }
+            if (!queueStore.retry(sid, itemId)) return false;
+            scheduleQueueDrainRef.current();
+            return true;
+        },
+        [queueStore, releaseUnknownQueueDispatch],
+    );
 
     const [isStopping, setIsStopping] = useState(false);
     const stoppingRef = useRef(false);
-    const cancelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const sendFollowUpNow = useCallback(
+        async (itemId: string) => {
+            const sid = sessionIdRef.current;
+            const client = clientRef.current;
+            if (!sid || stoppingRef.current) return;
+
+            if (turnActiveRef.current && !client?.connected) {
+                if (queueStore.prepareSendNow(sid, itemId)) {
+                    queueStore.markFailed(
+                        sid,
+                        itemId,
+                        "connection",
+                        "Cannot stop the active turn while disconnected",
+                    );
+                }
+                return;
+            }
+            const item = queueStore
+                .getSnapshot(sid)
+                .find((current) => current.id === itemId);
+            if (!item || !queueStore.prepareSendNow(sid, itemId)) return;
+            if (item.errorKind === "unknown") {
+                releaseUnknownQueueDispatch(itemId);
+            }
+
+            if (!turnActiveRef.current) {
+                scheduleQueueDrainRef.current();
+                return;
+            }
+            if (!client?.connected) return;
+
+            stoppingRef.current = true;
+            setIsStopping(true);
+            try {
+                await client.stopCurrentTurn();
+            } catch (err) {
+                const message =
+                    err instanceof Error ? err.message : String(err);
+                queueStore.markFailed(sid, itemId, "stop", message);
+                setIsStopping(false);
+                stoppingRef.current = false;
+            }
+        },
+        [queueStore, releaseUnknownQueueDispatch],
+    );
+
+    // Handler for new messages (from assistant-ui Composer). The custom
+    // composer calls enqueueFollowUp while running because assistant-ui's
+    // external-store runtime intentionally disables its built-in queue.
+    const handleNew = useCallback(
+        async (message: AppendMessage) => {
+            const textContent = Array.isArray(message.content)
+                ? message.content
+                      .filter(
+                          (part): part is { type: "text"; text: string } =>
+                              part.type === "text",
+                      )
+                      .map((part) => part.text)
+                      .join("")
+                : "";
+            if (!textContent.trim()) return;
+            const sid = sessionIdRef.current;
+            if (
+                turnActiveRef.current ||
+                stoppingRef.current ||
+                (sid ? queueStore.getSnapshot(sid).length > 0 : false)
+            ) {
+                const result = enqueueFollowUp(textContent);
+                if (!result.ok && result.reason === "limit") {
+                    throw new Error(i18n.t("chat:follow_up.error.limit"));
+                }
+                return;
+            }
+
+            try {
+                await dispatchInput(textContent);
+            } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                if (errMsg === "Input already pending") {
+                    // A previous turn is still in flight (often an unknown-outcome
+                    // tombstone). This is not a connection fault.
+                    logger.warn(
+                        "RuntimeAdapter",
+                        "sendInput blocked: input already pending",
+                    );
+                    throw new Error(
+                        i18n.t("chat:error.input_still_processing"),
+                    );
+                }
+                logger.error("RuntimeAdapter", "sendInput failed", {
+                    error: errMsg,
+                });
+                throw new Error(i18n.t("chat:error.send_failed_connection"));
+            }
+        },
+        [dispatchInput, enqueueFollowUp, queueStore],
+    );
 
     const handleCancel = useCallback(async () => {
         if (stoppingRef.current) return;
         stoppingRef.current = true;
         setIsStopping(true);
         const client = clientRef.current;
-        if (client?.connected) {
-            client.sendControl("stop");
+        if (!client?.connected) {
+            setIsStopping(false);
+            stoppingRef.current = false;
+            return;
         }
-        if (cancelTimeoutRef.current) {
-            clearTimeout(cancelTimeoutRef.current);
+        try {
+            await client.stopCurrentTurn();
+        } catch (err) {
+            logger.warn("RuntimeAdapter", "Stop did not reach terminal state", {
+                error: String(err),
+            });
+            setIsStopping(false);
+            stoppingRef.current = false;
         }
-        cancelTimeoutRef.current = setTimeout(() => {
-            if (stoppingRef.current) {
-                setIsRunning(false);
-                setIsStopping(false);
-                stoppingRef.current = false;
-            }
-        }, 2000);
     }, []);
 
     // This is deliberately an explicit one-shot action. A duplicate-session
@@ -1795,9 +2329,13 @@ export function useHotPlexRuntime({
         } catch (err) {
             sessionAlreadyConnectedRef.current = true;
             setConnectionState("already_connected");
-            logger.info("RuntimeAdapter", "Explicit duplicate-session retry failed", {
-                error: String(err),
-            });
+            logger.info(
+                "RuntimeAdapter",
+                "Explicit duplicate-session retry failed",
+                {
+                    error: String(err),
+                },
+            );
         }
     }, []);
 
@@ -1867,7 +2405,10 @@ export function useHotPlexRuntime({
                     if (msg.role !== "assistant") return msg;
                     let found = false;
                     const parts = msg.parts.map((p) => {
-                        if (p.type === "tool-call" && p.toolCallId === toolCallId) {
+                        if (
+                            p.type === "tool-call" &&
+                            p.toolCallId === toolCallId
+                        ) {
                             found = true;
                             const inter = p.args?.interaction;
                             return {
@@ -1897,7 +2438,10 @@ export function useHotPlexRuntime({
                         );
                         break;
                     case "question":
-                        await client.sendQuestionResponse(toolCallId, response.answers ?? {});
+                        await client.sendQuestionResponse(
+                            toolCallId,
+                            response.answers ?? {},
+                        );
                         break;
                     case "elicitation":
                         await client.sendElicitationResponse(
@@ -1911,32 +2455,43 @@ export function useHotPlexRuntime({
                 // WebSocket send only proves that the frame entered the socket.
                 // Stay in submitting until Gateway echoes the correlated response
                 // after the Worker native endpoint accepts it.
-                const existingTimer = interactionAckTimersRef.current.get(toolCallId);
+                const existingTimer =
+                    interactionAckTimersRef.current.get(toolCallId);
                 if (existingTimer) clearTimeout(existingTimer);
                 const timer = setTimeout(() => {
                     interactionAckTimersRef.current.delete(toolCallId);
-                    setMessages((prev) => prev.map((msg) => {
-                        if (msg.role !== "assistant") return msg;
-                        let found = false;
-                        const parts = msg.parts.map((part) => {
-                            if (part.type !== "tool-call" || part.toolCallId !== toolCallId) return part;
-                            const interaction = part.args?.interaction;
-                            if (!interaction || interaction.status !== "submitting") return part;
-                            found = true;
-                            return {
-                                ...part,
-                                args: {
-                                    ...part.args,
-                                    interaction: {
-                                        ...interaction,
-                                        status: "failed" as const,
-                                        error: "Timed out waiting for the Worker to confirm this response",
+                    setMessages((prev) =>
+                        prev.map((msg) => {
+                            if (msg.role !== "assistant") return msg;
+                            let found = false;
+                            const parts = msg.parts.map((part) => {
+                                if (
+                                    part.type !== "tool-call" ||
+                                    part.toolCallId !== toolCallId
+                                )
+                                    return part;
+                                const interaction = part.args?.interaction;
+                                if (
+                                    !interaction ||
+                                    interaction.status !== "submitting"
+                                )
+                                    return part;
+                                found = true;
+                                return {
+                                    ...part,
+                                    args: {
+                                        ...part.args,
+                                        interaction: {
+                                            ...interaction,
+                                            status: "failed" as const,
+                                            error: "Timed out waiting for the Worker to confirm this response",
+                                        },
                                     },
-                                },
-                            };
-                        });
-                        return found ? { ...msg, parts } : msg;
-                    }));
+                                };
+                            });
+                            return found ? { ...msg, parts } : msg;
+                        }),
+                    );
                 }, 15_000);
                 interactionAckTimersRef.current.set(toolCallId, timer);
             } catch (err) {
@@ -1951,7 +2506,10 @@ export function useHotPlexRuntime({
                         if (msg.role !== "assistant") return msg;
                         let found = false;
                         const parts = msg.parts.map((p) => {
-                            if (p.type === "tool-call" && p.toolCallId === toolCallId) {
+                            if (
+                                p.type === "tool-call" &&
+                                p.toolCallId === toolCallId
+                            ) {
                                 found = true;
                                 const inter = p.args?.interaction;
                                 return {
@@ -2040,6 +2598,25 @@ export function useHotPlexRuntime({
         [],
     );
 
+    const followUpQueue = useMemo<FollowUpQueueControls>(
+        () => ({
+            items: queuedItems,
+            enqueue: enqueueFollowUp,
+            updateText: updateFollowUp,
+            remove: removeFollowUp,
+            retry: retryFollowUp,
+            sendNow: sendFollowUpNow,
+        }),
+        [
+            queuedItems,
+            enqueueFollowUp,
+            updateFollowUp,
+            removeFollowUp,
+            retryFollowUp,
+            sendFollowUpNow,
+        ],
+    );
+
     // Stable extras reference — only changes when metrics or history state change
     const extras = useMemo(
         () => ({
@@ -2050,6 +2627,7 @@ export function useHotPlexRuntime({
             isStopping,
             connectionState,
             onRetryConnection: retrySessionConnection,
+            followUpQueue,
         }),
         [
             sessionMetrics,
@@ -2059,6 +2637,7 @@ export function useHotPlexRuntime({
             isStopping,
             connectionState,
             retrySessionConnection,
+            followUpQueue,
         ],
     );
 

--- a/webchat/lib/adapters/reconcile-turn.test.ts
+++ b/webchat/lib/adapters/reconcile-turn.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConversationRecord } from "@/lib/api/sessions";
+import type { HotPlexMessage } from "@/lib/types/message";
+import {
+    patchAuthoritativeAssistantContent,
+    selectAuthoritativeAssistantContent,
+} from "./reconcile-turn";
+
+function record(
+    seq: number,
+    role: "user" | "assistant",
+    content: string,
+    turnNum: number,
+): ConversationRecord {
+    return {
+        id: seq,
+        session_id: "session-1",
+        generation: 1,
+        turn_num: turnNum,
+        seq,
+        role,
+        content,
+        platform: "webchat",
+        user_id: "user-1",
+        model: "test",
+        success: true,
+        source: "normal",
+        tools: null,
+        tool_call_count: 0,
+        tokens_in: 0,
+        tokens_input: 0,
+        tokens_cache_write: 0,
+        tokens_cache_read: 0,
+        tokens_out: 0,
+        duration_ms: 0,
+        cost_usd: 0,
+        created_at: seq,
+    };
+}
+
+describe("turn reconciliation", () => {
+    const records = [
+        record(10, "user", "first", 1),
+        record(11, "assistant", "first answer", 1),
+        record(20, "user", "second", 2),
+        record(21, "assistant", "second answer", 2),
+    ];
+
+    it("selects the assistant bounded by the completed terminal sequence", () => {
+        expect(
+            selectAuthoritativeAssistantContent(records, { terminalSeq: 15 }),
+        ).toBe("first answer");
+    });
+
+    it("waits when the current turn user exists but its assistant has not flushed", () => {
+        const partiallyFlushed = [
+            record(10, "user", "first", 1),
+            record(11, "assistant", "first answer", 1),
+            record(20, "user", "second", 2),
+        ];
+
+        expect(
+            selectAuthoritativeAssistantContent(partiallyFlushed, {
+                terminalSeq: 25,
+            }),
+        ).toBeNull();
+    });
+
+    it("selects the assistant paired with the reconnecting input turn", () => {
+        expect(
+            selectAuthoritativeAssistantContent(records, {
+                inputContent: "first",
+            }),
+        ).toBe("first answer");
+    });
+
+    it("patches the captured assistant without touching the next pending turn", () => {
+        const messages: HotPlexMessage[] = [
+            {
+                id: "assistant-first",
+                role: "assistant",
+                parts: [{ type: "text", text: "first" }],
+                createdAt: new Date(1),
+                status: "complete",
+            },
+            {
+                id: "assistant-second",
+                role: "assistant",
+                parts: [],
+                createdAt: new Date(2),
+                status: "streaming",
+            },
+        ];
+
+        const patched = patchAuthoritativeAssistantContent(
+            messages,
+            "assistant-first",
+            "first answer",
+        );
+
+        expect(patched[0]?.parts).toEqual([
+            { type: "text", text: "first answer" },
+        ]);
+        expect(patched[1]).toBe(messages[1]);
+        expect(patched[1]?.parts).toEqual([]);
+    });
+});

--- a/webchat/lib/adapters/reconcile-turn.ts
+++ b/webchat/lib/adapters/reconcile-turn.ts
@@ -1,0 +1,90 @@
+import type { ConversationRecord } from "@/lib/api/sessions";
+import { concatTextParts } from "@/lib/adapters/merge-parts";
+import type { HotPlexMessage } from "@/lib/types/message";
+import type { MessagePart } from "@/lib/types/message-parts";
+
+export type TurnReconcileCriteria =
+    | { terminalSeq: number; inputContent?: never }
+    | { terminalSeq?: never; inputContent: string };
+
+export function selectAuthoritativeAssistantContent(
+    records: readonly ConversationRecord[],
+    criteria: TurnReconcileCriteria,
+): string | null {
+    let targetRecord: ConversationRecord | undefined;
+    if (criteria.terminalSeq !== undefined) {
+        const userRecord = records
+            .filter(
+                (record) =>
+                    record.role === "user" &&
+                    record.seq <= criteria.terminalSeq,
+            )
+            .sort((left, right) => right.seq - left.seq)[0];
+        if (userRecord) {
+            targetRecord = records
+                .filter(
+                    (record) =>
+                        record.role === "assistant" &&
+                        record.content &&
+                        record.generation === userRecord.generation &&
+                        record.turn_num === userRecord.turn_num &&
+                        record.seq <= criteria.terminalSeq,
+                )
+                .sort((left, right) => right.seq - left.seq)[0];
+        }
+    } else {
+        const userRecord = records
+            .filter(
+                (record) =>
+                    record.role === "user" &&
+                    record.content === criteria.inputContent,
+            )
+            .sort((left, right) => right.seq - left.seq)[0];
+        if (userRecord) {
+            targetRecord = records
+                .filter(
+                    (record) =>
+                        record.role === "assistant" &&
+                        record.content &&
+                        record.generation === userRecord.generation &&
+                        record.turn_num === userRecord.turn_num,
+                )
+                .sort((left, right) => right.seq - left.seq)[0];
+        }
+    }
+    return targetRecord?.content ?? null;
+}
+
+export function patchAuthoritativeAssistantContent(
+    messages: readonly HotPlexMessage[],
+    targetAssistantId: string,
+    fullText: string,
+): HotPlexMessage[] {
+    const targetIndex = messages.findIndex(
+        (message) =>
+            message.id === targetAssistantId && message.role === "assistant",
+    );
+    if (targetIndex === -1) return messages as HotPlexMessage[];
+
+    const target = messages[targetIndex];
+    const currentText = concatTextParts(target.parts);
+    if (currentText.length > 0 && !fullText.startsWith(currentText)) {
+        return messages as HotPlexMessage[];
+    }
+    if (fullText.length <= currentText.length) {
+        return messages as HotPlexMessage[];
+    }
+
+    const firstTextIndex = target.parts.findIndex((part) => part.type === "text");
+    const nonTextParts: MessagePart[] = target.parts.filter(
+        (part) => part.type !== "text",
+    );
+    const parts = [...nonTextParts];
+    parts.splice(firstTextIndex === -1 ? 0 : firstTextIndex, 0, {
+        type: "text",
+        text: fullText,
+    });
+    const next = [...messages];
+    next[targetIndex] = { ...target, parts };
+    return next;
+}

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -698,6 +698,37 @@ describe("BrowserHotPlexClient input retry identity", () => {
         expect(() => client.sendInput("second")).not.toThrow();
     });
 
+    it("releases an unknown tombstone only for an explicit user retry", async () => {
+        vi.stubGlobal("WebSocket", { OPEN: 1 });
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const internal = client as unknown as {
+            _sessionId: string;
+            ws: { readyState: number };
+            _send(value: Envelope): void;
+        };
+        internal._sessionId = "session-1";
+        internal.ws = { readyState: 1 };
+        const send = vi.spyOn(internal, "_send").mockImplementation(() => undefined);
+
+        const pending = client.sendInputAsync("first");
+        const clientMessageId = send.mock.calls[0][0].id;
+        route(client, envelope(EventKind.InputAck, {
+            client_message_id: clientMessageId,
+            execution_id: "exec-1",
+            status: "unknown",
+            error_code: "EXECUTION_TIMEOUT",
+        }));
+
+        await expect(pending).rejects.toThrow("EXECUTION_TIMEOUT");
+        expect(() => client.sendInput("automatic retry")).toThrow("Input already pending");
+        expect(client.acknowledgeUnknownInputForRetry()).toBe(true);
+        expect(client.acknowledgeUnknownInputForRetry()).toBe(false);
+        expect(() => client.sendInput("explicit retry")).not.toThrow();
+    });
+
     it("clears pendingInput on a delivered acknowledgement so a subsequent send works", () => {
         vi.stubGlobal("WebSocket", { OPEN: 1 });
         const client = new BrowserHotPlexClient({
@@ -831,7 +862,7 @@ describe("BrowserHotPlexClient input retry identity", () => {
         await expect(pending).rejects.toThrow("link lost");
     });
 
-    it("clears and resolves pending input immediately when sendControl('stop') is called", async () => {
+    it("keeps pending input until stop reaches a terminal done event", async () => {
         vi.stubGlobal("WebSocket", { OPEN: 1 });
         const client = new BrowserHotPlexClient({
             url: "ws://127.0.0.1:8888/ws",
@@ -852,9 +883,137 @@ describe("BrowserHotPlexClient input retry identity", () => {
         const pending = client.sendInputAsync("hello");
         expect(internal.pendingInput).not.toBeNull();
 
-        client.sendControl("stop");
+        const stopped = client.stopCurrentTurn();
 
+        expect(internal.pendingInput).not.toBeNull();
+        expect(() => client.sendInput("too early")).toThrow("Input already pending");
+
+        route(client, envelope(EventKind.Done, {
+            success: true,
+            reason: "stopped_by_user",
+        }));
+
+        await expect(stopped).resolves.toMatchObject({
+            reason: "stopped_by_user",
+        });
         expect(internal.pendingInput).toBeNull();
         await expect(pending).resolves.toBeUndefined();
+    });
+
+    it("coalesces repeated stop requests and accepts natural completion", async () => {
+        vi.stubGlobal("WebSocket", { OPEN: 1 });
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const internal = client as unknown as {
+            _sessionId: string;
+            _connected: boolean;
+            ws: { readyState: number } | null;
+            _send(value: Envelope): void;
+        };
+        internal._sessionId = "session-1";
+        internal._connected = true;
+        internal.ws = { readyState: 1 };
+        const send = vi.spyOn(internal, "_send").mockImplementation(() => undefined);
+
+        const first = client.stopCurrentTurn();
+        const second = client.stopCurrentTurn();
+
+        expect(second).toBe(first);
+        expect(send).toHaveBeenCalledTimes(1);
+        route(client, envelope(EventKind.Done, { success: true, reason: "completed" }));
+
+        await expect(first).resolves.toMatchObject({ reason: "completed" });
+        await expect(second).resolves.toMatchObject({ reason: "completed" });
+    });
+
+    it("keeps waiting for done when an unrelated gateway error arrives", async () => {
+        vi.stubGlobal("WebSocket", { OPEN: 1 });
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const internal = client as unknown as {
+            _sessionId: string;
+            _connected: boolean;
+            ws: { readyState: number } | null;
+            _send(value: Envelope): void;
+        };
+        internal._sessionId = "session-1";
+        internal._connected = true;
+        internal.ws = { readyState: 1 };
+        vi.spyOn(internal, "_send").mockImplementation(() => undefined);
+
+        const stopped = client.stopCurrentTurn();
+        let settled = false;
+        void stopped.finally(() => {
+            settled = true;
+        });
+        route(client, envelope(EventKind.Error, {
+            code: "WORKER_COMMAND_FAILED",
+            message: "unrelated worker command failed",
+        }));
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        route(client, envelope(EventKind.Done, { success: true, reason: "completed" }));
+        await expect(stopped).resolves.toMatchObject({ reason: "completed" });
+    });
+
+    it("rejects a stop waiter on timeout without releasing the active input", async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal("WebSocket", { OPEN: 1 });
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const internal = client as unknown as {
+            _sessionId: string;
+            _connected: boolean;
+            pendingInput: unknown;
+            ws: { readyState: number } | null;
+            _send(value: Envelope): void;
+        };
+        internal._sessionId = "session-1";
+        internal._connected = true;
+        internal.ws = { readyState: 1 };
+        vi.spyOn(internal, "_send").mockImplementation(() => undefined);
+
+        const pending = client.sendInputAsync("hello");
+        void pending.catch(() => undefined);
+        const stopped = client.stopCurrentTurn(500);
+        const rejected = expect(stopped).rejects.toThrow("Stop timeout");
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        await rejected;
+        expect(internal.pendingInput).not.toBeNull();
+        expect(() => client.sendInput("too early")).toThrow("Input already pending");
+        route(client, envelope(EventKind.Done, { success: true }));
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it("rejects a stop waiter when the client disconnects", async () => {
+        vi.stubGlobal("WebSocket", { OPEN: 1, CONNECTING: 0 });
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+        const internal = client as unknown as {
+            _sessionId: string;
+            _connected: boolean;
+            ws: { readyState: number; close: () => void } | null;
+            _send(value: Envelope): void;
+        };
+        internal._sessionId = "session-1";
+        internal._connected = true;
+        internal.ws = { readyState: 1, close: vi.fn() };
+        vi.spyOn(internal, "_send").mockImplementation(() => undefined);
+
+        const stopped = client.stopCurrentTurn();
+        client.disconnect();
+
+        await expect(stopped).rejects.toThrow("Client disconnected");
     });
 });

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -197,6 +197,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   // A tombstoned (unknown-outcome) input blocks new sends for at most this long
   // before being force-cleared, so an ambiguous outcome can never lock the chat.
   private static readonly TOMBSTONE_GRACE_MS = 120_000;
+  private static readonly STOP_SETTLE_TIMEOUT_MS = 10_000;
 
   private pendingInput: {
     content: string;
@@ -208,6 +209,12 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   } | null = null;
   private inputSettleTimer: ReturnType<typeof setTimeout> | null = null;
   private inputTombstoneTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingStop: {
+    promise: Promise<DoneData>;
+    resolve: (data: DoneData) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
   private pendingConnectReject: ((err: Error) => void) | null = null;
   private connectPromise: Promise<InitAckData> | null = null;
   private connectTarget: string | null = null;
@@ -588,10 +595,13 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         break;
       }
 
-      case EventKind.Done:
-        this.emit('done', event.data as DoneData, env);
+      case EventKind.Done: {
+        const doneData = event.data as DoneData;
+        this.emit('done', doneData, env);
+        this._settleStop({ kind: 'resolve', data: doneData });
         this._settlePending({ kind: 'resolve' });
         break;
+      }
 
       case EventKind.MessageDelta:
         this.emit('delta', event.data as MessageDeltaData, env);
@@ -738,6 +748,21 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     return pending.clientMessageId;
   }
 
+  /**
+   * Release an unknown-outcome tombstone only after the user explicitly asks
+   * to retry. This is deliberately separate from sendInput so automatic paths
+   * cannot bypass the duplicate-side-effect guard.
+   */
+  acknowledgeUnknownInputForRetry(): boolean {
+    if (!this.pendingInput?.tombstone) return false;
+    this._settlePending({
+      kind: 'reject',
+      error: new Error('Unknown input explicitly released for retry'),
+      force: true,
+    });
+    return true;
+  }
+
   async sendInputAsync(content: string): Promise<void> {
     if (this.pendingInput) {
       throw new Error('Input already pending');
@@ -784,9 +809,38 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   sendControl(action: 'terminate' | 'delete' | 'stop'): void {
     const env = createControlEnvelope(this._sessionId!, action);
     this._send(env);
-    if (action === 'stop') {
-      this._settlePending({ kind: 'resolve' });
+  }
+
+  /**
+   * Stop the active turn and wait for its terminal Done event. Concurrent calls
+   * share one waiter, so a double click cannot send duplicate stop frames or
+   * race multiple follow-up dispatches.
+   */
+  stopCurrentTurn(
+    timeoutMs = BrowserHotPlexClient.STOP_SETTLE_TIMEOUT_MS,
+  ): Promise<DoneData> {
+    if (this.pendingStop) return this.pendingStop.promise;
+
+    let resolve!: (data: DoneData) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<DoneData>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    const timer = setTimeout(() => {
+      this._settleStop({ kind: 'reject', error: new Error('Stop timeout') });
+    }, timeoutMs);
+    this.pendingStop = { promise, resolve, reject, timer };
+
+    try {
+      this.sendControl('stop');
+    } catch (error) {
+      this._settleStop({
+        kind: 'reject',
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
     }
+    return promise;
   }
 
   sendWorkerCommand(command: typeof WorkerStdioCommand[keyof typeof WorkerStdioCommand], args?: string, extra?: Record<string, unknown>): void {
@@ -809,6 +863,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
     }
 
     this._settlePending({ kind: 'reject', error: new Error('Client disconnected'), force: true });
+    this._settleStop({ kind: 'reject', error: new Error('Client disconnected') });
 
     this._releasePageSessionOwner();
     this._closeCurrentSocketForHandoff('Client disconnect');
@@ -996,11 +1051,28 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       this._reconnecting = false;
       this._clearInputTimers();
       this._settlePending({ kind: 'reject', error: new Error('Reconnect failed'), force: true });
+      this._settleStop({ kind: 'reject', error: new Error('Reconnect failed') });
       this.emit('reconnect_failed', this.reconnectAttempt);
     } else if (!this.shouldReconnect || this.closed) {
       this._clearInputTimers();
       this._settlePending({ kind: 'reject', error: new Error(reason || 'Disconnected'), force: true });
+      this._settleStop({ kind: 'reject', error: new Error(reason || 'Disconnected') });
       this.emit('disconnected', reason);
+    }
+  }
+
+  private _settleStop(outcome:
+    | { kind: 'resolve'; data: DoneData }
+    | { kind: 'reject'; error: Error },
+  ): void {
+    const pending = this.pendingStop;
+    if (!pending) return;
+    this.pendingStop = null;
+    clearTimeout(pending.timer);
+    if (outcome.kind === 'resolve') {
+      pending.resolve(outcome.data);
+    } else {
+      pending.reject(outcome.error);
     }
   }
 

--- a/webchat/locales/en/chat.json
+++ b/webchat/locales/en/chat.json
@@ -287,6 +287,46 @@
       }
     }
   },
+  "follow_up": {
+    "title": "Follow-up queue",
+    "count": "{{count}} queued",
+    "status": {
+      "queued": "Queued",
+      "sending": "Sending",
+      "failed": "Action needed"
+    },
+    "action": {
+      "expand": "Expand",
+      "collapse": "Collapse",
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "retry": "Retry",
+      "send_now": "Send now"
+    },
+    "error": {
+      "limit": "The queue can hold up to 20 messages. Your draft is preserved; resolve an existing item first.",
+      "blank": "The message cannot be blank.",
+      "unknown": "The delivery outcome is unknown. To avoid duplicate work, review it and retry manually.",
+      "connection": "The connection was interrupted. The message remains queued; retry it manually after reconnecting.",
+      "busy": "The previous turn is still active. The message was not sent; retry it manually later.",
+      "send": "Delivery was not confirmed. The message remains queued for a manual retry.",
+      "stop": "The current turn did not confirm it stopped, so this message was not sent. Retry it manually."
+    },
+    "aria": {
+      "panel": "Follow-up message queue",
+      "position": "Queue item {{position}}",
+      "expand": "Expand queued message {{position}}",
+      "collapse": "Collapse queued message {{position}}",
+      "edit": "Edit queued message {{position}}",
+      "edit_input": "Edit queued message {{position}} content",
+      "delete": "Delete queued message {{position}}",
+      "retry": "Retry queued message {{position}}",
+      "send_now": "Stop the current turn and send queued message {{position}} next",
+      "enqueue": "Add message to the follow-up queue"
+    }
+  },
   "aria": {
     "send": "Send message",
     "stop": "Stop generating",

--- a/webchat/locales/zh-CN/chat.json
+++ b/webchat/locales/zh-CN/chat.json
@@ -287,6 +287,46 @@
       }
     }
   },
+  "follow_up": {
+    "title": "后续消息队列",
+    "count": "{{count}} 条",
+    "status": {
+      "queued": "等待发送",
+      "sending": "正在发送",
+      "failed": "需要处理"
+    },
+    "action": {
+      "expand": "展开",
+      "collapse": "收起",
+      "edit": "编辑",
+      "save": "保存",
+      "cancel": "取消",
+      "delete": "删除",
+      "retry": "重试",
+      "send_now": "立即发送"
+    },
+    "error": {
+      "limit": "队列最多容纳 20 条消息。草稿已保留，请先处理现有项目。",
+      "blank": "消息不能为空。",
+      "unknown": "发送结果未知。为避免重复执行，请确认后手动重试。",
+      "connection": "连接中断，消息仍保留在队列中。请恢复连接后手动重试。",
+      "busy": "会话仍在处理上一轮，消息未发送。请稍后手动重试。",
+      "send": "消息未确认送达，已保留在队列中。请手动重试。",
+      "stop": "未能确认当前轮次已停止，消息没有发送。请手动重试。"
+    },
+    "aria": {
+      "panel": "后续消息队列",
+      "position": "队列第 {{position}} 项",
+      "expand": "展开队列第 {{position}} 条消息",
+      "collapse": "收起队列第 {{position}} 条消息",
+      "edit": "编辑队列第 {{position}} 条消息",
+      "edit_input": "编辑队列第 {{position}} 条消息内容",
+      "delete": "删除队列第 {{position}} 条消息",
+      "retry": "重试队列第 {{position}} 条消息",
+      "send_now": "停止当前轮次并立即发送队列第 {{position}} 条消息",
+      "enqueue": "将消息加入后续队列"
+    }
+  },
   "aria": {
     "send": "发送消息",
     "stop": "停止生成",

--- a/webchat/playwright.config.ts
+++ b/webchat/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+const playwrightPort = /^\d+$/.test(process.env.PLAYWRIGHT_PORT ?? '')
+  ? process.env.PLAYWRIGHT_PORT
+  : '3000';
+const baseURL = `http://127.0.0.1:${playwrightPort}`;
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -9,19 +15,24 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: chromiumExecutablePath
+          ? { executablePath: chromiumExecutablePath }
+          : undefined,
+      },
     },
   ],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
+    command: `pnpm exec next dev --hostname 127.0.0.1 --port ${playwrightPort}`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },


### PR DESCRIPTION
## 结论

完成 #902：WebChat 现在支持页面生命周期内、按会话隔离的可编辑后续消息 FIFO 队列，并正确处理停止当前轮次、ACK、断线重连、晚到事件与不确定投递结果。队列最多 20 条，不持久化 prompt 或 metadata。

Closes #902

## 主要变更

- 新增 page-scoped `FollowUpQueueStore`，支持排队、编辑、删除、重试和“立即发送”，会话之间严格隔离。
- 当前轮次运行或停止中提交消息时进入队列；终态到达后每次只投递一条，保证 FIFO 和 single-flight。
- “立即发送”会提升目标项、停止当前轮次、等待终态，再开启下一轮；断线时明确展示失败，不静默降级。
- 以 `client_message_id` 关联 ACK，覆盖 `accepted`、`delivered`、`failed`、`unknown`；`unknown` 必须显式重试，同时允许晚到 ACK/Done 安全收敛且不重复投递。
- 重连时使用服务端 init state 与历史 turn 做权威校准，按 assistant ID 精确修补当前轮，避免覆盖相邻轮次。
- 新增中英文同步文案、键盘交互和带队列位置的无障碍标签。
- Playwright 配置支持独立端口和本机 Chromium 路径，E2E 使用 mock AEP gateway 覆盖可靠性边界。
- 顺带纳入 `internal/gateway/handler.go`：忽略空白 input payload，避免进入命令分发或 Worker，并增加表驱动测试。

## 验证

- `make check`
- `make test-short` / pre-push 全部门禁（format、vet、module verify、lint、build、tests）
- `go test -race ./internal/gateway/...`：687 tests passed
- `pnpm test -- --run`：74 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `playwright test e2e/chat.spec.ts --workers=1`：12 tests passed
- 独立代码复审：Critical 0、Important 0、Ready Yes

## 风险与边界

- 队列只存在于当前页面内，刷新页面后清空，符合 issue 的隐私与生命周期要求。
- `unknown` 不会自动重投；只有用户显式操作或原始事件晚到并可确定收敛时才解除阻塞。
- 每个会话独立维护队列，切换会话不会串发。
