### PR TITLE
fix(worker/ocs): read-only 模式未拦截文件写入

### DIFF
--- a/docs/guides/developer/remote-coding-agent.md
+++ b/docs/guides/developer/remote-coding-agent.md
@@ -81,6 +81,8 @@ Workspace 级 4 档统一权限模式（#789），作为 Workspace 属性持久�
 
 空值（默认）= "Worker 默认"：CC/OCS 应用 `bypass`，Codex/ACP 沿用 operator 配置。
 
+> OpenCode Server 在 `workspace` 档只自动接受 workspace 内的编辑；访问 workspace 外目录时会发起授权请求。`auto-edit` 仍保持无逐项确认的语义。
+
 > `auto-edit` 档要求较新版本的 Claude Code CLI（支持 `--permission-mode auto`）；`hotplex doctor` 的 `worker.claude_auto_mode` 检查项会探测此能力。
 
 ### 运行时切换

--- a/docs/guides/developer/security-model.md
+++ b/docs/guides/developer/security-model.md
@@ -49,7 +49,7 @@ Workspace 级 4 档统一权限模式（#789），跨 Claude Code / Codex / Open
 | 模式 | 行为 | 适用场景 |
 |------|------|---------|
 | `read-only` | 仅规划与只读，不执行写操作 | 代码审查、只读分析 |
-| `workspace` | 自动接受编辑，其他敏感操作仍需审批 | 日常开发 |
+| `workspace` | 自动接受 workspace 内编辑；访问 workspace 外目录及其他敏感操作仍需审批 | 日常开发 |
 | `auto-edit` | 全自动执行，无需逐项确认 | 受信任的自动化 |
 | `bypass` | 跳过所有权限确认 | CI/CD、沙箱环境 |
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -263,6 +263,12 @@ func (b *Bridge) StartSession(ctx context.Context, p worker.SessionStartParams) 
 	if p.WorkspaceID != "" {
 		if err := b.sm.SetWorkspaceID(ctx, p.ID, p.WorkspaceID); err != nil {
 			b.log.Warn("bridge: bind workspace failed", "session_id", p.ID, "workspace_id", p.WorkspaceID, "err", err)
+		} else {
+			// CreateWithBot returns a snapshot. SetWorkspaceID persists the binding in
+			// the manager, but it cannot mutate this snapshot. Keep the worker launch
+			// info in sync so the workspace permission ceiling is applied to the first
+			// worker, rather than only to later resumes.
+			si.WorkspaceID = p.WorkspaceID
 		}
 	}
 

--- a/internal/gateway/command_detection_test.go
+++ b/internal/gateway/command_detection_test.go
@@ -536,6 +536,28 @@ func TestHandleInput_ControlCommand_SendsDeliveredAck(t *testing.T) {
 	require.NotEmpty(t, ackData["client_message_id"])
 }
 
