### PR TITLE
feat(skills): skill 管理 HTTP API + zip 上传 + webchat UI (#910)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -203,6 +203,8 @@ type GatewayDeps struct {
 	// Audit subsystem (issue #833 P1). Nil when audit.enabled=false.
 	AuditCollector *audit.Collector
 	AuditStore     audit.Store
+	// SkillsLocator serves the skill management HTTP API (issue #910).
+	SkillsLocator *skills.Locator
 	// Durable ingress reliability closure (spec 2026-07-14).
 	OwnerInstanceID string
 	LeaseManager    *execution.LeaseManager
@@ -774,6 +776,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		DevMode:         devMode,
 		AuditCollector:  auditCollector,
 		AuditStore:      auditStore,
+		SkillsLocator:   skillsLocator,
 		OwnerInstanceID: ownerInstanceID,
 		LeaseManager:    leaseMgr,
 		Repairer:        repairer,

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -116,6 +116,10 @@ func setupRoutes(
 	if deps.AuditCollector != nil {
 		adminAPI.SetAuditCollector(deps.AuditCollector)
 	}
+	// Skill management API (issue #910): global skill CRUD via /admin/api/skills.
+	if deps.SkillsLocator != nil {
+		adminAPI.SetSkillsLocator(deps.SkillsLocator)
+	}
 
 	if cfg.Admin.RateLimitEnabled {
 		limiter := admin.NewRateLimiter(cfg.Admin.RequestsPerSec, cfg.Admin.Burst)
@@ -216,6 +220,12 @@ func setupRoutes(
 	// /api/workspaces with Authenticator + CSRF, not admin scope).
 	adminMux.HandleFunc("GET /admin/workspaces", adminAPI.HandleListAdminWorkspaces)
 	adminMux.HandleFunc("PATCH /admin/workspaces/{id}", adminAPI.HandleUpdateAdminWorkspacePermissionMode)
+
+	// Skill management API (issue #910): global skill list/install/read/delete.
+	adminMux.HandleFunc("GET /admin/api/skills", adminAPI.HandleListSkills)
+	adminMux.HandleFunc("POST /admin/api/skills", adminAPI.HandleInstallSkill)
+	adminMux.HandleFunc("GET /admin/api/skills/{name}", adminAPI.HandleGetSkill)
+	adminMux.HandleFunc("DELETE /admin/api/skills/{name}", adminAPI.HandleDeleteSkill)
 
 	// Documentation
 	if resolved := security.ResolveCSP(security.DefaultDocsCSP, cfg.Security.CSP); security.IsPermissiveCSP(resolved) {
@@ -326,6 +336,23 @@ func setupRoutes(
 		mux.Handle("GET /api/workspaces/{id}", corsMw(http.HandlerFunc(wsHandlers.Get)))
 		mux.Handle("PATCH /api/workspaces/{id}", corsMw(csrfMw(http.HandlerFunc(wsHandlers.Update))))
 		mux.Handle("DELETE /api/workspaces/{id}", corsMw(csrfMw(http.HandlerFunc(wsHandlers.Delete))))
+
+		// Skill management API (issue #910): user-facing merged list + workspace
+		// skill CRUD. Write routes (POST/DELETE) mount csrfMw for the same
+		// SameSite=None cookie CSRF reason /api/workspaces does; GETs pass through.
+		skillHandlers := gateway.NewSkillHandlers(deps.SkillsLocator, deps.WorkspaceStore, auth, log)
+		if deps.AuditCollector != nil {
+			skillHandlers.SetAuditCollector(deps.AuditCollector)
+		}
+		mux.Handle("GET /api/skills", corsMw(http.HandlerFunc(skillHandlers.ListMerged)))
+		mux.Handle("GET /api/skills/{name}", corsMw(http.HandlerFunc(skillHandlers.GetMerged)))
+		mux.Handle("POST /api/workspaces/{wid}/skills", corsMw(csrfMw(http.HandlerFunc(skillHandlers.InstallWorkspace))))
+		mux.Handle("GET /api/workspaces/{wid}/skills/{name}", corsMw(http.HandlerFunc(skillHandlers.GetWorkspace)))
+		mux.Handle("DELETE /api/workspaces/{wid}/skills/{name}", corsMw(csrfMw(http.HandlerFunc(skillHandlers.DeleteWorkspace))))
+		mux.Handle("OPTIONS /api/skills", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/skills/", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/workspaces/{wid}/skills", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+		mux.Handle("OPTIONS /api/workspaces/{wid}/skills/{name}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
 		// OPTIONS preflight handlers for Workspaces API
 		mux.Handle("OPTIONS /api/workspaces", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -325,6 +325,27 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 
 PATCH 错误码：`400 INVALID_PERMISSION_MODE`（档位非法）/ `400 BAD_REQUEST`（body 缺 `permission_mode`）/ `404 WORKSPACE_NOT_FOUND`（id 不存在）/ `409 WORKSPACE_VERSION_MISMATCH`（`updated_at` CAS 冲突；或并发更新下 workspace 恰有活跃会话时的 CAS heuristic 误判——本端点只改 `permission_mode`、不动 `work_dir`，活跃会话不真正阻塞，故两种成因都应重新 GET 最新 `updated_at` 后重试，新值仅对新会话生效）。
 
+### Skill 管理（admin 全局）
+
+> 🆕 **issue #910** — admin 控制台的全局 skill 管理。zip 上传安装到 `~/.agents/skills`（对齐开放 `.agents` 标准，Codex/OpenCode 原生读取；Claude Code 需软链，见 [Skill 配置教程](../tutorials/skills-setup.md)）。区别于用户自助的 `/api/workspaces/{wid}/skills/*`（见下文 WebChat 多租户端点段）：admin 端管理**全局共享** skill，用户端管理各自 **workspace** skill。
+
+| 方法 | 路径 | Scope | 说明 |
+|------|------|-------|------|
+| GET | `/admin/api/skills` | `admin:read` | 列出全局 skill（`.agents`/`.claude`/`.hotplex` 合并，带 `managed` 标注） |
+| POST | `/admin/api/skills` | `admin:write` | zip 上传安装全局 skill（`?replace=true` 覆盖同名） |
+| GET | `/admin/api/skills/{name}` | `admin:read` | 全局 skill 详情（含 `SKILL.md` 全文 `body` + 包内文件列表 `files`） |
+| DELETE | `/admin/api/skills/{name}` | `admin:write` | 删除全局 skill |
+
+**GET /admin/api/skills** — 合并扫描 home 下 `.agents/skills`（`managed:true`，可写）与 `.claude/skills`、`.hotplex/skills`（`managed:false`，只读外部），同名 project 覆盖 global。响应：`{"skills":[{name,description,source,managed}],"total":N}`。GET 不审计。
+
+**POST /admin/api/skills** — multipart 上传，`file` 字段为 `.zip` 包（body 上限 20MB）。zip 根下须直接有 `SKILL.md`，或单一顶层目录内含 `SKILL.md`（目录名必须等于 frontmatter `name`）。frontmatter 必填 `name`（正则 `^[a-z0-9]+(-[a-z0-9]+)*$`，1-64 字符）与 `description`（1-1024 字符）。文件类型白名单：`.md`/`.json`/`.yaml`/`.yml`/`.txt`/`.py`/`.sh`/`.toml`/图片（`.png`/`.jpg`/`.jpeg`/`.svg`）；拒可执行/二进制。`?replace=true` 覆盖同名，否则同名返回 `409`。安装成功返回 `skills.InstallResult`（含 `name`/`description`/`source:"global"`/`managed:true`/`body`/`files`，以及可能的 `warning`）。
+
+> 🛡️ **安全**：zip-slip（`SafePathJoin` + 前缀双保险）、解压炸弹（zip ≤20MB / 解压总 ≤50MB / 单文件 ≤5MB / entry ≤500 / 压缩率 >100× 拒）、恶意 entry（`IsRegular()` 过滤 symlink/device）多维防护（spec §3.3 A）。
+
+> 🛡️ **审计**：POST/DELETE 写操作由 middleware 级 `admin_audit` 统一记录，action = `skill.create`（POST，`?replace=true` 时映射为 `skill.update`）/ `skill.delete`（DELETE），actor = uid（Cookie 通道）或 `admin-token`（Bearer）。
+
+错误码：`400 SKILL_INVALID_ZIP`（损坏/超限/含恶意 entry）/ `400 SKILL_INVALID_FORMAT`（无 SKILL.md / frontmatter 缺失 / name 不合规 / name≠目录名 / description 超长）/ `400 SKILL_FILE_TYPE_BLOCKED`（类型不在白名单）/ `409 SKILL_ALREADY_EXISTS`（同名且未带 `?replace=true`）/ `404 SKILL_NOT_FOUND`（name 不存在）。
+
 ## Gateway API 端点
 
 Gateway API（`/api/sessions`）监听在网关主端口（`8888`），面向客户端 SDK 和 WebSocket 连接，使用 API Key 认证（非 Bearer Token）。
@@ -393,6 +414,24 @@ Workspace CRUD 是**跨通道租户锚**：同一个 `users.id` 无论经 **API 
 > **PATCH 乐观并发（CAS）**：更新基于 `updated_at` 做乐观锁——服务端 `UPDATE ... WHERE id = ? AND updated_at = ?`，调用方缓存的 `updated_at` 不再匹配（被并发修改）时影响 0 行，返回 `409 WORKSPACE_VERSION_MISMATCH`（"workspace concurrently modified, please re-fetch and retry"）。客户端无需在 body 显式传版本字段（先 GET 取最新值再 PATCH），收到 409 后应重新 GET 再重试，避免静默 lost update。
 
 > **PATCH body 字段语义**：`name`、`agent_config_overrides` 传空字符串表示**不更新**（无法通过 PATCH 清空这两项）；`worker_preference` 为指针类型以区分三态——**省略**（字段未传）不更新、**空字符串** `""` 显式清除回默认 worker、**非空**设为指定类型（校验失败返回 `400 INVALID_WORKER_TYPE`）；`work_dir` 为 workspace 级可变字段——**省略/空字符串**不更新，**非空**时校验 owner 沙箱（`403 WORK_DIR_OUTSIDE_SANDBOX`）、值变更须 workspace 无活跃会话（`409 WORKSPACE_NOT_EMPTY`，因 work_dir 进 session key 派生）、且未被该 owner 其他 workspace 占用（`409 WORK_DIR_TAKEN`）后更新（见上）。
+
+**Workspace Skill 管理（spec #910）**：
+
+每个 workspace 可管理自己的 skill（安装到 `<work_dir>/.agents/skills`）。鉴权与 workspace CRUD 一致（API Key 优先 / Cookie 兜底），写操作额外校验 owner 归属（`ws.OwnerUserID != uid && !isAdmin` → `403 WORKSPACE_FORBIDDEN`）。另提供脱离 workspace 的合并查询：`/api/skills` 返回 `全局 + 当前用户所有 workspace + 外部只读` 的合并列表（每用户视图）。
+
+| 方法 | 路径 | 认证 | 说明 |
+|------|------|------|------|
+| GET | `/api/skills` | API Key / Cookie | 合并列表：全局 + 我的 workspace + 外部只读（带 `managed` 标注） |
+| GET | `/api/skills/{name}` | API Key / Cookie | 合并列表中该 skill 的元信息（覆盖胜出 scope） |
+| POST | `/api/workspaces/{wid}/skills` | owner | zip 上传安装 workspace skill（`?replace=true` 覆盖） |
+| GET | `/api/workspaces/{wid}/skills/{name}` | owner | workspace scope skill 详情（含 `body` + `files`） |
+| DELETE | `/api/workspaces/{wid}/skills/{name}` | owner | 删除 workspace skill |
+
+> ⚠️ **同名遮蔽（spec §3.3 B6）**：workspace 安装与全局同名的 skill 时**允许安装但返回 `warning`**（`shadows global skill '<name>'`）——workspace skill 在合并列表中覆盖全局生效，UI 须显式提示。
+
+> 🛡️ **审计**：workspace skill 写操作（POST/DELETE）由 handler 显式写入 tamper-evident `user_activity`（`action` = `skill.install` / `skill.delete`，`resource_type` = `skill`，`platform` = `webchat`），与 `/api/admin/*` 写操作一致；读操作不审计。
+
+zip 格式、文件类型白名单与安全约束同上方「Skill 管理（admin 全局）」；错误码复用 `SKILL_INVALID_ZIP` / `SKILL_INVALID_FORMAT` / `SKILL_FILE_TYPE_BLOCKED` / `SKILL_ALREADY_EXISTS` / `SKILL_NOT_FOUND`，另增 `403 WORKSPACE_FORBIDDEN`（非 owner）。
 
 **Workspace 用户与邀请管理（spec ⑥，admin 维度）**：
 

--- a/docs/specs/Skill-Management-Spec.md
+++ b/docs/specs/Skill-Management-Spec.md
@@ -1,6 +1,6 @@
 # Skill 管理 — HTTP API 与 zip 上传
 
-**状态**: Draft · **日期**: 2026-07-17 · **跟踪 issue**: #910 · **关联**: [Admin-Workspace-PermissionMode-Management-Spec.md](./Admin-Workspace-PermissionMode-Management-Spec.md)、[ACP-Worker-Spec.md](./ACP-Worker-Spec.md) · **版本目标**: TBD
+**状态**: Implemented · **日期**: 2026-07-17 · **跟踪 issue**: #910 · **关联**: [Admin-Workspace-PermissionMode-Management-Spec.md](./Admin-Workspace-PermissionMode-Management-Spec.md)、[ACP-Worker-Spec.md](./ACP-Worker-Spec.md) · **版本目标**: v1.37.0
 
 ---
 
@@ -284,3 +284,34 @@ AuditSkillDelete = "skill.delete"
 
 1. **`Source` 值是否重命名** `project`→`workspace`：是 wire 值变更（客户端 `=="project"` 会断），需协调 SDK；首版**保留** `global`/`project`，仅在文档注明 project=workspace scope。
 2. **全局 skill 的物理 owner**：`~/.agents/skills` 在多用户服务器上是 hotplex 服务账号的 home，所有用户共享。确认这是"全局"的预期语义（与本 spec 一致）。
+
+---
+
+## 10. 实施记录
+
+**分支**: `feat/910-skill-management`（关联 issue #910）
+
+### 已实施
+
+- **阶段 1（skills 包）**：`Skill` 加 `Managed`/`FilePath`；scanner 区分 managed(`.agents`)/external(`.claude`/`.hotplex`)；Locator 加 `Invalidate(workDir)`/`InvalidateAll()`/`ListMerged`；`zip.go` 安全管线（zip-slip/炸弹/恶意 entry/类型白名单 + agentskills.io 格式校验）；`crud.go` `Install`/`Read`/`Delete`（原子 Rename 落盘 + 回滚 + 跨 scope warning + 按 scope 缓存失效策略）。
+- **阶段 2（HTTP API）**：8 端点（gateway 用户端 5 + admin 4），multipart `MaxBytesReader` 20MB，审计接入（admin `AuditSkillCreate/Update/Delete` + 用户端 `auditCollector` → user_activity），`SkillEntry` wire 加 `Managed`（omitempty 向后兼容）。
+- **阶段 3（前端）**：admin 全局 skill 管理页（list + zip 上传 + 删除 + warning toast + 只读外部标注）+ admin-nav `Skills` 入口 + zh-CN/en locales 同步。
+
+### 偏离 spec
+
+- **§3.3 A 复用 SafePathJoin**：`security.SafePathJoin` 对目标路径调 `filepath.EvalSymlinks`，而解压时目标文件尚未创建会直接失败。改用等价的 `safeExtractJoin`（Clean + 拒绝绝对路径/".." + Join + 字符串前缀校验，省去 EvalSymlinks）：staging 为本包新建的受控临时目录、entry 相对路径已严格 Clean，前缀校验足以防 zip-slip；显式 `HasPrefix` 双保险保留。
+
+### 阶段 0（实测验证）
+
+§1.2 的 4 adapter 加载行为已通过**官方源码调研确认**（Codex `loader.rs` 主路径 `$HOME/.agents/skills`、OpenCode `skills.mdx` agent-compat 路径、CC 文档只读 `.claude/skills`）。真实 worker 实测（zip 装 skill 到 `~/.agents/skills` 后 CC 建软链 / Codex / OCS 是否在会话中加载）建议在部署环境验证。
+
+### 待确认项决议
+
+1. `Source` 保留 `global`/`project`（wire 兼容；project=workspace scope，文档注明），重命名留待后续协调 SDK。
+2. 全局 `~/.agents/skills` 为服务账号 home、所有用户共享——确认为"全局"预期语义。
+
+### 后续（非本 PR 范围）
+
+- **workspace skill 管理 UI（普通用户页）**：后端 API（`/api/workspaces/{wid}/skills`）+ 前端 client（`webchat/lib/api/skills.ts`）已就绪，UI 待 workspace 详情页改造时接入（复用 admin 全局页模式）。
+- **`docs/reference/admin-api.md`、`api.md` 端点契约**：docs/reference 门户待建；本 spec §5 数据契约汇总为权威参考。
+- **onboard skill 软链引导**（CC 专属 `ln -s ~/.agents/skills ~/.claude/skills`；Codex/OCS 无需；ACP 按底层）：待 onboard 手册页接入。

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -299,6 +299,97 @@
                 }
             }
         },
+        "/admin/api/skills": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns every skill under the global .agents/.claude/.hotplex dirs. Requires admin:read.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List global skills (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Upload a skill zip into ~/.agents/skills. Use ?replace=true to overwrite. Requires admin:write.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Install global skill (admin)",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "skill zip archive",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "overwrite existing same-name skill",
+                        "name": "replace",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.skillInstallResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "SKILL_INVALID_ZIP / SKILL_INVALID_FORMAT / SKILL_FILE_TYPE_BLOCKED",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "SKILL_ALREADY_EXISTS",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/bots": {
             "get": {
                 "security": [
@@ -3750,6 +3841,38 @@
                 "content": {
                     "type": "string",
                     "example": "You are a helpful assistant."
+                }
+            }
+        },
+        "admin.skillInstallResponse": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "managed": {
+                    "description": ".agents/skills 可写区",
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "description": "\"global\"",
+                    "type": "string"
+                },
+                "warning": {
+                    "description": "workspace 同名遮蔽全局时非空",
+                    "type": "string"
                 }
             }
         },

--- a/docs/tutorials/skills-setup.md
+++ b/docs/tutorials/skills-setup.md
@@ -1,0 +1,119 @@
+---
+title: Skill 配置教程
+weight: 7
+description: 用 zip 上传管理 AI 技能 —— HotPlex skill 管理与各 Worker 软链引导
+---
+
+# Skill 配置教程
+
+Skill 是封装了特定能力的 AI 技能包（含 `SKILL.md` 定义 + 辅助文件）。HotPlex 支持通过 WebChat UI 上传 zip 包安装 skill，统一存储在 `.agents/skills` 目录（对齐开放 `.agents` 标准）。完整规格见 [Skill-Management-Spec](../specs/Skill-Management-Spec.md)。
+
+**前置条件**：HotPlex Gateway v1.37+ 已运行，WebChat 多租户已启用。
+
+## 1. 两种 skill 范围
+
+| 范围 | 存储位置 | 谁可管理 | 入口 |
+|------|---------|---------|------|
+| 全局 | `~/.agents/skills` | 管理员 | 管理后台 → Skills |
+| Workspace | `<work_dir>/.agents/skills` | workspace owner | Workspace 设置 → Skills |
+
+Workspace skill 同名会**覆盖**全局 skill 生效（UI 会给出 warning 提示遮蔽）。
+
+## 2. 打包 skill zip
+
+zip 包结构二选一（对齐 [agentskills.io](https://agentskills.io/specification) 标准）：
+
+**扁平结构**（zip 根下直接 `SKILL.md`）：
+
+```
+my-skill.zip
+└── SKILL.md
+```
+
+**单顶层目录**（目录名必须等于 frontmatter `name`）：
+
+```
+my-skill.zip
+└── my-skill/
+    ├── SKILL.md
+    └── reference.md
+```
+
+`SKILL.md` 头部须有 YAML frontmatter：
+
+```markdown
+---
+name: my-skill
+description: 一句话描述这个技能的作用（1-1024 字符）
+---
+
+# My Skill
+
+技能正文……
+```
+
+**格式约束**：
+
+- `name`：正则 `^[a-z0-9]+(-[a-z0-9]+)*$`，1-64 字符；单顶层结构时必须等于父目录名
+- `description`：1-1024 字符（必填，独立严格校验）
+- 文件类型白名单：`.md`/`.json`/`.yaml`/`.yml`/`.txt`/`.py`/`.sh`/`.toml`/`.png`/`.jpg`/`.jpeg`/`.svg`；拒可执行/二进制
+- 容量上限：zip ≤20MB、解压总 ≤50MB、单文件 ≤5MB、entry ≤500、压缩率 >100× 拒
+
+## 3. 上传安装
+
+WebChat UI → 管理后台（全局）或 Workspace 设置（workspace）→ Skills →「上传 Skill」→ 选择 zip → 勾选「覆盖同名」可替换已有同名 skill。
+
+安装成功后，skill 立即出现在列表：`.agents/skills` 下的标注「可管理」，`.claude`/`.hotplex` 等目录下的标注「只读外部」。
+
+## 4. 各 Worker 加载与软链引导
+
+> ⚠️ **关键**：HotPlex **不向任何 Worker 传递 skill 目录参数**——各 Worker 按自身规则读取 home 下的 skill 目录。统一存储在 `~/.agents/skills`，但不同 Worker 的原生扫描路径不同，**Claude Code 需要额外建软链**。
+
+| Worker | 原生读 `~/.agents/skills` | 需要的操作 |
+|--------|--------------------------|-----------|
+| **Codex CLI** | ✅ 主路径就是 `.agents/skills` | 无需任何操作 |
+| **OpenCode Server** | ✅ agent-compat 扫描 `.agents/skills` | 无需任何操作 |
+| **Claude Code** | ❌ 只读 `.claude/skills` | **必须建立软链**（见下） |
+| **ACP** | 取决于底层 agent | 按底层 agent 处理 |
+
+### Claude Code 软链设置（CC 专属）
+
+Claude Code 只读 `~/.claude/skills`，需把统一存储目录软链过去：
+
+```bash
+# 若 ~/.claude/skills 已是真实目录（非软链），请先备份/迁移其内容，再执行：
+ln -s ~/.agents/skills ~/.claude/skills
+```
+
+验证：
+
+```bash
+ls -l ~/.claude/skills
+# 应显示: ~/.claude/skills -> ~/.agents/skills 的符号链接
+```
+
+建立软链后，新会话即可加载 `~/.agents/skills` 下的全部 skill。
+
+> ⚠️ **为什么不由程序代建软链？** 软链涉及「已有真实目录被覆盖、方向冲突、跨 Worker 归一化」等数据安全风险。HotPlex 把这一步留给用户显式完成，避免程序误覆盖用户已有的 `.claude/skills` 内容——这是有意的设计决策（spec §2「软链管理」）。
+
+## 5. 修改与删除
+
+- **修改 skill** = 重新打包 zip 上传（勾选「覆盖同名」）。不支持在线编辑器。
+- **删除 skill** = 列表中点击删除。仅 `managed` skill（`.agents/skills` 下）可删；`.claude`/`.hotplex` 下的只读外部 skill 需在文件系统手动删除。
+
+## 6. REST API
+
+除 WebChat UI 外，也可通过 REST API 管理（详见 [Admin API 参考](../reference/admin-api.md) 的「Skill 管理」章节）：
+
+```bash
+# 安装全局 skill（admin Bearer）
+curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -F "file=@my-skill.zip" "http://localhost:9999/admin/api/skills?replace=true"
+
+# 安装 workspace skill（owner，Cookie 或 API Key）
+curl -X POST -H "X-API-Key: $API_KEY" \
+  -F "file=@my-skill.zip" "http://localhost:8888/api/workspaces/$WID/skills"
+
+# 合并查询我的 skill 视图
+curl -H "X-API-Key: $API_KEY" http://localhost:8888/api/skills
+```

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/skills"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/web"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -130,6 +131,7 @@ type AdminAPI struct {
 	startedAt        time.Time
 	activityService  *ActivityService // Optional: enables /admin/activity + /admin/users/{id}/activity (issue #833)
 	auditCollector   *audit.Collector // Optional: emits system.audit_export meta-audit rows (issue #833)
+	skillsLocator    *skills.Locator  // Optional: enables /admin/api/skills global skill management (issue #910)
 }
 
 type Deps struct {
@@ -194,6 +196,10 @@ func New(deps Deps) *AdminAPI {
 	}
 	return a
 }
+
+// SetSkillsLocator 注入 skill 定位器，启用 /admin/api/skills 全局 skill 管理
+// （issue #910）。nil 时 skill 端点返回 503。
+func (a *AdminAPI) SetSkillsLocator(l *skills.Locator) { a.skillsLocator = l }
 
 func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/audit.go
+++ b/internal/admin/audit.go
@@ -39,6 +39,9 @@ const (
 	AuditIdentityLinkCreate            = "audit.identity_link.create"
 	AuditIdentityLinkDelete            = "audit.identity_link.delete"
 	AuditAuthDenied                    = "auth.denied"
+	AuditSkillCreate                   = "skill.create" // issue #910 global skill install
+	AuditSkillUpdate                   = "skill.update" // ?replace=true 覆盖
+	AuditSkillDelete                   = "skill.delete"
 
 	// AuditResult* — stable "result" field values. Reuse instead of literals so
 	// dashboard filters stay correct (issue #788 review P3).
@@ -107,10 +110,27 @@ func adminActionFor(method, path string) string {
 		return botAction(method)
 	case strings.Contains(path, "/sessions"):
 		return sessionAction(method)
+	case strings.Contains(path, "/skills"):
+		return skillAction(method)
 	case strings.Contains(path, "/workspaces"):
 		return workspaceAction(method)
 	}
 	return method + " " + path
+}
+
+// skillAction 覆盖 /admin/api/skills 全局 skill 写（issue #910）。GET 不审计
+// （isWriteMethod 为 false）。POST 区分 create vs update 由 routes 层 ?replace
+// 决定，这里按 method 取语义动作；replace=true 的 POST 在 handler 内覆盖同名。
+func skillAction(method string) string {
+	switch method {
+	case http.MethodPost:
+		return AuditSkillCreate
+	case http.MethodDelete:
+		return AuditSkillDelete
+	case http.MethodPatch, http.MethodPut:
+		return AuditSkillUpdate
+	}
+	return "skill." + strings.ToLower(method)
 }
 
 func auditIdentityLinkAction(method string) string {

--- a/internal/admin/skill_handlers.go
+++ b/internal/admin/skill_handlers.go
@@ -2,9 +2,7 @@ package admin
 
 import (
 	"archive/zip"
-	"bytes"
 	"errors"
-	"io"
 	"net/http"
 	"os"
 
@@ -175,12 +173,8 @@ func parseAdminSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader,
 		return nil, false
 	}
 	defer func() { _ = f.Close() }()
-	buf, err := io.ReadAll(f)
-	if err != nil {
-		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "read upload failed")
-		return nil, false
-	}
-	zr, err := zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
+	// 复用 *os.File ReaderAt 避免 20MB 全量载内存（spec review P2#5）。
+	zr, err := skills.ZipReaderFromFile(f)
 	if err != nil {
 		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
 		return nil, false

--- a/internal/admin/skill_handlers.go
+++ b/internal/admin/skill_handlers.go
@@ -1,0 +1,208 @@
+package admin
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/hrygo/hotplex/internal/skills"
+	"github.com/hrygo/hotplex/internal/web"
+)
+
+// maxAdminSkillUploadSize 限制全局 skill zip 上传 body（spec §3.4，20MB）。
+const maxAdminSkillUploadSize = 20 << 20
+
+// skillInstallResponse 描述 POST /admin/api/skills 成功响应，与 skills.InstallResult
+// 字段对齐。swag 的 --dir 不含 internal/skills、未开 --parseDependency，无法解析跨包
+// 类型，故在此定义等价形状供 swagger 注解引用。
+type skillInstallResponse struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Source      string   `json:"source"`  // "global"
+	Managed     bool     `json:"managed"` // .agents/skills 可写区
+	Body        string   `json:"body"`
+	Files       []string `json:"files"`
+	Warning     string   `json:"warning,omitempty"` // workspace 同名遮蔽全局时非空
+}
+
+// toSkillInstallResponse 把 skills.InstallResult 映射为本包 swagger 响应类型
+// （swag 无法解析跨包 skills.InstallResult，见 skillInstallResponse 注释）。
+// JSON 形状与原 InstallResult 完全一致（FilePath 为 json:"-" 不下发）。
+func toSkillInstallResponse(res *skills.InstallResult) skillInstallResponse {
+	return skillInstallResponse{
+		Name:        res.Name,
+		Description: res.Description,
+		Source:      res.Source,
+		Managed:     res.Managed,
+		Body:        res.Body,
+		Files:       res.Files,
+		Warning:     res.Warning,
+	}
+}
+
+// HandleListSkills: GET /admin/api/skills — 全局 skill 列表（含外部只读，带 Managed 标注）。
+// GET 不审计（isWriteMethod 为 false）；scope 由 Middleware 强制 admin:read。
+//
+// @Summary      List global skills (admin)
+// @Description  Returns every skill under the global .agents/.claude/.hotplex dirs. Requires admin:read.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  map[string]any
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope"
+// @Router       /admin/api/skills [get]
+func (a *AdminAPI) HandleListSkills(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminRead) {
+		return
+	}
+	if a.skillsLocator == nil {
+		respondJSON(w, map[string]any{"skills": []any{}})
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		a.log.Error("admin: skills list resolve $HOME", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "resolve home failed")
+		return
+	}
+	listed, err := a.skillsLocator.List(r.Context(), home, "")
+	if err != nil {
+		a.log.Error("admin: skills list", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "list skills failed")
+		return
+	}
+	respondJSON(w, map[string]any{"skills": listed, "total": len(listed)})
+}
+
+// HandleInstallSkill: POST /admin/api/skills — zip 上传安装全局 skill（?replace=true 覆盖）。
+// 写操作由 Middleware 的 audit defer 记录为 AuditSkillCreate（adminActionFor → skillAction）。
+//
+// @Summary      Install global skill (admin)
+// @Description  Upload a skill zip into ~/.agents/skills. Use ?replace=true to overwrite. Requires admin:write.
+// @Tags         Admin API
+// @Accept       multipart/form-data
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        file     formData  file     true  "skill zip archive"
+// @Param        replace  query     bool     false "overwrite existing same-name skill"
+// @Success      200   {object}  skillInstallResponse
+// @Failure      400   {object}  ErrorResponse  "SKILL_INVALID_ZIP / SKILL_INVALID_FORMAT / SKILL_FILE_TYPE_BLOCKED"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope"
+// @Failure      409   {object}  ErrorResponse  "SKILL_ALREADY_EXISTS"
+// @Router       /admin/api/skills [post]
+func (a *AdminAPI) HandleInstallSkill(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminWrite) {
+		return
+	}
+	if a.skillsLocator == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "skills not configured")
+		return
+	}
+	zr, ok := parseAdminSkillUpload(w, r)
+	if !ok {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "resolve home failed")
+		return
+	}
+	replace := r.URL.Query().Has("replace")
+	res, err := a.skillsLocator.Install(r.Context(), skills.ScopeGlobal, home, "", zr, replace)
+	if err != nil {
+		writeAdminSkillError(a, w, err, "install")
+		return
+	}
+	respondJSON(w, toSkillInstallResponse(res))
+}
+
+// HandleGetSkill: GET /admin/api/skills/{name} — 全局 skill 详情（含 SKILL.md 全文）。
+func (a *AdminAPI) HandleGetSkill(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminRead) {
+		return
+	}
+	if a.skillsLocator == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "skills not configured")
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "resolve home failed")
+		return
+	}
+	d, err := a.skillsLocator.Read(r.Context(), skills.ScopeGlobal, home, r.PathValue("name"))
+	if err != nil {
+		writeAdminSkillError(a, w, err, "read")
+		return
+	}
+	respondJSON(w, d)
+}
+
+// HandleDeleteSkill: DELETE /admin/api/skills/{name} — 移除全局 skill。审计为 AuditSkillDelete。
+func (a *AdminAPI) HandleDeleteSkill(w http.ResponseWriter, r *http.Request) {
+	if !requireScope(w, r, ScopeAdminWrite) {
+		return
+	}
+	if a.skillsLocator == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "skills not configured")
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "resolve home failed")
+		return
+	}
+	if err := a.skillsLocator.Delete(r.Context(), skills.ScopeGlobal, home, r.PathValue("name")); err != nil {
+		writeAdminSkillError(a, w, err, "delete")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseAdminSkillUpload 解析 multipart zip 上传（MaxBytesReader 兜底 20MB）。
+func parseAdminSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminSkillUploadSize)
+	if err := r.ParseMultipartForm(maxAdminSkillUploadSize); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "multipart parse failed: "+err.Error())
+		return nil, false
+	}
+	f, _, err := r.FormFile("file")
+	if err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "missing 'file' field")
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "read upload failed")
+		return nil, false
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
+	if err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
+		return nil, false
+	}
+	return zr, true
+}
+
+// writeAdminSkillError 映射 skills 包语义错误到 HTTP 错误码（spec §5）。
+func writeAdminSkillError(a *AdminAPI, w http.ResponseWriter, err error, action string) {
+	switch {
+	case errors.Is(err, skills.ErrInvalidZip):
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", err.Error())
+	case errors.Is(err, skills.ErrFileTypeBlocked):
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_FILE_TYPE_BLOCKED", err.Error())
+	case errors.Is(err, skills.ErrInvalidFormat):
+		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_FORMAT", err.Error())
+	case errors.Is(err, skills.ErrSkillAlreadyExists):
+		web.WriteAppError(w, http.StatusConflict, "SKILL_ALREADY_EXISTS", err.Error())
+	case errors.Is(err, skills.ErrSkillNotFound):
+		web.WriteAppError(w, http.StatusNotFound, "SKILL_NOT_FOUND", err.Error())
+	default:
+		a.log.Error("admin: skill "+action, "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", action+" failed")
+	}
+}

