### PR TITLE
docs(patrol): 2026-07-21 同步 SkillEntry.Managed 字段（issue #910）

### DIFF
--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -958,7 +958,7 @@ Gateway 返回 `skills_list` 事件：
     "type": "skills_list",
     "data": {
       "skills": [
-        { "name": "brainstorming", "description": "Collaborative design brainstorming", "source": "global" },
+        { "name": "brainstorming", "description": "Collaborative design brainstorming", "source": "global", "managed": true },
         { "name": "systematic-debugging", "description": "Structured bug diagnosis", "source": "project" }
       ],
       "total": 2
@@ -974,6 +974,7 @@ Gateway 返回 `skills_list` 事件：
 | `name`        | string   | Skill 名称，全局唯一标识                |
 | `description` | string   | Skill 功能描述                          |
 | `source`      | string   | 来源：`global`（用户级）或 `project`（项目级） |
+| `managed`     | bool     | `true` = 在 `.agents/skills`（UI 可安装/删除）；`omitempty` 时省略 = 只读外部 skill（`.claude`/`.hotplex`），issue #910 |
 
 **完成后 Gateway 自动发送 `done` 事件**，客户端应据此清除 `isRunning` 状态。
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -429,6 +429,13 @@ type SkillsListData struct {
     Total  int          `json:"total"`
     Filter string       `json:"filter,omitempty"`
 }
+
+type SkillEntry struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Source      string `json:"source"`            // "global"（home）或 "project"（workspace/workDir）
+    Managed     bool   `json:"managed,omitempty"` // issue #910：true = 在 .agents/skills（UI 可管理/可写）
+}
 ```
 
 #### `worker_command` — Worker stdio 命令触发


### PR DESCRIPTION
## Summary

自基线 \`310232b7\` 以来 2 个提交，PR #915 为 \`pkg/events.SkillEntry\` 新增 \`Managed\` 字段（\`json:"managed,omitempty"\`）但 \`skills_list\` wire 文档未同步。

- **`reference/events.md`**：补充 \`SkillEntry\` 结构体定义（此前 \`skills_list\` 仅引用 \`Skills []SkillEntry\` 却从未展开，与同文件 \`MCPServerInfo\` 风格不一致）
- **`guides/developer/websocket-integration.md`**：SkillEntry 字段表补 \`managed\` 行；skills_list JSON 示例展示 \`managed:true\`

**未改动**：ocs read-only 拦截修复（#913）让实际行为符合 \`security-model.md\` 已有承诺；\`admin-api.md\` 的 skill 端点文档已由 PR #915 完整覆盖（端点、zip 上传、安全防护、审计、错误码），经核对与 \`routes.go\` 完全一致。

## 验证

`make docs-build` 通过（62 documents，无断链）。

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)