### PR TITLE
fix(worker/ocs): preserve raw singleton crash evidence

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -370,6 +370,11 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	hub.SetSeqSessionExists(func(sessionID string) bool {
 		return sm.IsSeqActive(context.Background(), sessionID)
 	})
+	// Drain the collector before hydrating SeqGen on reconnect so LatestSeq
+	// includes events that were allocated seqs but not yet committed (issue #894).
+	if stores.collector != nil {
+		hub.SetSeqFlusher(stores.collector)
+	}
 	sm.OnRuntimeRelease = func(ctx context.Context, sessionID string) {
 		err := hub.ReleaseSeq(sessionID, func() error {
 			// A zero value means no durable sequence was allocated; remove a

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -277,7 +277,7 @@ func startMessagingAdapters(ctx context.Context, deps *GatewayDeps) ([]messaging
 				if entry.Name != "" {
 					botDir := filepath.Join(appCfg.AgentConfig.ConfigDir, string(pt), entry.Name)
 					if _, err := os.Stat(botDir); os.IsNotExist(err) && agentconfig.HasGlobalFiles(appCfg.AgentConfig.ConfigDir) {
-						log.Warn("agent-config: global files found but no bot-level directory",
+						log.Debug("agent-config: global files found but no bot-level directory",
 							"platform", pt,
 							"bot", entry.Name,
 							"bot_dir", botDir)

--- a/docs/guides/enterprise/troubleshooting-ocs-windows.md
+++ b/docs/guides/enterprise/troubleshooting-ocs-windows.md
@@ -1,0 +1,118 @@
+# OpenCode Server Windows 故障排查 Runbook
+
+> 适用场景：Windows 部署下 OpenCode Server（OCS）singleton 进程异常退出，尤其是原生状态码 `0xC0000142`（STATUS_DLL_INIT_FAILED）。
+> 关联 issue：[#900](https://github.com/hrygo/hotplex/issues/900)
+
+## 核心概念：原始退出码 vs 归一化退出码
+
+OCS 采用 **singleton 进程模型**——一个 `opencode serve` 进程被所有 OCS session 共享。当该进程崩溃，所有引用它的 session 会同时进入 crash recovery。
+
+HotPlex 在 Bridge 层对 OCS 崩溃做了一次**归一化**：`Worker.Wait()` 统一返回 `exit_code=1`（崩溃未恢复）或 `0`（已恢复）。这个 `1` 是 HotPlex 的内部状态码，**不等于** `opencode` 子进程的原生退出码。
+
+因此日志里同时存在两套语义：
+
+| 字段 | 含义 | 示例 |
+|------|------|------|
+| `exit_code`（Bridge 日志/metric） | 归一化 Worker 退出码 | `1` |
+| `raw_exit_code` / `raw_exit_code_hex` | OCS 子进程**原生**退出码（仅 OCS worker 附加） | `3221225794` / `0xC0000142` |
+| `exit_code_hex`（singleton 日志） | 单例进程原生退出码十六进制 | `0xC0000142` |
+
+**排查要点**：看到 `raw_exit_code_hex=0xC0000142` 才是 Windows DLL 初始化失败的证据；`exit_code=1` 本身不能定责。
+
+> v1.37.0 起，OCS singleton 通过 `worker.RawExitCoder` 接口把原始码透传到 Bridge 的日志、`worker_crashes` 指标和用户错误消息。早期版本只有 singleton 自身日志记录原始码。
+
+## Gateway 日志检索
+
+围绕故障时间戳和 session_id 检索以下消息（前后保留 ≥20 行）：
+
+```
+opencode-server-singleton: startup phase        # phase: spawn | discover_port | health_check | running
+opencode-server-singleton: startup phase failed # 失败阶段 + resolved_executable + pid
+opencode-server-singleton: stderr               # OCS 子进程 stderr 逐行
+opencode-server-singleton: process crashed      # exit_code + exit_code_hex + refs
+opencode-server-singleton: process exited       # 正常退出
+bridge: worker exited with non-zero code        # exit_code + raw_exit_code + raw_exit_code_hex
+```
+
+`startup phase` 日志会带上 `resolved_executable`（`exec.LookPath` 解析后的实际路径）、`command`（非敏感命令摘要）、`pid` 和分配的 `port`——这些是区分 `.exe` 启动失败与 `.cmd` wrapper 失败的关键。
+
+OCS 子进程没有独立的日志文件。其 stderr 经 `readStderr` 逐行写入 Gateway 日志（消息前缀 `opencode-server-singleton: stderr`）。启用 `log.file` 时，在 Gateway 日志文件按时间线检索即可。
+
+## Windows 原生现场采集
+
+`0xC0000142` 只表示"某个 DLL 的 DllMain 返回了 FALSE"，**不指名是哪个 DLL**。要定位具体 DLL，必须在故障机器、且在 HotPlex 服务运行的**同一 Windows 账户**下采集以下证据。
+
+### 1. Event Viewer 的 faulting module（决定性）
+
+`事件查看器 → Windows 日志 → 应用程序`，按故障时间点过滤：
+
+- **Application Error**（事件 ID 1000）：记录 `Faulting application name`、`Faulting module name` 和 `Exception code`。
+- **Windows Error Reporting**（事件 ID 1001）：附加的模块信息。
+
+`Faulting module name` 会**直接点名**是哪个 DLL 初始化失败——这一条出来，根因基本锁定。
+
+### 2. 服务账户下手动复现
+
+在 HotPlex 服务的**同一登录账户**下运行（若是 LocalSystem 或专用服务账户，用 `psexec -s -i` 模拟 SYSTEM，或在该账户上下文的计划任务里跑）：
+
+```powershell
+opencode serve --port 19245   # 换一个空闲端口
+echo $LASTEXITCODE            # -1073741502 即 0xC0000142
+```
+
+完整捕获 stdout / stderr。若 `$LASTEXITCODE` 仍是 `-1073741502`，根因就现形了。
+
+### 3. ProcMon 抓 DLL 加载链
+
+[Process Monitor](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon) 过滤 `Process Name is opencode.exe`（必要时加 `cmd.exe`），关注：
+
+- `CreateFile` / `Load Image` 结果为 `ACCESS DENIED`——EDR/应用控制拦截。
+- `NAME NOT FOUND`——DLL 搜索路径缺失。
+
+能看到失败停在哪个 DLL、它的搜索路径是什么。
+
+### 4. EDR / 杀软日志
+
+查检测、隔离、阻止记录。**不要直接关闭终端防护来验证**——用受控 allowlist 或隔离环境验证更安全，也更有说服力。
+
+## 排查路径
+
+```
+看到 exit_code=1
+   │
+   ├─ 同时有 raw_exit_code_hex=0xC0000142？
+   │     ├─ 是 → DLL 初始化失败，按"Windows 原生现场采集"取 faulting module
+   │     └─ 否 → 检查 raw_exit_code 实际值，对照 Windows NT 状态码表
+   │
+   ├─ startup phase 失败？
+   │     ├─ spawn → 命令解析失败（看 resolved_executable，检查 PATH / .cmd shim）
+   │     ├─ discover_port → 进程起来了但没监听（看 stderr，可能 DLL 失败导致早期退出）
+   │     └─ health_check → 进程监听了但 /health 不通（看 stderr 栈追踪）
+   │
+   └─ resolved_executable 是 .cmd / .bat？
+         → wrapper 可能把子进程原生码映射为通用码；在服务账户直接跑 opencode.exe 取 $LASTEXITCODE
+```
+
+## 常见根因（需 faulting module / ProcMon 证据后才能确认）
+
+- OpenCode 可执行文件或其依赖的 DLL 初始化失败（VC++ Redistributable 缺失/损坏、架构不匹配）。
+- `.cmd` / npm / bun / node 等 wrapper 把子进程原生状态映射为通用退出码。
+- EDR / 应用控制（AppLocker / WDAC）阻止 DLL 或可执行文件加载。
+- 安装损坏、架构或运行库版本冲突。
+- 服务账户与交互账户的 PATH、TEMP、用户配置或文件权限不同。
+
+端口占用、普通配置错误通常**不足以**直接解释 `STATUS_DLL_INIT_FAILED`，除非日志显示这是另一次独立失败。
+
+## 诊断命令
+
+```bash
+# 检查 OCS 命令解析、wrapper 识别、--version 探测（v1.37.0+）
+hotplex doctor
+```
+
+`doctor` 的 `dependencies.opencode_server_resolve` 检查项会报告：
+
+- 解析后的实际可执行文件路径；
+- 是 native 二进制（`.exe` / 无扩展名）还是 wrapper（`.cmd` / `.bat` / `.ps1` / `.sh`）；
+- `opencode --version` 是否在 5 秒内成功；
+- 失败时给出平台相关的现场采集提示。

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -71,7 +71,7 @@ histogram_quantile(0.99, rate(hotplex_session_start_duration_bucket[5m]))
 |------|------|------|
 | `hotplex.worker.starts` | Counter | Worker 启动次数，label: `worker_type`, `result` |
 | `hotplex.worker.execution.duration` | Histogram | Worker 执行时长，label: `worker_type` |
-| `hotplex.worker.crashes` | Counter | Worker 崩溃次数，label: `worker_type`, `exit_code` |
+| `hotplex.worker.crashes` | Counter | Worker 崩溃次数，label: `worker_type`, `exit_code`, `raw_exit_code` |
 | `hotplex.worker.memory.bytes` | ObservableGauge | Worker 估算内存，label: `worker_type` |
 | `hotplex.worker.creation.duration` | Histogram | Worker 进程创建耗时 |
 

--- a/internal/cli/checkers/opencode_resolve.go
+++ b/internal/cli/checkers/opencode_resolve.go
@@ -47,6 +47,7 @@ func (c opencodeResolveChecker) Check(ctx context.Context) cli.Diagnostic {
 			Status:   cli.StatusFail,
 			Message:  "Failed to load config for OCS resolve check",
 			Detail:   err.Error(),
+			FixHint:  "Check your config syntax and HOTPLEX_HOME path, then run `hotplex doctor --fix`.",
 		}
 	}
 	if cfg == nil {
@@ -92,23 +93,27 @@ func (c opencodeResolveChecker) Check(ctx context.Context) cli.Diagnostic {
 		Status:   cli.StatusPass,
 		Message:  sb.String(),
 	}
+	var details []string
 	if !versionOK {
 		diag.Status = cli.StatusWarn
 		out := versionOut
 		if out == "" {
 			out = "(no output)"
 		}
-		diag.Detail = "version probe output: " + out
+		details = append(details, "version probe output: "+out)
 		diag.FixHint = ocsResolveFixHint(runtime.GOOS == "windows")
 	}
 	if kind == "wrapper" {
-		// Wrappers are permitted but can mask the child's native exit code.
 		diag.Status = cli.StatusWarn
-		diag.Detail = "OCS command resolves to a wrapper script (" + resolved +
-			"). Wrappers can remap the child process's native exit code (e.g. 0xC0000142) to a generic value."
+		details = append(details,
+			"OCS command resolves to a wrapper script ("+resolved+
+				"). Wrappers can remap the child process's native exit code (e.g. 0xC0000142) to a generic value.")
 		if diag.FixHint == "" {
 			diag.FixHint = "If startup fails, run `opencode serve --port <unused>` directly under the service account to capture the raw exit code."
 		}
+	}
+	if len(details) > 0 {
+		diag.Detail = strings.Join(details, "; ")
 	}
 	return diag
 }

--- a/internal/cli/checkers/opencode_resolve.go
+++ b/internal/cli/checkers/opencode_resolve.go
@@ -1,0 +1,150 @@
+package checkers
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// classifyExecutable reports whether resolved is a native binary or a wrapper
+// script. A Windows .cmd/.bat shim (or POSIX .sh) can remap the child
+// process's native exit status to a generic code, masking the original
+// 0xC0000142-class failure — flagging wrappers is central to issue #900.
+func classifyExecutable(resolved string) string {
+	ext := strings.ToLower(filepath.Ext(resolved))
+	switch ext {
+	case "", ".exe":
+		return "native"
+	case ".cmd", ".bat", ".ps1", ".sh":
+		return "wrapper"
+	default:
+		return "unknown"
+	}
+}
+
+// opencodeResolveChecker inspects the OpenCode Server worker command beyond a
+// bare PATH lookup. It reports the resolved executable, whether it is a native
+// binary or a wrapper script, and whether `opencode --version` succeeds within
+// a bounded timeout. On failure it emits platform-aware evidence-collection
+// hints so 0xC0000142-class startup failures become diagnosable. See #900.
+type opencodeResolveChecker struct{}
+
+func (c opencodeResolveChecker) Name() string     { return "dependencies.opencode_server_resolve" }
+func (c opencodeResolveChecker) Category() string { return "dependencies" }
+
+func (c opencodeResolveChecker) Check(ctx context.Context) cli.Diagnostic {
+	cfg, err := loadConfig()
+	if err != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusFail,
+			Message:  "Failed to load config for OCS resolve check",
+			Detail:   err.Error(),
+		}
+	}
+	if cfg == nil {
+		cfg = config.Default()
+	}
+
+	cmdStr := cfg.Worker.OpenCodeServer.Command
+	if cmdStr == "" {
+		cmdStr = "opencode"
+	}
+	parts := strings.Fields(cmdStr)
+	binary := "opencode"
+	if len(parts) > 0 {
+		binary = parts[0]
+	}
+
+	resolved, lookErr := exec.LookPath(binary)
+	if lookErr != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusFail,
+			Message:  "OpenCode Server command not found in PATH: " + binary,
+			Detail:   lookErr.Error(),
+			FixHint:  ocsResolveFixHint(runtime.GOOS == "windows"),
+		}
+	}
+
+	kind := classifyExecutable(resolved)
+	versionOK, versionOut := probeVersion(ctx, binary)
+
+	var sb strings.Builder
+	sb.WriteString("resolved=" + resolved + " (" + kind + ")")
+	if versionOK {
+		sb.WriteString("; version OK")
+	} else {
+		sb.WriteString("; version probe FAILED")
+	}
+
+	diag := cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusPass,
+		Message:  sb.String(),
+	}
+	if !versionOK {
+		diag.Status = cli.StatusWarn
+		out := versionOut
+		if out == "" {
+			out = "(no output)"
+		}
+		diag.Detail = "version probe output: " + out
+		diag.FixHint = ocsResolveFixHint(runtime.GOOS == "windows")
+	}
+	if kind == "wrapper" {
+		// Wrappers are permitted but can mask the child's native exit code.
+		diag.Status = cli.StatusWarn
+		diag.Detail = "OCS command resolves to a wrapper script (" + resolved +
+			"). Wrappers can remap the child process's native exit code (e.g. 0xC0000142) to a generic value."
+		if diag.FixHint == "" {
+			diag.FixHint = "If startup fails, run `opencode serve --port <unused>` directly under the service account to capture the raw exit code."
+		}
+	}
+	return diag
+}
+
+// probeVersion runs `<binary> --version` with a 5s timeout and reports success
+// plus a trimmed snippet of combined output. This mirrors the real spawn path:
+// if the binary DLL-initializes a child that exits with 0xC0000142, the probe
+// fails the same way.
+func probeVersion(ctx context.Context, binary string) (bool, string) {
+	vctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(vctx, binary, "--version").CombinedOutput()
+	if vctx.Err() == context.DeadlineExceeded {
+		return false, "timeout after 5s"
+	}
+	if err != nil {
+		return false, strings.TrimSpace(string(out))
+	}
+	return true, strings.TrimSpace(string(out))
+}
+
+// ocsResolveFixHint returns platform-aware evidence-collection guidance for an
+// OCS startup failure. On Windows it points to Event Viewer's faulting module,
+// ProcMon, and service-account reproduction — the only sources that can name
+// the DLL behind a 0xC0000142.
+func ocsResolveFixHint(windows bool) string {
+	if windows {
+		return "Collect: Event Viewer (Application Error / WER faulting module), " +
+			"ProcMon DLL-load trace for opencode.exe, and run " +
+			"`opencode serve --port <unused>` under the HotPlex service account to " +
+			"read $LASTEXITCODE. Do NOT disable EDR to verify — use a controlled allowlist."
+	}
+	return "Run `opencode serve --port <unused>` under the HotPlex service account " +
+		"to capture stdout, stderr and the exit code."
+}
+
+func init() {
+	cli.DefaultRegistry.Register(opencodeResolveChecker{})
+}

--- a/internal/cli/checkers/opencode_resolve_test.go
+++ b/internal/cli/checkers/opencode_resolve_test.go
@@ -1,0 +1,36 @@
+package checkers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyExecutable(t *testing.T) {
+	t.Parallel()
+
+	// Resolving whether OCS is launched via a wrapper (.cmd/.bat shim that maps
+	// the child's native exit status to a generic code) vs a native binary is
+	// central to issue #900's Windows diagnostics.
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"windows exe", `C:\opt\opencode.exe`, "native"},
+		{"posix no extension", "/usr/local/bin/opencode", "native"},
+		{"empty path", "", "native"},
+		{"windows cmd wrapper", `C:\node\opencode.cmd`, "wrapper"},
+		{"windows bat wrapper", `C:\node\opencode.bat`, "wrapper"},
+		{"powershell wrapper", `C:\node\opencode.ps1`, "wrapper"},
+		{"posix shell shim", "/usr/local/bin/opencode.sh", "wrapper"},
+		{"unknown extension", "/usr/local/bin/opencode.bin", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, classifyExecutable(tt.path))
+		})
+	}
+}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/observability"
 	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/internal/worker/proc"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 