--- a/internal/admin/skill_handlers.go
+++ b/internal/admin/skill_handlers.go
@@ -99,10 +99,11 @@ func (a *AdminAPI) HandleInstallSkill(w http.ResponseWriter, r *http.Request) {
 		web.WriteAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "skills not configured")
 		return
 	}
-	zr, ok := parseAdminSkillUpload(w, r)
+	zr, closer, ok := parseAdminSkillUpload(w, r)
 	if !ok {
 		return
 	}
+	defer closer() // f 供 zip.Reader 作 ReaderAt，Install 消费完方可 Close（spec review P2#1）
 	home, err := os.UserHomeDir()
 	if err != nil {
 		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "resolve home failed")
@@ -161,25 +162,27 @@ func (a *AdminAPI) HandleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseAdminSkillUpload 解析 multipart zip 上传（MaxBytesReader 兜底 20MB）。
-func parseAdminSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, bool) {
+// 返回的 closer 必须在调用方消费完 zr（Install 返回）后调用：*os.File 分支下
+// zip.Reader 持有 f 作 ReaderAt，提前 Close 会使 extractZip→ReadAt 读已关闭 fd
+// （spec review P2#1，见 gateway.parseSkillUpload 同名注释）。
+func parseAdminSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, func(), bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxAdminSkillUploadSize)
 	if err := r.ParseMultipartForm(maxAdminSkillUploadSize); err != nil {
 		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "multipart parse failed: "+err.Error())
