### PR TITLE
docs(patrol): 2026-07-17 文档维护

### DIFF
--- a/docs/guides/enterprise/observability.md
+++ b/docs/guides/enterprise/observability.md
@@ -53,7 +53,7 @@ HotPlex 使用 `log/slog` JSON Handler 输出结构化日志，兼容 OTel Log D
 
 ## 2. OTel 原生指标体系
 
-HotPlex 使用统一的 `internal/observability/` 包，通过 OTel Meter API 注册 36 个指标，前缀为 `hotplex.`。应用代码零直接依赖 `prometheus/client_golang`。
+HotPlex 使用统一的 `internal/observability/` 包，通过 OTel Meter API 注册 58+ 个指标，前缀为 `hotplex.`。应用代码零直接依赖 `prometheus/client_golang`。
 
 指标通过 OTel Prometheus Exporter 以标准 Prometheus 格式暴露于 `GET /admin/metrics`，同时支持通过 OTLP gRPC 导出到 OTel Collector。
 
@@ -137,7 +137,52 @@ HotPlex 使用统一的 `internal/observability/` 包，通过 OTel Meter API �
 | `hotplex.retry.attempts` | Counter | — | LLM 重试尝试次数 |
 | `hotplex.retry.exhaustion` | Counter | — | 重试耗尽（最终失败）次数 |
 
+### 2.9 Execution & Lease-Repair 指标
+
+Durable ingress 的输入账本、owner lease 续约与终态修复子系统。
+
+| 指标 | 类型 | 标签 | 说明 |
+|------|------|------|------|
+| `hotplex.execution.accept` | Counter | — | 新输入被持久化接受 |
+| `hotplex.execution.duplicate` | Counter | — | 幂等去重（相同 ID + payload） |
+| `hotplex.execution.conflict` | Counter | — | Payload 冲突（相同 ID，不同 hash） |
+| `hotplex.execution.session_busy` | Counter | — | Active gate 拒绝（session 忙于此前 execution） |
+| `hotplex.execution.delivery_outcome` | Counter | `delivery_status` | Worker 投递结果（delivered/unknown/failed） |
+| `hotplex.execution.runtime_outcome` | Counter | `runtime_status` | Worker 运行终态（completed/failed/unknown） |
+| `hotplex.execution.delivery_latency` | Histogram | — | accept 到 delivery outcome 耗时 |
+| `hotplex.execution.runtime_duration` | Histogram | — | Worker turn 执行耗时 |
+| `hotplex.lease.renew_failure` | Counter | — | Owner lease 续约失败 |
+| `hotplex.lease.expired_recovery` | Counter | — | Lease 过期恢复（runtime 置 unknown + fence） |
+| `hotplex.repair.attempts` | Counter | — | 终态修复尝试 |
+| `hotplex.repair.success` | Counter | — | 终态修复成功 |
+| `hotplex.repair.timeout` | Counter | — | 终态修复超时（超过 MaxLifetime 放弃） |
+| `hotplex.repair.dropped` | Counter | — | 终态修复入队失败（回退 lease recovery） |
+
+### 2.10 Turn TTFT 指标
+
+Gateway 收到输入到首个可见 Worker 输出的耗时分段。TTFT 仅使用 Gateway 侧时间戳；
+浏览器绘制时间属于独立客户端遥测，不能与本指标混合。
+
+| 指标 | 类型 | 标签 | 说明 |
+|------|------|------|------|
+| `hotplex.turn.ttft` | Histogram | `worker_type`, `first_output`（reasoning/text） | 输入到首个可见输出的耗时 |
+| `hotplex.turn.first_text_latency` | Histogram | `worker_type` | 输入到首个文本 delta 的耗时 |
+| `hotplex.turn.stage_duration` | Histogram | `worker_type`, `stage`（admission/dispatch/first_output） | 三阶段耗时拆分 |
+| `hotplex.turn.without_output` | Counter | `worker_type`, `terminal_status` | 无可见输出即终止的 turn |
+| `hotplex.worker.empty_success_total` | Counter | `worker_type`, `platform` | 成功但无显示内容和工具调用的 turn（Turn-Integrity） |
+
+### 2.11 Forwarder & Turn-Integrity 诊断指标
+
+| 指标 | 类型 | 标签 | 说明 |
+|------|------|------|------|
+| `hotplex.gateway.forwarder.panics` | Counter | `worker_type` | Worker 事件转发 goroutine 已恢复的 panic |
+| `hotplex.gateway.stale_forwarder_event_total` | Counter | — | `/reset` 后旧 forwarder 观察到的事件（应永不为零） |
+| `hotplex.worker.assistant_snapshot_drift_total` | Counter | — | Full snapshot 非前缀漂移被重新下发 |
+| `hotplex.messaging.platform_terminal_fallback_total` | Counter | — | 平台因空内容发出合成终态回退 |
+
 ---