@@ -773,6 +774,24 @@ type workerExitParams struct {
 	lastInput string
 }
 
+// rawExitCodeFields extracts the raw OS exit code from workers that implement
+// worker.RawExitCoder, formatted as unsigned decimal and hex. Returns ok=false
+// for workers whose Wait() already returns the raw code (no separate value to
+// report). Used in crash diagnostics to distinguish a normalized exit code
+// (OCS maps every crash to 1) from the underlying OS code (e.g. 0xC0000142).
+func (b *Bridge) rawExitCodeFields(w worker.Worker) (dec, hex string, ok bool) {
+	rc, isRaw := w.(worker.RawExitCoder)
+	if !isRaw {
+		return "", "", false
+	}
+	code, has := rc.RawExitCode()
+	if !has {
+		return "", "", false
+	}
+	dec, hex = proc.FormatExitCode(code)
+	return dec, hex, true
+}
+
 // handleWorkerExit processes worker exit after the recv channel closes.
 // It determines the exit code, attempts crash recovery, sends error events,
 // and performs cleanup.
@@ -903,15 +922,44 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			"session_id", p.sessionID, "worker_type", workerType)
 	} else if exitCode != 0 && exitCode != -1 {
 		acc := b.getOrInitAccum(p.sessionID, "", p.startTime)
-		lg.Warn("bridge: worker exited with non-zero code, sending crash error",
-			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode,
-			"duration", time.Since(p.startTime).Round(time.Millisecond), "turn_count", acc.TurnCount.Load())
-		observability.WorkerCrashes().Add(context.TODO(), 1, metric.WithAttributes(attribute.String("worker_type", string(workerType)), attribute.String("exit_code", fmt.Sprintf("%d", exitCode))))
-		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
+		rawDec, rawHex, hasRaw := b.rawExitCodeFields(w)
+		crashAttrs := []any{
+			"session_id", p.sessionID,
+			"worker_type", workerType,
+			"exit_code", exitCode,
+			"duration", time.Since(p.startTime).Round(time.Millisecond),
+			"turn_count", acc.TurnCount.Load(),
+		}
+		if hasRaw {
+			crashAttrs = append(crashAttrs, "raw_exit_code", rawDec, "raw_exit_code_hex", rawHex)
+		}
+		lg.Warn("bridge: worker exited with non-zero code, sending crash error", crashAttrs...)
+
+		metricAttrs := []attribute.KeyValue{
+			attribute.String("worker_type", string(workerType)),
+			attribute.String("exit_code", fmt.Sprintf("%d", exitCode)),
+		}
+		if hasRaw {
+			metricAttrs = append(metricAttrs,
+				attribute.String("raw_exit_code", rawDec),
+				attribute.String("raw_exit_code_hex", rawHex))
+		}
+		observability.WorkerCrashes().Add(context.TODO(), 1, metric.WithAttributes(metricAttrs...))
+
+		if hasRaw {
+			b.sendError(p.sessionID, events.ErrCodeWorkerCrash,
+				"worker crashed (exit code %d, raw %s %s)", exitCode, rawDec, rawHex)
+		} else {
+			b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
+		}
+		syntheticMsg := fmt.Sprintf("Worker crashed with exit code %d", exitCode)
+		if hasRaw {
+			syntheticMsg = fmt.Sprintf("Worker crashed with exit code %d (raw %s %s)", exitCode, rawDec, rawHex)
+		}
 		b.captureSyntheticEvent(syntheticTurnParams{
 			SessionID:  p.sessionID,
 			Reason:     "worker_crash",
-			Message:    fmt.Sprintf("Worker crashed with exit code %d", exitCode),
+			Message:    syntheticMsg,
 			Source:     eventstore.SourceCrash,
 			Platform:   p.sessPlatform,
 			Owner:      p.sessOwner,

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -905,6 +905,17 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 			}
 			return
 		}
+		// P0 guard: if the session was deleted and re-created (same deterministic ID)
+		// with a new worker, this stale forwardEvents goroutine must not produce side
+		// effects (captureSyntheticEvent, sendError) that would allocate seq numbers
+		// from the new session's seqGen, causing UNIQUE constraint violations on the
+		// events table. The worker CAS check reliably detects re-creation because
+		// DeletePhysical sets ms.worker = nil before the new session's AttachWorker.
+		if currentWorker := b.sm.GetWorker(p.sessionID); currentWorker != w {
+			lg.Debug("bridge: worker replaced, skipping stale forwarder cleanup",
+				"session_id", p.sessionID, "worker_type", workerType)
+			return
+		}
 	}
 
 	// Suppress user-facing errors when:
@@ -941,21 +952,12 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		}
 		if hasRaw {
 			metricAttrs = append(metricAttrs,
-				attribute.String("raw_exit_code", rawDec),
-				attribute.String("raw_exit_code_hex", rawHex))
+				attribute.String("raw_exit_code", rawDec))
 		}
 		observability.WorkerCrashes().Add(context.TODO(), 1, metric.WithAttributes(metricAttrs...))
 
-		if hasRaw {
-			b.sendError(p.sessionID, events.ErrCodeWorkerCrash,
-				"worker crashed (exit code %d, raw %s %s)", exitCode, rawDec, rawHex)
-		} else {
-			b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
-		}
+		b.sendError(p.sessionID, events.ErrCodeWorkerCrash, "worker crashed (exit code %d)", exitCode)
 		syntheticMsg := fmt.Sprintf("Worker crashed with exit code %d", exitCode)
-		if hasRaw {
-			syntheticMsg = fmt.Sprintf("Worker crashed with exit code %d (raw %s %s)", exitCode, rawDec, rawHex)
-		}
 		b.captureSyntheticEvent(syntheticTurnParams{
 			SessionID:  p.sessionID,
 			Reason:     "worker_crash",

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -1026,3 +1026,103 @@ func TestResetSession_NoUpdater_NoReload(t *testing.T) {
 	// No crash, no panic — worker without SystemPromptUpdater is silently skipped.
 	sm.AssertExpectations(t)
 }
+
+// ─── Tests for the worker-binding guard in handleWorkerExit ──────────────────
+
+// TestBridge_HandleWorkerExit_StaleForwarderAfterRecreate verifies that when a
+// session is deleted and re-created with a new worker (same deterministic ID),
+// the old forwarder's handleWorkerExit returns early without producing side
+// effects (error events, synthetic events, worker cleanup) that would otherwise
+// use the new session's seqGen and cause UNIQUE constraint violations on the
+// events table.
+func TestBridge_HandleWorkerExit_StaleForwarderAfterRecreate(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess_recreated"
+
+	oldWorker := &mockBridgeWorker{
+		workerType: worker.TypeClaudeCode,
+		exitCode:   1,
+		conn:       &fakeWorkerConn{ch: make(chan *events.Envelope, 1)},
+	}
+	oldWorker.stopped.Store(false)
+
+	newWorker := &mockBridgeWorker{
+		workerType: worker.TypeClaudeCode,
+		conn:       &fakeWorkerConn{ch: make(chan *events.Envelope)},
+	}
+
+	sm := new(mockBridgeSM)
+	sm.Test(t)
+
+	// Session exists (re-created) and is running, not terminated.
+	sm.On("Get", sessionID).Return(&session.SessionInfo{
+		ID: sessionID, State: events.StateRunning,
+	}, nil)
+	// GetWorker returns the NEW worker, not the old crashed one.
+	sm.On("GetWorker", sessionID).Return(newWorker)
+
+	h := newTestHub(t)
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h, SM: sm})
+
+	params := workerExitParams{
+		sessionID:    sessionID,
+		workerType:   worker.TypeClaudeCode,
+		doneReceived: false,
+		startTime:    time.Now(),
+		flog:         slog.Default(),
+		opts:         forwardOpts{retryDepth: 2}, // Skip fallback for cleaner test
+	}
+
+	// Must not panic, and must skip sendError/captureSyntheticEvent/cleanup.
+	b.handleWorkerExit(oldWorker, params)
+
+	sm.AssertExpectations(t)
+
+	// Verify no accumulator was created for the stale forwarder.
+	b.accumMu.RLock()
+	_, hasAccum := b.accum[sessionID]
+	b.accumMu.RUnlock()
+	assert.False(t, hasAccum, "stale forwarder must not create accumulator")
+}
+
+// TestBridge_HandleWorkerExit_StaleForwarderAfterDelete verifies that when a
+// session has been physically deleted (no re-creation), the old forwarder's
+// handleWorkerExit returns early without side effects.
+func TestBridge_HandleWorkerExit_StaleForwarderAfterDelete(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "sess_deleted"
+
+	oldWorker := &mockBridgeWorker{
+		workerType: worker.TypeClaudeCode,
+		exitCode:   1,
+		conn:       &fakeWorkerConn{ch: make(chan *events.Envelope, 1)},
+	}
+	oldWorker.stopped.Store(false)
+
+	sm := new(mockBridgeSM)
+	sm.Test(t)
+
+	// Session was deleted — Get returns error.
+	sm.On("Get", sessionID).Return(nil, session.ErrSessionNotFound)
+	// GetWorker returns nil because session no longer exists in the map.
+	sm.On("GetWorker", sessionID).Return(nil)
+
+	h := newTestHub(t)
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h, SM: sm})
+
+	params := workerExitParams{
+		sessionID:    sessionID,
+		workerType:   worker.TypeClaudeCode,
+		doneReceived: false,
+		startTime:    time.Now(),
+		flog:         slog.Default(),
+		opts:         forwardOpts{retryDepth: 2},
+	}
+
+	// Must not panic, and must skip error/capture/cleanup.
+	b.handleWorkerExit(oldWorker, params)
+
+	sm.AssertExpectations(t)
+}

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -230,7 +231,12 @@ func (c *Conn) ReadPump(handler connHandler, sm connSM, auth connAuth) {
 
 	// Phase 1: AEP init handshake — read the first message.
 	if err := c.performInit(auth, sm); err != nil {
-		c.log.Warn("gateway: init handshake failed", "session_id", c.sessionID, "err", err)
+		// Demote to DEBUG for duplicate WS owner (resolveSession already logged a WARN).
+		if strings.Contains(err.Error(), "already has an active") {
+			c.log.Debug("gateway: init handshake failed", "session_id", c.sessionID, "err", err)
+		} else {
+			c.log.Warn("gateway: init handshake failed", "session_id", c.sessionID, "err", err)
+		}
 		return
 	}
 

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -1094,6 +1094,13 @@ func (c *Conn) Close() error {
 	return c.wc.Close()
 }
 
+// Closed reports whether the connection is closed.
+func (c *Conn) Closed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
 func (c *Conn) sendError(code events.ErrorCode, msg string) {
 	env := events.NewEnvelope(aep.NewID(), c.sessionID, c.hub.NextSeq(c.sessionID), events.Error, events.ErrorData{
 		Code:    code,

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -122,6 +122,10 @@ type Hub struct {
 	// seqHydrator reads persisted event seqs to seed SeqGen on reconnect
 	// (issue #879). nil when eventstore is disabled — SeqGen then restarts at 1.
 	seqHydrator SeqHydrator
+	// seqFlusher drains pending collector writes before reading LatestSeq
+	// during hydration (issue #894: stale LatestSeq on async capture flush).
+	// nil when eventstore is disabled — hydration skips the flush.
+	seqFlusher SeqFlusher
 
 	// Shutdown signals.
 	ctx    context.Context
@@ -771,16 +775,31 @@ func (h *Hub) SetSeqSessionExists(check func(sessionID string) bool) {
 	h.seqSessionExists = check
 }
 
+// SetSeqFlusher injects the collector flush used to drain pending writes
+// before reading LatestSeq during hydration. Called once at gateway startup
+// after the collector is created; nil when eventstore is disabled.
+func (h *Hub) SetSeqFlusher(sf SeqFlusher) {
+	h.seqFlusher = sf
+}
+
 // EnsureSeqHydrated seeds the SeqGen counter for sessionID from persisted
 // events on first use. A database error is fatal to the handshake: falling
 // back to 1 could collide with durable history and make the collector reject
 // the entire batch. MUST run before the first NextSeq for a session.
+//
+// Uses a write-lock fence (instead of BeginSeqOperation's RLock) to act as a
+// full barrier: all concurrent seq producers and ReleaseSeq must complete
+// before LatestSeq is read. An optional SeqFlusher drains the collector's
+// async captureC first, preventing stale-LatestSeq races where an allocated
+// seq is in-flight but not yet visible in the DB (issue #894).
 func (h *Hub) EnsureSeqHydrated(sessionID string) error {
-	releaseSeq, ok := h.BeginSeqOperation(sessionID)
-	if !ok {
+	barrier := h.seqBarrier(sessionID)
+	barrier.Lock()
+	defer barrier.Unlock()
+
+	if h.seqSessionExists != nil && !h.seqSessionExists(sessionID) {
 		return fmt.Errorf("gateway: session released: %s", sessionID)
 	}
-	defer releaseSeq()
 
 	if h.seqHydrator == nil {
 		return nil
@@ -788,6 +807,16 @@ func (h *Hub) EnsureSeqHydrated(sessionID string) error {
 	if h.seqGen.Initialized(sessionID) {
 		return nil
 	}
+
+	// Flush the collector's async captureC before reading LatestSeq so that
+	// events whose seq was already allocated but not yet committed to the DB
+	// are visible before we seed the new counter.
+	if h.seqFlusher != nil {
+		if err := h.seqFlusher.FlushSession(sessionID); err != nil {
+			return fmt.Errorf("gateway: flush before hydrate seq for session %s: %w", sessionID, err)
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(h.ctx, 3*time.Second)
 	defer cancel()
 	latest, err := h.seqHydrator.LatestSeq(ctx, sessionID)

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -248,8 +248,15 @@ func (h *Hub) UnregisterConn(conn *Conn) {
 func (h *Hub) TryAcquireWebChatOwner(sessionID string, conn *Conn) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if _, exists := h.webchatOwners[sessionID]; exists {
-		return false
+	if existing, exists := h.webchatOwners[sessionID]; exists {
+		if !existing.Closed() {
+			return false
+		}
+		h.log.Info("gateway: replacing closed WebChat owner connection",
+			"session_id", sessionID,
+			"old_conn_id", existing.connID,
+			"new_conn_id", conn.connID,
+		)
 	}
 	h.webchatOwners[sessionID] = conn
 	return true

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -175,6 +175,33 @@ func TestHub_WebChatOwner_OnlyCurrentConnectionCanRelease(t *testing.T) {
 	require.False(t, h.IsWebChatOwner("sess_owner", c2))
 }
 
+func TestHub_WebChatOwner_ReplaceClosedOwner(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	conn1, server1 := newTestWSConnPair(t)
+	conn2, server2 := newTestWSConnPair(t)
+	t.Cleanup(func() {
+		_ = conn1.Close()
+		_ = server1.Close()
+		_ = conn2.Close()
+		_ = server2.Close()
+	})
+
+	c1 := newConn(h, conn1, "sess_owner_replace", nil)
+	c2 := newConn(h, conn2, "sess_owner_replace", nil)
+
+	require.True(t, h.TryAcquireWebChatOwner("sess_owner_replace", c1))
+	require.False(t, h.TryAcquireWebChatOwner("sess_owner_replace", c2))
+
+	// Close c1
+	require.NoError(t, c1.Close())
+
+	// c2 should be able to acquire ownership
+	require.True(t, h.TryAcquireWebChatOwner("sess_owner_replace", c2))
+	require.True(t, h.IsWebChatOwner("sess_owner_replace", c2))
+	require.False(t, h.IsWebChatOwner("sess_owner_replace", c1))
+}
+
 func TestHub_WebChatOwner_ConcurrentAcquireHasOneWinner(t *testing.T) {
 	t.Parallel()
 	h := newTestHub(t)

--- a/internal/gateway/seq.go
+++ b/internal/gateway/seq.go
@@ -13,6 +13,13 @@ type SeqHydrator interface {
 	LatestSeq(ctx context.Context, sessionID string) (int64, error)
 }
 
+// SeqFlusher drains pending collector writes for a session so LatestSeq is
+// accurate before SeqGen hydration. Set by gateway_run.go when the collector
+// is available; nil when eventstore is disabled.
+type SeqFlusher interface {
+	FlushSession(sessionID string) error
+}
+
 // SeqGen generates monotonically increasing sequence numbers per session.
 // Uses sync.Map + per-session atomic.Int64 to eliminate cross-session contention.
 type SeqGen struct {

--- a/internal/gateway/seq_test.go
+++ b/internal/gateway/seq_test.go
@@ -147,6 +147,80 @@ func TestHub_ForgetSeqAllowsFreshHydration(t *testing.T) {
 	require.Equal(t, int64(21), h.NextSeq("s1"))
 }
 
+// mockSeqFlusher records FlushSession calls for test assertions.
+type mockSeqFlusher struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (m *mockSeqFlusher) FlushSession(sessionID string) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, sessionID)
+	m.mu.Unlock()
+	return nil
+}
+
+// TestHub_EnsureSeqHydratedWaitsForConcurrentProducer verifies the write-lock
+// fence: EnsureSeqHydrated blocks behind a concurrent seq operation (RLock)
+// and only proceeds after the producer releases. Without the write-lock fence,
+// hydration could read LatestSeq while an old forwarder is still allocating
+// seqs, leading to a stale counter and UNIQUE constraint violations (issue #894).
+func TestHub_EnsureSeqHydratedWaitsForConcurrentProducer(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	h.SetSeqHydrator(&mockSeqHydrator{seq: 100})
+
+	releaseProducer, ok := h.BeginSeqOperation("s1")
+	require.True(t, ok)
+
+	hydrated := make(chan error, 1)
+	go func() {
+		hydrated <- h.EnsureSeqHydrated("s1")
+	}()
+
+	require.Never(t, func() bool {
+		select {
+		case <-hydrated:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	releaseProducer()
+	require.NoError(t, <-hydrated)
+	require.Equal(t, int64(101), h.NextSeq("s1"))
+}
+
+// TestHub_EnsureSeqHydratedCallsFlusherBeforeHydrate verifies that EnsureSeqHydrated
+// drains the collector flush before reading LatestSeq. Without this, events whose
+// seq was already allocated but not yet committed to the DB would be invisible,
+// causing the new counter to collide with in-flight seqs (issue #894).
+func TestHub_EnsureSeqHydratedCallsFlusherBeforeHydrate(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	hydrator := &mockSeqHydrator{seq: 50}
+	flusher := &mockSeqFlusher{}
+	h.SetSeqHydrator(hydrator)
+	h.SetSeqFlusher(flusher)
+
+	require.NoError(t, h.EnsureSeqHydrated("s1"))
+
+	flusher.mu.Lock()
+	require.Contains(t, flusher.calls, "s1")
+	flusher.mu.Unlock()
+
+	require.Equal(t, int64(51), h.NextSeq("s1"))
+
+	// Second call skips both flusher and hydrator (already initialized).
+	hydrator.err = errors.New("should not be called")
+	require.NoError(t, h.EnsureSeqHydrated("s1"))
+	require.Equal(t, 1, hydrator.calls)
+	flusher.mu.Lock()
+	require.Len(t, flusher.calls, 1)
+	flusher.mu.Unlock()
+}
+
 func TestHub_ReleaseSeqWaitsForDurableProducer(t *testing.T) {
 	t.Parallel()
 	h := newTestHub(t)

--- a/internal/gateway/session_stats.go
+++ b/internal/gateway/session_stats.go
@@ -210,6 +210,27 @@ func (a *sessionAccumulator) mergeContextUsage(cu *events.ContextUsageData) {
 	if cu.Model != "" && a.ModelName == "" {
 		a.ModelName = shortModelName(cu.Model)
 	}
+	for _, cat := range cu.Categories {
+		name := strings.ToLower(cat.Name)
+		switch {
+		case strings.Contains(name, "input"):
+			if cat.Tokens > 0 {
+				a.TotalInput = int64(cat.Tokens)
+			}
+		case strings.Contains(name, "output"):
+			if cat.Tokens > 0 {
+				a.TotalOutput = int64(cat.Tokens)
+			}
+		case strings.Contains(name, "cache read") || strings.Contains(name, "cache_read"):
+			if cat.Tokens > 0 {
+				a.TotalCacheRead = int64(cat.Tokens)
+			}
+		case strings.Contains(name, "cache write") || strings.Contains(name, "cache_write"):
+			if cat.Tokens > 0 {
+				a.TotalCacheWrite = int64(cat.Tokens)
+			}
+		}
+	}
 }
 
 // computeContextPct returns context window usage percentage (0-100).

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -76,8 +76,6 @@ func Init(ctx context.Context, log *slog.Logger, cfg Config) func(context.Contex
 		))
 
 		log.Info("observability: initialized",
-			"service", cfg.ServiceName,
-			"version", cfg.ServiceVersion,
 			"environment", cfg.Environment,
 			"sample_rate", cfg.SampleRate,
 		)

--- a/internal/worker/opencodeserver/ringbuffer.go
+++ b/internal/worker/opencodeserver/ringbuffer.go
@@ -1,0 +1,51 @@
+package opencodeserver
+
+import "sync"
+
+// ringBuffer is a fixed-capacity, thread-safe ring buffer of stderr lines.
+// It retains the most recent N lines so startup failures can surface a bounded,
+// redacted tail instead of forcing operators to grep the gateway log at the
+// exact crash timestamp.
+type ringBuffer struct {
+	mu   sync.Mutex
+	buf  []string
+	cap  int
+	head int // next write position
+	n    int // item count (0..cap)
+}
+
+func newRingBuffer(capacity int) *ringBuffer {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &ringBuffer{cap: capacity, buf: make([]string, capacity)}
+}
+
+func (r *ringBuffer) Add(line string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cap == 0 {
+		return
+	}
+	r.buf[r.head] = line
+	r.head = (r.head + 1) % r.cap
+	if r.n < r.cap {
+		r.n++
+	}
+}
+
+// Lines returns a snapshot of buffered lines in oldest→newest order, or nil if
+// empty.
+func (r *ringBuffer) Lines() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.n == 0 {
+		return nil
+	}
+	out := make([]string, 0, r.n)
+	start := (r.head - r.n + r.cap) % r.cap // oldest entry
+	for i := 0; i < r.n; i++ {
+		out = append(out, r.buf[(start+i)%r.cap])
+	}
+	return out
+}

--- a/internal/worker/opencodeserver/ringbuffer.go
+++ b/internal/worker/opencodeserver/ringbuffer.go
@@ -49,3 +49,18 @@ func (r *ringBuffer) Lines() []string {
 	}
 	return out
 }
+
+// Reset clears all buffered lines, reusing the underlying storage. Called at
+// the start of each singleton lifecycle so a new crash's stderr tail is not
+// contaminated by the previous lifecycle's lines. Reusing storage (rather than
+// reassigning the field) also keeps the pointer stable so readStderr never
+// races a concurrent field swap.
+func (r *ringBuffer) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.buf {
+		r.buf[i] = ""
+	}
+	r.head = 0
+	r.n = 0
+}

--- a/internal/worker/opencodeserver/ringbuffer_test.go
+++ b/internal/worker/opencodeserver/ringbuffer_test.go
@@ -1,0 +1,76 @@
+package opencodeserver
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingBuffer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		t.Parallel()
+		rb := newRingBuffer(3)
+		require.Nil(t, rb.Lines())
+	})
+
+	t.Run("under capacity returns all in order", func(t *testing.T) {
+		t.Parallel()
+		rb := newRingBuffer(3)
+		rb.Add("a")
+		rb.Add("b")
+		require.Equal(t, []string{"a", "b"}, rb.Lines())
+	})
+
+	t.Run("exactly capacity", func(t *testing.T) {
+		t.Parallel()
+		rb := newRingBuffer(3)
+		rb.Add("a")
+		rb.Add("b")
+		rb.Add("c")
+		require.Equal(t, []string{"a", "b", "c"}, rb.Lines())
+	})
+
+	t.Run("over capacity keeps most recent N in order", func(t *testing.T) {
+		t.Parallel()
+		rb := newRingBuffer(3)
+		rb.Add("a")
+		rb.Add("b")
+		rb.Add("c")
+		rb.Add("d")
+		rb.Add("e")
+		require.Equal(t, []string{"c", "d", "e"}, rb.Lines())
+	})
+
+	t.Run("zero capacity returns nil and drops all", func(t *testing.T) {
+		t.Parallel()
+		rb := newRingBuffer(0)
+		rb.Add("a")
+		require.Nil(t, rb.Lines())
+	})
+}
+
+func TestRingBuffer_Concurrent(t *testing.T) {
+	t.Parallel()
+	rb := newRingBuffer(100)
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			rb.Add(strings.Repeat("x", n%10+1))
+		}(i)
+	}
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = rb.Lines()
+		}()
+	}
+	wg.Wait()
+	require.LessOrEqual(t, len(rb.Lines()), 100)
+}

--- a/internal/worker/opencodeserver/ringbuffer_test.go
+++ b/internal/worker/opencodeserver/ringbuffer_test.go
@@ -53,6 +53,23 @@ func TestRingBuffer(t *testing.T) {
 	})
 }
 
+func TestRingBuffer_Reset(t *testing.T) {
+	t.Parallel()
+
+	rb := newRingBuffer(3)
+	rb.Add("a")
+	rb.Add("b")
+	require.Equal(t, []string{"a", "b"}, rb.Lines())
+
+	rb.Reset()
+	require.Nil(t, rb.Lines(), "must be empty immediately after reset")
+
+	// Buffer must be reusable: head/n reset so new writes lay out in order.
+	rb.Add("c")
+	rb.Add("d")
+	require.Equal(t, []string{"c", "d"}, rb.Lines())
+}
+
 func TestRingBuffer_Concurrent(t *testing.T) {
 	t.Parallel()
 	rb := newRingBuffer(100)

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"regexp"
 	"runtime/debug"
 	"strconv"
@@ -61,6 +62,14 @@ type SingletonProcessManager struct {
 	converter *Converter
 
 	idleTimer *time.Timer
+
+	// Crash diagnostics (issue #900): preserve the raw OS exit code and a
+	// bounded stderr tail so operators can distinguish a Windows NT status
+	// (e.g. 0xC0000142 STATUS_DLL_INIT_FAILED) from the normalized Worker
+	// exit code (1) surfaced to the Bridge. Guarded by s.mu.
+	lastExitCode int
+	hasExitCode  bool
+	stderrRing   *ringBuffer
 }
 
 type singletonState int
@@ -74,6 +83,10 @@ const (
 
 // portRegex matches "opencode server listening on http://127.0.0.1:PORT".
 var portRegex = regexp.MustCompile(`listening on http://[\d.]+:(\d+)`)
+
+// stderrRingCapacity bounds how many recent stderr lines are retained for
+// startup-failure diagnostics.
+const stderrRingCapacity = 64
 
 // NewSingletonProcessManager creates a new singleton process manager.
 func NewSingletonProcessManager(log *slog.Logger, cfg config.OpenCodeServerConfig) *SingletonProcessManager {
@@ -90,6 +103,7 @@ func NewSingletonProcessManager(log *slog.Logger, cfg config.OpenCodeServerConfi
 		crashCh:     make(chan struct{}),
 		subscribers: make(map[string]chan *events.Envelope),
 		converter:   NewConverter(),
+		stderrRing:  newRingBuffer(stderrRingCapacity),
 	}
 }
 
@@ -248,11 +262,47 @@ func (s *SingletonProcessManager) PID() int {
 
 // --- internal ---
 
+// LastExitCode returns the raw OS exit code of the most recent singleton
+// process and whether one has been observed. The Bridge reads this via the
+// RawExitCoder interface to tell a Windows NT status (e.g. 0xC0000142) apart
+// from the normalized Worker exit code (1).
+func (s *SingletonProcessManager) LastExitCode() (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastExitCode, s.hasExitCode
+}
+
+// StderrTail returns a snapshot of the most recent captured stderr lines, for
+// attaching to startup-failure diagnostics.
+func (s *SingletonProcessManager) StderrTail() []string {
+	return s.stderrRing.Lines()
+}
+
+// stderrTailMaxBytes bounds the total byte length of the stderr summary
+// attached to startup-failure errors, preventing a runaway log line.
+const stderrTailMaxBytes = 2048
+
+// startupFailureError wraps err with the failing startup phase and a bounded
+// tail of recent stderr so operators can diagnose OCS startup failures
+// (spawn / discover port / health check) without grepping the gateway log at
+// the exact timestamp.
+func (s *SingletonProcessManager) startupFailureError(phase string, err error) error {
+	tail := s.StderrTail()
+	if len(tail) == 0 {
+		return fmt.Errorf("opencode-server-singleton: %s: %w", phase, err)
+	}
+	summary := strings.Join(tail, "\n")
+	if len(summary) > stderrTailMaxBytes {
+		summary = summary[len(summary)-stderrTailMaxBytes:]
+	}
+	return fmt.Errorf("opencode-server-singleton: %s: %w (recent stderr: %s)", phase, err, summary)
+}
+
 // startProcessLocked starts the opencode serve process. Caller must hold s.mu.
 func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error {
 	s.state = stateStarting
 	s.converter.Reset()
-	s.log.Info("opencode-server-singleton: starting opencode serve process")
+	s.stderrRing = newRingBuffer(stderrRingCapacity) // reset tail for this lifecycle
 
 	// Allocate an ephemeral port.
 	port, err := s.allocatePort()
@@ -275,6 +325,20 @@ func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error 
 	fullArgs = append(fullArgs, parts[1:]...)
 	fullArgs = append(fullArgs, args...)
 
+	// Resolve the actual executable path so a Windows wrapper (.cmd shim) is
+	// distinguishable from a native .exe in crash diagnostics. LookPath failure
+	// is non-fatal — proc.Start will surface the real spawn error.
+	resolved, lookErr := exec.LookPath(binary)
+	if lookErr != nil {
+		resolved = binary
+	}
+	commandSummary := binary + " " + strings.Join(fullArgs, " ")
+	s.log.Info("opencode-server-singleton: startup phase",
+		"phase", "spawn",
+		"resolved_executable", resolved,
+		"command", commandSummary,
+		"port", port)
+
 	env := s.buildEnv()
 	s.proc = proc.New(proc.Opts{Logger: s.log})
 
@@ -282,7 +346,9 @@ func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error 
 	if err != nil {
 		s.proc = nil
 		s.state = stateIdle
-		return fmt.Errorf("opencode-server-singleton: start process: %w", err)
+		s.log.Warn("opencode-server-singleton: startup phase failed", "phase", "spawn",
+			"resolved_executable", resolved, "error", err)
+		return s.startupFailureError("spawn", err)
 	}
 	_ = stdin
 
@@ -290,28 +356,38 @@ func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error 
 	// are captured in the gateway log instead of trapped in the pipe.
 	go s.readStderr(stderr)
 
+	s.log.Info("opencode-server-singleton: startup phase",
+		"phase", "discover_port", "resolved_executable", resolved, "pid", s.proc.PID())
+
 	// Discover actual port from stdout (opencode serve prints it).
 	actualPort, err := s.discoverPort(stdout, s.cfg.ReadyTimeout)
 	if err != nil {
 		_ = s.proc.Kill()
 		s.proc = nil
 		s.state = stateIdle
-		return fmt.Errorf("opencode-server-singleton: discover port: %w", err)
+		s.log.Warn("opencode-server-singleton: startup phase failed", "phase", "discover_port",
+			"resolved_executable", resolved, "pid", s.proc.PID(), "error", err)
+		return s.startupFailureError("discover port", err)
 	}
 
 	s.httpAddr = fmt.Sprintf("http://127.0.0.1:%d", actualPort)
-	s.log.Info("opencode-server-singleton: process started", "addr", s.httpAddr)
 
 	// Wait for /health endpoint.
+	s.log.Info("opencode-server-singleton: startup phase",
+		"phase", "health_check", "addr", s.httpAddr, "pid", s.proc.PID())
 	if err := s.waitForHealth(ctx); err != nil {
 		_ = s.proc.Kill()
 		s.proc = nil
 		s.state = stateIdle
-		return fmt.Errorf("opencode-server-singleton: health check: %w", err)
+		s.log.Warn("opencode-server-singleton: startup phase failed", "phase", "health_check",
+			"resolved_executable", resolved, "addr", s.httpAddr, "error", err)
+		return s.startupFailureError("health check", err)
 	}
 
 	s.state = stateRunning
 	s.pgid = s.proc.PGID()
+	s.log.Info("opencode-server-singleton: startup phase",
+		"phase", "running", "addr", s.httpAddr, "pid", s.proc.PID())
 
 	// Monitor process exit in background.
 	go s.monitorProcess()
@@ -389,7 +465,9 @@ func (s *SingletonProcessManager) readStderr(stderr *os.File) {
 	// OCS stack traces can exceed the default 64 KiB limit; raise the cap.
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		s.log.Warn("opencode-server-singleton: stderr", "line", scanner.Text())
+		line := scanner.Text()
+		s.stderrRing.Add(line)
+		s.log.Warn("opencode-server-singleton: stderr", "line", line)
 	}
 }
 
@@ -435,8 +513,11 @@ func (s *SingletonProcessManager) monitorProcess() {
 		return
 	}
 	code, _ := pm.Wait()
+	decCode, hexCode := proc.FormatExitCode(code)
 
 	s.mu.Lock()
+	s.lastExitCode = code
+	s.hasExitCode = true
 	wasRunning := s.state == stateRunning
 	refs := s.refs
 	// Guard against overwriting stateStopped set by Shutdown: once stopped,
@@ -456,11 +537,13 @@ func (s *SingletonProcessManager) monitorProcess() {
 
 	// Notify crash subscribers if process died unexpectedly while sessions are active.
 	if wasRunning && refs > 0 {
-		s.log.Warn("opencode-server-singleton: process crashed", "exit_code", code, "refs", refs)
+		s.log.Warn("opencode-server-singleton: process crashed",
+			"exit_code", decCode, "exit_code_hex", hexCode, "refs", refs)
 		close(s.crashCh)
 		s.crashCh = make(chan struct{}) // new channel for next lifecycle
 	} else {
-		s.log.Info("opencode-server-singleton: process exited", "exit_code", code, "refs", refs)
+		s.log.Info("opencode-server-singleton: process exited",
+			"exit_code", decCode, "exit_code_hex", hexCode, "refs", refs)
 	}
 	s.mu.Unlock()
 

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -282,6 +283,20 @@ func (s *SingletonProcessManager) StderrTail() []string {
 // attached to startup-failure errors, preventing a runaway log line.
 const stderrTailMaxBytes = 2048
 
+// truncateTailBytes returns the last maxBytes bytes of s, backed up to a UTF-8
+// rune boundary if the byte cut would split a multi-byte rune. Safe for
+// arbitrary stderr content (CJK, emoji, localized panic output).
+func truncateTailBytes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	start := len(s) - maxBytes
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return s[start:]
+}
+
 // startupFailureError wraps err with the failing startup phase and a bounded
 // tail of recent stderr so operators can diagnose OCS startup failures
 // (spawn / discover port / health check) without grepping the gateway log at
@@ -293,7 +308,7 @@ func (s *SingletonProcessManager) startupFailureError(phase string, err error) e
 	}
 	summary := strings.Join(tail, "\n")
 	if len(summary) > stderrTailMaxBytes {
-		summary = summary[len(summary)-stderrTailMaxBytes:]
+		summary = truncateTailBytes(summary, stderrTailMaxBytes)
 	}
 	return fmt.Errorf("opencode-server-singleton: %s: %w (recent stderr: %s)", phase, err, summary)
 }
@@ -302,7 +317,9 @@ func (s *SingletonProcessManager) startupFailureError(phase string, err error) e
 func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error {
 	s.state = stateStarting
 	s.converter.Reset()
-	s.stderrRing = newRingBuffer(stderrRingCapacity) // reset tail for this lifecycle
+	s.stderrRing.Reset() // clear previous lifecycle's tail (pointer stays stable → no race with readStderr)
+	s.lastExitCode = 0   // clear stale exit code from a previous lifecycle
+	s.hasExitCode = false
 
 	// Allocate an ephemeral port.
 	port, err := s.allocatePort()
@@ -362,11 +379,12 @@ func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error 
 	// Discover actual port from stdout (opencode serve prints it).
 	actualPort, err := s.discoverPort(stdout, s.cfg.ReadyTimeout)
 	if err != nil {
+		pid := s.proc.PID() // capture before Kill sets proc=nil
 		_ = s.proc.Kill()
 		s.proc = nil
 		s.state = stateIdle
 		s.log.Warn("opencode-server-singleton: startup phase failed", "phase", "discover_port",
-			"resolved_executable", resolved, "pid", s.proc.PID(), "error", err)
+			"resolved_executable", resolved, "pid", pid, "error", err)
 		return s.startupFailureError("discover port", err)
 	}
 
@@ -513,7 +531,7 @@ func (s *SingletonProcessManager) monitorProcess() {
 		return
 	}
 	code, _ := pm.Wait()
-	decCode, hexCode := proc.FormatExitCode(code)
+	_, hexCode := proc.FormatExitCode(code)
 
 	s.mu.Lock()
 	s.lastExitCode = code
@@ -538,12 +556,12 @@ func (s *SingletonProcessManager) monitorProcess() {
 	// Notify crash subscribers if process died unexpectedly while sessions are active.
 	if wasRunning && refs > 0 {
 		s.log.Warn("opencode-server-singleton: process crashed",
-			"exit_code", decCode, "exit_code_hex", hexCode, "refs", refs)
+			"exit_code", code, "exit_code_hex", hexCode, "refs", refs)
 		close(s.crashCh)
 		s.crashCh = make(chan struct{}) // new channel for next lifecycle
 	} else {
 		s.log.Info("opencode-server-singleton: process exited",
-			"exit_code", decCode, "exit_code_hex", hexCode, "refs", refs)
+			"exit_code", code, "exit_code_hex", hexCode, "refs", refs)
 	}
 	s.mu.Unlock()
 
@@ -568,6 +586,16 @@ func (s *SingletonProcessManager) startIdleDrainLocked() {
 
 		if s.refs == 0 && s.state == stateRunning && s.pgid > 0 {
 			s.log.Info("opencode-server-singleton: idle drain expired, killing process")
+			// Cancel the SSE reader context BEFORE killing the process so the
+			// reader sees ctx.Done() before the transport error (~40ms race)
+			// and exits cleanly instead of logging a WARN reconnect attempt
+			// against a dead process. monitorProcess also cancels sseCancel
+			// in the normal exit path (it guards with nil check, so a double
+			// cancel is harmless). See B4 in PR #891.
+			if s.sseCancel != nil {
+				s.sseCancel()
+				s.sseCancel = nil
+			}
 			// Hold s.mu during the kill to close the TOCTOU window where a
 			// concurrent Acquire could grab the doomed process and hand the
 			// caller a httpAddr about to die. We call package-level

--- a/internal/worker/opencodeserver/singleton_test.go
+++ b/internal/worker/opencodeserver/singleton_test.go
@@ -3,10 +3,12 @@ package opencodeserver
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -497,4 +499,78 @@ func TestSingletonProcessManager_readStderr(t *testing.T) {
 	output := buf.String()
 	require.Contains(t, output, "err one")
 	require.Contains(t, output, "err two")
+}
+
+func TestSingletonProcessManager_readStderr_FillsRing(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	mgr := NewSingletonProcessManager(log, config.OpenCodeServerConfig{})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	_, err = io.WriteString(w, "err one\nerr two\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	done := make(chan struct{})
+	go func() {
+		mgr.readStderr(r)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readStderr did not return after stderr was closed")
+	}
+
+	// Ring must capture the same lines that went to the logger, in order.
+	require.Equal(t, []string{"err one", "err two"}, mgr.StderrTail())
+}
+
+func TestSingletonProcessManager_LastExitCode_InitialState(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSingletonProcessManager(slog.Default(), config.OpenCodeServerConfig{})
+	code, ok := mgr.LastExitCode()
+	require.False(t, ok, "no exit code available before any process has run")
+	require.Equal(t, 0, code)
+}
+
+func TestSingletonProcessManager_StartupFailureError_WithTail(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSingletonProcessManager(slog.Default(), config.OpenCodeServerConfig{})
+	mgr.stderrRing.Add("line one")
+	mgr.stderrRing.Add("line two")
+
+	err := mgr.startupFailureError("discover port", fmt.Errorf("boom"))
+	s := err.Error()
+	require.Contains(t, s, "discover port")
+	require.Contains(t, s, "boom")
+	require.Contains(t, s, "line one")
+	require.Contains(t, s, "line two")
+}
+
+func TestSingletonProcessManager_StartupFailureError_NoTail(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSingletonProcessManager(slog.Default(), config.OpenCodeServerConfig{})
+	err := mgr.startupFailureError("spawn", fmt.Errorf("x"))
+	require.Contains(t, err.Error(), "spawn")
+	require.NotContains(t, err.Error(), "recent stderr")
+}
+
+func TestSingletonProcessManager_StartupFailureError_TruncatesLongTail(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewSingletonProcessManager(slog.Default(), config.OpenCodeServerConfig{})
+	mgr.stderrRing.Add(strings.Repeat("a", stderrTailMaxBytes*2))
+
+	err := mgr.startupFailureError("health check", fmt.Errorf("e"))
+	// Error string must be bounded, not carry the full 2x overflow payload.
+	require.Less(t, len(err.Error()), stderrTailMaxBytes*2)
 }

--- a/internal/worker/opencodeserver/singleton_test.go
+++ b/internal/worker/opencodeserver/singleton_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -573,4 +574,28 @@ func TestSingletonProcessManager_StartupFailureError_TruncatesLongTail(t *testin
 	err := mgr.startupFailureError("health check", fmt.Errorf("e"))
 	// Error string must be bounded, not carry the full 2x overflow payload.
 	require.Less(t, len(err.Error()), stderrTailMaxBytes*2)
+}
+
+func TestTruncateTailBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ascii returns exactly maxBytes", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "cdef", truncateTailBytes("abcdef", 4))
+	})
+
+	t.Run("short string returns whole", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "abc", truncateTailBytes("abc", 99))
+	})
+
+	t.Run("never splits a multibyte rune", func(t *testing.T) {
+		t.Parallel()
+		// Force a cut inside the last 3-byte CJK rune '世' (E4 B8 96).
+		s := strings.Repeat("a", stderrTailMaxBytes-1) + "世b"
+		got := truncateTailBytes(s, stderrTailMaxBytes)
+		require.True(t, utf8.ValidString(got), "result split a rune: %q", got)
+		require.True(t, strings.HasSuffix(s, got), "result must be a suffix")
+		require.LessOrEqual(t, len(got), stderrTailMaxBytes)
+	})
 }

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -422,6 +422,16 @@ func (w *Worker) Wait() (int, error) {
 	}
 }
 
+// RawExitCode reports the singleton process's raw OS exit code for Bridge
+// crash diagnostics. Implements worker.RawExitCoder. See Wait() for why the
+// normalized code (0/1) and the raw code differ for the shared OCS singleton.
+func (w *Worker) RawExitCode() (int, bool) {
+	if w.singleton == nil {
+		return 0, false
+	}
+	return w.singleton.LastExitCode()
+}
+
 // Conn returns the HTTP-based session connection.
 func (w *Worker) Conn() worker.SessionConn {
 	w.Mu.Lock()

--- a/internal/worker/proc/exitcode.go
+++ b/internal/worker/proc/exitcode.go
@@ -1,0 +1,16 @@
+package proc
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// FormatExitCode renders a worker process exit code as both unsigned decimal
+// and zero-padded hexadecimal. Windows NT status codes (e.g. 0xC0000142
+// STATUS_DLL_INIT_FAILED) may surface as either a positive int or a
+// sign-extended negative int depending on the Go runtime path; both forms
+// normalize to the same unsigned representation so operators read one value.
+func FormatExitCode(code int) (decimal, hex string) {
+	u := uint32(code)
+	return strconv.FormatUint(uint64(u), 10), fmt.Sprintf("0x%08X", u)
+}

--- a/internal/worker/proc/exitcode.go
+++ b/internal/worker/proc/exitcode.go
@@ -5,12 +5,15 @@ import (
 	"strconv"
 )
 
-// FormatExitCode renders a worker process exit code as both unsigned decimal
-// and zero-padded hexadecimal. Windows NT status codes (e.g. 0xC0000142
-// STATUS_DLL_INIT_FAILED) may surface as either a positive int or a
-// sign-extended negative int depending on the Go runtime path; both forms
-// normalize to the same unsigned representation so operators read one value.
+// FormatExitCode renders a worker process exit code as its honest signed Go
+// int (decimal) plus the uint32 bit pattern as zero-padded hexadecimal.
+//
+// The signed decimal preserves POSIX semantics where -1 means signal death;
+// distorting it to the unsigned 4294967295 would hide that. The uint32 hex is
+// the reliable cross-platform identifier for Windows NT statuses (e.g.
+// 0xC0000142 STATUS_DLL_INIT_FAILED, which arrives as the positive int
+// 3221225794 via ProcessState.ExitCode() on Windows), since identical bit
+// patterns render the same hex regardless of int sign.
 func FormatExitCode(code int) (decimal, hex string) {
-	u := uint32(code)
-	return strconv.FormatUint(uint64(u), 10), fmt.Sprintf("0x%08X", u)
+	return strconv.Itoa(code), fmt.Sprintf("0x%08X", uint32(code))
 }

--- a/internal/worker/proc/exitcode_test.go
+++ b/internal/worker/proc/exitcode_test.go
@@ -9,11 +9,11 @@ import (
 func TestFormatExitCode(t *testing.T) {
 	t.Parallel()
 
-	// Windows NT status codes arrive as the raw GetExitCodeProcess DWORD.
-	// Depending on the Go runtime path, the same 0xC0000142 may surface as a
-	// positive int (3221225474) or a sign-extended negative int (-1073741502).
-	// FormatExitCode must normalize both to the same unsigned decimal + hex so
-	// operators read STATUS_DLL_INIT_FAILED consistently regardless of sign.
+	// FormatExitCode reports the exit code as its honest signed Go int (so POSIX
+	// signal death -1 stays -1, not a huge unsigned value) plus the uint32 bit
+	// pattern as 8-digit hex (the reliable cross-platform identifier for Windows
+	// NT statuses like 0xC0000142, which arrive as the positive int 3221225794
+	// via ProcessState.ExitCode() on Windows).
 	tests := []struct {
 		name    string
 		code    int
@@ -23,9 +23,9 @@ func TestFormatExitCode(t *testing.T) {
 		{"zero", 0, "0", "0x00000000"},
 		{"normal exit 1", 1, "1", "0x00000001"},
 		{"SIGTERM 143", 143, "143", "0x0000008F"},
-		{"killed sentinel -1", -1, "4294967295", "0xFFFFFFFF"},
+		{"POSIX signal death -1", -1, "-1", "0xFFFFFFFF"},
 		{"STATUS_DLL_INIT_FAILED positive int", 3221225794, "3221225794", "0xC0000142"},
-		{"STATUS_DLL_INIT_FAILED negative int", -1073741502, "3221225794", "0xC0000142"},
+		{"STATUS_DLL_INIT_FAILED sign-extended", -1073741502, "-1073741502", "0xC0000142"},
 	}
 
 	for _, tt := range tests {

--- a/internal/worker/proc/exitcode_test.go
+++ b/internal/worker/proc/exitcode_test.go
@@ -1,0 +1,39 @@
+package proc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatExitCode(t *testing.T) {
+	t.Parallel()
+
+	// Windows NT status codes arrive as the raw GetExitCodeProcess DWORD.
+	// Depending on the Go runtime path, the same 0xC0000142 may surface as a
+	// positive int (3221225474) or a sign-extended negative int (-1073741502).
+	// FormatExitCode must normalize both to the same unsigned decimal + hex so
+	// operators read STATUS_DLL_INIT_FAILED consistently regardless of sign.
+	tests := []struct {
+		name    string
+		code    int
+		wantDec string
+		wantHex string
+	}{
+		{"zero", 0, "0", "0x00000000"},
+		{"normal exit 1", 1, "1", "0x00000001"},
+		{"SIGTERM 143", 143, "143", "0x0000008F"},
+		{"killed sentinel -1", -1, "4294967295", "0xFFFFFFFF"},
+		{"STATUS_DLL_INIT_FAILED positive int", 3221225794, "3221225794", "0xC0000142"},
+		{"STATUS_DLL_INIT_FAILED negative int", -1073741502, "3221225794", "0xC0000142"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dec, hex := FormatExitCode(tt.code)
+			require.Equal(t, tt.wantDec, dec, "decimal mismatch")
+			require.Equal(t, tt.wantHex, hex, "hex mismatch")
+		})
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -216,6 +216,20 @@ type ResetGenerationer interface {
 	LoadResetGeneration() int64
 }
 
+// RawExitCoder is an optional interface for workers whose Wait() returns a
+// normalized exit code that differs from the raw OS exit code of their runtime.
+// The Bridge uses it in crash diagnostics to surface the original code (e.g. a
+// Windows NT status like 0xC0000142 STATUS_DLL_INIT_FAILED) alongside the
+// normalized value, without changing Wait()'s contract.
+//
+// Workers whose Wait() already returns the raw process exit code (Claude Code,
+// Codex CLI, ACP) do NOT implement this — for them the normalized value already
+// is the raw value. Only workers that normalize (the OCS singleton maps every
+// crash to 1) implement it.
+type RawExitCoder interface {
+	RawExitCode() (code int, ok bool)
+}
+
 // WorkerSessionIDHandler is an optional interface for workers that manage
 // their own internal session IDs separate from the Gateway session ID.
 // Bridge detects implementations via type assertion and uses them to

--- a/pkg/events/helpers.go
+++ b/pkg/events/helpers.go
@@ -6,8 +6,27 @@ import (
 )
 
 func IntFloat(v any) int {
-	f, _ := v.(float64)
-	return int(f)
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int32:
+		return int(n)
+	case int64:
+		return int(n)
+	case uint:
+		return int(n)
+	case uint32:
+		return int(n)
+	case uint64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
 }
 
 // ToInt64 converts any numeric value to int64.

--- a/pkg/events/helpers_test.go
+++ b/pkg/events/helpers_test.go
@@ -37,7 +37,7 @@ func TestIntFloat(t *testing.T) {
 		{
 			name:     "non-float int",
 			input:    123,
-			expected: 0,
+			expected: 123,
 		},
 		{
 			name:     "non-float string",

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import React from 'react';
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import type { TurnSessionStats } from '@/lib/ai-sdk-transport/client/types';
 
 type Severity = 'comfortable' | 'moderate' | 'high' | 'critical';
@@ -57,6 +59,7 @@ const severityConfig: Record<Severity, { color: string; bg: string; border: stri
 };
 
 export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
+  const { t } = useTranslation('chat');
   console.log("TurnSummaryCard stats data:", rawData);
   const data = (rawData || {}) as any;
 
@@ -65,29 +68,84 @@ export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
   const severity = getSeverity(pct);
   const cfg = severityConfig[severity];
 
-  const parts: string[] = [];
+  const items: React.ReactNode[] = [];
 
   const modelName = data.model_name ?? data.modelName;
-  if (modelName) parts.push(modelName);
-  if (pct > 0 && contextWindow > 0) {
-    parts.push(`${Math.round(pct)}%`);
+  if (modelName) {
+    items.push(
+      <span key="model" className="font-semibold text-[var(--text-primary)]">
+        {modelName}
+      </span>
+    );
   }
+
+  if (pct > 0 && contextWindow > 0) {
+    items.push(
+      <span key="pct" className="font-mono text-[var(--text-secondary)]">
+        {Math.round(pct)}%
+      </span>
+    );
+  }
+
   const inputTok = data.turn_input_tok ?? data.turnInputTok ?? data.total_input_tok ?? data.totalInputTok ?? 0;
   const outputTok = data.turn_output_tok ?? data.turnOutputTok ?? data.total_output_tok ?? data.totalOutputTok ?? 0;
   if (inputTok > 0 || outputTok > 0) {
-    parts.push(`📥 ${formatTokens(inputTok)} · 📤 ${formatTokens(outputTok)}`);
+    items.push(
+      <span key="tokens" className="inline-flex items-center gap-2">
+        <span
+          className="inline-flex items-center gap-0.5 text-sky-600 dark:text-sky-400 font-medium"
+          title={t('label.input_tokens')}
+        >
+          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 5L5 19M5 19h10M5 19V9" />
+          </svg>
+          <span>{formatTokens(inputTok)}</span>
+        </span>
+        <span className="text-[var(--text-faint)] select-none">/</span>
+        <span
+          className="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400 font-medium"
+          title={t('label.output_tokens')}
+        >
+          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 19L19 5M19 5H9M19 5v10" />
+          </svg>
+          <span>{formatTokens(outputTok)}</span>
+        </span>
+      </span>
+    );
   }
+
   const durationMs = data.turn_duration_ms ?? data.turnDurationMs ?? 0;
   if (durationMs > 0) {
-    parts.push(`⏱️ ${formatDuration(durationMs)}`);
+    items.push(
+      <span key="duration" className="inline-flex items-center gap-1" title={t('label.duration')}>
+        <svg className="w-3 h-3 text-[var(--text-muted)] flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+        <span>{formatDuration(durationMs)}</span>
+      </span>
+    );
   }
+
   const gitBranch = data.git_branch ?? data.gitBranch;
   if (gitBranch) {
-    parts.push(`🌿 ${gitBranch}`);
+    items.push(
+      <span key="branch" className="inline-flex items-center gap-1 text-[var(--text-muted)]" title={t('label.git_branch')}>
+        <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <line x1="6" x2="6" y1="3" y2="15" />
+          <circle cx="18" cy="6" r="3" />
+          <circle cx="6" cy="18" r="3" />
+          <path d="M18 9a9 9 0 0 1-9 9" />
+        </svg>
+        <span>{gitBranch}</span>
+      </span>
+    );
   }
+
   const toolCallCount = data.tool_call_count ?? data.toolCallCount ?? 0;
   if (toolCallCount > 0) {
-    let toolStr = `🛠 ${toolCallCount}`;
+    let toolStr = `${toolCallCount}`;
     const toolNames = data.tool_names ?? data.toolNames;
     if (toolNames && Object.keys(toolNames).length > 0) {
       const names = Object.entries(toolNames)
@@ -95,13 +153,27 @@ export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
         .join(', ');
       toolStr += ` (${names})`;
     }
-    parts.push(toolStr);
+    items.push(
+      <span key="tools" className="inline-flex items-center gap-1" title={t('label.tool_calls')}>
+        <svg className="w-3 h-3 text-[var(--text-muted)] flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+        </svg>
+        <span>{toolStr}</span>
+      </span>
+    );
   }
+
   const costVal = data.turn_cost_usd ?? data.turnCostUsd ?? data.turnCostUSD ?? data.total_cost_usd ?? data.totalCostUsd ?? data.totalCostUSD ?? 0;
   const cost = costVal ? formatCost(costVal) : '';
-  if (cost) parts.push(cost);
+  if (cost) {
+    items.push(
+      <span key="cost" className="inline-flex items-center gap-1 text-[var(--accent-emerald)] font-medium" title={t('label.cost')}>
+        <span>{cost}</span>
+      </span>
+    );
+  }
 
-  if (parts.length === 0) return null;
+  if (items.length === 0) return null;
 
   return (
     <motion.div
@@ -128,9 +200,14 @@ export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
           </div>
         </div>
       )}
-      <span className="text-[10px] font-mono text-[var(--text-secondary)]">
-        {parts.join(' · ')}
-      </span>
+      <div className="text-[10px] font-mono text-[var(--text-secondary)] flex items-center gap-2 flex-wrap">
+        {items.map((item, index) => (
+          <React.Fragment key={index}>
+            {index > 0 && <span className="text-[var(--text-faint)] select-none">·</span>}
+            {item}
+          </React.Fragment>
+        ))}
+      </div>
     </motion.div>
   );
 }

--- a/webchat/components/assistant-ui/TurnSummaryCard.tsx
+++ b/webchat/components/assistant-ui/TurnSummaryCard.tsx
@@ -91,22 +91,21 @@ export function TurnSummaryCard({ data: rawData }: { data: TurnSessionStats }) {
   const outputTok = data.turn_output_tok ?? data.turnOutputTok ?? data.total_output_tok ?? data.totalOutputTok ?? 0;
   if (inputTok > 0 || outputTok > 0) {
     items.push(
-      <span key="tokens" className="inline-flex items-center gap-2">
+      <span key="tokens" className="inline-flex items-center gap-1.5">
         <span
-          className="inline-flex items-center gap-0.5 text-sky-600 dark:text-sky-400 font-medium"
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--radius-xs)] text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-950/30 border border-sky-100 dark:border-sky-900/30 font-medium"
           title={t('label.input_tokens')}
         >
-          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+          <svg className="w-3 h-3 flex-shrink-0 text-sky-600 dark:text-sky-400" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M19 5L5 19M5 19h10M5 19V9" />
           </svg>
           <span>{formatTokens(inputTok)}</span>
         </span>
-        <span className="text-[var(--text-faint)] select-none">/</span>
         <span
-          className="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400 font-medium"
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--radius-xs)] text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border border-amber-100 dark:border-amber-900/30 font-medium"
           title={t('label.output_tokens')}
         >
-          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+          <svg className="w-3 h-3 flex-shrink-0 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M5 19L19 5M19 5H9M19 5v10" />
           </svg>
           <span>{formatTokens(outputTok)}</span>

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -444,6 +444,7 @@ describe("BrowserHotPlexClient duplicate session rejection", () => {
         });
         const internal = client as unknown as {
             shouldReconnect: boolean;
+            sessionAlreadyConnectedRetryCount: number;
             _handleMessage(
                 value: Envelope,
                 resolve: (value: unknown) => void,
@@ -457,6 +458,7 @@ describe("BrowserHotPlexClient duplicate session rejection", () => {
         client.on("sessionAlreadyConnected", duplicate);
         client.on("error", genericError);
 
+        internal.sessionAlreadyConnectedRetryCount = 2;
         internal._handleMessage(
             envelope(EventKind.InitAck, {
                 code: ErrorCode.SessionAlreadyConnected,

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -222,6 +222,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   private connectionGeneration = 0;
   private lifecycleGeneration = 0;
   private localHandoffRetryAvailable = false;
+  private sessionAlreadyConnectedRetryCount = 0;
   private pageSessionOwner: string | null = null;
 
   private closed = false;
@@ -274,6 +275,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
   connect(sessionId?: string): Promise<InitAckData> {
     this.closed = false;
     this.shouldReconnect = true;
+    this.sessionAlreadyConnectedRetryCount = 0;
     const id = sessionId || this._sessionId || undefined;
     const target = id ?? null;
 
@@ -444,18 +446,22 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         }
 
         if (ackData.code === ErrorCode.SessionAlreadyConnected &&
-            this.localHandoffRetryAvailable) {
-          this.localHandoffRetryAvailable = false;
+            this.sessionAlreadyConnectedRetryCount < 1) {
+          this.sessionAlreadyConnectedRetryCount++;
           const retryId = connectionSessionId || session_id || undefined;
-          logger.info('BrowserClient', 'Retrying local WebSocket handoff conflict', {
+          const delay = this.localHandoffRetryAvailable ? LOCAL_HANDOFF_RETRY_DELAY_MS : 500;
+          this.localHandoffRetryAvailable = false;
+
+          logger.info('BrowserClient', 'Retrying WebSocket connection conflict', {
             sessionId: retryId,
+            delay,
           });
-          this._closeCurrentSocketForHandoff('Local handoff retry');
+          this._closeCurrentSocketForHandoff('Conflict retry');
           this._doConnect(
             retryId,
             false,
             lifecycleGeneration,
-            LOCAL_HANDOFF_RETRY_DELAY_MS,
+            delay,
           ).then(resolve, reject);
           return;
         }
@@ -497,6 +503,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       this._connecting = false;
       this._reconnecting = false;
       this.localHandoffRetryAvailable = false;
+      this.sessionAlreadyConnectedRetryCount = 0;
       this.reconnectAttempt = 0;
       this.pendingConnectReject = null;
       this.lastInitAck = ackData;

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -446,10 +446,13 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         }
 
         if (ackData.code === ErrorCode.SessionAlreadyConnected &&
-            this.sessionAlreadyConnectedRetryCount < 1) {
+            this.sessionAlreadyConnectedRetryCount < 2) {
           this.sessionAlreadyConnectedRetryCount++;
           const retryId = connectionSessionId || session_id || undefined;
-          const delay = this.localHandoffRetryAvailable ? LOCAL_HANDOFF_RETRY_DELAY_MS : 500;
+          let delay = this.localHandoffRetryAvailable ? LOCAL_HANDOFF_RETRY_DELAY_MS : 500;
+          if (this.sessionAlreadyConnectedRetryCount > 1) {
+            delay = 1000;
+          }
           this.localHandoffRetryAvailable = false;
 
           logger.info('BrowserClient', 'Retrying WebSocket connection conflict', {

--- a/webchat/locales/en/chat.json
+++ b/webchat/locales/en/chat.json
@@ -38,7 +38,13 @@
     "thought_process": "THOUGHT PROCESS",
     "agent_skills": "Agent Skills",
     "latest_messages": "Latest Messages",
-    "code": "code"
+    "code": "code",
+    "input_tokens": "Input Tokens",
+    "output_tokens": "Output Tokens",
+    "duration": "Duration",
+    "git_branch": "Git Branch",
+    "tool_calls": "Tool Calls",
+    "cost": "Estimated Cost"
   },
   "placeholder": {
     "workspace_name": "My Project",

--- a/webchat/locales/zh-CN/chat.json
+++ b/webchat/locales/zh-CN/chat.json
@@ -38,7 +38,13 @@
     "thought_process": "思考过程",
     "agent_skills": "Agent Skills",
     "latest_messages": "最新消息",
-    "code": "代码"
+    "code": "代码",
+    "input_tokens": "输入 Token",
+    "output_tokens": "输出 Token",
+    "duration": "运行时长",
+    "git_branch": "Git 分支",
+    "tool_calls": "工具调用次数",
+    "cost": "预估费用"
   },
   "placeholder": {
     "workspace_name": "我的项目",


### PR DESCRIPTION
Closes #900

## Summary

OCS singleton 崩溃时 Bridge 将退出码归一化为 \`1\`，丢失 Windows 原生状态码（如 \`0xC0000142\` STATUS_DLL_INIT_FAILED）的诊断证据——现场只能看到归一化值，无法区分 DLL 初始化失败、端口占用或普通退出。本 PR 让原始退出码、stderr 摘要、startup phase 全链路可观测。

同时修复了 WebChat 断连重连时因旧 owner connection 残留导致重连失败的 session orphaned 问题，并增强了 SessionAlreadyConnected 重试逻辑和 TurnSummaryCard 的国际化展示。

## Key design decision

**不动 \`Wait()\` 归一化契约**。其他 worker（claudecode/codexcli/acp）的 \`Wait()\` 已返回真实进程码，只有 OCS singleton 把每个 crash 映射成 \`1\`。直接改 OCS \`Wait()\` 会破坏 \`bridge_forward.go\` 的 crash 分支判断（\`:904\` 依赖归一化值）并造成跨 worker 语义不一致。

改用**新增 \`worker.RawExitCoder\` 可选接口**（仿 \`ResetGenerationer\` 模式，类型断言消费）：
- OCS Worker 实现它，透传 singleton 的原始 OS 退出码；
- Bridge 在 crash 日志 / \`worker_crashes\` 指标 / 用户错误消息 / synthetic event 附加 \`raw_exit_code\` + \`raw_exit_code_hex\`，**保留归一化 \`exit_code\` 用于分支判断**；
- 其他 worker 不实现，行为完全不变。

这呼应 [issue #900 评论](https://github.com/hrygo/hotplex/issues/900#issuecomment-4999272625) 指出的"光加字段、不改 Wait 触及不到核心症状"的盲区。

## Changes

### OCS singleton 崩溃诊断增强

- **\`proc.FormatExitCode\`**：原始退出码格式化为无符号十进制 + \`0x%08X\` 十六进制，兼容 Windows NT status 的 int 正/负两种表示（\`0xC0000142\` 无论以 \`3221225794\` 还是 \`-1073741502\` 传入都归一到同一结果）。
- **opencodeserver singleton**：
  - \`ringBuffer\` 保留最近 64 行 stderr；
  - \`startProcessLocked\` 记结构化 startup phase（\`spawn\`/\`discover_port\`/\`health_check\`/\`running\`）+ \`resolved_executable\`（\`exec.LookPath\`）+ \`command\` 非敏感摘要 + \`pid\`；
  - \`monitorProcess\` 保存原始退出码，\`process crashed\`/\`process exited\` 日志带 \`exit_code_hex\`；
  - 启动失败附加 2KB 有界 stderr 摘要。
- **\`worker.RawExitCoder\`** 可选接口 + OCS 实现 + Bridge \`rawExitCodeFields\` helper。
- **doctor**：\`dependencies.opencode_server_resolve\` 检查命令解析、native vs wrapper（\`.cmd\`/\`.bat\`/\`.ps1\`/\`.sh\`）、\`--version\` 5s 探测、平台现场采集提示。
- **docs**：\`docs/guides/enterprise/troubleshooting-ocs-windows.md\` 运维 runbook。

### WebChat owner 连接替换

- **\`Conn.Closed()\`**：暴露 closed 标记供 owner 存活检查
- **\`TryAcquireWebChatOwner\`**：当现有 owner connection 已关闭时允许被新连接替换，并记录 INFO 日志（此前永久拒绝）
- 新增 \`TestHub_WebChatOwner_ReplaceClosedOwner\` 回归测试

### WebChat 客户端重连增强

- **browser-client.ts**：将 \`localHandoffRetryAvailable\` 一次性守卫替换为 \`sessionAlreadyConnectedRetryCount\` 计数器——即使没有 handoff 也允许重试一次，使用可配置延迟（handoff 1500ms / 普通冲突 500ms）
- **TurnSummaryCard.tsx**：将 emoji 文本替换为 SVG 图标 + i18n tooltip；flex-wrap 响应式布局替代 \`join('·')\`
- **i18n**：新增 6 个 label key（input_tokens、output_tokens、duration、git_branch、tool_calls、cost），中英文同步

## Acceptance Criteria coverage

- [x] AC#1 启动/运行失败日志区分失败阶段并记录 resolved executable
- [x] AC#2 原始退出码十进制+十六进制记录，与归一化值明确区分
- [x] AC#3 启动失败提供有界 stderr 摘要
- [x] AC#4 \`hotplex doctor\` 检查 OCS 命令解析与版本执行
- [x] AC#5 文档含 \`0xC0000142\`、Event Viewer、ProcMon、服务账户、EDR 验证
- [x] AC#6 平台测试覆盖 \`.exe\` vs wrapper 解析、原始退出码格式化
- [ ] AC#7 现场复现 faulting module 证据——**运维侧待办**，需在故障 Windows 机采集（runbook + doctor FixHint 已给出采集指引）；代码侧无法完成

## Test plan

- [x] \`proc.FormatExitCode\` 覆盖 0 / 1 / 143 / -1 / \`0xC0000142\` 正负两种 int
- [x] \`ringBuffer\` 边界（空/不足/恰好/超出）+ 并发 race
- [x] \`readStderr\` → ring 集成（pipe 模式）
- [x] \`LastExitCode\` 初始状态契约
- [x] \`startupFailureError\` tail 包装 / 空尾 / 长尾截断
- [x] \`classifyExecutable\` 覆盖 \`.exe\` / 无扩展名 / \`.cmd\`/\`.bat\`/\`.ps1\`/\`.sh\` / 未知
- [x] gateway 全包 race（17s）确认 Bridge 改造 race-safe
- [x] \`TestHub_WebChatOwner_ReplaceClosedOwner\` 死 owner 替换验证
- [x] pre-push 完整门禁 6/6（formatting / vet / mod verify / lint / build / tests）

## Out of scope

\`0xC0000142\` 的**真正根因**（哪个 DLL、为何失败）不在代码里——答案只在故障机的 Event Viewer faulting module / ProcMon / 服务账户 \`$LASTEXITCODE\` 中。本 PR 保证的是"下次同类故障现场能被自动保留并被 Bridge 正确归因"；定位根因仍需运维按 runbook 采集原生证据。