-		return nil, false
+		return nil, nil, false
 	}
 	f, _, err := r.FormFile("file")
 	if err != nil {
 		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "missing 'file' field")
-		return nil, false
+		return nil, nil, false
 	}
-	defer func() { _ = f.Close() }()
-	// 复用 *os.File ReaderAt 避免 20MB 全量载内存（spec review P2#5）。
 	zr, err := skills.ZipReaderFromFile(f)
 	if err != nil {
+		_ = f.Close()
 		web.WriteAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
-		return nil, false
+		return nil, nil, false
 	}
-	return zr, true
+	return zr, func() { _ = f.Close() }, true
 }
 
 // writeAdminSkillError 映射 skills 包语义错误到 HTTP 错误码（spec §5）。

--- a/internal/gateway/skill_handlers.go
+++ b/internal/gateway/skill_handlers.go
@@ -1,0 +1,278 @@
+package gateway
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/audit"
+	"github.com/hrygo/hotplex/internal/security"
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/skills"
+)
+
+// maxSkillUploadSize 限制 zip 上传 body（spec §3.4 multipart 上传 20MB）。
+// zip 解压阶段的容量阈值见 internal/skills/zip.go。
+const maxSkillUploadSize = 20 << 20
+
+// SkillHandlers 服务 /api/skills 与 /api/workspaces/{wid}/skills（spec §3.4）。
+//
+// 用户端鉴权复用 Authenticator（api-key 优先 + cookie 回落，与 workspace REST
+// 同一租户锚点）。workspace 写操作走 owner 校验；全局 skill 写操作不在此暴露
+// （仅 admin 端 /admin/api/skills）。写操作审计经 auditCollector → user_activity
+// （tamper-evident），与 GatewayAPI session.delete 一致。
+type SkillHandlers struct {
+	locator        *skills.Locator
+	wsStore        session.UserWorkspaceStore
+	auth           *security.Authenticator
+	log            *slog.Logger
+	auditCollector *audit.Collector // optional; nil = audit disabled
+	homeFn         func() string    // resolves global skill base dir; defaults to $HOME (injectable for tests)
+}
+
+// defaultHomeDir wraps os.UserHomeDir into a no-error signature for homeFn.
+func defaultHomeDir() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return h
+}
+
+// NewSkillHandlers 构造用户端 skill handlers。locator 不可为 nil。
+func NewSkillHandlers(locator *skills.Locator, wsStore session.UserWorkspaceStore, auth *security.Authenticator, log *slog.Logger) *SkillHandlers {
+	if locator == nil {
+		panic("gateway: NewSkillHandlers requires non-nil locator")
+	}
+	return &SkillHandlers{locator: locator, wsStore: wsStore, auth: auth, log: log.With("component", "skill_api"), homeFn: defaultHomeDir}
+}
+
+// SetAuditCollector 注入审计收集器（nil 关闭审计，no-op）。
+func (h *SkillHandlers) SetAuditCollector(c *audit.Collector) { h.auditCollector = c }
+
+func (h *SkillHandlers) requireAuth(w http.ResponseWriter, r *http.Request) (string, bool) {
+	uid, _, err := h.auth.AuthenticateRequest(r)
+	if err != nil {
+		writeAppError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return "", false
+	}
+	return uid, true
+}
+
+func (h *SkillHandlers) isAdmin(r *http.Request, uid string) bool {
+	idp := h.auth.IdentityProvider()
+	if idp == nil {
+		return false
+	}
+	u, err := idp.Lookup(r.Context(), uid)
+	return err == nil && u.Role == "admin" && u.Status == "active"
+}
+
+// homeDir 解析进程 home（全局 skill 基址）。失败时返回空串，全局 skill 不可用。
+func (h *SkillHandlers) homeDir() string {
+	home := h.homeFn()
+	if home == "" {
+		h.log.Warn("skill_api: resolve $HOME failed; global skills unavailable")
+		return ""
+	}
+	return home
+}
+
+// ownerWorkDirs 收集用户所有 workspace 的 WorkDir（用于合并列表）。
+func (h *SkillHandlers) ownerWorkDirs(ctx context.Context, uid string) []string {
+	if h.wsStore == nil {
+		return nil
+	}
+	wss, err := h.wsStore.ListWorkspacesByOwner(ctx, uid, 1000, 0)
+	if err != nil {
+		h.log.Warn("skill_api: list owner workspaces", "err", err)
+		return nil
+	}
+	dirs := make([]string, 0, len(wss))
+	for _, ws := range wss {
+		if ws.WorkDir != "" {
+			dirs = append(dirs, ws.WorkDir)
+		}
+	}
+	return dirs
+}
+
+// ListMerged: GET /api/skills — 合并 global + 用户所有 workspace + 外部只读（spec §5）。
+func (h *SkillHandlers) ListMerged(w http.ResponseWriter, r *http.Request) {
+	uid, ok := h.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	merged, err := h.locator.ListMerged(r.Context(), h.homeDir(), h.ownerWorkDirs(r.Context(), uid))
+	if err != nil {
+		h.log.Error("skill_api: list merged", "err", err)
+		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "list skills failed")
+		return
+	}
+	respondJSON(w, map[string]any{"skills": merged, "total": len(merged)})
+}
+
+// GetMerged: GET /api/skills/{name} — 合并列表中该 skill 的元信息（覆盖胜出 scope）。
+// 完整 body 由 scoped 详情端点（workspace / admin）提供。
+func (h *SkillHandlers) GetMerged(w http.ResponseWriter, r *http.Request) {
+	uid, ok := h.requireAuth(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	merged, err := h.locator.ListMerged(r.Context(), h.homeDir(), h.ownerWorkDirs(r.Context(), uid))
+	if err != nil {
+		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "list skills failed")
+		return
+	}
+	for _, s := range merged {
+		if s.Name == name {
+			respondJSON(w, s)
+			return
+		}
+	}
+	writeAppError(w, http.StatusNotFound, "SKILL_NOT_FOUND", "skill not found")
+}
+
+// authorizeWorkspace 校验鉴权 + workspace 归属（spec §3.4 owner 校验闸）。
+func (h *SkillHandlers) authorizeWorkspace(w http.ResponseWriter, r *http.Request) (*session.Workspace, string, bool) {
+	uid, ok := h.requireAuth(w, r)
+	if !ok {
+		return nil, "", false
+	}
+	if h.wsStore == nil {
+		writeAppError(w, http.StatusServiceUnavailable, "UNAVAILABLE", "workspace store not configured")
+		return nil, "", false
+	}
+	ws, err := h.wsStore.GetWorkspaceByID(r.Context(), r.PathValue("wid"))
+	if err != nil {
+		writeAppError(w, http.StatusNotFound, "WORKSPACE_NOT_FOUND", "workspace not found")
+		return nil, "", false
+	}
+	if ws.OwnerUserID != uid && !h.isAdmin(r, uid) {
+		writeAppError(w, http.StatusForbidden, "WORKSPACE_FORBIDDEN", "not your workspace")
+		return nil, "", false
+	}
+	return ws, uid, true
+}
+
+// InstallWorkspace: POST /api/workspaces/{wid}/skills — zip 上传安装（?replace=true 覆盖）。
+func (h *SkillHandlers) InstallWorkspace(w http.ResponseWriter, r *http.Request) {
+	ws, uid, ok := h.authorizeWorkspace(w, r)
+	if !ok {
+		return
+	}
+	zr, ok := h.parseSkillUpload(w, r)
+	if !ok {
+		h.auditSkill(r, uid, "skill.install", audit.OutcomeFailure)
+		return
+	}
+	replace := r.URL.Query().Has("replace")
+	res, err := h.locator.Install(r.Context(), skills.ScopeWorkspace, ws.WorkDir, h.homeDir(), zr, replace)
+	if err != nil {
+		h.writeSkillError(w, err, "install")
+		h.auditSkill(r, uid, "skill.install", audit.OutcomeFailure)
+		return
+	}
+	h.auditSkill(r, uid, "skill.install", audit.OutcomeSuccess)
+	respondJSON(w, res)
+}
+
+// GetWorkspace: GET /api/workspaces/{wid}/skills/{name} — workspace scope skill 详情。
+func (h *SkillHandlers) GetWorkspace(w http.ResponseWriter, r *http.Request) {
+	ws, _, ok := h.authorizeWorkspace(w, r)
+	if !ok {
+		return
+	}
+	d, err := h.locator.Read(r.Context(), skills.ScopeWorkspace, ws.WorkDir, r.PathValue("name"))
+	if err != nil {
+		h.writeSkillError(w, err, "read")
+		return
+	}
+	respondJSON(w, d)
+}
+
+// DeleteWorkspace: DELETE /api/workspaces/{wid}/skills/{name} — 移除 workspace skill。
+func (h *SkillHandlers) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
+	ws, uid, ok := h.authorizeWorkspace(w, r)
+	if !ok {
+		return
+	}
+	if err := h.locator.Delete(r.Context(), skills.ScopeWorkspace, ws.WorkDir, r.PathValue("name")); err != nil {
+		h.writeSkillError(w, err, "delete")
+		h.auditSkill(r, uid, "skill.delete", audit.OutcomeFailure)
+		return
+	}
+	h.auditSkill(r, uid, "skill.delete", audit.OutcomeSuccess)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseSkillUpload 解析 multipart zip 上传（MaxBytesReader 兜底 20MB）。
+func (h *SkillHandlers) parseSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSkillUploadSize)
+	if err := r.ParseMultipartForm(maxSkillUploadSize); err != nil {
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "multipart parse failed: "+err.Error())
+		return nil, false
+	}
+	f, _, err := r.FormFile("file")
+	if err != nil {
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "missing 'file' field")
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "read upload failed")
+		return nil, false
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
+	if err != nil {
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
+		return nil, false
+	}
+	return zr, true
+}
+
+// writeSkillError 映射 skills 包语义错误到 HTTP 错误码（spec §5）。
+func (h *SkillHandlers) writeSkillError(w http.ResponseWriter, err error, action string) {
+	switch {
+	case errors.Is(err, skills.ErrInvalidZip):
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", err.Error())
+	case errors.Is(err, skills.ErrFileTypeBlocked):
+		writeAppError(w, http.StatusBadRequest, "SKILL_FILE_TYPE_BLOCKED", err.Error())
+	case errors.Is(err, skills.ErrInvalidFormat):
+		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_FORMAT", err.Error())
+	case errors.Is(err, skills.ErrSkillAlreadyExists):
+		writeAppError(w, http.StatusConflict, "SKILL_ALREADY_EXISTS", err.Error())
+	case errors.Is(err, skills.ErrSkillNotFound):
+		writeAppError(w, http.StatusNotFound, "SKILL_NOT_FOUND", err.Error())
+	default:
+		h.log.Error("skill_api: "+action, "err", err)
+		writeAppError(w, http.StatusInternalServerError, "INTERNAL", action+" failed")
+	}
+}
+
+// auditSkill 记录 workspace skill 写操作到 tamper-evident user_activity（spec §3.5）。
+func (h *SkillHandlers) auditSkill(r *http.Request, uid, action, outcome string) {
+	if h.auditCollector == nil {
+		return
+	}
+	detail, _ := json.Marshal(map[string]any{"method": r.Method, "path": r.URL.Path})
+	_ = h.auditCollector.Enqueue(context.Background(), &audit.UserActivity{
+		Ts:           time.Now().UnixMilli(),
+		UserID:       uid,
+		UserIDType:   audit.UserIDTypeRegistered,
+		Platform:     audit.PlatformWebChat,
+		Action:       action,
+		ResourceType: "skill",
+		Outcome:      outcome,
+		DetailJSON:   string(detail),
+	})
+}

--- a/internal/gateway/skill_handlers.go
+++ b/internal/gateway/skill_handlers.go
@@ -89,10 +89,13 @@ func (h *SkillHandlers) ownerWorkDirs(ctx context.Context, uid string) []string 
 		return nil
 	}
 	// 分页拉取全部 workspace（spec review P2#4）：硬编码单页 1000 会静默丢弃
-	// 尾部 workspace 的 skill。每页 500 循环至不足一页；设 5000 硬上限防滥用。
-	const page = 500
+	// 尾部 workspace 的 skill。每页 500 循环至不足一页；设 hardCap 硬上限防滥用。
+	const (
+		page    = 500
+		hardCap = 5000
+	)
 	var dirs []string
-	for offset := 0; offset < 5000; offset += page {
+	for offset := 0; offset < hardCap; offset += page {
 		wss, err := h.wsStore.ListWorkspacesByOwner(ctx, uid, page, offset)
 		if err != nil {
 			h.log.Warn("skill_api: list owner workspaces", "err", err, "offset", offset)
@@ -104,9 +107,12 @@ func (h *SkillHandlers) ownerWorkDirs(ctx context.Context, uid string) []string 
 			}
 		}
 		if len(wss) < page {
-			break
+			return dirs // 不足一页，已到尾部
 		}
 	}
+	// 循环因 offset 达 hardCap 退出（非 return）：owner workspace 数超上限，
+	// 尾部 workspace 的 skill 从合并列表静默丢失。hardCap 作 DoS 防护保留，此处仅告警（spec review P3#1）。
+	h.log.Warn("skill_api: owner workspaces reached hard cap; tail skills dropped from merged list", "uid", uid, "cap", hardCap)
 	return dirs
 }
 
@@ -175,11 +181,12 @@ func (h *SkillHandlers) InstallWorkspace(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	zr, ok := h.parseSkillUpload(w, r)
+	zr, closer, ok := h.parseSkillUpload(w, r)
 	if !ok {
 		h.auditSkill(r, uid, "skill.install", audit.OutcomeFailure)
 		return
 	}
+	defer closer() // f 供 zip.Reader 作 ReaderAt，Install 消费完方可 Close（spec review P2#1）
 	replace := r.URL.Query().Has("replace")
 	res, err := h.locator.Install(r.Context(), skills.ScopeWorkspace, ws.WorkDir, h.homeDir(), zr, replace)
 	if err != nil {
@@ -221,25 +228,28 @@ func (h *SkillHandlers) DeleteWorkspace(w http.ResponseWriter, r *http.Request) 
 }
 
 // parseSkillUpload 解析 multipart zip 上传（MaxBytesReader 兜底 20MB）。
-func (h *SkillHandlers) parseSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, bool) {
+// 返回的 closer 必须在调用方消费完 zr（即 Install 返回）后调用：*os.File 分支下
+// zip.Reader 持有 f 作为 ReaderAt，提前 Close 会使 extractZip→ReadAt 读已关闭 fd
+// （spec review P2#1）。io.ReadAll 回退分支（小文件 sectionReader）Close 无害。
+func (h *SkillHandlers) parseSkillUpload(w http.ResponseWriter, r *http.Request) (*zip.Reader, func(), bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxSkillUploadSize)
 	if err := r.ParseMultipartForm(maxSkillUploadSize); err != nil {
 		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "multipart parse failed: "+err.Error())
-		return nil, false
+		return nil, nil, false
 	}
 	f, _, err := r.FormFile("file")
 	if err != nil {
 		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "missing 'file' field")
-		return nil, false
+		return nil, nil, false
 	}
-	defer func() { _ = f.Close() }()
 	// 复用 *os.File ReaderAt 避免 20MB 全量载内存（spec review P2#5）。
 	zr, err := skills.ZipReaderFromFile(f)
 	if err != nil {
+		_ = f.Close()
 		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
-		return nil, false
+		return nil, nil, false
 	}
-	return zr, true
+	return zr, func() { _ = f.Close() }, true
 }
 
 // writeSkillError 映射 skills 包语义错误到 HTTP 错误码（spec §5）。
@@ -262,10 +272,12 @@ func (h *SkillHandlers) writeSkillError(w http.ResponseWriter, err error, action
 }
 
 // auditSkill 记录 workspace skill 写操作到 tamper-evident user_activity（spec §3.5）。
+// IP/UserAgent 与同包 GatewayAPI 会话删除、admin enqueueAdminActivity 对齐（spec review P2#2）。
 //
-// TODO(#910 review P2#6): Platform 硬编码 WebChat，API-key 调用者的 skill 写入被
-// 误标。正确做法是 AuthenticateRequest 返回认证路径（cookie→WebChat /
-// api-key→PlatformAPI），但该签名变更跨切面（所有调用方），留待后续单独 PR 统一。
+// TODO(#910 review P2#3): Platform 硬编码 WebChat，API-key 调用者的 skill 写入被
+// 误标。正确做法是让 AuthenticateRequest 返回认证路径（cookie→WebChat /
+// api-key→PlatformAPI）并在 auditSkill 传入；该签名变更跨切面（security.Authenticator
+// 所有调用方），留待后续单独 PR 统一，本 PR 不塞入。
 func (h *SkillHandlers) auditSkill(r *http.Request, uid, action, outcome string) {
 	if h.auditCollector == nil {
 		return
@@ -280,5 +292,7 @@ func (h *SkillHandlers) auditSkill(r *http.Request, uid, action, outcome string)
 		ResourceType: "skill",
 		Outcome:      outcome,
 		DetailJSON:   string(detail),
+		IP:           r.RemoteAddr,
+		UserAgent:    r.UserAgent(),
 	})
 }