+
+
 
 ## 3. OpenTelemetry 分布式追踪
 
@@ -237,6 +282,9 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 | WS 连接数 | `hotplex_gateway_connections` | Time series | 连接趋势 |
 | Worker 崩溃率 | `rate(hotplex_worker_crashes_total[5m])` | Time series | 稳定性 |
 | Worker 执行 P99 | `histogram_quantile(0.99, rate(hotplex_worker_execution_duration_bucket[5m]))` | Time series | 性能 |
+| TTFT P95 | `histogram_quantile(0.95, sum by (le, worker_type) (rate(hotplex_turn_ttft_bucket[15m])))` | Time series | 首输出延迟 |
+| TTFT 阶段拆分 | `histogram_quantile(0.95, sum by (le, stage) (rate(hotplex_turn_stage_duration_bucket[15m])))` | Time series | 延迟归因 |
+| 投递成功率 | `sum(rate(hotplex_execution_delivery_outcome_total{delivery_status="delivered"}[5m])) / sum(rate(hotplex_execution_delivery_outcome_total[5m]))` | Stat | 输入可靠性 |
 | Delta 背压丢弃 | `rate(hotplex_gateway_deltas_dropped_total[5m])` | Time series | 流量压力 |
 | Cron 错误率 | `rate(hotplex_cron_errors_total[5m])` | Time series | 定时任务健康 |
 | 错误分类 | `hotplex_gateway_errors_total` | Stacked bar | 错误归因 |
@@ -271,6 +319,10 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 | PoolDoubleRelease | `increase(hotplex_pool_release_errors_total[1h])` | > 0 | P2 | 代码 Bug 信号 |
 | LLMRetryExhaustion | `rate(hotplex_retry_exhaustion_total[5m])` | > 0 | P1 | LLM 调用不可用 |
 | RepeatedSessionConnectionConflict | `rate(hotplex_gateway_webchat_duplicate_connection_rejected_total[10m])` | 持续 > 0 | P2 | 客户端并发重连或连接切换未排空 |
+| HighDeliveryFailureRate | `rate(hotplex_execution_delivery_outcome_total{delivery_status!="delivered"}[5m]) / rate(hotplex_execution_delivery_outcome_total[5m])` | > 5% | P1 | Worker 投递失败率过高 |
+| HighEmptySuccessTurn | `rate(hotplex_worker_empty_success_total_total[5m]) / rate(hotplex_worker_starts_total[5m])` | > 1% | P2 | 空 success turn 占比异常 |
+| HighLeaseRenewFailure | `rate(hotplex_lease_renew_failure_total[5m])` | 持续 > 0 | P1 | Owner lease 续约持续失败 |
+| HighTTFTP99 | `histogram_quantile(0.99, sum by (le) (rate(hotplex_turn_ttft_bucket[15m])))` | > 30s | P1 | TTFT P99 超过阈值 |
 
 ### SLO 参考
 