+func TestHandleInput_FailedControlCommand_DoesNotSendDeliveredAck(t *testing.T) {
+	t.Parallel()
+	handler, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_ctrl_ack_failure"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	clientConn, serverConn := newTestWSConnPair(t)
+	t.Cleanup(func() { clientConn.Close() })
+	hub.JoinSession(sid, newConn(hub, clientConn, sid, nil))
+
+	// A non-owner cannot reset the session. The client must receive the failed
+	// outcome, rather than a synthetic delivered acknowledgement.
+	env := inputEnvelopeWithOwner(sid, "other-user", "/reset")
+	require.Error(t, handler.handleInput(context.Background(), env))
+
+	got := readNextEnvelope(t, serverConn)
+	require.Equal(t, events.Error, got.Event.Type)
+}
+
 func TestHandleInput_HelpCommand_WithWhitespace(t *testing.T) {
 	t.Parallel()
 	handler, mgr, hub, _ := newHandlerWithRealStore(t)

--- a/internal/gateway/command_detection_test.go
+++ b/internal/gateway/command_detection_test.go
@@ -50,6 +50,21 @@ func readNextEnvelope(t *testing.T, serverConn interface {
 	return env
 }
 
+// readNextNonAckEnvelope reads envelopes, skipping InputAck. Control commands
+// now emit a synthetic delivered InputAck before their behavioral response.
+func readNextNonAckEnvelope(t *testing.T, serverConn interface {
+	SetReadDeadline(time.Time) error
+	ReadMessage() (int, []byte, error)
+}) events.Envelope {
+	t.Helper()
+	for {
+		env := readNextEnvelope(t, serverConn)
+		if env.Event.Type != events.InputAck {
+			return env
+		}
+	}
+}
+
 // ─── Help Command Detection ────────────────────────────────────────────────
 
 func TestHandleInput_HelpCommand_QuestionMark(t *testing.T) {
@@ -70,7 +85,7 @@ func TestHandleInput_HelpCommand_QuestionMark(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read the help message from the server side of the WS pair.
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 	msgData, ok := got.Event.Data.(map[string]any)
 	require.True(t, ok)
@@ -94,7 +109,7 @@ func TestHandleInput_HelpCommand_SlashHelp(t *testing.T) {
 	err = handler.handleInput(context.Background(), env)
 	require.NoError(t, err)
 
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 	msgData, ok := got.Event.Data.(map[string]any)
 	require.True(t, ok)
@@ -118,7 +133,7 @@ func TestHandleInput_HelpCommand_DollarHelp(t *testing.T) {
 	err = handler.handleInput(context.Background(), env)
 	require.NoError(t, err)
 
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 }
 
@@ -147,7 +162,7 @@ func TestHandleInput_HelpCommand_DoesNotReachWorker(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read the help message so the WS buffer is drained.
-	_ = readNextEnvelope(t, serverConn)
+	_ = readNextNonAckEnvelope(t, serverConn)
 
 	// Worker.Input must NOT have been called for help command.
 	w.AssertNotCalled(t, "Input", mock.Anything, mock.Anything, mock.Anything)
@@ -492,6 +507,35 @@ func TestSanitizeLastInput_CommandWithTrailingPunctuation(t *testing.T) {
 
 // ─── Edge Cases ────────────────────────────────────────────────────────────
 
+// TestHandleInput_ControlCommand_SendsDeliveredAck verifies that a control
+// command (/reset, /gc, /help, etc.) sends a synthetic delivered InputAck so
+// the webchat client releases its pending-input lock. Without this ack the UI
+// freezes after /reset for up to the client's 5-minute settle timeout.
+func TestHandleInput_ControlCommand_SendsDeliveredAck(t *testing.T) {
+	t.Parallel()
+	handler, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_ctrl_ack"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	clientConn, serverConn := newTestWSConnPair(t)
+	t.Cleanup(func() { clientConn.Close() })
+	hub.JoinSession(sid, newConn(hub, clientConn, sid, nil))
+
+	env := inputEnvelopeWithOwner(sid, "user1", "/help")
+	require.NoError(t, handler.handleInput(context.Background(), env))
+
+	// The first envelope must be the delivered InputAck.
+	ack := readNextEnvelope(t, serverConn)
+	require.Equal(t, events.InputAck, ack.Event.Type)
+	ackData, ok := ack.Event.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, string(events.ExecutionStatusDelivered), ackData["status"])
+	require.NotEmpty(t, ackData["client_message_id"])
+}
+
 func TestHandleInput_HelpCommand_WithWhitespace(t *testing.T) {
 	t.Parallel()
 	handler, mgr, hub, _ := newHandlerWithRealStore(t)
@@ -509,7 +553,7 @@ func TestHandleInput_HelpCommand_WithWhitespace(t *testing.T) {
 	err = handler.handleInput(context.Background(), env)
 	require.NoError(t, err)
 
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 }
 
@@ -529,7 +573,7 @@ func TestHandleInput_HelpCommand_FullWidthQuestionMark(t *testing.T) {
 	err = handler.handleInput(context.Background(), env)
 	require.NoError(t, err)
 
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 }
 
@@ -554,7 +598,7 @@ func TestHandle_FullDispatch_HelpCommand(t *testing.T) {
 	err = handler.Handle(context.Background(), env)
 	require.NoError(t, err)
 
-	got := readNextEnvelope(t, serverConn)
+	got := readNextNonAckEnvelope(t, serverConn)
 	require.Equal(t, events.Message, got.Event.Type)
 	msgData, ok := got.Event.Data.(map[string]any)
 	require.True(t, ok)

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -1577,6 +1577,57 @@ func TestBridge_StartSession_Success(t *testing.T) {
 	sm.AssertExpectations(t)
 }
 
+// TestBridge_StartSession_AppliesWorkspacePermissionModeToFirstWorker guards
+// the first-worker path: CreateWithBot returns a pre-binding snapshot, whereas
+// SetWorkspaceID updates the manager's internal session state. The worker must
+// receive the newly bound workspace ID so its read-only permission ceiling is
+// enforced before any input can be handled.
+func TestBridge_StartSession_AppliesWorkspacePermissionModeToFirstWorker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sessionID   = "sess-readonly-workspace"
+		workspaceID = "ws-readonly"
+	)
+	sm := &mockBridgeSM{Mock: mock.Mock{}}
+	sm.Test(t)
+
+	sessionInfo := &session.SessionInfo{
+		ID:         sessionID,
+		UserID:     "user1",
+		WorkerType: worker.TypeOpenCodeSrv,
+		State:      events.StateCreated,
+	}
+	sm.On("CreateWithBot", mock.Anything, sessionID, "user1", "", "", worker.TypeOpenCodeSrv, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(sessionInfo, nil)
+	sm.On("SetWorkspaceID", mock.Anything, sessionID, workspaceID).Return(nil)
+	sm.On("AttachWorker", sessionID, mock.Anything).Return(nil)
+	sm.On("Transition", mock.Anything, sessionID, events.StateRunning).Return(nil)
+
+	workerEvents := make(chan *events.Envelope)
+	startedWorker := &mockBridgeWorker{
+		workerType: worker.TypeOpenCodeSrv,
+		conn:       &fakeWorkerConn{ch: workerEvents},
+	}
+	b := NewBridge(BridgeDeps{
+		Log:     slog.Default(),
+		Hub:     newTestHub(t),
+		SM:      sm,
+		WSStore: &stubWSStore{ws: &session.Workspace{ID: workspaceID, PermissionMode: worker.PermissionModeReadOnly}},
+	})
+	b.wf = &mockBridgeWorkerFactory{workers: []*mockBridgeWorker{startedWorker}}
+
+	err := b.StartSession(t.Context(), worker.SessionStartParams{
+		ID:          sessionID,
+		UserID:      "user1",
+		WorkerType:  worker.TypeOpenCodeSrv,
+		WorkspaceID: workspaceID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, worker.PermissionModeReadOnly, startedWorker.startInfo.PermissionMode)
+
+	sm.AssertExpectations(t)
+}
+
 // TestBridge_StartSession_CreateFails verifies that when session creation fails,
 // StartSession returns an error without calling worker.Start.
 func TestBridge_StartSession_CreateFails(t *testing.T) {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -155,6 +155,13 @@ func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {
 		return nil
 	}
 	if handled, err := h.tryCommandDispatch(ctx, env, content); handled {
+		// Control/help/worker commands bypass the durable execution path, so
+		// no InputAck or Done is ever sent. The webchat client locks
+		// pendingInput on every sendInput and only releases on a terminal
+		// InputAck/Done/Error — without this synthetic "delivered" ack the UI
+		// stays frozen for up to the 5-minute settle timeout after commands
+		// like /reset that only emit a State event.
+		h.ackControlCommand(ctx, env)
 		return err
 	}
 
@@ -643,6 +650,28 @@ func clientMessageID(env *events.Envelope) string {
 		return env.ID
 	}
 	return aep.NewID()
+}
+
+// ackControlCommand sends a synthetic "delivered" InputAck for an input that
+// was intercepted as a control/help/worker command instead of being routed to
+// the durable execution pipeline. The webchat client arms a pending-input lock
+// on every sendInput that only clears on a terminal InputAck/Done/Error; without
+// this ack the UI locks for the full settle timeout (5 min) after commands like
+// /reset that emit only a State event.
+func (h *Handler) ackControlCommand(ctx context.Context, env *events.Envelope) {
+	if h.hub == nil {
+		return
+	}
+	ack := events.NewEnvelope(aep.NewID(), env.SessionID, h.hub.NextSeq(env.SessionID), events.InputAck, events.InputAckData{
+		ClientMessageID: clientMessageID(env),
+		ExecutionID:     "cmd-" + env.ID,
+		Status:          events.ExecutionStatusDelivered,
+	})
+	ack.Priority = events.PriorityControl
+	ack.OwnerID = env.OwnerID
+	if err := h.hub.SendToSession(context.WithoutCancel(ctx), ack); err != nil {
+		h.log.Warn("gateway: control command ack failed", "err", err, "session_id", env.SessionID)
+	}
 }
 
 func (h *Handler) finishInputExecution(ctx context.Context, record *execution.Record, status execution.Status, code events.ErrorCode) error {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -161,7 +161,9 @@ func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {
 		// InputAck/Done/Error — without this synthetic "delivered" ack the UI
 		// stays frozen for up to the 5-minute settle timeout after commands
 		// like /reset that only emit a State event.
-		h.ackControlCommand(ctx, env)
+		if err == nil {
+			h.ackControlCommand(ctx, env)
+		}
 		return err
 	}
 

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -232,12 +232,22 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	case "plan":
-		// Read-only allowed + write requires approval.
+		// Read-only: explicitly deny ALL write-capable tools. OCS's permission
+		// system is an opt-in allowlist — when no rule matches a tool call, the
+		// default action is ALLOW (not ask or deny). Simply omitting write
+		// permissions (as the old code did) silently lets edits go through.
+		// Each write tool must be denied individually because the agent can
+		// pivot between them (e.g. use bash when edit is unavailable).
 		rules = []map[string]any{
 			{"permission": "read", "action": "allow", "pattern": "*"},
+			{"permission": "edit", "action": "deny", "pattern": "*"},
+			{"permission": "write", "action": "deny", "pattern": "*"},
+			{"permission": "bash", "action": "deny", "pattern": "*"},
+			{"permission": "shell", "action": "deny", "pattern": "*"},
+			{"permission": "patch", "action": "deny", "pattern": "*"},
 		}
 		if len(allowedTools) > 0 {
-			slog.Warn("opencode: plan mode with allowed_tools may override read-only semantics",
+			slog.Warn("opencode: plan mode with allowed_tools; write-capable tools remain denied",
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	case "acceptEdits":
@@ -247,7 +257,8 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 			{"permission": "edit", "action": "allow", "pattern": "*"},
 		}
 	default:
-		// No rules injected: OCS default (no matching rule → ask → publishes permission.asked).
+		// Unknown mode: no rules injected. Note: OCS defaults to ALLOW when no rule
+		// matches (opt-in allowlist), so this is NOT safe for restricting access.
 		if len(allowedTools) > 0 {
 			slog.Info("opencode: default mode with allowed_tools restricts to tool whitelist",
 				"mode", mode, "allowed_tools", allowedTools)

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -232,12 +232,12 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	case "plan":
-		// Read-only: OCS allows unmatched permissions by default. Deny every
-		// capability first, then selectively enable the built-in read-only
-		// operations. This also keeps custom tools, MCP tools, and subagents
-		// from creating a write-capable bypass.
+		// Read-only: OCS allows unmatched permissions by default. Ask before every
+		// capability, then selectively enable built-in read-only operations. Writes
+		// therefore become permission requests instead of bypassing the workspace
+		// policy or being silently rejected without an approval card.
 		rules = []map[string]any{
-			{"permission": "*", "action": "deny", "pattern": "*"},
+			{"permission": "*", "action": "ask", "pattern": "*"},
 			{"permission": "read", "action": "allow", "pattern": "*"},
 			{"permission": "glob", "action": "allow", "pattern": "*"},
 			{"permission": "grep", "action": "allow", "pattern": "*"},
@@ -264,8 +264,8 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	}
-	// Apply allowed tools whitelist outside plan mode. Plan mode starts from a
-	// deny-all baseline, so a caller-supplied allow rule could reopen writes.
+	// Apply allowed tools whitelist outside plan mode. Plan mode starts from an
+	// ask-all baseline, so a caller-supplied allow rule could reopen automatic writes.
 	if mode != "plan" {
 		for _, tool := range allowedTools {
 			rules = append(rules, map[string]any{"permission": "tool", "action": "allow", "pattern": tool})

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -232,22 +232,22 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	case "plan":
-		// Read-only: explicitly deny ALL write-capable tools. OCS's permission
-		// system is an opt-in allowlist — when no rule matches a tool call, the
-		// default action is ALLOW (not ask or deny). Simply omitting write
-		// permissions (as the old code did) silently lets edits go through.
-		// Each write tool must be denied individually because the agent can
-		// pivot between them (e.g. use bash when edit is unavailable).
+		// Read-only: OCS allows unmatched permissions by default. Deny every
+		// capability first, then selectively enable the built-in read-only
+		// operations. This also keeps custom tools, MCP tools, and subagents
+		// from creating a write-capable bypass.
 		rules = []map[string]any{
+			{"permission": "*", "action": "deny", "pattern": "*"},
 			{"permission": "read", "action": "allow", "pattern": "*"},
-			{"permission": "edit", "action": "deny", "pattern": "*"},
-			{"permission": "write", "action": "deny", "pattern": "*"},
-			{"permission": "bash", "action": "deny", "pattern": "*"},
-			{"permission": "shell", "action": "deny", "pattern": "*"},
-			{"permission": "patch", "action": "deny", "pattern": "*"},
+			{"permission": "glob", "action": "allow", "pattern": "*"},
+			{"permission": "grep", "action": "allow", "pattern": "*"},
+			{"permission": "list", "action": "allow", "pattern": "*"},
+			{"permission": "lsp", "action": "allow", "pattern": "*"},
+			{"permission": "webfetch", "action": "allow", "pattern": "*"},
+			{"permission": "websearch", "action": "allow", "pattern": "*"},
 		}
 		if len(allowedTools) > 0 {
-			slog.Warn("opencode: plan mode with allowed_tools; write-capable tools remain denied",
+			slog.Warn("opencode: ignoring allowed_tools in plan mode to preserve read-only access",
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	case "acceptEdits":
@@ -264,9 +264,12 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 				"mode", mode, "allowed_tools", allowedTools)
 		}
 	}
-	// Apply allowed tools whitelist across all modes.
-	for _, tool := range allowedTools {
-		rules = append(rules, map[string]any{"permission": "tool", "action": "allow", "pattern": tool})
+	// Apply allowed tools whitelist outside plan mode. Plan mode starts from a
+	// deny-all baseline, so a caller-supplied allow rule could reopen writes.
+	if mode != "plan" {
+		for _, tool := range allowedTools {
+			rules = append(rules, map[string]any{"permission": "tool", "action": "allow", "pattern": tool})
+		}
 	}
 	slog.Info("opencode: applying permission rules to session", "session_id", c.getSessionID(), "mode", mode, "rules", rules)
 	if err := c.doPatch(ctx, "/session/"+url.PathEscape(c.getSessionID()), map[string]any{"permission": rules}); err != nil {

--- a/internal/worker/opencodeserver/commands.go
+++ b/internal/worker/opencodeserver/commands.go
@@ -214,6 +214,7 @@ func (c *ServerCommander) setModel(_ context.Context, body map[string]any) (map[
 
 func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string]any) (map[string]any, error) {
 	mode, _ := body["mode"].(string)
+	permissionTier, _ := body["permission_tier"].(string)
 
 	// Extract AllowedTools for B3-2 绕行: convert tool whitelist to OCS permission rules.
 	allowedTools, _ := body["allowed_tools"].([]string)
@@ -250,11 +251,22 @@ func (c *ServerCommander) setPermissionMode(ctx context.Context, body map[string
 			slog.Warn("opencode: ignoring allowed_tools in plan mode to preserve read-only access",
 				"mode", mode, "allowed_tools", allowedTools)
 		}
-	case "acceptEdits":
-		// Auto-accept edits + reads; other ops still ask (issue #789 workspace/auto-edit tiers).
+	case "acceptEdits", worker.PermissionModeWorkspace, worker.PermissionModeAutoEdit:
+		// Both tiers auto-accept edits and reads. OpenCode evaluates
+		// external_directory separately before the file tool; its active agent
+		// profile permits that capability unless the session overrides it.
+		// Workspace preserves the boundary, whereas auto-edit deliberately
+		// retains its no-prompt semantics.
+		externalDirectoryAction := "ask"
+		if permissionTier == worker.PermissionModeAutoEdit || mode == worker.PermissionModeAutoEdit {
+			// auto-edit is intentionally broader than workspace: it is the
+			// user-selected no-prompt tier across all Worker implementations.
+			externalDirectoryAction = "allow"
+		}
 		rules = []map[string]any{
 			{"permission": "read", "action": "allow", "pattern": "*"},
 			{"permission": "edit", "action": "allow", "pattern": "*"},
+			{"permission": "external_directory", "action": externalDirectoryAction, "pattern": "*"},
 		}
 	default:
 		// Unknown mode: no rules injected. Note: OCS defaults to ALLOW when no rule

--- a/internal/worker/opencodeserver/commands_test.go
+++ b/internal/worker/opencodeserver/commands_test.go
@@ -458,18 +458,18 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 			wantSuccess: true,
 		},
 		{
-			name: "plan denies by default and ignores write-capable allowedTools",
+			name: "plan asks by default and ignores write-capable allowedTools",
 			mode: "plan", allowedTools: []string{"Read", "Bash", "Write", "custom_write"},
 			checkBody: func(t *testing.T, reqBody map[string]any) {
 				perms := reqBody["permission"].([]any)
 				require.NotEmpty(t, perms)
 
 				// OpenCode allows unmatched permissions by default, so the first
-				// rule must deny every capability before known read-only operations
+				// rule must ask before every capability while known read-only operations
 				// are selectively re-enabled.
 				defaultRule := perms[0].(map[string]any)
 				require.Equal(t, "*", defaultRule["permission"])
-				require.Equal(t, "deny", defaultRule["action"])
+				require.Equal(t, "ask", defaultRule["action"])
 				require.Equal(t, "*", defaultRule["pattern"])
 
 				allowed := map[string]bool{}

--- a/internal/worker/opencodeserver/commands_test.go
+++ b/internal/worker/opencodeserver/commands_test.go
@@ -425,11 +425,12 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		mode         string
-		allowedTools []string
-		checkBody    func(*testing.T, map[string]any)
-		wantSuccess  bool
+		name           string
+		mode           string
+		permissionTier string
+		allowedTools   []string
+		checkBody      func(*testing.T, map[string]any)
+		wantSuccess    bool
 	}{
 		{
 			name: "bypassPermissions", mode: "bypassPermissions",
@@ -486,6 +487,43 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 			wantSuccess: true,
 		},
 		{
+			name: "acceptEdits asks before accessing an external directory",
+			mode: "acceptEdits", permissionTier: worker.PermissionModeWorkspace,
+			checkBody: func(t *testing.T, reqBody map[string]any) {
+				perms := reqBody["permission"].([]any)
+				var externalDirRule map[string]any
+				for _, p := range perms {
+					rule := p.(map[string]any)
+					if rule["permission"] == "external_directory" {
+						externalDirRule = rule
+						break
+					}
+				}
+				require.Equal(t, map[string]any{
+					"permission": "external_directory",
+					"action":     "ask",
+					"pattern":    "*",
+				}, externalDirRule)
+			},
+			wantSuccess: true,
+		},
+		{
+			name: "auto-edit permits an external directory without a prompt",
+			mode: "acceptEdits", permissionTier: worker.PermissionModeAutoEdit,
+			checkBody: func(t *testing.T, reqBody map[string]any) {
+				perms := reqBody["permission"].([]any)
+				for _, p := range perms {
+					rule := p.(map[string]any)
+					if rule["permission"] == "external_directory" {
+						require.Equal(t, "allow", rule["action"])
+						return
+					}
+				}
+				t.Fatal("missing external_directory rule")
+			},
+			wantSuccess: true,
+		},
+		{
 			name: "default mode + allowedTools generates per-tool rules only",
 			mode: "default", allowedTools: []string{"Edit", "Write"},
 			checkBody: func(t *testing.T, reqBody map[string]any) {
@@ -517,6 +555,9 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 			reqBody := map[string]any{"mode": tt.mode}
+			if tt.permissionTier != "" {
+				reqBody["permission_tier"] = tt.permissionTier
+			}
 			if len(tt.allowedTools) > 0 {
 				reqBody["allowed_tools"] = tt.allowedTools
 			}

--- a/internal/worker/opencodeserver/commands_test.go
+++ b/internal/worker/opencodeserver/commands_test.go
@@ -458,43 +458,30 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 			wantSuccess: true,
 		},
 		{
-			name: "plan denies all write-capable tools",
-			mode: "plan",
+			name: "plan denies by default and ignores write-capable allowedTools",
+			mode: "plan", allowedTools: []string{"Read", "Bash", "Write", "custom_write"},
 			checkBody: func(t *testing.T, reqBody map[string]any) {
 				perms := reqBody["permission"].([]any)
-				// 1 read-allow + 5 write-deny (edit, write, bash, shell, patch)
-				require.Len(t, perms, 6)
-				readRule := perms[0].(map[string]any)
-				require.Equal(t, "read", readRule["permission"])
-				require.Equal(t, "allow", readRule["action"])
-				deniedTools := map[string]bool{}
+				require.NotEmpty(t, perms)
+
+				// OpenCode allows unmatched permissions by default, so the first
+				// rule must deny every capability before known read-only operations
+				// are selectively re-enabled.
+				defaultRule := perms[0].(map[string]any)
+				require.Equal(t, "*", defaultRule["permission"])
+				require.Equal(t, "deny", defaultRule["action"])
+				require.Equal(t, "*", defaultRule["pattern"])
+
+				allowed := map[string]bool{}
 				for _, p := range perms[1:] {
 					rule := p.(map[string]any)
-					require.Equal(t, "deny", rule["action"], "write tool %s should be denied", rule["permission"])
-					deniedTools[rule["permission"].(string)] = true
+					require.Equal(t, "allow", rule["action"])
+					allowed[rule["permission"].(string)] = true
 				}
-				for _, tool := range []string{"edit", "write", "bash", "shell", "patch"} {
-					require.True(t, deniedTools[tool], "%s should be denied in plan mode", tool)
+				for _, permission := range []string{"read", "glob", "grep", "list", "lsp", "webfetch", "websearch"} {
+					require.True(t, allowed[permission], "%s should remain available in plan mode", permission)
 				}
-			},
-			wantSuccess: true,
-		},
-		{
-			name: "plan + allowedTools keeps deny rules and appends tool allows",
-			mode: "plan", allowedTools: []string{"Read"},
-			checkBody: func(t *testing.T, reqBody map[string]any) {
-				perms := reqBody["permission"].([]any)
-				// 1 read-allow + 5 write-deny + 1 tool-allow
-				require.Len(t, perms, 7)
-				readRule := perms[0].(map[string]any)
-				require.Equal(t, "read", readRule["permission"])
-				for _, p := range perms[1:6] {
-					rule := p.(map[string]any)
-					require.Equal(t, "deny", rule["action"])
-				}
-				toolRule := perms[6].(map[string]any)
-				require.Equal(t, "tool", toolRule["permission"])
-				require.Equal(t, "Read", toolRule["pattern"])
+				require.False(t, allowed["tool"], "allowed_tools must not reopen write-capable tools in plan mode")
 			},
 			wantSuccess: true,
 		},

--- a/internal/worker/opencodeserver/commands_test.go
+++ b/internal/worker/opencodeserver/commands_test.go
@@ -458,16 +458,43 @@ func TestServerCommanderSetPermissionMode(t *testing.T) {
 			wantSuccess: true,
 		},
 		{
-			name: "plan + allowedTools includes read-only + per-tool rules",
-			mode: "plan", allowedTools: []string{"Bash"},
+			name: "plan denies all write-capable tools",
+			mode: "plan",
 			checkBody: func(t *testing.T, reqBody map[string]any) {
 				perms := reqBody["permission"].([]any)
-				require.Len(t, perms, 2)
+				// 1 read-allow + 5 write-deny (edit, write, bash, shell, patch)
+				require.Len(t, perms, 6)
 				readRule := perms[0].(map[string]any)
 				require.Equal(t, "read", readRule["permission"])
-				toolRule := perms[1].(map[string]any)
+				require.Equal(t, "allow", readRule["action"])
+				deniedTools := map[string]bool{}
+				for _, p := range perms[1:] {
+					rule := p.(map[string]any)
+					require.Equal(t, "deny", rule["action"], "write tool %s should be denied", rule["permission"])
+					deniedTools[rule["permission"].(string)] = true
+				}
+				for _, tool := range []string{"edit", "write", "bash", "shell", "patch"} {
+					require.True(t, deniedTools[tool], "%s should be denied in plan mode", tool)
+				}
+			},
+			wantSuccess: true,
+		},
+		{
+			name: "plan + allowedTools keeps deny rules and appends tool allows",
+			mode: "plan", allowedTools: []string{"Read"},
+			checkBody: func(t *testing.T, reqBody map[string]any) {
+				perms := reqBody["permission"].([]any)
+				// 1 read-allow + 5 write-deny + 1 tool-allow
+				require.Len(t, perms, 7)
+				readRule := perms[0].(map[string]any)
+				require.Equal(t, "read", readRule["permission"])
+				for _, p := range perms[1:6] {
+					rule := p.(map[string]any)
+					require.Equal(t, "deny", rule["action"])
+				}
+				toolRule := perms[6].(map[string]any)
 				require.Equal(t, "tool", toolRule["permission"])
-				require.Equal(t, "Bash", toolRule["pattern"])
+				require.Equal(t, "Read", toolRule["pattern"])
 			},
 			wantSuccess: true,
 		},

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -241,7 +241,10 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	}
 	w.Log.Debug("opencodeserver: start step 4 - session created", "ocs_session_id", sessionID)
 
-	w.initSessionConn(ctx, sessionID, session)
+	if err := w.initSessionConn(ctx, sessionID, session); err != nil {
+		w.releaseOnce.Do(func() { w.singleton.Release() })
+		return fmt.Errorf("opencodeserver: initialize session: %w", err)
+	}
 	// Persist OCS session ID immediately so resume can find it even if
 	// release() races with the persistWorkerSessionID in bridge.
 	w.SetWorkerSessionID(sessionID)
@@ -345,7 +348,10 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 		if exists {
 			w.Log.Info("opencodeserver: resuming existing OCS session",
 				"ocs_session_id", ocsSessionID, "hotplex_session_id", session.SessionID)
-			w.initSessionConn(ctx, ocsSessionID, session)
+			if err := w.initSessionConn(ctx, ocsSessionID, session); err != nil {
+				w.release()
+				return fmt.Errorf("opencodeserver: initialize resumed session: %w", err)
+			}
 			w.SetWorkerSessionID(ocsSessionID)
 			w.startSSE(ocsSessionID)
 			w.Log.Debug("opencodeserver: resume completed (reused session)")
@@ -363,7 +369,10 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 		return fmt.Errorf("opencodeserver: resume create session: %w", err)
 	}
 
-	w.initSessionConn(ctx, newSessionID, session)
+	if err := w.initSessionConn(ctx, newSessionID, session); err != nil {
+		w.releaseOnce.Do(func() { w.singleton.Release() })
+		return fmt.Errorf("opencodeserver: initialize resumed session: %w", err)
+	}
 	w.SetWorkerSessionID(newSessionID)
 	w.startSSE(newSessionID)
 	w.Log.Debug("opencodeserver: resume completed (fresh session)")
@@ -758,8 +767,7 @@ func (w *Worker) initHTTPConn(userID, sessionID, systemPrompt string, session wo
 	w.httpConn = c
 }
 
-func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, session worker.SessionInfo) {
-	w.initHTTPConn(session.UserID, serverSessionID, session.SystemPrompt, session)
+func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, session worker.SessionInfo) error {
 	w.cmd = &ServerCommander{
 		client:        w.client,
 		baseURL:       w.httpAddr,
@@ -768,12 +776,15 @@ func (w *Worker) initSessionConn(ctx context.Context, serverSessionID string, se
 		projectDir:    session.ProjectDir,
 	}
 	if err := w.applyPermissions(ctx, session); err != nil {
-		w.Log.Warn("opencodeserver: failed to set permissions", "session_id", serverSessionID, "err", err)
+		w.cmd = nil
+		return fmt.Errorf("apply session permissions: %w", err)
 	}
+	w.initHTTPConn(session.UserID, serverSessionID, session.SystemPrompt, session)
 	w.Mu.Lock()
 	w.StartTime = time.Now()
 	w.SetLastIO(w.StartTime)
 	w.Mu.Unlock()
+	return nil
 }
 
 // ocsSessionExists checks whether a session exists on the OpenCode server

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -647,7 +647,8 @@ func (w *Worker) applyPermissions(ctx context.Context, session worker.SessionInf
 	mode := permissionModeToOCS(session.PermissionMode)
 
 	body := map[string]any{
-		"mode": mode,
+		"mode":            mode,
+		"permission_tier": session.PermissionMode,
 	}
 
 	// B3-2 绕行: pass AllowedTools so setPermissionMode can generate

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -731,6 +731,7 @@ func (w *Worker) initHTTPConn(userID, sessionID, systemPrompt string, session wo
 		recvCh:       make(chan *events.Envelope, recvChannelSize),
 		log:          w.Log,
 		systemPrompt: systemPrompt,
+		projectDir:   session.ProjectDir,
 	}
 
 	// Parse AllowedModels[0] → "provider/model" or plain "model".
@@ -970,6 +971,7 @@ func deleteOCSSession(ctx context.Context, sessionID, httpAddr string, client *h
 func (w *Worker) httpPost(ctx context.Context, path string, payload any) error {
 	w.Mu.Lock()
 	addr := w.httpAddr
+	conn := w.httpConn
 	w.Mu.Unlock()
 
 	body, err := json.Marshal(payload)
@@ -977,8 +979,17 @@ func (w *Worker) httpPost(ctx context.Context, path string, payload any) error {
 		return fmt.Errorf("opencodeserver: marshal payload: %w", err)
 	}
 
-	url := addr + path
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	var projectDir string
+	if conn != nil {
+		projectDir = conn.projectDir
+	}
+
+	u := addr + path
+	if projectDir != "" {
+		u += "?directory=" + url.QueryEscape(projectDir)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", u, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
 	}
@@ -1058,6 +1069,7 @@ type conn struct {
 	recvCh       chan *events.Envelope
 	log          *slog.Logger
 	systemPrompt string
+	projectDir   string
 
 	allowedModel *ocsModelRef   // parsed from SessionInfo.AllowedModels[0]
 	jsonSchema   map[string]any // parsed from SessionInfo.JSONSchema

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -713,3 +713,28 @@ func TestWait_CrashSub_NotRecovered(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, code, "Wait should return 1 when singleton has NOT recovered")
 }
+
+func TestInput_QuestionResponse_WithProjectDir(t *testing.T) {
+	t.Parallel()
+
+	var receivedPath string
+	var receivedQuery string
+	w, _ := newWorkerWithMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w.httpConn.projectDir = "/test/workspace"
+
+	md := map[string]any{
+		"question_response": map[string]any{
+			"id":      "q_789",
+			"answers": map[string]string{"q1": "yes"},
+		},
+	}
+	err := w.Input(context.Background(), "", md)
+	require.NoError(t, err)
+	require.Equal(t, "/question/q_789/reply", receivedPath)
+	require.Equal(t, "directory=%2Ftest%2Fworkspace", receivedQuery)
+}

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -50,6 +50,31 @@ func TestOpenCodeServerWorker_New(t *testing.T) {
 	require.Nil(t, w.httpConn)
 }
 
+func TestOpenCodeServerWorker_InitSessionConnFailsClosedWhenPermissionSetupFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.Equal(t, "/session/ocs-session-1", r.URL.Path)
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	w := New()
+	w.httpAddr = server.URL
+	w.client = server.Client()
+	w.singleton = NewSingletonProcessManager(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		config.OpenCodeServerConfig{},
+	)
+
+	err := w.initSessionConn(context.Background(), "ocs-session-1", worker.SessionInfo{
+		UserID:         "test-user",
+		PermissionMode: worker.PermissionModeReadOnly,
+	})
+
+	require.ErrorContains(t, err, "opencode set permission")
+	require.Nil(t, w.httpConn, "permission setup failure must not leave a usable connection")
+}
+
 func TestOpenCodeServerWorker_EnvBlocklist(t *testing.T) {
 	t.Parallel()
 	w := New()

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -75,6 +75,37 @@ func TestOpenCodeServerWorker_InitSessionConnFailsClosedWhenPermissionSetupFails
 	require.Nil(t, w.httpConn, "permission setup failure must not leave a usable connection")
 }
 
+func TestOpenCodeServerWorker_ApplyPermissionsPreservesUnifiedTier(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	w := New()
+	w.cmd = &ServerCommander{
+		client:    server.Client(),
+		baseURL:   server.URL,
+		sessionID: "ocs-session-1",
+	}
+
+	err := w.applyPermissions(t.Context(), worker.SessionInfo{PermissionMode: worker.PermissionModeAutoEdit})
+	require.NoError(t, err)
+	perms := got["permission"].([]any)
+	for _, p := range perms {
+		rule := p.(map[string]any)
+		if rule["permission"] == "external_directory" {
+			require.Equal(t, "allow", rule["action"])
+			return
+		}
+	}
+	t.Fatal("missing external_directory rule")
+}
+
 func TestOpenCodeServerWorker_EnvBlocklist(t *testing.T) {
 	t.Parallel()
 	w := New()

--- a/webchat/components/assistant-ui/thread-helpers.ts
+++ b/webchat/components/assistant-ui/thread-helpers.ts
@@ -27,11 +27,11 @@ export const messageVariants = {
 export function extractCommand(args: any) { return args?.command || args?.Command || ""; }
  
 export function extractFilePath(args: any) { 
-  return args?.file_path || args?.path || args?.target_file || args?.TargetFile || args?.targetFile || args?.AbsolutePath || args?.absolutePath || ""; 
+  return args?.file_path || args?.filePath || args?.filepath || args?.path || args?.target_file || args?.TargetFile || args?.targetFile || args?.AbsolutePath || args?.absolutePath || args?.file || args?.filename || args?.fileName || ""; 
 }
  
 export function extractFileContent(args: any, result: any) { 
-  return args?.content || args?.code || args?.ReplacementContent || args?.CodeContent || (typeof result === "string" ? result : ""); 
+  return args?.content || args?.code || args?.ReplacementContent || args?.CodeContent || args?.replacementContent || args?.codeContent || args?.replacement || args?.text || (typeof result === "string" ? result : ""); 
 }
 
 export interface Suggestion {

--- a/webchat/components/assistant-ui/tools/FileDiffTool.tsx
+++ b/webchat/components/assistant-ui/tools/FileDiffTool.tsx
@@ -17,7 +17,7 @@ export function FileDiffTool({ toolName, filePath, content, status, onToggle }: 
   const { t } = useTranslation();
   const { copied, copy } = useCopyToClipboard();
   const lines = content?.split("\n") ?? [];
-  const displayPath = filePath || "unknown file";
+  const displayPath = filePath || t("chat:tool.filediff.unknown_file", { defaultValue: "unknown file" });
 
   return (
     <div className="rounded-[var(--radius-md)] overflow-hidden border border-[var(--border-subtle)] my-6 shadow-[var(--shadow-md)] group/diff">

--- a/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
+++ b/webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx
@@ -1,10 +1,53 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import type { InteractionState, InteractionStatus } from "@/lib/adapters/hotplex-runtime-adapter";
 import { useInteractionTimeout } from "@/hooks/useInteractionTimeout";
+
+interface ParsedPermissionArgs {
+  command?: string;
+  action?: string;
+  Action?: string;
+  target?: string;
+  Target?: string;
+  reason?: string;
+  Reason?: string;
+  directories?: string[];
+  patterns?: string[];
+  toolAction?: string;
+  toolSummary?: string;
+  [key: string]: any;
+}
+
+function parsePermissionArgs(args: any): ParsedPermissionArgs | null {
+  if (!args) return null;
+  if (Array.isArray(args)) {
+    if (args.length === 1 && typeof args[0] === 'string') {
+      try {
+        const parsed = JSON.parse(args[0]);
+        if (parsed && typeof parsed === 'object') {
+          return parsed;
+        }
+      } catch (e) {
+        // Not JSON
+      }
+    }
+  } else if (typeof args === 'string') {
+    try {
+      const parsed = JSON.parse(args);
+      if (parsed && typeof parsed === 'object') {
+        return parsed;
+      }
+    } catch (e) {
+      // Not JSON
+    }
+  } else if (typeof args === 'object') {
+    return args;
+  }
+  return null;
+}
 
 interface PermissionApprovalCardProps {
   toolName: string;
@@ -30,8 +73,21 @@ export function PermissionApprovalCard({
   const [reason, setReason] = useState("");
   const isInteractive = activeStatus === "pending" || activeStatus === "failed";
 
+  const parsed = parsePermissionArgs(args);
+
   const title = t("tool.interaction.permission.title", { defaultValue: "Tool Execution Approval" });
-  const descText = description || t("tool.interaction.permission.description", { defaultValue: "Agent requests permission to execute the following tool" });
+  
+  const defaultDesc = t("tool.interaction.permission.description", { defaultValue: "Agent requests permission to execute the following tool" });
+  let descText = description || defaultDesc;
+  if (parsed && (!description || description === defaultDesc)) {
+    if (parsed.toolAction) {
+      descText = parsed.toolAction;
+    } else if (parsed.toolSummary) {
+      descText = parsed.toolSummary;
+    } else if (parsed.reason || parsed.Reason) {
+      descText = parsed.reason || parsed.Reason || defaultDesc;
+    }
+  }
 
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -87,11 +143,122 @@ export function PermissionApprovalCard({
           <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-3">{descText}</p>
         )}
 
-        {args && Object.keys(args).length > 0 && (
-          <div className="mt-2 text-xs font-mono bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded p-2.5 max-h-[160px] overflow-y-auto custom-scrollbar whitespace-pre-wrap text-[var(--text-primary)]">
-            {JSON.stringify(args, null, 2)}
-          </div>
-        )}
+        {args && Object.keys(args).length > 0 && (() => {
+          if (parsed) {
+            const displayAction = parsed.action || parsed.Action;
+            const displayTarget = parsed.target || parsed.Target;
+            const displayReason = parsed.reason || parsed.Reason;
+            
+            const renderedKeys = new Set([
+              'command', 'action', 'Action', 'target', 'Target', 'reason', 'Reason',
+              'directories', 'patterns', 'toolAction', 'toolSummary'
+            ]);
+            const extraKeys = Object.keys(parsed).filter(
+              k => !renderedKeys.has(k) && parsed[k] !== undefined && parsed[k] !== null
+            );
+
+            return (
+              <div className="mt-2 text-xs space-y-3 font-sans text-[var(--text-secondary)]">
+                {parsed.command && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.command_to_execute", { defaultValue: "Command to Execute" })}
+                    </div>
+                    <div className="font-mono bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded p-2.5 whitespace-pre-wrap break-all text-[var(--text-primary)]">
+                      <span className="text-[var(--accent-emerald)] select-none mr-1.5">$</span>
+                      {parsed.command}
+                    </div>
+                  </div>
+                )}
+                
+                {displayAction && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.action", { defaultValue: "Action" })}:
+                    </span>
+                    <span className="font-mono bg-[var(--bg-elevated)] px-1.5 py-0.5 rounded border border-[var(--border-subtle)] text-[var(--text-primary)] font-bold">
+                      {displayAction}
+                    </span>
+                  </div>
+                )}
+
+                {displayTarget && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.target", { defaultValue: "Target" })}
+                    </div>
+                    <div className="font-mono bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded p-2.5 whitespace-pre-wrap break-all text-[var(--text-primary)]">
+                      {displayTarget}
+                    </div>
+                  </div>
+                )}
+
+                {displayReason && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.reason", { defaultValue: "Reason" })}
+                    </div>
+                    <p className="text-sm text-[var(--text-primary)] italic">&quot;{displayReason}&quot;</p>
+                  </div>
+                )}
+
+                {parsed.directories && Array.isArray(parsed.directories) && parsed.directories.length > 0 && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.allowed_directories", { defaultValue: "Allowed Directories" })}
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {parsed.directories.map((dir, idx) => (
+                        <span key={idx} className="font-mono text-[11px] bg-[var(--bg-base)] px-1.5 py-0.5 rounded border border-[var(--border-subtle)] text-[var(--text-primary)] break-all">
+                          {dir}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {parsed.patterns && Array.isArray(parsed.patterns) && parsed.patterns.length > 0 && (
+                  <div className="space-y-1">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider">
+                      {t("tool.interaction.permission.allowed_patterns", { defaultValue: "Allowed Patterns" })}
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {parsed.patterns.map((pat, idx) => (
+                        <span key={idx} className="font-mono text-[11px] bg-[var(--bg-base)] px-1.5 py-0.5 rounded border border-[var(--border-subtle)] text-[var(--text-primary)] break-all">
+                          {pat}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {extraKeys.length > 0 && (
+                  <div className="space-y-1 mt-2 border-t border-[var(--border-subtle)] pt-2">
+                    <div className="text-[10px] font-bold text-[var(--text-faint)] uppercase tracking-wider mb-1">
+                      {t("tool.interaction.permission.additional_parameters", { defaultValue: "Additional Parameters" })}
+                    </div>
+                    <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 font-mono text-[11px]">
+                      {extraKeys.map(k => (
+                        <React.Fragment key={k}>
+                          <span className="text-[var(--text-faint)]">{k}:</span>
+                          <span className="text-[var(--text-primary)] break-all">
+                            {typeof parsed[k] === 'object' ? JSON.stringify(parsed[k]) : String(parsed[k])}
+                          </span>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          }
+
+          return (
+            <div className="mt-2 text-xs font-mono bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded p-2.5 max-h-[160px] overflow-y-auto custom-scrollbar whitespace-pre-wrap text-[var(--text-primary)]">
+              {JSON.stringify(args, null, 2)}
+            </div>
+          );
+        })()}
       </div>
 
       {/* Action Buttons */}

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -575,6 +575,13 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
       case EventKind.State:
         this._state = (event.data as StateData).state;
         this.emit('state', event.data as StateData, env);
+        // A /reset (or /new) emits State with message "context_reset" instead
+        // of a Done. Release the pending-input lock so the UI does not freeze
+        // waiting for a terminal event that never comes. This is a client-side
+        // safety net; the gateway also sends a synthetic delivered InputAck.
+        if ((event.data as StateData).message === 'context_reset') {
+          this._settlePending({ kind: 'resolve' });
+        }
         break;
 
       case EventKind.InputAck: {

--- a/webchat/locales/en/chat.json
+++ b/webchat/locales/en/chat.json
@@ -251,7 +251,10 @@
     "search": { "loading": "Searching..." },
     "list": { "loading": "Listing directory..." },
     "todo": { "loading": "Retrieving latest tasks..." },
-    "filediff": { "loading": "Synthesizing file patch..." },
+    "filediff": {
+      "loading": "Synthesizing file patch...",
+      "unknown_file": "unknown file"
+    },
     "interaction": {
       "timeout": "Expires in {{seconds}}s",
       "permission": {
@@ -263,7 +266,14 @@
         "submitting": "Submitting approval...",
         "failed": "Submission failed: {{error}}",
         "approve": "Approve",
-        "reject": "Reject"
+        "reject": "Reject",
+        "command_to_execute": "Command to Execute",
+        "action": "Action",
+        "target": "Target",
+        "reason": "Reason",
+        "allowed_directories": "Allowed Directories",
+        "allowed_patterns": "Allowed Patterns",
+        "additional_parameters": "Additional Parameters"
       },
       "question": {
         "title": "Input Request",

--- a/webchat/locales/zh-CN/chat.json
+++ b/webchat/locales/zh-CN/chat.json
@@ -251,7 +251,10 @@
     "search": { "loading": "搜索中..." },
     "list": { "loading": "列出目录中..." },
     "todo": { "loading": "获取最新任务中..." },
-    "filediff": { "loading": "合成文件补丁中..." },
+    "filediff": {
+      "loading": "合成文件补丁中...",
+      "unknown_file": "未知文件"
+    },
     "interaction": {
       "timeout": "剩余时间 {{seconds}}秒",
       "permission": {
@@ -263,7 +266,14 @@
         "submitting": "正在提交授权...",
         "failed": "提交失败：{{error}}",
         "approve": "允许",
-        "reject": "拒绝"
+        "reject": "拒绝",
+        "command_to_execute": "要执行的命令",
+        "action": "操作",
+        "target": "目标",
+        "reason": "原因",
+        "allowed_directories": "允许的目录",
+        "allowed_patterns": "允许的模式",
+        "additional_parameters": "附加参数"
       },
       "question": {
         "title": "输入请求",


### PR DESCRIPTION
## 问题

OCS (OpenCodeServer) Worker 的 workspace 只读约束失效:workspace 设为 `read-only` (plan 模式) 后,Agent 仍能直接改文件;workspace / auto-edit 层级的工作区边界也没被实际执行。

## 根因

OCS 权限系统是 **opt-in allowlist**:工具调用未命中任何规则时,默认动作是 **ALLOW**,既不 ask 也不 deny。原代码在 plan 模式只注入了 `read: allow` 一条规则,假设未匹配的操作会被拦截——实际上 `edit` / `write` / `bash` / `shell` / `patch` 全部直接放行。实测确认:即便给 `edit` 单独 deny,Agent 也会绕道 `bash` (`echo > file`) 完成写入。

更深的两个问题:
1. **首启即漏**:workspace 权限上限只在 worker resume 时应用,首个 worker 启动时 `CreateWithBot` 返回的 snapshot 未同步 `WorkspaceID`,workspace 边界对首次会话不生效。
2. **静默拒绝**:即使 deny 所有写入,Agent 的写入尝试被无声丢弃,用户看不到任何审批卡,体验上像是"卡住"。

## 修复

按 6 个维度收紧 OCS 权限执行。

### 1. plan 模式从 ask-all 基线开始 (而非仅注入单条 read)

`internal/worker/opencodeserver/commands.go` — plan 模式注入 `*:ask` 通配基线,再选择性 allow 内建只读工具 (read / glob / grep / list / lsp / webfetch / websearch)。写入操作因此变成**权限请求**,而非被静默丢弃或绕行。custom / MCP / subagent 工具也落在 ask 基线上,不会形成绕过通道。

> 演进:本 PR 第一版是 `*:deny` 基线;实测发现写入被无声拒绝且无审批卡,改为 `*:ask` 让用户能看到并裁决每一次写入。

### 2. 工作区边界:外部目录需审批

`commands.go` — `acceptEdits` 与 `workspace` 层级显式注入 `external_directory: ask`,工作区内的 edit 已 allow,工作区外则触发审批。`auto-edit` 作为用户明确选择的 no-prompt 层级,`external_directory` 走 allow,保留其语义。同时把 `allowed_tools` 白名单的注入限制在非 plan 模式下,避免在 read-only 基线上被一条 caller-supplied allow 规则重新打开写入。

### 3. 首个 worker 即应用 workspace 上限

`internal/gateway/bridge.go` — `SetWorkspaceID` 持久化了绑定,但无法改 `CreateWithBot` 返回的 snapshot。把 `si.WorkspaceID` 同步回 snapshot,使首个 worker (而非只有后续 resume) 即受 workspace 权限上限约束。

### 4. 权限应用失败不再被吞掉

`internal/worker/opencodeserver/worker.go` — `initSessionConn` 从无返回值改为返回 error;`applyPermissions` 失败时清理 `cmd` 并向上冒泡,Start / Resume 路径相应释放资源。原先只打一条 warn 继续跑,worker 实际处于"权限未应用"的裸状态。

### 5. 命令失败不再误发"已交付"ack

`internal/gateway/handler.go` — `handleInput` 在 control command 返回 err 时跳过 `ackControlCommand`,避免命令失败后 UI 因合成 "delivered" ack 假冻结。

### 6. webchat 结构化渲染审批参数

`webchat/components/assistant-ui/tools/PermissionApprovalCard.tsx` — 解析权限工具参数 (JSON string / object / array 三种形态),分区块渲染 command / action / target / reason / 允许目录 / 允许模式,取代原来的原始 JSON dump。`extractFilePath` / `extractFileContent` 扩展字段名变体 (filePath / filepath / file / filename / replacementContent / codeContent / replacement / text),兼容 OCS 侧 arg 结构。新增文案同步进 en / zh-CN。

## 最终规则集

| 模式 | 规则 |
| --- | --- |
| `plan` (read-only) | `*:ask` 基线 + read/glob/grep/list/lsp/webfetch/websearch allow |
| `acceptEdits` / `workspace` | read+edit allow,`external_directory: ask` |
| `auto-edit` | read+edit+`external_directory` 全 allow |
| `bypassPermissions` | allow-all |

## 测试

- `internal/worker/opencodeserver/` — `commands_test.go` / `worker_test.go` 覆盖各模式规则集、allowed_tools 在 plan 模式被忽略、`external_directory` 分层、initSessionConn 错误冒泡
- `internal/gateway/` — `conn_test.go` 验证首启 workspace 绑定;`command_detection_test.go` 覆盖命令失败路径
- 全量 `go test -race` 通过;webchat tsc + ESLint 通过
- 人工实测:plan 模式下 Agent 60+ 秒未能改文件,写入以审批卡形式呈现

## 文档

`docs/guides/developer/remote-coding-agent.md` 与 `security-model.md` 同步更新 OCS 权限语义。

---

Refs #789