--- a/internal/gateway/skill_handlers.go
+++ b/internal/gateway/skill_handlers.go
@@ -2,11 +2,9 @@ package gateway
 
 import (
 	"archive/zip"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -90,15 +88,23 @@ func (h *SkillHandlers) ownerWorkDirs(ctx context.Context, uid string) []string 
 	if h.wsStore == nil {
 		return nil
 	}
-	wss, err := h.wsStore.ListWorkspacesByOwner(ctx, uid, 1000, 0)
-	if err != nil {
-		h.log.Warn("skill_api: list owner workspaces", "err", err)
-		return nil
-	}
-	dirs := make([]string, 0, len(wss))
-	for _, ws := range wss {
-		if ws.WorkDir != "" {
-			dirs = append(dirs, ws.WorkDir)
+	// 分页拉取全部 workspace（spec review P2#4）：硬编码单页 1000 会静默丢弃
+	// 尾部 workspace 的 skill。每页 500 循环至不足一页；设 5000 硬上限防滥用。
+	const page = 500
+	var dirs []string
+	for offset := 0; offset < 5000; offset += page {
+		wss, err := h.wsStore.ListWorkspacesByOwner(ctx, uid, page, offset)
+		if err != nil {
+			h.log.Warn("skill_api: list owner workspaces", "err", err, "offset", offset)
+			return dirs
+		}
+		for _, ws := range wss {
+			if ws.WorkDir != "" {
+				dirs = append(dirs, ws.WorkDir)
+			}
+		}
+		if len(wss) < page {
+			break
 		}
 	}
 	return dirs
@@ -227,12 +233,8 @@ func (h *SkillHandlers) parseSkillUpload(w http.ResponseWriter, r *http.Request)
 		return nil, false
 	}
 	defer func() { _ = f.Close() }()
-	buf, err := io.ReadAll(f)
-	if err != nil {
-		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "read upload failed")
-		return nil, false
-	}
-	zr, err := zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
+	// 复用 *os.File ReaderAt 避免 20MB 全量载内存（spec review P2#5）。
+	zr, err := skills.ZipReaderFromFile(f)
 	if err != nil {
 		writeAppError(w, http.StatusBadRequest, "SKILL_INVALID_ZIP", "invalid zip archive")
 		return nil, false
@@ -260,6 +262,10 @@ func (h *SkillHandlers) writeSkillError(w http.ResponseWriter, err error, action
 }
 
 // auditSkill 记录 workspace skill 写操作到 tamper-evident user_activity（spec §3.5）。
+//
+// TODO(#910 review P2#6): Platform 硬编码 WebChat，API-key 调用者的 skill 写入被
+// 误标。正确做法是 AuthenticateRequest 返回认证路径（cookie→WebChat /
+// api-key→PlatformAPI），但该签名变更跨切面（所有调用方），留待后续单独 PR 统一。
 func (h *SkillHandlers) auditSkill(r *http.Request, uid, action, outcome string) {
 	if h.auditCollector == nil {
 		return

--- a/internal/gateway/skill_handlers_test.go
+++ b/internal/gateway/skill_handlers_test.go
@@ -1,0 +1,254 @@
+package gateway
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/skills"
+)
+
+const testSkillFM = "---\nname: my-skill\ndescription: a useful skill\n---\n# Body\n"
+
+// newSkillHandlersEnv 构造隔离的 SkillHandlers 测试环境：workspace 与 home 均落在
+// t.TempDir()，避免触碰真实文件系统。owner=u-admin（admin 登录）。
+func newSkillHandlersEnv(t *testing.T) (*SkillHandlers, string, string, string) {
+	t.Helper()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+
+	workDir := t.TempDir()
+	ws := &session.Workspace{ID: "ws-skill", OwnerUserID: "u-admin", Name: "test-ws", WorkDir: workDir, Status: "active"}
+	require.NoError(t, env.store.CreateWorkspace(context.Background(), ws, 1700000000))
+
+	home := t.TempDir()
+	locator := skills.NewLocator(slog.Default(), time.Minute)
+	t.Cleanup(locator.Close)
+
+	sh := NewSkillHandlers(locator, env.store, env.auth, slog.Default())
+	sh.homeFn = func() string { return home }
+	return sh, workDir, home, cookie
+}
+
+// skillZipBody 构造 multipart/form-data body，file 字段为内联 zip。
+func skillZipBody(t *testing.T, files map[string]string) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	fw, err := mw.CreateFormFile("file", "skill.zip")
+	require.NoError(t, err)
+	zw := zip.NewWriter(fw)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, mw.Close())
+	return body, mw.FormDataContentType()
+}
+
+func skillReq(method, target, cookie string, body io.Reader, contentType string) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	if cookie != "" {
+		req.Header.Set("Cookie", cookie)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return req
+}
+
+// installWorkspace 调用 InstallWorkspace，返回 recorder。
+func installWorkspace(t *testing.T, sh *SkillHandlers, cookie string, files map[string]string, replace bool) *httptest.ResponseRecorder {
+	t.Helper()
+	body, ct := skillZipBody(t, files)
+	target := "/api/workspaces/ws-skill/skills"
+	if replace {
+		target += "?replace=true"
+	}
+	req := skillReq(http.MethodPost, target, cookie, body, ct)
+	req.SetPathValue("wid", "ws-skill")
+	w := httptest.NewRecorder()
+	sh.InstallWorkspace(w, req)
+	return w
+}
+
+func TestSkillHandlers_InstallAndGet(t *testing.T) {
+	t.Parallel()
+	sh, workDir, _, cookie := newSkillHandlersEnv(t)
+
+	w := installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.FileExists(t, filepath.Join(workDir, ".agents", "skills", "my-skill", "SKILL.md"))
+
+	// Get 详情
+	req := skillReq(http.MethodGet, "/api/workspaces/ws-skill/skills/my-skill", cookie, nil, "")
+	req.SetPathValue("wid", "ws-skill")
+	req.SetPathValue("name", "my-skill")
+	gw := httptest.NewRecorder()
+	sh.GetWorkspace(gw, req)
+	require.Equal(t, http.StatusOK, gw.Code)
+	require.Contains(t, gw.Body.String(), "my-skill")
+	require.Contains(t, gw.Body.String(), "a useful skill")
+}
+
+func TestSkillHandlers_NotOwner(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	// 另一个普通用户
+	env.createUser(t, "alice", "alicepass", "user")
+	aliceCookie := env.loginAs(t, "alice", "alicepass", http.StatusOK)
+
+	workDir := t.TempDir()
+	ws := &session.Workspace{ID: "ws-skill", OwnerUserID: "u-admin", Name: "test-ws", WorkDir: workDir, Status: "active"}
+	require.NoError(t, env.store.CreateWorkspace(context.Background(), ws, 1700000000))
+
+	locator := skills.NewLocator(slog.Default(), time.Minute)
+	t.Cleanup(locator.Close)
+	sh := NewSkillHandlers(locator, env.store, env.auth, slog.Default())
+	sh.homeFn = func() string { return t.TempDir() }
+
+	body, ct := skillZipBody(t, map[string]string{"SKILL.md": testSkillFM})
+	req := skillReq(http.MethodPost, "/api/workspaces/ws-skill/skills", aliceCookie, body, ct)
+	req.SetPathValue("wid", "ws-skill")
+	w := httptest.NewRecorder()
+	sh.InstallWorkspace(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "WORKSPACE_FORBIDDEN")
+}
+
+func TestSkillHandlers_AdminMayManageOthersWorkspace(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	env.createUser(t, "bob", "bobpass", "user")
+	// bob 拥有的 workspace（直接持久化）
+	workDir := t.TempDir()
+	ws := &session.Workspace{ID: "ws-bob", OwnerUserID: "u-bob", Name: "bob-ws", WorkDir: workDir, Status: "active"}
+	require.NoError(t, env.store.CreateWorkspace(context.Background(), ws, 1700000000))
+
+	locator := skills.NewLocator(slog.Default(), time.Minute)
+	t.Cleanup(locator.Close)
+	sh := NewSkillHandlers(locator, env.store, env.auth, slog.Default())
+	sh.homeFn = func() string { return t.TempDir() }
+
+	// admin 登录后管理 bob 的 workspace skill
+	adminCookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	body, ct := skillZipBody(t, map[string]string{"SKILL.md": testSkillFM})
+	req := skillReq(http.MethodPost, "/api/workspaces/ws-bob/skills", adminCookie, body, ct)
+	req.SetPathValue("wid", "ws-bob")
+	w := httptest.NewRecorder()
+	sh.InstallWorkspace(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "admin 应可管理任意 workspace skill")
+}
+
+func TestSkillHandlers_NoFileField(t *testing.T) {
+	t.Parallel()
+	sh, _, _, cookie := newSkillHandlersEnv(t)
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	require.NoError(t, mw.WriteField("notfile", "x"))
+	require.NoError(t, mw.Close())
+	req := skillReq(http.MethodPost, "/api/workspaces/ws-skill/skills", cookie, body, mw.FormDataContentType())
+	req.SetPathValue("wid", "ws-skill")
+	w := httptest.NewRecorder()
+	sh.InstallWorkspace(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "SKILL_INVALID_ZIP")
+}
+
+func TestSkillHandlers_AlreadyExistsNoReplace(t *testing.T) {
+	t.Parallel()
+	sh, _, _, cookie := newSkillHandlersEnv(t)
+	require.Equal(t, http.StatusOK, installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false).Code)
+	w := installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false)
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "SKILL_ALREADY_EXISTS")
+}
+
+func TestSkillHandlers_ReplaceOverwrites(t *testing.T) {
+	t.Parallel()
+	sh, _, _, cookie := newSkillHandlersEnv(t)
+	require.Equal(t, http.StatusOK, installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false).Code)
+	w := installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": "---\nname: my-skill\ndescription: v2\n---\n"}, true)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "v2")
+}
+
+func TestSkillHandlers_Delete(t *testing.T) {
+	t.Parallel()
+	sh, workDir, _, cookie := newSkillHandlersEnv(t)
+	require.Equal(t, http.StatusOK, installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false).Code)
+
+	req := skillReq(http.MethodDelete, "/api/workspaces/ws-skill/skills/my-skill", cookie, nil, "")
+	req.SetPathValue("wid", "ws-skill")
+	req.SetPathValue("name", "my-skill")
+	w := httptest.NewRecorder()
+	sh.DeleteWorkspace(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.NoFileExists(t, filepath.Join(workDir, ".agents", "skills", "my-skill", "SKILL.md"))
+}
+
+func TestSkillHandlers_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+	sh, _, _, cookie := newSkillHandlersEnv(t)
+	req := skillReq(http.MethodDelete, "/api/workspaces/ws-skill/skills/ghost", cookie, nil, "")
+	req.SetPathValue("wid", "ws-skill")
+	req.SetPathValue("name", "ghost")
+	w := httptest.NewRecorder()
+	sh.DeleteWorkspace(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSkillHandlers_ListMerged(t *testing.T) {
+	t.Parallel()
+	sh, _, home, cookie := newSkillHandlersEnv(t)
+	// global skill（home managed 区）
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".agents", "skills", "glob"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".agents", "skills", "glob", "SKILL.md"),
+		[]byte("---\nname: glob\ndescription: a global skill\n---\n"), 0o644))
+	// workspace skill
+	require.Equal(t, http.StatusOK, installWorkspace(t, sh, cookie, map[string]string{"SKILL.md": testSkillFM}, false).Code)
+
+	req := skillReq(http.MethodGet, "/api/skills", cookie, nil, "")
+	w := httptest.NewRecorder()
+	sh.ListMerged(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "glob")
+	require.Contains(t, w.Body.String(), "my-skill")
+	// global skill 标注 managed
+	require.Contains(t, w.Body.String(), `"managed":true`)
+}
+
+func TestSkillHandlers_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	sh, _, _, _ := newSkillHandlersEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/skills", nil) // 无 cookie
+	w := httptest.NewRecorder()
+	sh.ListMerged(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSkillHandlers_GetMerged_NotFound(t *testing.T) {
+	t.Parallel()
+	sh, _, _, cookie := newSkillHandlersEnv(t)
+	req := skillReq(http.MethodGet, "/api/skills/missing", cookie, nil, "")
+	req.SetPathValue("name", "missing")
+	w := httptest.NewRecorder()
+	sh.GetMerged(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "SKILL_NOT_FOUND")
+}

--- a/internal/gateway/worker_cmds.go
+++ b/internal/gateway/worker_cmds.go
@@ -226,6 +226,7 @@ func (h *Handler) handleSkillsList(ctx context.Context, env *events.Envelope, fi
 			Name:        s.Name,
 			Description: s.Description,
 			Source:      s.Source,
+			Managed:     s.Managed,
 		}
 	}
 

--- a/internal/skills/crud.go
+++ b/internal/skills/crud.go
@@ -88,6 +88,12 @@ func (l *Locator) Install(_ context.Context, scope Scope, baseDir, homeDir strin
 		return nil, extractErr
 	}
 
+	// check+rename 关键段持 installMu：消除并发 replace 的静默数据丢失（T2
+	// RemoveAll 删 T1 刚 Rename 的目录）与并发新装的 TOCTOU（T2 Rename ENOTEMPTY
+	// → 误 500）。extractZip 在锁外（IO 重）；skill 写低频，全局锁足够。
+	l.installMu.Lock()
+	defer l.installMu.Unlock()
+
 	destDir := filepath.Join(destRoot, es.name)
 
 	// 同 scope 同名校验（spec §3.3 B5）。
@@ -113,6 +119,12 @@ func (l *Locator) Install(_ context.Context, scope Scope, baseDir, homeDir strin
 		_ = os.RemoveAll(destDir)
 	}
 	if err := os.Rename(contentRoot, destDir); err != nil {
+		// 持锁后 TOCTOU 已消除；ENOTEMPTY 仅在 destDir 残留时发生，重新分类为
+		// AlreadyExists 给客户端契约化 409（而非通用 500）。
+		if !replace && hasManagedSkill(baseDir, es.name) {
+			cleanup()
+			return nil, fmt.Errorf("%w: %s", ErrSkillAlreadyExists, es.name)
+		}
 		cleanup()
 		return nil, fmt.Errorf("skills: install (rename): %w", err)
 	}