@@ -279,3 +331,6 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 | Session 创建成功率 | `session.start.attempts` vs `session.start.errors` | >= 99.5% |
 | Worker 可用性 | `1 - crashes/starts` | >= 99% |
 | Worker 执行 P99 | `worker.execution.duration` | < 300s |
+| 输入投递成功率 | `execution.delivery_outcome{delivery_status="delivered"}` | >= 99% |
+| Lease 续约成功率 | `lease.renew_failure` 持续为 0 | == 100% |
+| TTFT P95 | `turn.ttft` P95 | < 10s |

--- a/docs/reference/aep-protocol.md
+++ b/docs/reference/aep-protocol.md
@@ -320,6 +320,40 @@ ACP 专用：映射 `AgentPlanUpdate`，Agent 的计划/任务列表变更通知
 
 ACP 专用：映射 `CurrentModeUpdate`，Agent 执行模式切换通知。
 
+### runtime.execution.started / runtime.execution.completed / runtime.execution.failed（执行生命周期）
+
+三个 additive S→C 事件，通过 `execution_id` 将输入接受 (`input.ack`) 关联到 Worker
+终态结果。旧客户端不识别时静默忽略。
+
+```json
+// runtime.execution.started
+{ "type": "runtime.execution.started", "data": {
+    "execution_id": "exec_<uuid>",
+    "status": "started",
+    "started_at": 1710000000123
+} }
+
+// runtime.execution.completed
+{ "type": "runtime.execution.completed", "data": {
+    "execution_id": "exec_<uuid>",
+    "status": "completed",
+    "started_at": 1710000000123,
+    "finished_at": 1710000012345
+} }
+
+// runtime.execution.failed
+{ "type": "runtime.execution.failed", "data": {
+    "execution_id": "exec_<uuid>",
+    "status": "failed",
+    "error_code": "WORKER_CRASH",
+    "started_at": 1710000000123,
+    "finished_at": 1710000012345
+} }
+```
+
+**时序约束**：`started` 在 `input.ack(delivered)` 之后、`done` 之前发送。
+`completed`/`failed` 在 `done` 之后发送（终态通知，与 run 结果分离）。
+
 ### state（状态变更）
 
 ```json
@@ -499,10 +533,12 @@ Client                          Server
   |--- input(content) ----------->|--- state(running)
   |<-- input.ack(accepted) -------|--- 持久化入口账本
   |<-- input.ack(delivered) ------|--- Worker 接受输入
+  |<-- runtime.execution.started -|-- execution 执行开始
   |                               |--- message.start
   |<-- message.delta * ------------|--- message.delta
   |<-- message.end ---------------|
   |<-- done(success) -------------|--- state(idle)
+  |<-- runtime.execution.completed|-- execution 终态通知
   |                               |
 ```
 
