### PR TITLE
docs(patrol): 2026-07-23 文档维护

### DIFF
--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -334,15 +334,18 @@ PATCH 错误码：`400 INVALID_PERMISSION_MODE`（档位非法）/ `400 BAD_REQU
 | GET | `/admin/api/skills` | `admin:read` | 列出全局 skill（`.agents`/`.claude`/`.hotplex` 合并，带 `managed` 标注） |
 | POST | `/admin/api/skills` | `admin:write` | zip 上传安装全局 skill（`?replace=true` 覆盖同名） |
 | GET | `/admin/api/skills/{name}` | `admin:read` | 全局 skill 详情（含 `SKILL.md` 全文 `body` + 包内文件列表 `files`） |
+| PUT | `/admin/api/skills/{name}` | `admin:write` | 在线更新 `SKILL.md` 全文（JSON `{"body":"..."}`，区别于 POST 的 zip 上传） |
 | DELETE | `/admin/api/skills/{name}` | `admin:write` | 删除全局 skill |
 
 **GET /admin/api/skills** — 合并扫描 home 下 `.agents/skills`（`managed:true`，可写）与 `.claude/skills`、`.hotplex/skills`（`managed:false`，只读外部），同名 project 覆盖 global。响应：`{"skills":[{name,description,source,managed}],"total":N}`。GET 不审计。
 
 **POST /admin/api/skills** — multipart 上传，`file` 字段为 `.zip` 包（body 上限 20MB）。zip 根下须直接有 `SKILL.md`，或单一顶层目录内含 `SKILL.md`（目录名必须等于 frontmatter `name`）。frontmatter 必填 `name`（正则 `^[a-z0-9]+(-[a-z0-9]+)*$`，1-64 字符）与 `description`（1-1024 字符）。文件类型白名单：`.md`/`.json`/`.yaml`/`.yml`/`.txt`/`.py`/`.sh`/`.toml`/图片（`.png`/`.jpg`/`.jpeg`/`.svg`）；拒可执行/二进制。`?replace=true` 覆盖同名，否则同名返回 `409`。安装成功返回 `skills.InstallResult`（含 `name`/`description`/`source:"global"`/`managed:true`/`body`/`files`，以及可能的 `warning`）。
 
+**PUT /admin/api/skills/{name}** — 在线更新已存在 skill 的 `SKILL.md` 全文。请求体为 JSON `{"body":"<完整 SKILL.md 文本>"}`（非 multipart、非 zip），仅改写 `SKILL.md`、不动包内其他文件。frontmatter 须合规（`name`/`description` 缺失或 `name` 不匹配正则返回 `400 SKILL_INVALID_FORMAT`），`name` 须为合法 skill 名。仅 `managed`（`.agents/skills`）skill 可改；外部只读 skill（`.claude`/`.hotplex`）返回 `404 SKILL_NOT_FOUND`。成功返回更新后的 skill detail（同 GET 详情结构）。
+
 > 🛡️ **安全**：zip-slip（`SafePathJoin` + 前缀双保险）、解压炸弹（zip ≤20MB / 解压总 ≤50MB / 单文件 ≤5MB / entry ≤500 / 压缩率 >100× 拒）、恶意 entry（`IsRegular()` 过滤 symlink/device）多维防护（spec §3.3 A）。
 
-> 🛡️ **审计**：POST/DELETE 写操作由 middleware 级 `admin_audit` 统一记录，action = `skill.create`（POST，`?replace=true` 时映射为 `skill.update`）/ `skill.delete`（DELETE），actor = uid（Cookie 通道）或 `admin-token`（Bearer）。
+> 🛡️ **审计**：POST/PUT/DELETE 写操作由 middleware 级 `admin_audit` 统一记录，action = `skill.create`（POST，`?replace=true` 时映射为 `skill.update`）/ `skill.update`（PUT）/ `skill.delete`（DELETE），actor = uid（Cookie 通道）或 `admin-token`（Bearer）。
 
 错误码：`400 SKILL_INVALID_ZIP`（损坏/超限/含恶意 entry）/ `400 SKILL_INVALID_FORMAT`（无 SKILL.md / frontmatter 缺失 / name 不合规 / name≠目录名 / description 超长）/ `400 SKILL_FILE_TYPE_BLOCKED`（类型不在白名单）/ `409 SKILL_ALREADY_EXISTS`（同名且未带 `?replace=true`）/ `404 SKILL_NOT_FOUND`（name 不存在）。
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -285,7 +285,7 @@ LLM Provider 返回临时错误（429、529、400 等）时的自动重试配置
 |------|------|--------|----------|------|
 | `command` | string | `claude` | `HOTPLEX_WORKER_CLAUDE_CODE_COMMAND` | Worker 启动命令。支持带子命令，如 `ccr code` |
 | `permission_mode` | string | `""` (= `bypass`) | `HOTPLEX_WORKER_CLAUDE_CODE_PERMISSION_MODE` | Claude Code 的 operator 默认/上限权限模式 tier。对 platform/cron 会话（bridge 注入空 sessionMode）直接作为有效模式；对 workspace 会话作为 permissiveness 上限，有效模式取 session 模式与 operator 的较低者（防越权）。合法值 `read-only`/`workspace`/`auto-edit`/`bypass`/空，空 = `bypass`（向后兼容 legacy 默认）。与 `codex_cli.sandbox`+`approval_mode`、`acp.auto_approve` 对应；区别于 `default_permission_mode`（后者是 bridge 为 workspace 会话解析的有效模式，归一化为 `workspace`） |
-| `permission_prompt` | bool | `false` | — | 启用 `--permission-prompt-tool` stdio 模式。开启后权限请求会转发到 Slack/飞书交互 UI |
+| `permission_prompt` | bool | `true` | — | 启用 `--permission-prompt-tool` stdio 模式。开启后权限请求会转发到 Slack/飞书交互 UI。config.yaml 默认开启（#920），使 headless Worker 的权限请求默认走交互 UI 而非静默拒绝；字段缺省时 Go 零值为 `false`（行为回退为静默拒绝） |
 | `permission_auto_approve` | []string | `["ExitPlanMode"]` | — | 自动批准的工具名称列表（无需转发用户交互 UI） |
 | `mcp_servers` | map | `{}` | — | 用户配置的 MCP Server。空值 = 使用默认发现机制 |
 

--- a/docs/tutorials/skills-setup.md
+++ b/docs/tutorials/skills-setup.md
@@ -98,7 +98,7 @@ ls -l ~/.claude/skills
 
 ## 5. 修改与删除
 
-- **修改 skill** = 重新打包 zip 上传（勾选「覆盖同名」）。不支持在线编辑器。
+- **修改 skill** 有两种方式：① 在线编辑——在 skill 详情的「Body」标签页直接改写 `SKILL.md` 全文并保存（对应 `PUT /admin/api/skills/{name}`，仅 `managed` skill 可改）；② 重新打包 zip 上传覆盖（勾选「覆盖同名」）。两种方式都只更新 `SKILL.md`，包内其他文件需通过 zip 覆盖替换。
 - **删除 skill** = 列表中点击删除。仅 `managed` skill（`.agents/skills` 下）可删；`.claude`/`.hotplex` 下的只读外部 skill 需在文件系统手动删除。
 
 ## 6. REST API
@@ -109,6 +109,11 @@ ls -l ~/.claude/skills
 # 安装全局 skill（admin Bearer）
 curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
   -F "file=@my-skill.zip" "http://localhost:9999/admin/api/skills?replace=true"
+
+# 在线更新全局 skill 的 SKILL.md 全文（admin Bearer）
+curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"body\":\"$(jq -Rs . < SKILL.md)\"}" \
+  "http://localhost:9999/admin/api/skills/my-skill"
 
 # 安装 workspace skill（owner，Cookie 或 API Key）
 curl -X POST -H "X-API-Key: $API_KEY" \


### PR DESCRIPTION
## Summary

映射 `1ad003d5..cd266be5` 变更窗口（22 commits）的文档影响，聚焦 **permission ceiling（#920）** 与 **skill 管理 full CRUD（#910/#919/2d836d8a）** 两大主题。

- **reference/admin-api.md** — 补全 `PUT /admin/api/skills/{name}` 端点（2d836d8a 引入的 full CRUD 缺 Update 行）：表格行 + 端点语义说明（JSON `{"body":"..."}` 在线更新 SKILL.md，区别于 POST zip 上传）+ 审计映射 `skill.update`
- **reference/configuration.md** — `permission_prompt` 默认值 `false`→`true`，对齐 #920 在 config.yaml 默认开启（原文档与 config.yaml:226 矛盾）
- **tutorials/skills-setup.md** — 更新「修改」描述（在线编辑 body / zip 覆盖两种方式，原「不支持在线编辑器」因 PUT 端点 + webchat body 编辑视图已过时）+ REST API 段补 PUT 示例

判定无需修改：session-lifecycle/resource-limits/multi-tenant（permission ceiling 属安全模型，已在 security-model.md/remote-coding-agent.md 覆盖）；audit/metrics（audit.md 已在 #99f8c206 commit 内同步，无新指标）。

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)