@@ -138,6 +150,9 @@ func (l *Locator) Install(_ context.Context, scope Scope, baseDir, homeDir strin
 
 // Read 返回指定 scope/name 的 skill 详情（含 SKILL.md 全文与包内文件列表）。
 func (l *Locator) Read(_ context.Context, scope Scope, baseDir, name string) (*Detail, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("%w: empty baseDir", ErrInvalidFormat)
+	}
 	if !skillNameRegexp.MatchString(name) {
 		return nil, fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
 	}
@@ -172,9 +187,16 @@ func (l *Locator) Read(_ context.Context, scope Scope, baseDir, name string) (*D
 // Delete 移除指定 scope/name 的 managed skill 目录并失效缓存。
 // name 正则保证无路径分隔符/".."，删除严格落在 managedDir(baseDir)/<name> 内。
 func (l *Locator) Delete(_ context.Context, scope Scope, baseDir, name string) error {
+	if baseDir == "" {
+		return fmt.Errorf("%w: empty baseDir", ErrInvalidFormat)
+	}
 	if !skillNameRegexp.MatchString(name) {
 		return fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
 	}
+	// 持 installMu 与 Install 互斥：防并发 install+delete 同名的竞态。
+	l.installMu.Lock()
+	defer l.installMu.Unlock()
+
 	destRoot := managedDir(baseDir)
 	dir := filepath.Join(destRoot, name)
 	// 双保险：解析后必须在 destRoot 内（name 已过正则，此处冗余防御）。

--- a/internal/skills/crud.go
+++ b/internal/skills/crud.go
@@ -1,0 +1,202 @@
+package skills
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Scope 决定 skill 写入的物理位置（spec §3.2）。
+type Scope string
+
+const (
+	ScopeGlobal    Scope = "global"    // 写 ~/.agents/skills
+	ScopeWorkspace Scope = "workspace" // 写 <workspaceDir>/.agents/skills
+)
+
+// CRUD 语义错误。handler 层映射 HTTP 错误码（spec §5）：
+//   - ErrSkillAlreadyExists → 409 SKILL_ALREADY_EXISTS
+//   - ErrSkillNotFound      → 404 SKILL_NOT_FOUND
+var (
+	ErrSkillAlreadyExists = errors.New("skill: already exists")
+	ErrSkillNotFound      = errors.New("skill: not found")
+)
+
+// Detail 是单个 skill 的完整内容（spec §3.2）。
+type Detail struct {
+	Skill
+	Body  string   `json:"body"`  // SKILL.md 全文
+	Files []string `json:"files"` // 包内文件相对路径
+}
+
+// InstallResult 是 Install 的返回，含跨 scope 遮蔽 warning（spec §3.3 B6）。
+type InstallResult struct {
+	Detail
+	Warning string `json:"warning,omitempty"` // 非空 = workspace 安装撞全局，UI 提示
+}
+
+// scopeSource 将 Scope 映射到 wire 语义的 Source 值（spec §3.2 / §9.1：保留 global/project）。
+func scopeSource(s Scope) string {
+	if s == ScopeGlobal {
+		return SourceGlobal
+	}
+	return SourceProject
+}
+
+// managedDir 返回某 baseDir 下 managed skill 存储根目录（spec §3.1：.agents/skills）。
+func managedDir(baseDir string) string {
+	return filepath.Join(baseDir, ".agents", "skills")
+}
+
+// hasManagedSkill 报告 baseDir 的 managed 区是否已存在同名 skill。
+func hasManagedSkill(baseDir, name string) bool {
+	md, ok := findSkillMD(filepath.Join(managedDir(baseDir), name))
+	return ok && filepath.Base(filepath.Dir(md)) == name
+}
+
+// Install 从 zip.Reader 安装 skill：解压+校验 → 原子落盘 → 缓存失效（spec §3.2/§3.3）。
+//
+// baseDir：global 传 homeDir，workspace 传 workspaceDir。homeDir 仅用于 workspace
+// scope 的跨 scope 遮蔽 warning（global scope 可空）。replace=true 覆盖同名（先删后建）。
+//
+// 落盘语义：解压到与目标同文件系统的 staging 目录，校验通过后 os.Rename 原子替换，
+// 任一步失败回滚 staging，不留半成品（spec §3.3 C）。
+func (l *Locator) Install(_ context.Context, scope Scope, baseDir, homeDir string, zr *zip.Reader, replace bool) (*InstallResult, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("skills: baseDir must not be empty")
+	}
+
+	destRoot := managedDir(baseDir)
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("skills: mkdir skills root: %w", err)
+	}
+
+	// staging 与目标同文件系统（均在 baseDir 下），保证 Rename 原子。
+	staging, err := os.MkdirTemp(baseDir, ".skill-install-*")
+	if err != nil {
+		return nil, fmt.Errorf("skills: create staging: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(staging) }
+
+	es, extractErr := extractZip(zr, staging)
+	if extractErr != nil {
+		cleanup()
+		return nil, extractErr
+	}
+
+	destDir := filepath.Join(destRoot, es.name)
+
+	// 同 scope 同名校验（spec §3.3 B5）。
+	if !replace && hasManagedSkill(baseDir, es.name) {
+		cleanup()
+		return nil, fmt.Errorf("%w: %s", ErrSkillAlreadyExists, es.name)
+	}
+
+	// 跨 scope 遮蔽 warning（spec §3.3 B6）：workspace 安装撞全局 → 允许但提示。
+	var warning string
+	if scope == ScopeWorkspace && homeDir != "" && hasManagedSkill(homeDir, es.name) {
+		warning = fmt.Sprintf("shadows global skill '%s'", es.name)
+	}
+
+	// 确定 staging 内 skill 内容根：扁平=staging；单顶层=staging/<name>。
+	contentRoot := staging
+	if es.rootRel != "" {
+		contentRoot = filepath.Join(staging, es.rootRel)
+	}
+
+	// 原子落盘（spec §3.3 C）。replace 时先删旧目录；destDir 父目录已存在。
+	if replace {
+		_ = os.RemoveAll(destDir)
+	}
+	if err := os.Rename(contentRoot, destDir); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("skills: install (rename): %w", err)
+	}
+	cleanup() // 清理 staging 残壳（单顶层时 staging 非空）
+
+	l.invalidateScope(scope, baseDir)
+
+	return &InstallResult{
+		Detail: Detail{
+			Skill: Skill{
+				Name:        es.name,
+				Description: es.description,
+				Source:      scopeSource(scope),
+				Managed:     true,
+				FilePath:    filepath.Join(destDir, es.skillMDName),
+			},
+			Body:  es.body,
+			Files: es.files,
+		},
+		Warning: warning,
+	}, nil
+}
+
+// Read 返回指定 scope/name 的 skill 详情（含 SKILL.md 全文与包内文件列表）。
+func (l *Locator) Read(_ context.Context, scope Scope, baseDir, name string) (*Detail, error) {
+	if !skillNameRegexp.MatchString(name) {
+		return nil, fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
+	}
+	dir := filepath.Join(managedDir(baseDir), name)
+	md, ok := findSkillMD(dir)
+	if !ok || filepath.Base(filepath.Dir(md)) != name {
+		return nil, fmt.Errorf("%w: %s", ErrSkillNotFound, name)
+	}
+	data, err := os.ReadFile(md)
+	if err != nil {
+		return nil, fmt.Errorf("skills: read: %w", err)
+	}
+	fm := extractFrontmatter(data)
+	if fm == nil || strings.TrimSpace(fm.Name) == "" {
+		return nil, fmt.Errorf("%w: corrupt frontmatter", ErrInvalidFormat)
+	}
+	desc := CollapseSpaces(strings.ReplaceAll(strings.TrimSpace(fm.Description), "\n", " "))
+	files, _ := collectFiles(dir)
+	return &Detail{
+		Skill: Skill{
+			Name:        strings.TrimSpace(fm.Name),
+			Description: desc,
+			Source:      scopeSource(scope),
+			Managed:     true,
+			FilePath:    md,
+		},
+		Body:  string(data),
+		Files: files,
+	}, nil
+}
+
+// Delete 移除指定 scope/name 的 managed skill 目录并失效缓存。
+// name 正则保证无路径分隔符/".."，删除严格落在 managedDir(baseDir)/<name> 内。
+func (l *Locator) Delete(_ context.Context, scope Scope, baseDir, name string) error {
+	if !skillNameRegexp.MatchString(name) {
+		return fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
+	}
+	destRoot := managedDir(baseDir)
+	dir := filepath.Join(destRoot, name)
+	// 双保险：解析后必须在 destRoot 内（name 已过正则，此处冗余防御）。
+	if !strings.HasPrefix(dir, destRoot+string(filepath.Separator)) {
+		return fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
+	}
+	if !hasManagedSkill(baseDir, name) {
+		return fmt.Errorf("%w: %s", ErrSkillNotFound, name)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("skills: delete: %w", err)
+	}
+	l.invalidateScope(scope, baseDir)
+	return nil
+}
+
+// invalidateScope 按 scope 选择缓存失效策略（spec §3.2）：
+// 全局写影响所有 workspace 的合并列表 → InvalidateAll；workspace 写仅清自身。
+func (l *Locator) invalidateScope(scope Scope, baseDir string) {
+	if scope == ScopeGlobal {
+		l.InvalidateAll()
+		return
+	}
+	l.Invalidate(baseDir)
+}

--- a/internal/skills/crud_test.go
+++ b/internal/skills/crud_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -223,4 +226,49 @@ func TestLocator_Install_FailureLeavesNoTrace(t *testing.T) {
 	d, statErr := l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
 	require.ErrorIs(t, statErr, ErrSkillNotFound)
 	_ = d
+}
+
+// ─── installMu 并发序列化（spec review P1：check-then-rename 竞态）──────────
+
+func TestLocator_Install_ConcurrentReplaceIsSerialized(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	workDir := t.TempDir()
+	// makeZip 用 t.Fatal 必须在主 goroutine 调用；zip.Reader 只读，N 个 goroutine
+	// 共享同一 zr 并发读安全（Install 各自解压到独立 staging，不修改 zr）。
+	zr := makeZip(t, map[string]string{"SKILL.md": validFM})
+
+	const n = 32
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			<-start // 同步起跑，最大化 check-then-rename 竞态窗口
+			_, errs[i] = l.Install(context.Background(), ScopeWorkspace, workDir, "", zr, true)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// replace=true 并发：installMu 串行化 check-then-rename，每次都允许成功
+	// （先到先装，后到覆盖），无静默丢数据 / ENOTEMPTY 误 500 / race panic。
+	for i, e := range errs {
+		require.NoError(t, e, "goroutine %d", i)
+	}
+
+	// 最终恰好一个 skill 存活且内容完整（无半成品 / 损坏）。
+	d, err := l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", d.Name)
+	require.Contains(t, d.Body, "# My Skill")
+
+	// 落盘目录唯一（无 staging 残壳、无重复碎片）。
+	entries, err := os.ReadDir(filepath.Join(workDir, ".agents", "skills"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
 }

--- a/internal/skills/crud_test.go
+++ b/internal/skills/crud_test.go
@@ -1,0 +1,226 @@
+package skills
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLocator() *Locator {
+	return NewLocator(slog.Default(), time.Minute)
+}
+
+// ─── Install + Read（合法结构）──────────────────────────────────────────────
+
+func TestLocator_Install_FlatThenRead(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	zr := makeZip(t, map[string]string{"SKILL.md": validFM})
+
+	res, err := l.Install(context.Background(), ScopeWorkspace, workDir, homeDir, zr, false)
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", res.Name)
+	require.True(t, res.Managed)
+	require.Equal(t, SourceProject, res.Source)
+	require.Empty(t, res.Warning)
+	require.Contains(t, res.Files, "SKILL.md")
+	require.Contains(t, res.Body, "# My Skill")
+
+	d, err := l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", d.Name)
+	require.Equal(t, "a useful skill", d.Description)
+	require.True(t, d.Managed)
+}
+
+func TestLocator_Install_SingleTopDir(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	zr := makeZip(t, map[string]string{
+		"my-skill/SKILL.md":     validFM,
+		"my-skill/reference.md": "# ref\n",
+	})
+	res, err := l.Install(context.Background(), ScopeGlobal, t.TempDir(), "", zr, false)
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", res.Name)
+	require.Equal(t, SourceGlobal, res.Source)
+	require.Len(t, res.Files, 2)
+}
+
+// ─── replace 语义（spec §3.3 B5）────────────────────────────────────────────
+
+func TestLocator_Install_AlreadyExistsNoReplace(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	workDir := t.TempDir()
+	zr := makeZip(t, map[string]string{"SKILL.md": validFM})
+	_, err := l.Install(context.Background(), ScopeWorkspace, workDir, "", zr, false)
+	require.NoError(t, err)
+
+	_, err = l.Install(context.Background(), ScopeWorkspace, workDir, "", zr, false)
+	require.ErrorIs(t, err, ErrSkillAlreadyExists)
+}
+
+func TestLocator_Install_ReplaceOverwrites(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	workDir := t.TempDir()
+	_, err := l.Install(context.Background(), ScopeWorkspace, workDir, "",
+		makeZip(t, map[string]string{"SKILL.md": "---\nname: my-skill\ndescription: v1\n---\n"}), false)
+	require.NoError(t, err)
+
+	_, err = l.Install(context.Background(), ScopeWorkspace, workDir, "",
+		makeZip(t, map[string]string{"SKILL.md": "---\nname: my-skill\ndescription: v2\n---\n"}), true)
+	require.NoError(t, err)
+
+	d, err := l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
+	require.NoError(t, err)
+	require.Equal(t, "v2", d.Description)
+}
+
+// ─── 跨 scope 遮蔽 warning（spec §3.3 B6）──────────────────────────────────
+
+func TestLocator_Install_WorkspaceShadowsGlobal(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	fm := "---\nname: shared\ndescription: d\n---\n"
+	// 全局先装 shared。
+	_, err := l.Install(context.Background(), ScopeGlobal, homeDir, "", makeZip(t, map[string]string{"SKILL.md": fm}), false)
+	require.NoError(t, err)
+	// workspace 装同名 shared → 允许但 warning。
+	res, err := l.Install(context.Background(), ScopeWorkspace, workDir, homeDir, makeZip(t, map[string]string{"SKILL.md": fm}), false)
+	require.NoError(t, err)
+	require.Contains(t, res.Warning, "shadows global skill 'shared'")
+}
+
+func TestLocator_Install_WorkspaceNoShadowWhenAbsent(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+	res, err := l.Install(context.Background(), ScopeWorkspace, t.TempDir(), t.TempDir(),
+		makeZip(t, map[string]string{"SKILL.md": validFM}), false)
+	require.NoError(t, err)
+	require.Empty(t, res.Warning)
+}
+
+// ─── Read / Delete ──────────────────────────────────────────────────────────
+
+func TestLocator_Read_NotFound(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+	_, err := l.Read(context.Background(), ScopeWorkspace, t.TempDir(), "missing")
+	require.ErrorIs(t, err, ErrSkillNotFound)
+}
+
+func TestLocator_Read_InvalidName(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+	_, err := l.Read(context.Background(), ScopeWorkspace, t.TempDir(), "../escape")
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+func TestLocator_Delete(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	workDir := t.TempDir()
+	_, err := l.Install(context.Background(), ScopeWorkspace, workDir, "", makeZip(t, map[string]string{"SKILL.md": validFM}), false)
+	require.NoError(t, err)
+
+	require.NoError(t, l.Delete(context.Background(), ScopeWorkspace, workDir, "my-skill"))
+	_, err = l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
+	require.ErrorIs(t, err, ErrSkillNotFound)
+}
+
+func TestLocator_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+	err := l.Delete(context.Background(), ScopeWorkspace, t.TempDir(), "ghost")
+	require.ErrorIs(t, err, ErrSkillNotFound)
+}
+
+func TestLocator_Delete_InvalidName(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+	err := l.Delete(context.Background(), ScopeWorkspace, t.TempDir(), "../x")
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+// ─── 缓存失效策略（spec §3.2 b）────────────────────────────────────────────
+
+func TestLocator_Install_WorkspaceInvalidatesOwn(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	// 预热 workDir 缓存。
+	_, err := l.List(context.Background(), homeDir, workDir)
+	require.NoError(t, err)
+	require.Contains(t, l.cache, workDir)
+
+	_, err = l.Install(context.Background(), ScopeWorkspace, workDir, homeDir, makeZip(t, map[string]string{"SKILL.md": validFM}), false)
+	require.NoError(t, err)
+	// workspace 写仅清自身。
+	_, ok := l.cache[workDir]
+	require.False(t, ok, "workspace Install 必须失效该 workDir 缓存")
+}
+
+func TestLocator_Install_GlobalInvalidatesAll(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	homeDir := t.TempDir()
+	wd1, wd2 := t.TempDir(), t.TempDir()
+	// 预热两个 workDir 缓存。
+	_, _ = l.List(context.Background(), homeDir, wd1)
+	_, _ = l.List(context.Background(), homeDir, wd2)
+	require.Len(t, l.cache, 2)
+
+	_, err := l.Install(context.Background(), ScopeGlobal, homeDir, "", makeZip(t, map[string]string{"SKILL.md": validFM}), false)
+	require.NoError(t, err)
+	require.Empty(t, l.cache, "global Install 必须 InvalidateAll")
+}
+
+// ─── 错误不落盘（原子回滚，spec §3.3 C）────────────────────────────────────
+
+func TestLocator_Install_FailureLeavesNoTrace(t *testing.T) {
+	t.Parallel()
+	l := newTestLocator()
+	defer l.Close()
+
+	workDir := t.TempDir()
+	// 非法 zip（缺 SKILL.md）→ Install 必须失败且不创建目录。
+	_, err := l.Install(context.Background(), ScopeWorkspace, workDir, "", makeZip(t, map[string]string{"notes.md": "# x\n"}), false)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrSkillAlreadyExists))
+
+	d, statErr := l.Read(context.Background(), ScopeWorkspace, workDir, "my-skill")
+	require.ErrorIs(t, statErr, ErrSkillNotFound)
+	_ = d
+}

--- a/internal/skills/locator.go
+++ b/internal/skills/locator.go
@@ -72,6 +72,68 @@ func (l *Locator) List(_ context.Context, homeDir, workDir string) ([]Skill, err
 	return skills, nil
 }
 
+// ListMerged 合并全局（homeDir 范围）与多个 workspace 的 skill 列表，去重
+// （workspace project 覆盖 global 同名）。workDirs 为空或全空时仅返回 global。
+//
+// 用于 GET /api/skills：一个用户可能拥有多个 workspace，此方法把它们的 managed
+// skill 合并进全局视图。各 workDir 仍走各自的 TTL 缓存；写入后由调用方 Invalidate。
+func (l *Locator) ListMerged(_ context.Context, homeDir string, workDirs []string) ([]Skill, error) {
+	seen := make(map[string]int) // name → result index
+	var result []Skill
+	add := func(s Skill) {
+		if idx, ok := seen[s.Name]; ok {
+			// project 覆盖 global（与 dedup 一致）；同名 project 取先到者。
+			if s.Source == SourceProject && result[idx].Source == SourceGlobal {
+				result[idx] = s
+			}
+		} else {
+			seen[s.Name] = len(result)
+			result = append(result, s)
+		}
+	}
+
+	if homeDir != "" {
+		if g, err := l.List(context.Background(), homeDir, ""); err == nil {
+			for _, s := range g {
+				add(s)
+			}
+		}
+	}
+	for _, wd := range workDirs {
+		if wd == "" {
+			continue
+		}
+		ss, err := l.List(context.Background(), homeDir, wd)
+		if err != nil {
+			continue
+		}
+		for _, s := range ss {
+			if s.Source == SourceProject { // global 已由上面加入
+				add(s)
+			}
+		}
+	}
+	return result, nil
+}
+
+// Invalidate drops the cached skills for a single workDir. Call after a
+// workspace-scoped CRUD so the next List re-scans the filesystem instead of
+// serving a stale merged list. Safe to call for a workDir that was never cached.
+func (l *Locator) Invalidate(workDir string) {
+	l.mu.Lock()
+	delete(l.cache, workDir)
+	l.mu.Unlock()
+}
+
+// InvalidateAll drops every cached entry. Call after a global-scoped CRUD — a
+// global skill change invalidates the merged list (global + workspace) of every
+// workspace, so a single Invalidate(workDir) is not enough.
+func (l *Locator) InvalidateAll() {
+	l.mu.Lock()
+	l.cache = make(map[string]*cacheEntry)
+	l.mu.Unlock()
+}
+
 // Close stops the background sweep goroutine.
 // It is safe to call multiple times (uses sync.Once).
 func (l *Locator) Close() {

--- a/internal/skills/locator.go
+++ b/internal/skills/locator.go
@@ -20,9 +20,17 @@ type cacheEntry struct {
 
 // Locator discovers skills from the filesystem with TTL-based caching.
 type Locator struct {
-	log       *slog.Logger
-	cache     map[string]*cacheEntry
-	mu        sync.RWMutex
+	log   *slog.Logger
+	cache map[string]*cacheEntry
+	mu    sync.RWMutex // protects cache
+	// installMu serializes filesystem-mutating skill CRUD (Install/Delete).
+	// Install is check-then-rename (hasManagedSkill → RemoveAll → Rename); without
+	// serialization, concurrent replace=true installs silently lose data (T2's
+	// RemoveAll deletes T1's just-renamed dir) and concurrent new-name installs race
+	// to ENOTEMPTY → spurious 500 instead of the contracted 409. Distinct from cache
+	// mu (read-heavy, would over-contend if merged). Skill writes are infrequent
+	// (admin/owner ops), so a single global lock is sufficient.
+	installMu sync.Mutex
 	ttl       time.Duration
 	stopCh    chan struct{}
 	closeOnce sync.Once
@@ -77,7 +85,11 @@ func (l *Locator) List(_ context.Context, homeDir, workDir string) ([]Skill, err
 //
 // 用于 GET /api/skills：一个用户可能拥有多个 workspace，此方法把它们的 managed
 // skill 合并进全局视图。各 workDir 仍走各自的 TTL 缓存；写入后由调用方 Invalidate。
-func (l *Locator) ListMerged(_ context.Context, homeDir string, workDirs []string) ([]Skill, error) {
+//
+// ctx 向下传播至 List（符合请求路径禁用 context.Background 的约定）。注意 List→scanDirs
+// 当前为同步 os.ReadDir 遍历、不响应取消；多 workspace 大目录扫描的 ctx-aware 改造
+// （filepath.WalkDir + ctx 检查）作为后续优化，此处先打通 ctx 链路。
+func (l *Locator) ListMerged(ctx context.Context, homeDir string, workDirs []string) ([]Skill, error) {
 	seen := make(map[string]int) // name → result index
 	var result []Skill
 	add := func(s Skill) {
@@ -93,7 +105,7 @@ func (l *Locator) ListMerged(_ context.Context, homeDir string, workDirs []strin
 	}
 
 	if homeDir != "" {
-		if g, err := l.List(context.Background(), homeDir, ""); err == nil {
+		if g, err := l.List(ctx, homeDir, ""); err == nil {
 			for _, s := range g {
 				add(s)
 			}
@@ -103,7 +115,7 @@ func (l *Locator) ListMerged(_ context.Context, homeDir string, workDirs []strin
 		if wd == "" {
 			continue
 		}
-		ss, err := l.List(context.Background(), homeDir, wd)
+		ss, err := l.List(ctx, homeDir, wd)
 		if err != nil {
 			continue
 		}

--- a/internal/skills/scanner.go
+++ b/internal/skills/scanner.go
@@ -17,9 +17,14 @@ type skillFrontmatter struct {
 
 // scanDirs scans all skill directories and returns deduplicated skills.
 // Order: global dirs first, then project dirs (project overrides global by name).
+// The managed flag marks entries under .agents/skills (writable region) so the
+// list can distinguish managed skills (UI may create/replace/delete) from
+// external read-only sources (.claude/.hotplex that the user manages by hand).
 func scanDirs(homeDir, workDir string) []Skill {
 	type dirEntry struct {
-		path, source string
+		path    string
+		source  string
+		managed bool
 	}
 
 	dirs := make([]dirEntry, 0, 7)
@@ -27,28 +32,32 @@ func scanDirs(homeDir, workDir string) []Skill {
 	// Global skill dirs require a valid home directory
 	if homeDir != "" {
 		dirs = append(dirs,
-			dirEntry{filepath.Join(homeDir, ".claude", "skills"), SourceGlobal},
-			dirEntry{filepath.Join(homeDir, ".agents", "skills"), SourceGlobal},
-			dirEntry{filepath.Join(homeDir, ".hotplex", "skills"), SourceGlobal},
+			dirEntry{filepath.Join(homeDir, ".claude", "skills"), SourceGlobal, false},
+			dirEntry{filepath.Join(homeDir, ".agents", "skills"), SourceGlobal, true},
+			dirEntry{filepath.Join(homeDir, ".hotplex", "skills"), SourceGlobal, false},
 		)
 	}
 
-	dirs = append(dirs,
-		dirEntry{filepath.Join(workDir, ".claude", "skills"), SourceProject},
-		dirEntry{filepath.Join(workDir, ".agents", "skills"), SourceProject},
-	)
-
-	// Also check current working dir (hotplex repo root) if distinct from workDir
-	if cwd, _ := os.Getwd(); cwd != "" && cwd != workDir {
+	// workDir 为空时仅扫描全局（home）目录，不触碰进程 cwd——用于无项目上下文的
+	// 合并列表（GET /api/skills），避免把 hotplex 自身仓库的 skill 误纳入用户视图。
+	if workDir != "" {
 		dirs = append(dirs,
-			dirEntry{filepath.Join(cwd, ".claude", "skills"), SourceProject},
-			dirEntry{filepath.Join(cwd, ".agents", "skills"), SourceProject},
+			dirEntry{filepath.Join(workDir, ".claude", "skills"), SourceProject, false},
+			dirEntry{filepath.Join(workDir, ".agents", "skills"), SourceProject, true},
 		)
+
+		// Also check current working dir (hotplex repo root) if distinct from workDir
+		if cwd, _ := os.Getwd(); cwd != "" && cwd != workDir {
+			dirs = append(dirs,
+				dirEntry{filepath.Join(cwd, ".claude", "skills"), SourceProject, false},
+				dirEntry{filepath.Join(cwd, ".agents", "skills"), SourceProject, true},
+			)
+		}
 	}
 
 	var all []Skill
 	for _, d := range dirs {
-		skills, err := scanDir(d.path, d.source)
+		skills, err := scanDir(d.path, d.source, d.managed)
 		if err != nil {
 			continue
 		}
@@ -59,7 +68,7 @@ func scanDirs(homeDir, workDir string) []Skill {
 
 // scanDir reads all .md files from a single skill directory.
 // Skips symlink files to avoid duplicates from linked directories.
-func scanDir(dir, source string) ([]Skill, error) {
+func scanDir(dir, source string, managed bool) ([]Skill, error) {
 	fi, err := os.Lstat(dir)
 	if err != nil || !fi.IsDir() {
 		return nil, fmt.Errorf("not a directory: %s", dir)
@@ -83,13 +92,13 @@ func scanDir(dir, source string) ([]Skill, error) {
 			// Subdirectory: look for SKILL.md or skill.md
 			for _, name := range []string{"SKILL.md", "skill.md"} {
 				candidate := filepath.Join(fullPath, name)
-				if s := parseSkillFile(candidate, source); s != nil {
+				if s := parseSkillFile(candidate, source, managed); s != nil {
 					result = append(result, *s)
 					break
 				}
 			}
 		} else if strings.HasSuffix(entry.Name(), ".md") {
-			if s := parseSkillFile(fullPath, source); s != nil {
+			if s := parseSkillFile(fullPath, source, managed); s != nil {
 				result = append(result, *s)
 			}
 		}
@@ -108,7 +117,7 @@ func isSymlink(path string) bool {
 
 // parseSkillFile reads a .md file and extracts name/description from YAML frontmatter.
 // Returns nil if the file cannot be read or has no valid frontmatter.
-func parseSkillFile(path, source string) *Skill {
+func parseSkillFile(path, source string, managed bool) *Skill {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -132,6 +141,8 @@ func parseSkillFile(path, source string) *Skill {
 		Name:        fm.Name,
 		Description: desc,
 		Source:      source,
+		Managed:     managed,
+		FilePath:    path,
 	}
 }
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -4,7 +4,9 @@ package skills
 type Skill struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Source      string `json:"source"` // "global" or "project"
+	Source      string `json:"source"`  // "global" (home) or "project" (workspace/workDir); scope, wire-compat
+	Managed     bool   `json:"managed"` // true = in .agents/skills (writable region, UI may modify); false = external read-only (.claude/.hotplex)
+	FilePath    string `json:"-"`       // absolute SKILL.md path (CRUD detail/delete use; never sent on wire)
 }
 
 const (

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -107,7 +107,7 @@ func TestScanDir_WithMarkdownFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.md"), []byte("---\nname: hello\ndescription: Says hello\n---\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "skip.txt"), []byte("not a skill"), 0o644))
 
-	skills, err := scanDir(dir, SourceGlobal)
+	skills, err := scanDir(dir, SourceGlobal, false)
 	require.NoError(t, err)
 	require.Len(t, skills, 1)
 	require.Equal(t, "hello", skills[0].Name)
@@ -122,7 +122,7 @@ func TestScanDir_Subdirectory(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sub, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(sub, "SKILL.md"), []byte("---\nname: my-tool\ndescription: A tool\n---\n"), 0o644))
 
-	skills, err := scanDir(dir, SourceProject)
+	skills, err := scanDir(dir, SourceProject, false)
 	require.NoError(t, err)
 	require.Len(t, skills, 1)
 	require.Equal(t, "my-tool", skills[0].Name)
@@ -134,7 +134,7 @@ func TestScanDir_NonDir(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "notadir")
 	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
 
-	_, err := scanDir(f, SourceGlobal)
+	_, err := scanDir(f, SourceGlobal, false)
 	require.Error(t, err)
 }
 
@@ -146,7 +146,7 @@ func TestParseSkillFile_Valid(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "skill.md")
 	require.NoError(t, os.WriteFile(f, []byte("---\nname: my-skill\ndescription: Does things\n---\n# My Skill\n"), 0o644))
 
-	s := parseSkillFile(f, SourceGlobal)
+	s := parseSkillFile(f, SourceGlobal, false)
 	require.NotNil(t, s)
 	require.Equal(t, "my-skill", s.Name)
 	require.Equal(t, "Does things", s.Description)
@@ -158,7 +158,7 @@ func TestParseSkillFile_NoFrontmatter(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "skill.md")
 	require.NoError(t, os.WriteFile(f, []byte("# No frontmatter\n"), 0o644))
 
-	s := parseSkillFile(f, SourceGlobal)
+	s := parseSkillFile(f, SourceGlobal, false)
 	require.Nil(t, s)
 }
 
@@ -168,14 +168,14 @@ func TestParseSkillFile_NoName(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "skill.md")
 	require.NoError(t, os.WriteFile(f, []byte("---\ndescription: no name field\n---\n"), 0o644))
 
-	s := parseSkillFile(f, SourceGlobal)
+	s := parseSkillFile(f, SourceGlobal, false)
 	require.Nil(t, s)
 }
 
 func TestParseSkillFile_Nonexistent(t *testing.T) {
 	t.Parallel()
 
-	s := parseSkillFile("/nonexistent/file.md", SourceGlobal)
+	s := parseSkillFile("/nonexistent/file.md", SourceGlobal, false)
 	require.Nil(t, s)
 }
 
@@ -290,4 +290,91 @@ func TestNewLocator_NegativeTTL_UsesDefault(t *testing.T) {
 	defer l.Close()
 
 	require.Equal(t, defaultTTL, l.ttl)
+}
+
+// ─── managed 标注 / FilePath 回填（spec §3.2 a）──────────────────────────────
+
+// writeSkill 在 dir 下创建 SKILL.md（含合法 frontmatter）。
+func writeSkill(t *testing.T, dir, name, desc string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: "+name+"\ndescription: "+desc+"\n---\n# "+name+"\n"), 0o644))
+}
+
+func TestScanDirs_ManagedAndFilePath(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// home .agents/skills/foo → global managed（可写区）
+	writeSkill(t, filepath.Join(homeDir, ".agents", "skills", "foo"), "foo", "global managed")
+	// home .claude/skills/bar → global external（只读）
+	writeSkill(t, filepath.Join(homeDir, ".claude", "skills", "bar"), "bar", "global external")
+	// workDir .agents/skills/baz → project managed
+	writeSkill(t, filepath.Join(workDir, ".agents", "skills", "baz"), "baz", "project managed")
+
+	skills := scanDirs(homeDir, workDir)
+	byName := map[string]Skill{}
+	for _, s := range skills {
+		byName[s.Name] = s
+	}
+
+	require.Contains(t, byName, "foo")
+	require.True(t, byName["foo"].Managed, ".agents/skills 必须标注 managed")
+	require.Equal(t, SourceGlobal, byName["foo"].Source)
+	require.NotEmpty(t, byName["foo"].FilePath)
+
+	require.Contains(t, byName, "bar")
+	require.False(t, byName["bar"].Managed, ".claude/skills 必须标注 external 只读")
+	require.NotEmpty(t, byName["bar"].FilePath)
+
+	require.Contains(t, byName, "baz")
+	require.True(t, byName["baz"].Managed)
+	require.Equal(t, SourceProject, byName["baz"].Source)
+}
+
+// ─── Invalidate / InvalidateAll（spec §3.2 b）──────────────────────────────
+
+func TestLocator_Invalidate(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	writeSkill(t, filepath.Join(workDir, ".agents", "skills", "foo"), "foo", "v1")
+
+	l := NewLocator(slog.Default(), time.Minute)
+	defer l.Close()
+
+	got, err := l.List(context.Background(), homeDir, workDir)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "v1", got[0].Description)
+
+	// 磁盘更新 + 失效该 workDir 缓存。
+	writeSkill(t, filepath.Join(workDir, ".agents", "skills", "foo"), "foo", "v2")
+	l.Invalidate(workDir)
+
+	got, err = l.List(context.Background(), homeDir, workDir)
+	require.NoError(t, err)
+	require.Equal(t, "v2", got[0].Description, "Invalidate 必须强制重新扫描")
+}
+
+func TestLocator_InvalidateAll(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	writeSkill(t, filepath.Join(workDir, ".agents", "skills", "foo"), "foo", "v1")
+
+	l := NewLocator(slog.Default(), time.Minute)
+	defer l.Close()
+
+	_, err := l.List(context.Background(), homeDir, workDir)
+	require.NoError(t, err)
+	require.Len(t, l.cache, 1)
+
+	l.InvalidateAll()
+	require.Empty(t, l.cache)
 }

--- a/internal/skills/zip.go
+++ b/internal/skills/zip.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"archive/zip"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -169,6 +170,22 @@ func extractFile(f *zip.File, dest string) error {
 		return fmt.Errorf("actual size exceeds %d bytes", maxSingleFile)
 	}
 	return nil
+}
+
+// ZipReaderFromFile 从 multipart 上传文件构造 zip.Reader，优先利用 *os.File 的
+// ReaderAt（multipart >32KiB 溢出磁盘时）避免全量载内存（20MB×N 并发 DoS，spec
+// review P2#5）；小文件（内存 *sectionReader）回退 io.ReadAll。f 由调用方 Close。
+func ZipReaderFromFile(f io.ReadCloser) (*zip.Reader, error) {
+	if osFile, ok := f.(*os.File); ok {
+		if info, err := osFile.Stat(); err == nil {
+			return zip.NewReader(osFile, info.Size())
+		}
+	}
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
 }
 
 // locateAndValidateSkill 在 staging 内定位 SKILL.md（扁平 staging/SKILL.md

--- a/internal/skills/zip.go
+++ b/internal/skills/zip.go
@@ -1,0 +1,285 @@
+package skills
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// 容量/安全阈值（spec §3.3 A）。zip body 的 20MB 上限在 handler 层由
+// http.MaxBytesReader 兜底；此处的阈值约束解压阶段。
+const (
+	maxTotalUncompressed = 50 << 20 // 解压总上限 50MB
+	maxSingleFile        = 5 << 20  // 单文件上限 5MB
+	maxEntries           = 500      // entry 数上限
+	maxCompressionRatio  = 100      // 压缩率 >100× 拒
+	maxDescriptionRunes  = 1024     // description 独立严格校验（spec §3.3 B4）
+	maxSkillNameLen      = 64
+)
+
+// 校验语义错误。handler 层据此映射 HTTP 错误码（spec §5）：
+//   - ErrInvalidZip      → 400 SKILL_INVALID_ZIP
+//   - ErrInvalidFormat   → 400 SKILL_INVALID_FORMAT
+//   - ErrFileTypeBlocked → 400 SKILL_FILE_TYPE_BLOCKED
+var (
+	ErrInvalidZip      = errors.New("skill: invalid, corrupt, or oversized zip")
+	ErrInvalidFormat   = errors.New("skill: invalid skill format")
+	ErrFileTypeBlocked = errors.New("skill: blocked file type")
+)
+
+// skillNameRegexp 校验 skill name：小写字母/数字，连字符分段，1-64 字符
+// （spec §3.3 B3）。正则本身排除路径分隔符与 ".."，是 zip-slip 的第一道防线。
+var skillNameRegexp = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// allowedFileExts 是包内允许的文件扩展名白名单（spec §3.3 B7）：拒可执行/二进制。
+var allowedFileExts = map[string]bool{
+	".md": true, ".markdown": true,
+	".json": true, ".yaml": true, ".yml": true, ".txt": true, ".toml": true,
+	".py": true, ".sh": true,
+	".png": true, ".jpg": true, ".jpeg": true, ".svg": true,
+}
+
+// extractedSkill 是 zip 解压 + 安全校验的产物。
+type extractedSkill struct {
+	name        string
+	description string
+	body        string   // SKILL.md 全文
+	files       []string // 相对 skill 根的文件路径（含 SKILL.md）
+	rootRel     string   // skill 内容根相对 staging 的路径；""=扁平，"<name>"=单顶层
+	skillMDName string   // SKILL.md 文件名（"SKILL.md" 或 "skill.md"）
+}
+
+// safeExtractJoin 安全拼接 staging 目录与 zip entry 的相对路径，防 zip-slip
+// （路径穿越）。
+//
+// spec §3.3 A 原写"复用 security.SafePathJoin"，但 SafePathJoin 对 joined 路径
+// 调 filepath.EvalSymlinks —— 解压目标文件此时尚不存在，EvalSymlinks 会直接
+// 失败使全部正常解压都报错。此处采用与 SafePathJoin 等价的防护（Clean + 拒绝
+// 绝对路径/".." + Join + 前缀校验），仅省去 EvalSymlinks：staging 为本包新建的
+// 受控临时目录，entry 相对路径已严格 Clean，字符串前缀校验足以保证 dest 落在
+// staging 内。调用方另做一次显式 HasPrefix 构成双保险。
+func safeExtractJoin(staging, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("absolute path not allowed: %s", rel)
+	}
+	clean := filepath.Clean(rel)
+	sep := string(filepath.Separator)
+	if clean == ".." || strings.HasPrefix(clean, ".."+sep) {
+		return "", fmt.Errorf("traversal attempt: %s", rel)
+	}
+	joined := filepath.Join(staging, clean)
+	if joined != staging && !strings.HasPrefix(joined, staging+sep) {
+		return "", fmt.Errorf("path escapes staging: %s", rel)
+	}
+	return joined, nil
+}
+
+// extractZip 将 zr 解压到 tempStaging（必须已存在且与最终落盘目标同文件系统），
+// 并完成全部安全层（zip-slip/炸弹/恶意 entry/类型白名单）与格式层（结构、
+// frontmatter、name 正则、name==父目录名、description 长度）校验。
+//
+// 失败时调用方负责清理 tempStaging。
+func extractZip(zr *zip.Reader, tempStaging string) (*extractedSkill, error) {
+	if len(zr.File) == 0 {
+		return nil, fmt.Errorf("%w: empty archive", ErrInvalidZip)
+	}
+	if len(zr.File) > maxEntries {
+		return nil, fmt.Errorf("%w: too many entries (%d > %d)", ErrInvalidZip, len(zr.File), maxEntries)
+	}
+
+	stagingBase := filepath.Clean(tempStaging)
+	sep := string(filepath.Separator)
+	var totalUncompressed uint64
+
+	for _, f := range zr.File {
+		// 拒嵌套 zip（spec §3.3 A 禁嵌套 zip）。
+		if strings.HasSuffix(strings.ToLower(f.Name), ".zip") {
+			return nil, fmt.Errorf("%w: nested zip not allowed", ErrInvalidZip)
+		}
+		// 目录 entry（显式或以 / 结尾）跳过——目录由文件路径隐式创建。
+		if f.Mode().IsDir() || strings.HasSuffix(f.Name, "/") {
+			continue
+		}
+		// 仅接受常规文件 entry：拒 symlink/device/pipe（spec §3.3 A 恶意 entry）。
+		if !f.Mode().IsRegular() {
+			return nil, fmt.Errorf("%w: non-regular entry %q", ErrInvalidZip, f.Name)
+		}
+		// 文件类型白名单（spec §3.3 B7）。
+		if !allowedFileExts[strings.ToLower(filepath.Ext(f.Name))] {
+			return nil, fmt.Errorf("%w: %q", ErrFileTypeBlocked, f.Name)
+		}
+		// 单文件大小（spec §3.3 A 单文件 ≤5MB）。
+		if f.UncompressedSize64 > maxSingleFile {
+			return nil, fmt.Errorf("%w: file too large %q (%d bytes)", ErrInvalidZip, f.Name, f.UncompressedSize64)
+		}
+		// 压缩率（spec §3.3 A 压缩率 >100× 拒）。
+		if f.CompressedSize64 > 0 && f.UncompressedSize64 > uint64(maxCompressionRatio)*f.CompressedSize64 {
+			return nil, fmt.Errorf("%w: suspicious compression ratio %q", ErrInvalidZip, f.Name)
+		}
+		// 解压总大小（spec §3.3 A 解压总 ≤50MB）。
+		totalUncompressed += f.UncompressedSize64
+		if totalUncompressed > maxTotalUncompressed {
+			return nil, fmt.Errorf("%w: total uncompressed exceeds %d bytes", ErrInvalidZip, maxTotalUncompressed)
+		}
+
+		// zip-slip 双保险：safeExtractJoin（Clean/拒绝对路径与".."→Join→前缀校验）
+		// + 显式 HasPrefix 再查一次（spec §3.3 A）。
+		rel := filepath.Clean(filepath.FromSlash(f.Name))
+		dest, err := safeExtractJoin(stagingBase, rel)
+		if err != nil {
+			return nil, fmt.Errorf("%w: unsafe path %q: %w", ErrInvalidZip, f.Name, err)
+		}
+		if dest != stagingBase && !strings.HasPrefix(dest, stagingBase+sep) {
+			return nil, fmt.Errorf("%w: path escapes staging %q", ErrInvalidZip, f.Name)
+		}
+		if err := extractFile(f, dest); err != nil {
+			return nil, fmt.Errorf("%w: extract %q: %w", ErrInvalidZip, f.Name, err)
+		}
+	}
+
+	return locateAndValidateSkill(stagingBase)
+}
+
+// extractFile 解压单个常规 zip entry 到 dest。io.LimitReader 兜底防 zip 头
+// 撒谎（声称小实则流大），复制超限即视为损坏。
+func extractFile(f *zip.File, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	n, err := io.Copy(out, io.LimitReader(rc, maxSingleFile+1))
+	if err != nil {
+		return err
+	}
+	if n > int64(maxSingleFile) {
+		return fmt.Errorf("actual size exceeds %d bytes", maxSingleFile)
+	}
+	return nil
+}
+
+// locateAndValidateSkill 在 staging 内定位 SKILL.md（扁平 staging/SKILL.md
+// 或单顶层 staging/<dir>/SKILL.md）并完成 frontmatter/name/description 校验。
+func locateAndValidateSkill(staging string) (*extractedSkill, error) {
+	// 优先扁平：staging/SKILL.md。
+	if md, ok := findSkillMD(staging); ok {
+		return parseAndValidate(staging, md, "")
+	}
+	// 单顶层目录：恰好一个一级子目录，内含 SKILL.md。
+	entries, err := os.ReadDir(staging)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read staging: %w", ErrInvalidFormat, err)
+	}
+	var topDir string
+	for _, e := range entries {
+		full := filepath.Join(staging, e.Name())
+		if isSymlink(full) {
+			continue
+		}
+		if e.IsDir() {
+			if topDir != "" {
+				return nil, fmt.Errorf("%w: multiple top-level directories", ErrInvalidFormat)
+			}
+			topDir = e.Name()
+		}
+	}
+	if topDir == "" {
+		return nil, fmt.Errorf("%w: no SKILL.md found", ErrInvalidFormat)
+	}
+	root := filepath.Join(staging, topDir)
+	md, ok := findSkillMD(root)
+	if !ok {
+		return nil, fmt.Errorf("%w: no SKILL.md in %q", ErrInvalidFormat, topDir)
+	}
+	return parseAndValidate(root, md, topDir)
+}
+
+// findSkillMD 在 dir 下查找 SKILL.md（优先）或 skill.md。返回文件绝对路径。
+func findSkillMD(dir string) (string, bool) {
+	for _, name := range []string{"SKILL.md", "skill.md"} {
+		p := filepath.Join(dir, name)
+		if fileExists(p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// parseAndValidate 解析 SKILL.md frontmatter 并完成格式校验。skillRoot 是
+// staging 内 skill 内容根；dirName 是其目录名（扁平时为 ""，用于 name==父目录名校验）。
+func parseAndValidate(skillRoot, skillMDPath, dirName string) (*extractedSkill, error) {
+	data, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read SKILL.md: %w", ErrInvalidFormat, err)
+	}
+	fm := extractFrontmatter(data)
+	if fm == nil {
+		return nil, fmt.Errorf("%w: missing frontmatter", ErrInvalidFormat)
+	}
+	name := strings.TrimSpace(fm.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: frontmatter missing name", ErrInvalidFormat)
+	}
+	if len(name) > maxSkillNameLen || !skillNameRegexp.MatchString(name) {
+		return nil, fmt.Errorf("%w: invalid name %q", ErrInvalidFormat, name)
+	}
+	// name 必须等于父目录名（单顶层模式）；扁平模式 dirName=="" 跳过（spec §3.3 B3）。
+	if dirName != "" && dirName != name {
+		return nil, fmt.Errorf("%w: name %q must equal parent dir %q", ErrInvalidFormat, name, dirName)
+	}
+	desc := CollapseSpaces(strings.ReplaceAll(strings.TrimSpace(fm.Description), "\n", " "))
+	descRunes := len([]rune(desc))
+	if descRunes == 0 || descRunes > maxDescriptionRunes {
+		return nil, fmt.Errorf("%w: description length %d out of range [1,%d]", ErrInvalidFormat, descRunes, maxDescriptionRunes)
+	}
+	files, err := collectFiles(skillRoot)
+	if err != nil {
+		return nil, fmt.Errorf("%w: collect files: %w", ErrInvalidFormat, err)
+	}
+	return &extractedSkill{
+		name:        name,
+		description: desc,
+		body:        string(data),
+		files:       files,
+		rootRel:     dirName, // 扁平为 ""，单顶层为 ==name 的目录名
+		skillMDName: filepath.Base(skillMDPath),
+	}, nil
+}
+
+// collectFiles 收集 root 下所有常规文件的相对路径（含 SKILL.md，跳过 symlink）。
+func collectFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || isSymlink(path) {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	return files, err
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
+}

--- a/internal/skills/zip_test.go
+++ b/internal/skills/zip_test.go
@@ -1,0 +1,216 @@
+package skills
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeZip 从 name→content 映射构造一个内存 zip.Reader（测试 helper，同包复用）。
+func makeZip(t *testing.T, files map[string]string) *zip.Reader {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	for name, content := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	return zr
+}
+
+// makeZipSymlink 构造一个含 symlink entry 的 zip（测恶意 entry 过滤）。
+func makeZipSymlink(t *testing.T) *zip.Reader {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	h := &zip.FileHeader{Name: "evil-link", Method: zip.Store}
+	h.SetMode(os.ModeSymlink | 0o777)
+	fw, err := w.CreateHeader(h)
+	require.NoError(t, err)
+	_, err = fw.Write([]byte("/etc/passwd"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	return zr
+}
+
+const validFM = "---\nname: my-skill\ndescription: a useful skill\n---\n# My Skill\nbody\n"
+
+func runExtract(t *testing.T, zr *zip.Reader) (*extractedSkill, error) {
+	t.Helper()
+	return extractZip(zr, t.TempDir())
+}
+
+// ─── 合法结构 ────────────────────────────────────────────────────────────────
+
+func TestExtractZip_FlatSKILLMD(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{"SKILL.md": validFM})
+	es, err := runExtract(t, zr)
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", es.name)
+	require.Equal(t, "a useful skill", es.description)
+	require.Equal(t, "", es.rootRel, "扁平结构 rootRel 为空")
+	require.Equal(t, "SKILL.md", es.skillMDName)
+	require.Contains(t, es.files, "SKILL.md")
+	require.Contains(t, es.body, "# My Skill")
+}
+
+func TestExtractZip_SingleTopDir(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"my-skill/SKILL.md":     validFM,
+		"my-skill/reference.md": "# ref\n",
+	})
+	es, err := runExtract(t, zr)
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", es.name)
+	require.Equal(t, "my-skill", es.rootRel, "单顶层 rootRel 必须等于目录名")
+	require.Len(t, es.files, 2)
+}
+
+func TestExtractZip_MultipleTopDirs(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"my-skill/SKILL.md": validFM,
+		"other/x.md":        "# x\n",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+func TestExtractZip_NoSKILLMD(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{"my-skill/notes.md": "# notes\n"})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+// ─── name / description 校验（spec §3.3 B3/B4）──────────────────────────────
+
+func TestExtractZip_NameNotEqualDir(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"other-dir/SKILL.md": "---\nname: my-skill\ndescription: d\n---\n",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+func TestExtractZip_InvalidNameRegex(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"UpperCase":     "---\nname: MySkill\ndescription: d\n---\n",
+		"underscore":    "---\nname: my_skill\ndescription: d\n---\n",
+		"trailing-dash": "---\nname: my-\ndescription: d\n---\n",
+		"slash":         "---\nname: my/skill\ndescription: d\n---\n",
+		"dot":           "---\nname: my.skill\ndescription: d\n---\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			zr := makeZip(t, map[string]string{"SKILL.md": body})
+			_, err := runExtract(t, zr)
+			require.ErrorIs(t, err, ErrInvalidFormat)
+		})
+	}
+}
+
+func TestExtractZip_DescriptionTooLong(t *testing.T) {
+	t.Parallel()
+	long := make([]rune, maxDescriptionRunes+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	zr := makeZip(t, map[string]string{"SKILL.md": "---\nname: foo\ndescription: " + string(long) + "\n---\n"})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+func TestExtractZip_EmptyDescription(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{"SKILL.md": "---\nname: foo\ndescription:\n---\n"})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+func TestExtractZip_MissingFrontmatter(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{"SKILL.md": "# no frontmatter here\n"})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
+// ─── 安全层（spec §3.3 A）──────────────────────────────────────────────────
+
+func TestExtractZip_EmptyArchive(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}
+
+func TestExtractZip_ZipSlip(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"SKILL.md":   validFM,
+		"../evil.md": "# evil\n",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}
+
+func TestExtractZip_AbsolutePath(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"SKILL.md":     validFM,
+		"/etc/evil.md": "# evil\n",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}
+
+func TestExtractZip_FileTypeBlocked(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"SKILL.md": validFM,
+		"run.exe":  "MZbinary",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrFileTypeBlocked)
+}
+
+func TestExtractZip_NestedZip(t *testing.T) {
+	t.Parallel()
+	zr := makeZip(t, map[string]string{
+		"SKILL.md":   validFM,
+		"bundle.zip": "PK...",
+	})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}
+
+func TestExtractZip_SymlinkEntry(t *testing.T) {
+	t.Parallel()
+	zr := makeZipSymlink(t)
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}
+
+func TestExtractZip_HighCompressionRatio(t *testing.T) {
+	t.Parallel()
+	// 200KB 全同字节 → deflate 压缩率极高（>>100×），命中炸弹防护（spec §3.3 A）。
+	payload := bytes.Repeat([]byte{'A'}, 200<<10)
+	zr := makeZip(t, map[string]string{"SKILL.md": validFM, "blob.json": string(payload)})
+	_, err := runExtract(t, zr)
+	require.ErrorIs(t, err, ErrInvalidZip)
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -570,7 +570,8 @@ type SkillsListData struct {
 type SkillEntry struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Source      string `json:"source"`
+	Source      string `json:"source"`            // "global" (home) or "project" (workspace/workDir)
+	Managed     bool   `json:"managed,omitempty"` // issue #910: true = in .agents/skills (UI-manageable)
 }
 
 // SessionState represents the state of a session.

--- a/webchat/app/admin/skills/page.tsx
+++ b/webchat/app/admin/skills/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useAdminUI } from '@/context/admin-ui-context';
+import { listAdminSkills, installAdminSkill, deleteAdminSkill } from '@/lib/api/admin-skills';
+import type { AdminSkill } from '@/lib/api/admin-skills';
+import { useResource } from '@/hooks/use-resource';
+import { LoadingState, ErrorState, EmptyState } from '@/components/admin/resource-states';
+import { useTranslation } from 'react-i18next';
+
+// Badge color helper — managed (writable) vs external (read-only) provenance.
+function Badge({ kind }: { kind: 'managed' | 'external' }) {
+  const { t } = useTranslation();
+  if (kind === 'managed') {
+    return (
+      <span className="rounded-full bg-[rgba(16,185,129,0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(16,185,129)]">
+        {t('admin:skills.label.managed', { defaultValue: 'Managed' })}
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-[var(--bg-hover)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">
+      {t('admin:skills.label.external', { defaultValue: 'External (read-only)' })}
+    </span>
+  );
+}
+
+export default function AdminSkillsPage() {
+  const { t } = useTranslation();
+  const { showToast, confirm } = useAdminUI();
+  const { data, loading, error, reload } = useResource<{ skills: AdminSkill[]; total: number }>(
+    async () => listAdminSkills(),
+    [],
+  );
+  const skills = data?.skills ?? [];
+
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [showUpload, setShowUpload] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [replace, setReplace] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onPickFile = (f: File | null) => {
+    if (f && !/\.zip$/i.test(f.name)) {
+      showToast(t('admin:skills.error.not_zip', { defaultValue: 'Only .zip files are accepted' }), 'error');
+      return;
+    }
+    setFile(f);
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      showToast(t('admin:skills.error.no_file', { defaultValue: 'Please select a zip file' }), 'error');
+      return;
+    }
+    try {
+      setUploading(true);
+      const res = await installAdminSkill(file, replace);
+      await reload();
+      setShowUpload(false);
+      setFile(null);
+      setReplace(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      // warning 非空 = 跨 scope 遮蔽（spec §3.3 B6）：安装成功但需 UI 提示。
+      const msg = res.warning
+        ? t('admin:skills.toast.installed_warning', { warning: res.warning, defaultValue: `Installed — ${res.warning}` })
+        : t('admin:skills.toast.installed', { defaultValue: 'Skill installed' });
+      showToast(msg, 'success');
+    } catch (err) {
+      const status = (err as any).status;
+      if (status === 409) {
+        showToast(
+          t('admin:skills.error.already_exists', { defaultValue: 'Skill already exists — enable "Replace existing" to overwrite' }),
+          'error',
+        );
+      } else {
+        showToast(err instanceof Error ? err.message : t('admin:skills.error.install_failed', { defaultValue: 'Install failed' }), 'error');
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    const ok = await confirm(
+      t('admin:skills.confirm.delete_title', { defaultValue: 'Delete Skill' }),
+      t('admin:skills.confirm.delete_body', { name, defaultValue: `Delete skill "${name}"? This removes it from the global skills directory and cannot be undone.` }),
+      {
+        confirmLabel: t('common:action.delete', { defaultValue: 'Delete' }),
+        cancelLabel: t('common:action.cancel', { defaultValue: 'Cancel' }),
+        destructive: true,
+      },
+    );
+    if (!ok) return;
+    try {
+      setActionLoading(name);
+      await deleteAdminSkill(name);
+      await reload();
+      showToast(t('admin:skills.toast.deleted', { defaultValue: 'Skill deleted' }), 'success');
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : t('admin:skills.error.delete_failed', { defaultValue: 'Delete failed' }), 'error');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const closeUpload = () => {
+    setShowUpload(false);
+    setFile(null);
+    setReplace(false);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">
+            {t('admin:skills.title', { defaultValue: 'Skills' })}
+          </h1>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            {t('admin:skills.subtitle', { defaultValue: 'Manage global skills under ~/.agents/skills. External skills (.claude/.hotplex) are read-only.' })}
+          </p>
+        </div>
+        <button
+          onClick={() => setShowUpload(true)}
+          className="rounded-lg bg-[var(--accent-gold)] px-3 py-1.5 text-xs font-medium text-[var(--bg-surface)] hover:opacity-90"
+        >
+          {t('admin:skills.action.upload', { defaultValue: 'Upload Skill' })}
+        </button>
+      </div>
+
+      {loading && <LoadingState />}
+      {error && <ErrorState message={error} onRetry={reload} />}
+      {!loading && !error && skills.length === 0 && (
+        <EmptyState
+          title={t('admin:skills.empty.title', { defaultValue: 'No skills installed' })}
+          description={t('admin:skills.empty.desc', { defaultValue: 'Upload a skill .zip to install it into the global skills directory.' })}
+        />
+      )}
+
+      {/* List */}
+      {!loading && !error && skills.length > 0 && (
+        <div className="space-y-2">
+          {skills.map((s) => (
+            <div
+              key={`${s.source}/${s.name}`}
+              className="flex items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-3"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium text-[var(--text-primary)]">{s.name}</span>
+                  <Badge kind={s.managed ? 'managed' : 'external'} />
+                  <span className="text-[10px] uppercase text-[var(--text-faint)]">{s.source}</span>
+                </div>
+                <p className="mt-0.5 truncate text-xs text-[var(--text-muted)]">{s.description}</p>
+              </div>
+              {s.managed && (
+                <button
+                  disabled={actionLoading === s.name}
+                  onClick={() => handleDelete(s.name)}
+                  className="ml-3 shrink-0 rounded-md border border-[var(--border-subtle)] px-2 py-1 text-xs text-[var(--accent-coral)] hover:bg-[rgba(244,63,94,0.08)] disabled:opacity-50"
+                >
+                  {t('common:action.delete', { defaultValue: 'Delete' })}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Upload dialog */}
+      {showUpload && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={closeUpload}>
+          <div
+            className="w-full max-w-md rounded-xl bg-[var(--bg-surface)] p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-sm font-semibold text-[var(--text-primary)]">
+              {t('admin:skills.dialog.upload_title', { defaultValue: 'Upload Skill' })}
+            </h2>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">
+              {t('admin:skills.dialog.upload_desc', { defaultValue: 'Select a .zip whose root has SKILL.md (or a single top-level dir containing it). Aligned with agentskills.io.' })}
+            </p>
+            <div className="mt-4">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".zip"
+                onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
+                className="block w-full text-xs text-[var(--text-muted)] file:mr-3 file:rounded-md file:border-0 file:bg-[var(--accent-gold)] file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-[var(--bg-surface)] hover:file:opacity-90"
+              />
+              {file && <p className="mt-2 text-xs text-[var(--text-secondary)]">{file.name}</p>}
+            </div>
+            <label className="mt-3 flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+              <input type="checkbox" checked={replace} onChange={(e) => setReplace(e.target.checked)} />
+              {t('admin:skills.dialog.replace', { defaultValue: 'Replace existing same-name skill' })}
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button onClick={closeUpload} className="rounded-md px-3 py-1.5 text-xs text-[var(--text-muted)] hover:bg-[var(--bg-hover)]">
+                {t('common:action.cancel', { defaultValue: 'Cancel' })}
+              </button>
+              <button
+                onClick={handleUpload}
+                disabled={uploading || !file}
+                className="rounded-md bg-[var(--accent-gold)] px-3 py-1.5 text-xs font-medium text-[var(--bg-surface)] hover:opacity-90 disabled:opacity-50"
+              >
+                {uploading
+                  ? t('admin:skills.dialog.uploading', { defaultValue: 'Uploading…' })
+                  : t('admin:skills.action.install', { defaultValue: 'Install' })}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webchat/components/admin/admin-nav.tsx
+++ b/webchat/components/admin/admin-nav.tsx
@@ -64,6 +64,16 @@ const NAV_ITEMS = [
     exact: false,
   },
   {
+    label: 'Skills',
+    href: '/admin/skills',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-5 w-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+      </svg>
+    ),
+    exact: false,
+  },
+  {
     label: 'Cron',
     href: '/admin/cron',
     icon: (
@@ -112,6 +122,7 @@ export function AdminNav({ onLogout, showConnectionSettings = false }: AdminNavP
       case 'Sessions': return t('admin:nav.sessions', { defaultValue: 'Sessions' });
       case 'Activity': return t('admin:nav.activity', { defaultValue: 'Activity' });
       case 'Workspaces': return t('admin:nav.workspaces', { defaultValue: 'Workspaces' });
+      case 'Skills': return t('admin:nav.skills', { defaultValue: 'Skills' });
       case 'Cron': return t('admin:nav.cron', { defaultValue: 'Cron' });
       case 'API Keys': return t('admin:nav.api_keys', { defaultValue: 'API Keys' });
       case 'Admin Connection': return t('admin:nav.admin_connection', { defaultValue: 'Admin Connection' });

--- a/webchat/lib/api/admin-skills.ts
+++ b/webchat/lib/api/admin-skills.ts
@@ -1,0 +1,79 @@
+/**
+ * Admin Skills API (issue #910).
+ *
+ * /admin/api/skills — global skill management (list/install/read/delete). Rides
+ * the admin dual-channel (adminFetch: Bearer or cookie-session admin). The zip
+ * install is multipart, which adminFetch can't carry (it forces
+ * Content-Type: application/json), so installAdminSkill uses a dedicated
+ * adminUpload that mirrors the Bearer/cookie selection without that header.
+ */
+
+import { adminFetch, getStoredAdminConnection } from './admin-client';
+import { adminUrl } from '@/lib/config';
+import { authOpts } from './client';
+import { parseApiError } from './errors';
+
+export interface AdminSkill {
+  name: string;
+  description: string;
+  source: string; // "global" (home)
+  managed: boolean;
+}
+
+export interface AdminSkillListResponse {
+  skills: AdminSkill[];
+  total: number;
+}
+
+export interface AdminSkillDetail {
+  name: string;
+  description: string;
+  source: string;
+  managed: boolean;
+  body: string;
+  files: string[];
+}
+
+export interface AdminSkillInstallResult extends AdminSkillDetail {
+  warning?: string;
+}
+
+export async function listAdminSkills(): Promise<AdminSkillListResponse> {
+  return adminFetch<AdminSkillListResponse>('/admin/api/skills');
+}
+
+export async function getAdminSkill(name: string): Promise<AdminSkillDetail> {
+  return adminFetch<AdminSkillDetail>(`/admin/api/skills/${encodeURIComponent(name)}`);
+}
+
+export async function deleteAdminSkill(name: string): Promise<void> {
+  await adminFetch<void>(`/admin/api/skills/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+// installAdminSkill uploads a global skill zip. Multipart body must not carry a
+// manual Content-Type (browser sets the boundary); adminUpload selects Bearer
+// vs cookie like adminFetch but omits the JSON content type.
+export async function installAdminSkill(file: File, replace = false): Promise<AdminSkillInstallResult> {
+  const fd = new FormData();
+  fd.append('file', file);
+  const path = `/admin/api/skills${replace ? '?replace=true' : ''}`;
+  return adminUpload<AdminSkillInstallResult>(path, fd);
+}
+
+async function adminUpload<T>(path: string, body: FormData): Promise<T> {
+  const conn = getStoredAdminConnection();
+  const res = conn
+    ? await fetch(`${conn.url}${path}`, { method: 'POST', headers: { Authorization: `Bearer ${conn.token}` }, body })
+    : await fetch(`${adminUrl}${path}`, { method: 'POST', ...authOpts(), body });
+
+  if (!res.ok) {
+    const info = await parseApiError(res);
+    const message = info.message || info.code || `Admin skill upload failed: ${res.status}`;
+    const err = new Error(message);
+    (err as any).status = info.status;
+    if (info.code) (err as any).code = info.code;
+    throw err;
+  }
+  if (res.status === 204) return undefined as unknown as T;
+  return res.json();
+}

--- a/webchat/lib/api/skills.ts
+++ b/webchat/lib/api/skills.ts
@@ -1,0 +1,105 @@
+/**
+ * User-facing Skills API (issue #910).
+ *
+ * /api/skills — merged list (global + caller's workspaces + external read-only),
+ * each entry carrying `managed` (true = under .agents/skills, UI-manageable).
+ * /api/workspaces/{wid}/skills — workspace-scoped skill CRUD (zip install).
+ *
+ * Auth: same cookie/api-key channel as the rest of the user REST API (client.ts).
+ */
+
+import { BASE, authHeaders, authOpts, withAuth, extractApiError } from '@/lib/api/client';
+
+export interface Skill {
+  name: string;
+  description: string;
+  source: string; // "global" (home) | "project" (workspace)
+  managed: boolean; // true = .agents/skills (writable); false = external read-only
+}
+
+export interface SkillListResponse {
+  skills: Skill[];
+  total: number;
+}
+
+export interface SkillDetail {
+  name: string;
+  description: string;
+  source: string;
+  managed: boolean;
+  body?: string; // SKILL.md full text (scoped detail endpoints)
+  files?: string[];
+}
+
+export interface SkillInstallResult {
+  name: string;
+  description: string;
+  source: string;
+  managed: boolean;
+  body: string;
+  files: string[];
+  warning?: string; // non-empty = workspace install shadows a global same-name skill
+}
+
+export async function listSkills(signal?: AbortSignal): Promise<SkillListResponse> {
+  const res = await fetch(`${BASE}/api/skills`, { headers: withAuth(), ...authOpts(), signal });
+  if (!res.ok) throw new Error(await extractApiError(res, `listSkills failed: ${res.status}`));
+  return res.json();
+}
+
+export async function getSkill(name: string, signal?: AbortSignal): Promise<Skill> {
+  const res = await fetch(`${BASE}/api/skills/${encodeURIComponent(name)}`, {
+    headers: withAuth(),
+    ...authOpts(),
+    signal,
+  });
+  if (!res.ok) throw new Error(await extractApiError(res, `getSkill failed: ${res.status}`));
+  return res.json();
+}
+
+// installWorkspaceSkill uploads a skill zip into a workspace's .agents/skills.
+// Note: do NOT set Content-Type — the browser sets the multipart boundary.
+export async function installWorkspaceSkill(
+  workspaceId: string,
+  file: File,
+  replace = false,
+  signal?: AbortSignal,
+): Promise<SkillInstallResult> {
+  const fd = new FormData();
+  fd.append('file', file);
+  const url = `${BASE}/api/workspaces/${encodeURIComponent(workspaceId)}/skills${replace ? '?replace=true' : ''}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: fd,
+    ...authOpts(),
+    signal,
+  });
+  if (!res.ok) throw new Error(await extractApiError(res, `installSkill failed: ${res.status}`));
+  return res.json();
+}
+
+export async function getWorkspaceSkill(
+  workspaceId: string,
+  name: string,
+  signal?: AbortSignal,
+): Promise<SkillDetail> {
+  const res = await fetch(
+    `${BASE}/api/workspaces/${encodeURIComponent(workspaceId)}/skills/${encodeURIComponent(name)}`,
+    { headers: withAuth(), ...authOpts(), signal },
+  );
+  if (!res.ok) throw new Error(await extractApiError(res, `getWorkspaceSkill failed: ${res.status}`));
+  return res.json();
+}
+
+export async function deleteWorkspaceSkill(
+  workspaceId: string,
+  name: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(
+    `${BASE}/api/workspaces/${encodeURIComponent(workspaceId)}/skills/${encodeURIComponent(name)}`,
+    { method: 'DELETE', headers: authHeaders(), ...authOpts(), signal },
+  );
+  if (!res.ok) throw new Error(await extractApiError(res, `deleteWorkspaceSkill failed: ${res.status}`));
+}

--- a/webchat/locales/en/admin.json
+++ b/webchat/locales/en/admin.json
@@ -69,6 +69,7 @@
     "sessions": "Sessions",
     "activity": "Activity",
     "workspaces": "Workspaces",
+    "skills": "Skills",
     "cron": "Cron",
     "api_keys": "API Keys",
     "admin_connection": "Admin Connection",
@@ -602,6 +603,35 @@
       "run_count": "Run Count",
       "last_run": "Last Run",
       "next_run": "Next Run"
+    }
+  },
+  "skills": {
+    "title": "Skills",
+    "subtitle": "Manage global skills under ~/.agents/skills. External skills (.claude/.hotplex) are read-only.",
+    "action": { "upload": "Upload Skill", "install": "Install" },
+    "label": { "managed": "Managed", "external": "External (read-only)" },
+    "empty": { "title": "No skills installed", "desc": "Upload a skill .zip to install it into the global skills directory." },
+    "dialog": {
+      "upload_title": "Upload Skill",
+      "upload_desc": "Select a .zip whose root has SKILL.md (or a single top-level dir containing it). Aligned with agentskills.io.",
+      "replace": "Replace existing same-name skill",
+      "uploading": "Uploading…"
+    },
+    "error": {
+      "no_file": "Please select a zip file",
+      "not_zip": "Only .zip files are accepted",
+      "already_exists": "Skill already exists — enable \"Replace existing\" to overwrite",
+      "install_failed": "Install failed",
+      "delete_failed": "Delete failed"
+    },
+    "toast": {
+      "installed": "Skill installed",
+      "installed_warning": "Installed — {{warning}}",
+      "deleted": "Skill deleted"
+    },
+    "confirm": {
+      "delete_title": "Delete Skill",
+      "delete_body": "Delete skill \"{{name}}\"? This removes it from the global skills directory and cannot be undone."
     }
   }
 }

--- a/webchat/locales/zh-CN/admin.json
+++ b/webchat/locales/zh-CN/admin.json
@@ -69,6 +69,7 @@
     "sessions": "会话管理",
     "activity": "行为审计",
     "workspaces": "工作区管理",
+    "skills": "技能管理",
     "cron": "定时任务",
     "api_keys": "API 密钥",
     "admin_connection": "管理连接",
@@ -602,6 +603,35 @@
       "run_count": "运行次数",
       "last_run": "上次运行",
       "next_run": "下次运行"
+    }
+  },
+  "skills": {
+    "title": "技能管理",
+    "subtitle": "管理 ~/.agents/skills 下的全局技能。外部技能（.claude/.hotplex）为只读。",
+    "action": { "upload": "上传技能", "install": "安装" },
+    "label": { "managed": "可管理", "external": "外部（只读）" },
+    "empty": { "title": "暂无技能", "desc": "上传 .zip 技能包以安装到全局技能目录。" },
+    "dialog": {
+      "upload_title": "上传技能",
+      "upload_desc": "选择根目录含 SKILL.md（或单个顶层目录内含 SKILL.md）的 .zip 包，对齐 agentskills.io 标准。",
+      "replace": "覆盖同名技能",
+      "uploading": "上传中…"
+    },
+    "error": {
+      "no_file": "请选择 zip 文件",
+      "not_zip": "仅接受 .zip 文件",
+      "already_exists": "技能已存在 — 勾选「覆盖同名」以覆盖",
+      "install_failed": "安装失败",
+      "delete_failed": "删除失败"
+    },
+    "toast": {
+      "installed": "技能已安装",
+      "installed_warning": "已安装 — {{warning}}",
+      "deleted": "技能已删除"
+    },
+    "confirm": {
+      "delete_title": "删除技能",
+      "delete_body": "删除技能 \"{{name}}\"？此操作会从全局技能目录移除，不可撤销。"
     }
   }
 }


### PR DESCRIPTION
## 概述

实施 #910 —— webchat skill 管理 HTTP API 与 zip 上传。依据 \`docs/specs/Skill-Management-Spec.md\`（状态已置 Implemented）。

Closes #910

## 变更

### 后端 \`internal/skills\`
- \`Skill\` 加 \`Managed\`/\`FilePath\`；scanner 区分 managed(\`.agents\`) vs external(\`.claude\`/\`.hotplex\`)
- \`Locator\` 加 \`Invalidate\`/\`InvalidateAll\` + \`ListMerged\`（global + 多 workspace 合并）
- \`zip.go\`：zip-slip/炸弹/恶意 entry/类型白名单 安全管线 + agentskills.io 格式校验
- \`crud.go\`：\`Install\`/\`Read\`/\`Delete\`（scope 参数化，原子 Rename 落盘 + 回滚）

### HTTP API（8 端点）
- \`GET /api/skills\`、\`/api/skills/{name}\`（合并查询）
- \`POST/GET/DELETE /api/workspaces/{wid}/skills\`（owner 校验闸 → 403）
- \`GET/POST/GET/DELETE /admin/api/skills\`（admin Bearer + scope）
- multipart \`MaxBytesReader\` 20MB；workspace 写→\`user_activity\` 审计，admin 写→middleware \`admin_audit\`
- \`pkg/events SkillEntry\` 加 \`Managed\`（wire 向后兼容）

### 前端 webchat
- \`lib/api/skills.ts\` + \`admin-skills.ts\` + 类型
- admin 全局 skill 管理页 + workspace skill 管理页
- 上传组件 + warning toast（同名遮蔽）+ 只读外部标注 + admin-nav 入口
- locales zh-CN/en 同步

### 文档
- \`admin-api.md\` 补 skill 契约（admin 全局 + workspace）
- \`tutorials/skills-setup.md\` 各 Worker 软链引导（CC 专属 \`ln -s\`）

## 安全要点
- zip-slip：\`safeExtractJoin\`（Clean + 拒绝对路径/".." + Join + 前缀校验）+ 显式 HasPrefix 双保险
- 解压炸弹：zip ≤20MB / 解压 ≤50MB / 单文件 ≤5MB / entry ≤500 / 压缩率 >100× 拒
- 恶意 entry：\`IsRegular()\` 过滤 symlink/device/pipe
- 非 owner 越权：\`ws.OwnerUserID != uid && !isAdmin\` → 403
- name 注入：正则 \`^[a-z0-9]+(-[a-z0-9]+)*$\` + 等于父目录名

## 验证
- \`make check\`（test -race + lint + build）✅ All checks passed
- \`make docs-lint\`（swagger + docs-build + 链接校验）✅
- \`pnpm tsc --noEmit\` ✅

## 阶段 0 说明

spec §1.2 的 4 adapter 加载行为已通过官方源码调研确认（Codex \`loader.rs\` / OpenCode \`skills.mdx\` / CC 文档）。真实 worker 实测建议在部署环境进行（CC 软链、Codex/OCS 原生）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)