@@ -511,7 +547,7 @@ Client                          Server
 ```
 Client ←→ Server
 
-Input Flow:     input → input.ack(accepted) → input.ack(delivered|unknown|failed) → [tool_call → tool_result]* → [message.delta*] → done
+Input Flow:     input → input.ack(accepted) → input.ack(delivered|unknown|failed) → runtime.execution.started → [tool_call → tool_result]* → [message.delta*] → done → runtime.execution.{completed,failed}
 Control Flow:   control(action) → state(new_state) / error
 Interactive:    permission_request ←→ permission_response
                 question_request ←→ question_response
@@ -523,4 +559,4 @@ Heartbeat:      ping ←→ pong
 
 **必须支持**：`init`、`input`、`control`、`ping`、`init_ack`、`message.delta`、`state`、`error`、`done`、`pong`
 
-**可选扩展**：`input.ack`、`message.start/end`、`message`、`tool_call/result`、`tool_update`、`plan`、`mode_update`、`reasoning`、`step`、`raw`、`permission_*`、`question_*`、`elicitation_*`、`context_usage`、`mcp_status`、`worker_command`
+**可选扩展**：`input.ack`、`runtime.execution.*`、`message.start/end`、`message`、`tool_call/result`、`tool_update`、`plan`、`mode_update`、`reasoning`、`step`、`raw`、`permission_*`、`question_*`、`elicitation_*`、`context_usage`、`mcp_status`、`worker_command`

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -139,6 +139,31 @@ type InputAckData struct {
 `delivered`、`unknown` 或 `failed`。`unknown` 表示存在重复副作用风险，Gateway
 不会自动重投。重复 Envelope 只返回当前记录，并将 `duplicate` 设为 `true`。
 
+#### `runtime.execution.{started,completed,failed}` — 执行生命周期
+
+三个 S→C additive 事件，通过 `execution_id` 把 `input.ack` 的输入接受关联到 Worker
+终态结果。旧客户端不识别这些 Kind 时静默忽略。
+
+```go
+type RuntimeExecutionData struct {
+    ExecutionID string    `json:"execution_id"`
+    Status      string    `json:"status"`       // started / completed / failed
+    ErrorCode   ErrorCode `json:"error_code,omitempty"`
+    StartedAt   int64     `json:"started_at,omitempty"`   // Unix 毫秒
+    FinishedAt  int64     `json:"finished_at,omitempty"`  // Unix 毫秒
+}
+```
+
+| 事件 | Status | 语义 |
+|------|--------|------|
+| `runtime.execution.started` | `started` | Worker 已接受输入，执行开始 |
+| `runtime.execution.completed` | `completed` | Worker 成功完成此轮执行 |
+| `runtime.execution.failed` | `failed` | Worker 执行失败，`error_code` 提供分类 |
+
+**时序约束**：`runtime.execution.started` 在 `input.ack(delivered)` 之后、`done` 之前
+发送。`runtime.execution.completed` 或 `runtime.execution.failed` 在 `done` 之后
+发送（作为 execution 账本的终态通知，与 run 结果分离）。
+
 #### `state` — 状态变更
 
 ```go

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -253,6 +253,87 @@ rate(hotplex_cron_duration_sum[5m]) / rate(hotplex_cron_duration_count[5m])
 | `hotplex.retry.attempts` | Counter | LLM 重试尝试次数 |
 | `hotplex.retry.exhaustion` | Counter | 重试耗尽（最终失败）次数 |
 
+## Execution 指标
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.execution.accept` | Counter | 新输入被持久化接受的次数 |
+| `hotplex.execution.duplicate` | Counter | 幂等去重（相同 Envelope ID + payload 静默抑制） |
+| `hotplex.execution.conflict` | Counter | Payload 冲突（相同 Envelope ID，不同 SHA-256 hash） |
+| `hotplex.execution.session_busy` | Counter | Active gate 拒绝（session 已有 pending/running execution） |
+| `hotplex.execution.delivery_outcome` | Counter | Worker 投递结果，label: `delivery_status`（delivered / unknown / failed） |
+| `hotplex.execution.runtime_outcome` | Counter | Worker 运行终态，label: `runtime_status`（completed / failed / unknown） |
+| `hotplex.execution.delivery_latency` | Histogram | accept 到 delivery outcome 耗时（秒），bounds: 0.01–10 |
+| `hotplex.execution.runtime_duration` | Histogram | Worker turn 执行耗时（秒），bounds: 0.5–300 |
+
+### 常用查询
+
+```promql
+# 投递成功率
+sum(rate(hotplex_execution_delivery_outcome_total{delivery_status="delivered"}[5m]))
+/
+sum(rate(hotplex_execution_delivery_outcome_total[5m]))
+
+# 冲突率（可能为客户端 bug 或重放攻击）
+rate(hotplex_execution_conflict_total[5m])
+
+# Active gate 拒绝率
+rate(hotplex_execution_session_busy_total[5m])
+
+# P95 投递延迟
+histogram_quantile(0.95, rate(hotplex_execution_delivery_latency_bucket[5m]))
+```
+
+## Lease-Repair 指标
+
+Durable ingress 的 owner lease 续约与终态修复子系统。
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.lease.renew_failure` | Counter | Owner lease 续约失败次数 |
+| `hotplex.lease.expired_recovery` | Counter | Lease 过期后恢复（runtime 置为 unknown + 设置 fence） |
+| `hotplex.repair.attempts` | Counter | 终态修复尝试次数 |
+| `hotplex.repair.success` | Counter | 终态修复成功次数 |
+| `hotplex.repair.timeout` | Counter | 终态修复超时（超过 MaxLifetime 放弃） |
+| `hotplex.repair.dropped` | Counter | 终态修复入队失败（队列满，回退 lease recovery） |
+
+### 常用查询
+
+```promql
+# Lease 续约失败率
+rate(hotplex_lease_renew_failure_total[5m])
+
+# 修复成功率
+rate(hotplex_repair_success_total[5m]) / rate(hotplex_repair_attempts_total[5m])
+
+# 修复超时率（indicating systemic Worker stuck）
+rate(hotplex_repair_timeout_total[5m]) / rate(hotplex_repair_attempts_total[5m])
+```
+
+## Turn-Integrity 诊断指标
+
+Turn-Integrity 子系统（Fix E）用于检测和量化空 success turn、stale forwarder
+事件分割、assistant snapshot 漂移以及平台终态回退。
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.worker.empty_success_total` | Counter | 成功但未产出可显示内容和工具调用的 turn，label: `worker_type`, `platform` |
+| `hotplex.gateway.stale_forwarder_event_total` | Counter | `/reset` 替换 Conn 后仍被旧 forwarder 观察到的事件数 |
+| `hotplex.worker.assistant_snapshot_drift_total` | Counter | Full assistant snapshot 非前缀扩展被重新完整下发而非静默吞咽 |
+| `hotplex.messaging.platform_terminal_fallback_total` | Counter | 平台适配器因空内容发出的合成终态消息回退 |
+
+### 常用查询
+
+```promql
+# 空 success turn 占比
+rate(hotplex_worker_empty_success_total_total[5m])
+/
+rate(hotplex_worker_starts_total[5m])
+
+# Stale forwarder 事件（不为零表示冻结绑定未能阻止双消费者）
+rate(hotplex_gateway_stale_forwarder_event_total_total[5m])
+```
+
 ## SLO 参考
 
 | SLO | 指标 | 目标 |


### PR DESCRIPTION
## 修复内容

### runtime.execution 事件文档
- **`reference/events.md`**：新增 `runtime.execution.{started,completed,failed}` 三个 S→C additive 事件字段参考。通过 `execution_id` 把 `input.ack` 的输入接受关联到 Worker 终态结果。
- **`reference/aep-protocol.md`**：新增 runtime.execution 事件协议说明（JSON 示例、时序约束）、更新 Init 握手流程图和全双工通信流。

### 指标文档
- **`reference/metrics.md`**：新增 **Execution**（8 指标）、**Lease-Repair**（6 指标）、**Turn-Integrity**（4 指标）三组共 18 个指标小节，含常用 PromQL 查询。

### 企业运维指南
- **`guides/enterprise/observability.md`**：新增 **2.9 Execution & Lease-Repair**（14 指标）、**2.10 Turn TTFT**（5 指标）、**2.11 Forwarder 诊断**（4 指标）小节；更新 Grafana 面板（TTFT P95、投递成功率、TTFT 阶段拆分）和 4 条可靠性告警规则（HighDeliveryFailureRate / HighEmptySuccessTurn / HighLeaseRenewFailure / HighTTFTP99）；新增 SLO 条目（投递成功率、Lease 续约、TTFT P95）。

## 验证
- `make docs-build` 通过（56 文档 + 2 资源，无断链）
- 指标名与 `internal/observability/instruments.go` 100% 一致

Closes #898
Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)