### PR TITLE
feat(gateway): SESSION_BUSY mid-turn passthrough + buffer fallback

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -557,6 +557,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	handler.SetAuditCollector(auditCollector)
 	hub.SetAuditCollector(auditCollector)
 	bridge.SetAuditCollector(auditCollector) // tool.call audit (issue #833 P2)
+	bridge.SetPendingReplayer(handler)       // SESSION_BUSY mid-turn replay (done-time fallback)
 
 	if cfg.Worker.AutoRetry.Enabled {
 		log.Info("gateway: LLM auto-retry enabled", "max_retries", cfg.Worker.AutoRetry.MaxRetries, "base_delay", cfg.Worker.AutoRetry.BaseDelay)

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -340,9 +340,23 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	var cronScheduler *cron.Scheduler
 	var cronDelivery *cron.Delivery
 	var cronAttRouter *cronAttachedRouter
+	// bridge is forward-declared (and assigned later at NewBridge) so this
+	// closure can clear busy-supplement buffers on session end. Mirrors the
+	// existing cronScheduler pattern. Nil before assignment — ClearPending is
+	// nil-safe via b.pending guard, but the bridge pointer itself is checked
+	// here to keep the test path (no gateway_run wiring) honest.
+	var bridge *gateway.Bridge
 
 	sm.OnTerminate = func(sessionID string) {
 		log.Info("gateway: session terminated", "session_id", sessionID)
+		// SESSION_BUSY mid-turn cleanup (Task 11): the session is gone (either
+		// TERMINATED or DELETED — see manager.go:notifyStateChange), so any
+		// buffered supplements are stale. Clearing here funnels every end-of-
+		// life path (client /terminate, /delete, /gc, crash cleanup, GC sweep,
+		// HTTP DELETE) through a single hook instead of patching each call site.
+		if bridge != nil {
+			bridge.ClearPending(sessionID)
+		}
 		if cronScheduler != nil {
 			cronScheduler.CleanupForSession(sessionID)
 		}
@@ -515,7 +529,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		log.Debug("config: agent config resolved", "dir", agentConfigDir)
 	}
 
-	bridge := gateway.NewBridge(gateway.BridgeDeps{
+	bridge = gateway.NewBridge(gateway.BridgeDeps{
 		Log:                    log,
 		Hub:                    hub,
 		SM:                     sm,

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -291,6 +291,8 @@ rate(hotplex_cron_duration_sum[5m]) / rate(hotplex_cron_duration_count[5m])
 | `hotplex.execution.duplicate` | Counter | 幂等去重（相同 Envelope ID + payload 静默抑制） |
 | `hotplex.execution.conflict` | Counter | Payload 冲突（相同 Envelope ID，不同 SHA-256 hash） |
 | `hotplex.execution.session_busy` | Counter | Active gate 拒绝（session 已有 pending/running execution） |
+| `hotplex.execution.mid_turn_injected` | Counter | 用户追问在 busy 时被透传注入当前 turn（worker 支持 mid-turn） |
+| `hotplex.execution.supplement_buffered` | Counter | 用户追问在 busy 时被暂存待 done 后重投（worker 不支持 mid-turn 的兜底） |
 | `hotplex.execution.delivery_outcome` | Counter | Worker 投递结果，label: `delivery_status`（delivered / unknown / failed） |
 | `hotplex.execution.runtime_outcome` | Counter | Worker 运行终态，label: `runtime_status`（completed / failed / unknown） |
 | `hotplex.execution.delivery_latency` | Histogram | accept 到 delivery outcome 耗时（秒），bounds: 0.01–10 |

--- a/docs/superpowers/plans/2026-07-25-session-busy-midturn.md
+++ b/docs/superpowers/plans/2026-07-25-session-busy-midturn.md
@@ -1,0 +1,1105 @@
+# IM 渠道 SESSION_BUSY mid-turn 透传 + 兜底 — 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** IM 渠道用户在 turn 执行中追问撞 SESSION_BUSY 时，由 gateway 按 worker 能力分流——支持 mid-turn 的 worker（CC/codex）直接注入当前 turn，不支持的（acp/ocs）gateway 暂存并在 done 后合并重投，消除黑洞。
+
+**Architecture:** gateway `deliverToWorker` 的 `ErrSessionBusy` 分支探测 worker 是否实现 `MidTurnInjector`：是则透传（CC 写 stdin / codex `turn/steer`），否则存入 bridge 的 `PendingBuffer`。文案经 hub 广播 `message`+`Metadata["supplement_mode"]`，三 conn 识别后发各自 i18n 文案。done 时 bridge 异步重投兜底 pending。
+
+**Tech Stack:** Go（gofmt/tab 缩进）、`go.opentelemetry.io/otel/metric`、testify/require、`pkg/events`+`pkg/aep`。
+
+**Spec:** [`docs/superpowers/specs/2026-07-25-session-busy-midturn-design.md`](../specs/2026-07-25-session-busy-midturn-design.md)
+
+## Global Constraints
+
+- **Mutex**：显式 `mu` 字段，不嵌入 struct，不传 `*sync.Mutex` 指针跨函数。
+- **错误**：哨兵 `Err` 前缀；`fmt.Errorf("...: %w", err)` 包装。
+- **测试**：testify/require、table-driven、`t.Parallel()`、单模块 ≤5s（`-count=1 -race`）；禁止 `time.Sleep` 等待异步（用 `require.Eventually` 或 channel）。
+- **改源码用 Edit 工具**，禁止 `sed -i`。
+- **CC `InjectMidTurn` 不得调 `SetLastInput`**（崩溃恢复 `bridge_worker.go` 重投 lastInput，mid-turn 内容污染会导致误重投）——只复用 `writeStreamInputLocked`。
+- **不改 active gate**（partial unique index `idx_execution_one_active_per_session` 不动）。
+- **不改 AEP wire contract**（不新增 event Kind；文案复用 `message` + metadata key）。
+- **mid-turn input 不进 execution ledger**（不占 active gate 槽）。
+- 文案托管在各 messaging 渠道（i18n），gateway 不硬编码渠道文案。
+
+---
+
+## File Structure
+
+| 文件 | 责任 |
+|---|---|
+| `internal/observability/instruments.go` | 新增 `MidTurnInjected`/`SupplementBuffered` counter（仿 `ExecutionSessionBusy`） |
+| `internal/worker/worker.go` | 新增 `MidTurnInjector` 可选接口 |
+| `internal/worker/claudecode/worker.go` | CC 实现 `InjectMidTurn`（复用 `writeStreamInputLocked`，不 `SetLastInput`） |
+| `internal/worker/codexcli/worker.go` | codex 实现 `InjectMidTurn`（调 `manager.SteerTurn`） |
+| `internal/gateway/pending_buffer.go`（新） | `PendingBuffer`（Append/DrainAndMerge/Clear/ClearAll）+ 私有 `cloneForReplay` |
+| `internal/gateway/bridge.go` | `pending *PendingBuffer` 字段 + 代理方法；`PendingReplayer` 接口 + `SetPendingReplayer` late setter |
+| `internal/gateway/bridge_forward.go` | `finishRuntimeOnDone` 成功后异步重投 |
+| `internal/gateway/handler.go` | busy 分支 `handleSupplementOnBusy` + `notifySupplement` + `DeliverReplay` |
+| `cmd/hotplex/gateway_run.go` | 注入 `bridge.SetPendingReplayer(handler)` |
+| `internal/messaging/{feishu,slack,yuanxin}/conn*.go` | message 处理识别 `supplement_mode` 发文案 |
+| `docs/reference/metrics.md` | 记录两个新 counter |
+
+---
+
+## Task 1: 新增 observability metrics
+
+**Files:**
+- Modify: `internal/observability/instruments.go`（Durable Ingress 块，`ExecutionSessionBusy` 附近）
+- Modify: `docs/reference/metrics.md`（Execution 指标表）
+- Test: `internal/observability/instruments_test.go`（若已有 counter 测试模式，跟随）
+
+**Interfaces:**
+- Produces: `observability.MidTurnInjected() metric.Int64Counter`、`observability.SupplementBuffered() metric.Int64Counter`
+
+- [ ] **Step 1: 在 `instruments.go` 的 Durable Ingress `var` 块（`ExecutionSessionBusy` 同块）加两个变量**
+
+```go
+	midTurnInjected       metric.Int64Counter
+	midTurnInjectedInit   sync.Once
+	supplementBuffered    metric.Int64Counter
+	supplementBufferedInit sync.Once
+```
+
+- [ ] **Step 2: 在 `ExecutionSessionBusy()` 访问器（`instruments.go:1122-1134`）后加两个访问器**
+
+```go
+// MidTurnInjected counts user supplements injected into a running turn
+// (worker implements MidTurnInjector; CC headless stream-json / codex turn-steer).
+func MidTurnInjected() metric.Int64Counter {
+	midTurnInjectedInit.Do(func() {
+		var err error
+		midTurnInjected, err = Meter().Int64Counter(
+			"hotplex.execution.mid_turn_injected",
+			metric.WithDescription("User supplements injected into a running turn (mid-turn passthrough)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.execution.mid_turn_injected", err)
+		}
+	})
+	return midTurnInjected
+}
+
+// SupplementBuffered counts user supplements buffered for replay when the
+// worker does not support mid-turn injection (acp/ocs fallback).
+func SupplementBuffered() metric.Int64Counter {
+	supplementBufferedInit.Do(func() {
+		var err error
+		supplementBuffered, err = Meter().Int64Counter(
+			"hotplex.execution.supplement_buffered",
+			metric.WithDescription("User supplements buffered for replay (worker lacks mid-turn support)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.execution.supplement_buffered", err)
+		}
+	})
+	return supplementBuffered
+}
+```
+
+- [ ] **Step 3: 在 `docs/reference/metrics.md` Execution 指标表加两行**
+
+```markdown
+| `hotplex.execution.mid_turn_injected` | Counter | 用户追问在 busy 时被透传注入当前 turn（worker 支持 mid-turn） |
+| `hotplex.execution.supplement_buffered` | Counter | 用户追问在 busy 时被暂存待 done 后重投（worker 不支持 mid-turn 的兜底） |
+```
+
+- [ ] **Step 4: 编译验证**
+
+Run: `go build ./internal/observability/...`
+Expected: 无错误。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/observability/instruments.go docs/reference/metrics.md
+git commit -m "feat(observability): add mid_turn_injected + supplement_buffered counters"
+```
+
+---
+
+## Task 2: 新增 `MidTurnInjector` 可选接口
+
+**Files:**
+- Modify: `internal/worker/worker.go`（`PermissionCeilingReporter` 接口 `:166` 附近）
+
+**Interfaces:**
+- Produces: `worker.MidTurnInjector`（`InjectMidTurn(ctx, content, metadata) error`）
+
+- [ ] **Step 1: 在 `PermissionCeilingReporter` 接口后加新接口**
+
+```go
+// MidTurnInjector is implemented by workers that can accept a user message
+// mid-turn — injecting it into the currently running turn rather than starting
+// a new one. Gateway probes this via type assertion at the SESSION_BUSY branch;
+// workers that don't implement it fall back to pending-buffer replay.
+//
+// Implementations MUST NOT update crash-recovery lastInput: a mid-turn inject
+// is supplemental, not the turn's primary input.
+type MidTurnInjector interface {
+	// InjectMidTurn delivers a user message into the active turn of the worker.
+	// It must return an error if the turn is no longer active (caller falls back
+	// to pending-buffer replay).
+	InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error
+}
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `go build ./internal/worker/...`
+Expected: 无错误。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/worker/worker.go
+git commit -m "feat(worker): add MidTurnInjector optional interface"
+```
+
+---
+
+## Task 3: CC 实现 `InjectMidTurn`
+
+**Files:**
+- Modify: `internal/worker/claudecode/worker.go`（`Input` 方法 `:521` 后）
+- Test: `internal/worker/claudecode/input_test.go`（或 `worker_test.go`，跟随现有 mid-turn/stdin 测试位置）
+
+**Interfaces:**
+- Consumes: `worker.MidTurnInjector`（Task 2）
+- Produces: `(*Worker).InjectMidTurn` —— 复用 `writeStreamInputLocked`（`input.go:43`），**不调 `SetLastInput`**
+
+- [ ] **Step 1: 写失败测试**（验证 InjectMidTurn 写 stdin 且不调 SetLastInput）
+
+```go
+func TestInjectMidTurn_WritesStdinWithoutSetLastInput(t *testing.T) {
+	t.Parallel()
+	w, baseConn := newTestWorkerWithPipeConn(t) // 现有测试 helper：构造 *Worker + *base.Conn（pipe stdin）
+	content := "BONUS: tell me 7+8"
+
+	require.NoError(t, w.InjectMidTurn(t.Context(), content, nil))
+
+	// 断言 stdin 收到 stream-json user 消息
+	frame, err := baseConn.ReadStringFromStdin(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, frame, content)
+	require.Contains(t, frame, `"type":"user"`)
+
+	// 关键约束：InjectMidTurn 不得更新 lastInput（崩溃恢复重投 lastInput）
+	require.Empty(t, baseConn.LastInput(), "InjectMidTurn must not SetLastInput")
+}
+```
+
+> 若 `newTestWorkerWithPipeConn`/`ReadStringFromStdin` helper 不存在，复用现有 `worker_test.go` 里测 `Input` 写 stdin 的 helper（同模式）；`base.Conn.LastInput()` 取值器若未导出，用 `SetLastInput` 后 `LastInput()` 的现有访问路径（确认 `base/conn.go` 暴露）。
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run: `go test ./internal/worker/claudecode/ -run TestInjectMidTurn -count=1`
+Expected: FAIL（`InjectMidTurn` 未定义）。
+
+- [ ] **Step 3: 实现 `InjectMidTurn`**（在 `Input` 方法后插入；复制 `Input` 的 `:539-574` stdin 写段，**去掉 `:575 SetLastInput`**，加 `SetLastIO`）
+
+```go
+// InjectMidTurn delivers a user message into the active turn by writing the
+// same stream-json user frame to stdin. Claude Code (headless --print
+// --input-format stream-json) absorbs it into the running turn rather than
+// queuing a new one (verified by mid-turn injection probe, 2026-07-25).
+//
+// Unlike Input, it MUST NOT call SetLastInput: this is a supplemental inject,
+// not the turn's primary input — crash recovery (bridge_worker.go) replays
+// lastInput and must not replay a mid-turn supplement.
+func (w *Worker) InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error {
+	conn := w.Conn()
+	if conn == nil {
+		return fmt.Errorf("claudecode: not started")
+	}
+	baseConn, ok := conn.(*base.Conn)
+	if !ok {
+		return fmt.Errorf("claudecode: inject requires base conn")
+	}
+	stdin, mu := baseConn.StdinUnlocked()
+	if stdin == nil {
+		return &worker.WorkerError{Kind: worker.ErrKindUnavailable, Message: "claudecode: stdin closed"}
+	}
+	// Mutex acquired inside the closure for the same orphan-write reason as Input
+	// (see Input comment, worker.go:544-554).
+	if err := base.WriteWithCtxBounded(ctx, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		return writeStreamInputLocked(stdin, content)
+	}); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return &worker.WorkerError{
+				Kind:    worker.ErrKindUnavailable,
+				Message: "claudecode: stdin write stalled (worker not reading input)",
+				Cause:   err,
+			}
+		}
+		return fmt.Errorf("claudecode: inject mid-turn: %w", err)
+	}
+	w.SetLastIO(time.Now())
+	return nil
+}
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run: `go test ./internal/worker/claudecode/ -run TestInjectMidTurn -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 5: 确认 `*Worker` 现在满足 `worker.MidTurnInjector`**（编译期断言）
+
+在 `worker.go` 末尾加（或测试文件加）：
+```go
+var _ worker.MidTurnInjector = (*Worker)(nil)
+```
+Run: `go build ./internal/worker/claudecode/`
+Expected: 无错误（若报错说明签名不匹配，修正）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/worker/claudecode/worker.go internal/worker/claudecode/*_test.go
+git commit -m "feat(claudecode): implement InjectMidTurn (reuses stdin write, no SetLastInput)"
+```
+
+---
+
+## Task 4: codex 实现 `InjectMidTurn`
+
+**Files:**
+- Modify: `internal/worker/codexcli/worker.go`（`StopCurrentTurn` `:529` 后）
+- Test: `internal/worker/codexcli/worker_test.go`（跟随现有测试位置）
+
+**Interfaces:**
+- Consumes: `worker.MidTurnInjector`（Task 2）、`(*CodexAppServerManager).SteerTurn(threadID, expectedTurnID, text)`（`manager.go:1093`，已存在）
+- Produces: `(*AppServerWorker).InjectMidTurn`
+
+- [ ] **Step 1: 写失败测试**（mock manager，验证 SteerTurn 被正确参数调用；无 active turn 时返回 error）
+
+```go
+func TestInjectMidTurn_SteersActiveTurn(t *testing.T) {
+	t.Parallel()
+	w := newTestAppServerWorker(t) // 现有 helper
+	w.threadID = "thr_1"
+	w.turnID = "turn_1"
+
+	require.NoError(t, w.InjectMidTurn(t.Context(), "more info", nil))
+
+	calls := w.manager.SteerTurnCalls() // mock 记录
+	require.Len(t, calls, 1)
+	require.Equal(t, "thr_1", calls[0].ThreadID)
+	require.Equal(t, "turn_1", calls[0].ExpectedTurnID)
+	require.Equal(t, "more info", calls[0].Text)
+}
+
+func TestInjectMidTurn_NoActiveTurn(t *testing.T) {
+	t.Parallel()
+	w := newTestAppServerWorker(t)
+	// threadID/turnID 空
+	require.Error(t, w.InjectMidTurn(t.Context(), "x", nil))
+}
+```
+
+> 复用现有 codex 测试里 mock `*CodexAppServerManager` 的模式（`StopCurrentTurn`/`InterruptTurn` 已有测试，照抄 mock）。若 `SteerTurnCalls` 记录器不存在，在 mock manager 上加（同 InterruptTurn mock 模式）。
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run: `go test ./internal/worker/codexcli/ -run TestInjectMidTurn -count=1`
+Expected: FAIL。
+
+- [ ] **Step 3: 实现 `InjectMidTurn`**（照抄 `StopCurrentTurn:529-539` 锁模式）
+
+```go
+// InjectMidTurn steers the active turn with supplemental user input via the
+// app-server turn/steer RPC. Unlike Input (turn/start), it does not start a
+// new turn and does not update lastInput. Returns an error if no turn is
+// active so the gateway can fall back to pending-buffer replay.
+func (w *AppServerWorker) InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error {
+	w.mu.Lock()
+	tid := w.threadID
+	turnID := w.turnID
+	w.mu.Unlock()
+	if tid == "" || turnID == "" {
+		return fmt.Errorf("codexcli: no active turn to steer")
+	}
+	_, err := w.manager.SteerTurn(tid, turnID, content)
+	return err
+}
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run: `go test ./internal/worker/codexcli/ -run TestInjectMidTurn -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 5: 编译期断言**
+
+在 `worker.go` 末尾加：`var _ worker.MidTurnInjector = (*AppServerWorker)(nil)`
+Run: `go build ./internal/worker/codexcli/`
+Expected: 无错误。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/worker/codexcli/worker.go internal/worker/codexcli/*_test.go
+git commit -m "feat(codexcli): implement InjectMidTurn via turn/steer (first caller)"
+```
+
+---
+
+## Task 5: `PendingBuffer` + `cloneForReplay`
+
+**Files:**
+- Create: `internal/gateway/pending_buffer.go`
+- Test: `internal/gateway/pending_buffer_test.go`
+
+**Interfaces:**
+- Consumes: `events.Clone`（`pkg/events/events.go:126`）、`aep.NewID()`（`pkg/aep/codec.go:189`）
+- Produces: `PendingBuffer`（Append/DrainAndMerge/Clear/ClearAll）、`cloneForReplay`
+
+- [ ] **Step 1: 写失败测试**（table-driven：单条原样/多条合并编号/去重/上限20/空/并发）
+
+```go
+func TestPendingBuffer_DrainAndMerge(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		inputs  []string
+		wantSub []string // merged 中应包含的子串
+		single  bool
+	}{
+		{"single passthrough", []string{"继续"}, []string{"继续"}, true},
+		{"multi merged numbered", []string{"继续", "补充", "换角度"},
+			[]string{"3 条消息", "1. 继续", "2. 补充", "3. 换角度"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pb := NewPendingBuffer()
+			env := newInputEnvelope(t, "sess_1", "orig")
+			for _, c := range tc.inputs {
+				pb.Append("sess_1", c, env)
+			}
+			merged, repr, ok := pb.DrainAndMerge("sess_1")
+			require.True(t, ok)
+			require.NotNil(t, repr)
+			if tc.single {
+				require.Equal(t, tc.inputs[0], merged)
+			} else {
+				for _, s := range tc.wantSub {
+					require.Contains(t, merged, s)
+				}
+			}
+			// drain 后清空
+			_, _, ok2 := pb.DrainAndMerge("sess_1")
+			require.False(t, ok2)
+		})
+	}
+}
+
+func TestPendingBuffer_DedupAdjacentAndCap(t *testing.T) {
+	t.Parallel()
+	pb := NewPendingBuffer()
+	env := newInputEnvelope(t, "s", "x")
+	// 相邻完全相同去重
+	pb.Append("s", "同", env); pb.Append("s", "同", env)
+	merged, _, _ := pb.DrainAndMerge("s")
+	require.Equal(t, "同", merged) // 只剩一条
+
+	// 上限 20：塞 25 条，只保留最新 20，合并后编号 1..20
+	for i := 0; i < 25; i++ {
+		pb.Append("s", fmt.Sprintf("m%d", i), env)
+	}
+	merged, _, _ = pb.DrainAndMerge("s")
+	require.Contains(t, merged, "20 条消息")
+	require.Contains(t, merged, "1. m5")  // 最旧保留的是 m5（丢 m0..m4）
+	require.Contains(t, merged, "20. m24")
+}
+
+func TestPendingBuffer_Concurrent(t *testing.T) {
+	t.Parallel()
+	pb := NewPendingBuffer()
+	env := newInputEnvelope(t, "s", "x")
+	done := make(chan struct{})
+	for i := 0; i < 50; i++ {
+		go func() { pb.Append("s", "c", env); done <- struct{}{} }()
+		go func() { pb.DrainAndMerge("s"); done <- struct{}{} }()
+	}
+	for i := 0; i < 100; i++ { <-done }
+}
+
+func TestCloneForReplay_NewIDs(t *testing.T) {
+	t.Parallel()
+	orig := newInputEnvelope(t, "s", "old")
+	orig.Event.Data.(map[string]any)["client_message_id"] = "cmid_orig"
+	c := cloneForReplay(orig, "new content")
+	require.NotEqual(t, orig.ID, c.ID)
+	require.NotEqual(t, "cmid_orig", c.Event.Data.(map[string]any)["client_message_id"])
+	require.Equal(t, "new content", c.Event.Data.(map[string]any)["content"])
+	require.Equal(t, "s", c.SessionID)            // 复用 session
+	require.Zero(t, c.Seq)                          // 由 hub 重分配
+}
+```
+
+`newInputEnvelope` helper（测试文件内）：
+```go
+func newInputEnvelope(t *testing.T, sid, content string) *events.Envelope {
+	t.Helper()
+	return events.NewEnvelope("evt_orig", sid, 0, events.Input, map[string]any{
+		"content":            content,
+		"client_message_id":  "cmid_orig",
+	})
+}
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run: `go test ./internal/gateway/ -run TestPendingBuffer -count=1`
+Expected: FAIL（`PendingBuffer` 未定义）。
+
+- [ ] **Step 3: 创建 `internal/gateway/pending_buffer.go`**
+
+```go
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hrygo/hotplex/pkg/aep"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// maxPendingPerSession caps buffered supplements per session to bound memory.
+const maxPendingPerSession = 20
+
+type pendingEntry struct {
+	content    string
+	envelope   *events.Envelope
+	receivedAt int64
+}
+
+// PendingBuffer holds user supplements that arrived while a session was busy,
+// keyed by sessionID. Only used for workers that do NOT implement
+// MidTurnInjector (acp/ocs fallback); mid-turn-capable workers inject directly.
+type PendingBuffer struct {
+	mu    sync.Mutex
+	items map[string][]pendingEntry
+}
+
+func NewPendingBuffer() *PendingBuffer {
+	return &PendingBuffer{items: make(map[string][]pendingEntry)}
+}
+
+// Append adds a supplement. Adjacent identical content is deduped; over the
+// per-session cap the oldest are dropped to keep the newest.
+func (p *PendingBuffer) Append(sessionID, content string, env *events.Envelope) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	items := p.items[sessionID]
+	if n := len(items); n > 0 && items[n-1].content == content {
+		return
+	}
+	items = append(items, pendingEntry{content: content, envelope: events.Clone(env), receivedAt: time.Now().UnixMilli()})
+	if len(items) > maxPendingPerSession {
+		items = items[len(items)-maxPendingPerSession:]
+	}
+	p.items[sessionID] = items
+}
+
+// DrainAndMerge atomically removes and returns the merged supplement for a
+// session. A single entry is returned verbatim; multiple are joined with a
+// header and 1-based numbering. repr is the last entry's envelope (template
+// for replay). ok is false if nothing was buffered.
+func (p *PendingBuffer) DrainAndMerge(sessionID string) (string, *events.Envelope, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	items := p.items[sessionID]
+	if len(items) == 0 {
+		delete(p.items, sessionID)
+		return "", nil, false
+	}
+	delete(p.items, sessionID)
+	repr := items[len(items)-1].envelope
+	if len(items) == 1 {
+		return items[0].content, repr, true
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "（以下是上一轮执行期间追加的 %d 条消息，请一并处理）\n", len(items))
+	for i, it := range items {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, strings.TrimSpace(it.content))
+	}
+	return b.String(), repr, true
+}
+
+func (p *PendingBuffer) Clear(sessionID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, sessionID)
+}
+
+func (p *PendingBuffer) ClearAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items = make(map[string][]pendingEntry)
+}
+
+// cloneForReplay builds a fresh Input envelope for replay: new id + new
+// client_message_id (avoids UNIQUE(session_id, client_message_id) dedup),
+// replaced content, reused session/owner/metadata, seq=0 (re-assigned by hub).
+// Lives in gateway (not pkg/events) because it needs aep.NewID and pkg/events
+// cannot import pkg/aep (cycle).
+func cloneForReplay(env *events.Envelope, content string) *events.Envelope {
+	c := events.Clone(env) // deep-copies Event.Data map + Metadata
+	c.ID = aep.NewID()
+	c.Seq = 0
+	if data, ok := c.Event.Data.(map[string]any); ok {
+		data["content"] = content
+		data["client_message_id"] = aep.NewID()
+	}
+	return c
+}
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run: `go test ./internal/gateway/ -run "TestPendingBuffer|TestCloneForReplay" -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/pending_buffer.go internal/gateway/pending_buffer_test.go
+git commit -m "feat(gateway): add PendingBuffer + cloneForReplay for busy supplements"
+```
+
+---
+
+## Task 6: Bridge 持有 `PendingBuffer` + `PendingReplayer` late setter
+
+**Files:**
+- Modify: `internal/gateway/bridge.go`（Bridge struct `:43-100`、`SetAuditCollector` `:225` 附近、`NewBridge` 初始化处）
+
+**Interfaces:**
+- Consumes: `PendingBuffer`（Task 5）
+- Produces: `(*Bridge).BufferPending`、`ClearPending`、`ClearAllPending`、`PendingReplayer` 接口、`SetPendingReplayer`、内部 `b.pending`（同包 `bridge_forward` 用）
+
+- [ ] **Step 1: 在 `Bridge` struct 加字段**（`accum`/`accumMu` `:74-82` 附近，遵循 granular mutex 模式）
+
+```go
+	pending   *PendingBuffer   // busy-supplement buffer (acp/ocs fallback)
+	replayer  PendingReplayer  // late-injected (Bridge built before Handler)
+```
+
+- [ ] **Step 2: 在 `NewBridge`（构造函数）初始化 `pending`**
+
+```go
+	pending: NewPendingBuffer(),
+```
+（在 `BridgeDeps` 构造的 struct literal 里加这一行。）
+
+- [ ] **Step 3: 加 `PendingReplayer` 接口 + setter + 代理方法**（`SetAuditCollector:225` 后）
+
+```go
+// PendingReplayer replays a buffered supplement as a fresh input turn.
+// Implemented by Handler (which owns deliverToWorker); injected after Bridge
+// construction via SetPendingReplayer because Bridge is built before Handler.
+type PendingReplayer interface {
+	DeliverReplay(ctx context.Context, env *events.Envelope) error
+}
+
+// SetPendingReplayer late-injects the replay target (Handler). Optional: nil
+// leaves done-time replay disabled (supplements buffered but not replayed).
+func (b *Bridge) SetPendingReplayer(r PendingReplayer) { b.replayer = r }
+
+// BufferPending appends a busy-supplement for the fallback path (worker lacks
+// mid-turn support). Called from Handler's SESSION_BUSY branch.
+func (b *Bridge) BufferPending(sessionID string, env *events.Envelope, content string) {
+	if b.pending != nil {
+		b.pending.Append(sessionID, content, env)
+	}
+}
+
+func (b *Bridge) ClearPending(sessionID string) {
+	if b.pending != nil {
+		b.pending.Clear(sessionID)
+	}
+}
+
+func (b *Bridge) ClearAllPending() {
+	if b.pending != nil {
+		b.pending.ClearAll()
+	}
+}
+```
+
+- [ ] **Step 4: 编译验证**
+
+Run: `go build ./internal/gateway/...`
+Expected: 无错误。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/bridge.go
+git commit -m "feat(gateway): Bridge holds PendingBuffer + PendingReplayer late setter"
+```
+
+---
+
+## Task 7: Handler busy 分支透传/兜底 + `notifySupplement` + `DeliverReplay`
+
+**Files:**
+- Modify: `internal/gateway/handler.go`（busy 分支 `:536-540`、新增三个方法）
+- Test: `internal/gateway/handler_test.go`（跟随现有 busy/SESSION_BUSY 测试位置）
+
+**Interfaces:**
+- Consumes: `worker.MidTurnInjector`、`observability.MidTurnInjected/SupplementBuffered`（Task 1）、`h.bridge.BufferPending`（Task 6）、`h.sm.GetWorker`、`h.hub.SendToSession/NextSeq`
+- Produces: `(*Handler).handleSupplementOnBusy`、`(*Handler).notifySupplement`、`(*Handler).DeliverReplay`
+
+- [ ] **Step 1: 写失败测试**（mock worker：实现 MidTurnInjector → 透传；不实现 → buffer；透传失败 → 回退 buffer）
+
+```go
+type mockMidTurnWorker struct {
+	mockWorker             // 现有 mock，满足 worker.Worker
+	injectErr   error
+	injected    string
+	injectCount int
+}
+
+func (m *mockMidTurnWorker) InjectMidTurn(ctx context.Context, content string, md map[string]any) error {
+	m.injectCount++
+	m.injected = content
+	return m.injectErr
+}
+
+func TestHandleSupplementOnBusy_Passthrough(t *testing.T) {
+	t.Parallel()
+	h, sm := newTestHandler(t) // 现有 helper
+	mw := &mockMidTurnWorker{}
+	sm.worker = mw
+	env := newInputEnvelope(t, "s", "追问")
+
+	err := h.handleSupplementOnBusy(t.Context(), env, "追问")
+	require.NoError(t, err)            // 透传成功不报错
+	require.Equal(t, "追问", mw.injected)
+}
+
+func TestHandleSupplementOnBusy_FallbackBuffer(t *testing.T) {
+	t.Parallel()
+	h, sm := newTestHandler(t)
+	sm.worker = &mockWorkerNoMidTurn{} // 不实现 MidTurnInjector
+	env := newInputEnvelope(t, "s", "追问")
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+	// bridge buffer 收到
+	merged, _, ok := h.bridge.pending.DrainAndMerge("s")
+	require.True(t, ok)
+	require.Equal(t, "追问", merged)
+}
+
+func TestHandleSupplementOnBusy_InjectFailureFallsBack(t *testing.T) {
+	t.Parallel()
+	h, sm := newTestHandler(t)
+	mw := &mockMidTurnWorker{injectErr: errors.New("turn ended")}
+	sm.worker = mw
+	env := newInputEnvelope(t, "s", "追问")
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+	require.Equal(t, 1, mw.injectCount)            // 试了透传
+	merged, _, ok := h.bridge.pending.DrainAndMerge("s")
+	require.True(t, ok)                            // 失败 → 回退 buffer
+	require.Equal(t, "追问", merged)
+}
+```
+
+> 复用现有 `handler_test.go` 的 `newTestHandler`/`mockWorker` 模式（参考现有 SESSION_BUSY 测试）。`newInputEnvelope` 同 Task 5。
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run: `go test ./internal/gateway/ -run TestHandleSupplementOnBusy -count=1`
+Expected: FAIL。
+
+- [ ] **Step 3: 改造 busy 分支**（`handler.go:536-540`）
+
+将：
+```go
+		if errors.Is(err, execution.ErrSessionBusy) {
+			observability.ExecutionSessionBusy().Add(ctx, 1)
+			h.cancelRetryIfNeeded(env.SessionID)
+			return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session has an active execution")
+		}
+```
+改为：
+```go
+		if errors.Is(err, execution.ErrSessionBusy) {
+			observability.ExecutionSessionBusy().Add(ctx, 1)
+			h.cancelRetryIfNeeded(env.SessionID)
+			return h.handleSupplementOnBusy(ctx, env, content)
+		}
+```
+
+- [ ] **Step 4: 实现三个方法**（`deliverToWorker` 后或 `tryInteractionResponse` 后）
+
+```go
+// handleSupplementOnBusy routes a SESSION_BUSY input to mid-turn passthrough
+// (worker implements MidTurnInjector) or the fallback pending buffer.
+func (h *Handler) handleSupplementOnBusy(ctx context.Context, env *events.Envelope, content string) error {
+	if w := h.sm.GetWorker(env.SessionID); w != nil {
+		if inj, ok := w.(worker.MidTurnInjector); ok && !w.IsStopped() {
+			if err := inj.InjectMidTurn(ctx, content, nil); err == nil {
+				observability.MidTurnInjected().Add(ctx, 1)
+				if h.bridge != nil {
+					h.bridge.CaptureInboundEvent(env.SessionID, env.Seq, events.Input, env.Event.Data)
+				}
+				h.notifySupplement(ctx, env.SessionID, "injected")
+				return nil
+			} else {
+				h.log.Warn("gateway: mid-turn inject failed, falling back to buffer",
+					"session_id", env.SessionID, "err", err)
+			}
+		}
+	}
+	if h.bridge != nil {
+		h.bridge.BufferPending(env.SessionID, env, content)
+		observability.SupplementBuffered().Add(ctx, 1)
+		h.notifySupplement(ctx, env.SessionID, "buffered")
+		return nil
+	}
+	return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session has an active execution")
+}
+
+// notifySupplement broadcasts a marker message so platform conns can render
+// their own i18n "supplement accepted" text. Metadata carries the mode
+// ("injected"|"buffered"); Content is empty (conns substitute their text).
+func (h *Handler) notifySupplement(ctx context.Context, sessionID, mode string) {
+	env := events.NewEnvelope(aep.NewID(), sessionID, h.hub.NextSeq(sessionID),
+		events.Message, events.MessageData{Content: ""})
+	env.Metadata = map[string]any{"supplement_mode": mode}
+	_ = h.hub.SendToSession(ctx, env)
+}
+
+// DeliverReplay replays a buffered supplement as a fresh input. Implements
+// bridge.PendingReplayer; active gate is already released by the prior Done.
+func (h *Handler) DeliverReplay(ctx context.Context, env *events.Envelope) error {
+	data, _ := env.Event.Data.(map[string]any)
+	content, _ := data["content"].(string)
+	return h.deliverToWorker(ctx, env, content)
+}
+```
+
+- [ ] **Step 5: 运行测试，确认通过**
+
+Run: `go test ./internal/gateway/ -run TestHandleSupplementOnBusy -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 6: 确认 `*Handler` 满足 `PendingReplayer`**
+
+在 `handler.go` 末尾加：`var _ PendingReplayer = (*Handler)(nil)`
+Run: `go build ./internal/gateway/`
+Expected: 无错误。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/gateway/handler.go internal/gateway/handler_test.go
+git commit -m "feat(gateway): SESSION_BUSY branch — mid-turn passthrough or buffer fallback"
+```
+
+---
+
+## Task 8: `finishRuntimeOnDone` 异步重投
+
+**Files:**
+- Modify: `internal/gateway/bridge_forward.go`（`finishRuntimeOnDone:474`，`FinishRuntime` 成功后 `:527` 附近）
+
+**Interfaces:**
+- Consumes: `b.pending.DrainAndMerge`、`b.replayer`（Task 6）、`cloneForReplay`（Task 5）
+
+- [ ] **Step 1: 写失败测试**（mock replayer，drain 后调用 DeliverReplay 一次；无 pending 不调用）
+
+```go
+func TestFinishRuntimeOnDone_ReplaysPending(t *testing.T) {
+	t.Parallel()
+	b, fc := newTestBridgeWithDoneEnv(t) // 现有 helper：构造 Bridge + forwardContext + Done envelope
+	b.executionStore = newFakeExecStoreWithOpen(t, "s", "exec_1") // 返回可 FinishRuntime 的 open 记录
+	rp := &fakeReplayer{}
+	b.SetPendingReplayer(rp)
+	b.pending.Append("s", "追问", newInputEnvelope(t, "s", "x"))
+
+	b.finishRuntimeOnDone("s", fc, fc.doneEnv)
+
+	require.Eventually(t, func() bool { return rp.calls.Load() == 1 },
+		time.Second, 10*time.Millisecond)
+	require.Equal(t, "追问", rp.lastContent.Load())
+}
+
+func TestFinishRuntimeOnDone_NoPendingNoReplay(t *testing.T) {
+	t.Parallel()
+	b, fc := newTestBridgeWithDoneEnv(t)
+	b.executionStore = newFakeExecStoreWithOpen(t, "s", "exec_1")
+	rp := &fakeReplayer{}
+	b.SetPendingReplayer(rp)
+	b.finishRuntimeOnDone("s", fc, fc.doneEnv)
+	time.Sleep(50 * time.Millisecond) // 给 goroutine 机会（仅此处可接受短 sleep：断言非触发）
+	require.Zero(t, rp.calls.Load())
+}
+```
+
+> `fakeReplayer` 记录 calls/lastContent（atomic）。`newInputEnvelope` 同 Task 5。`newTestBridgeWithDoneEnv`/`newFakeExecStoreWithOpen` 复用现有 bridge_forward 测试模式。
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run: `go test ./internal/gateway/ -run TestFinishRuntimeOnDone_Replays -count=1`
+Expected: FAIL。
+
+- [ ] **Step 3: 在 `finishRuntimeOnDone` 的 success 路径插入重投**
+
+在 `FinishRuntime` err-block 之后、`observability.ExecutionRuntimeOutcome().Add(...)`（`:527`）**之前**插入：
+
+```go
+	// Replay buffered supplements now that the active gate is released. This
+	// method runs under processForwardedEvent's held seq lease, so replay
+	// MUST run async (it re-enters deliverToWorker → acceptInputExecution →
+	// NextSeq); do not call BeginSeqOperation here.
+	if b.pending != nil && b.replayer != nil {
+		if merged, repr, ok := b.pending.DrainAndMerge(sessionID); ok {
+			replayEnv := cloneForReplay(repr, merged)
+			go func() {
+				if err := b.replayer.DeliverReplay(context.Background(), replayEnv); err != nil {
+					b.log.Warn("bridge: supplement replay failed", "session_id", sessionID, "err", err)
+					// replay 又 busy（done 后瞬间被占）：递归存回，等下一个 done
+					b.pending.Append(sessionID, merged, replayEnv)
+				}
+			}()
+		}
+	}
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run: `go test ./internal/gateway/ -run TestFinishRuntimeOnDone -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/bridge_forward.go internal/gateway/bridge_forward_test.go
+git commit -m "feat(gateway): replay buffered supplements after Done (async, lease-safe)"
+```
+
+---
+
+## Task 9: 注入 `SetPendingReplayer`
+
+**Files:**
+- Modify: `cmd/hotplex/gateway_run.go`（`:557-559` `SetAuditCollector` 注入链）
+
+- [ ] **Step 1: 在 `bridge.SetAuditCollector(auditCollector)` 后加一行**
+
+```go
+	bridge.SetPendingReplayer(handler)
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `go build ./cmd/hotplex/...`
+Expected: 无错误。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/hotplex/gateway_run.go
+git commit -m "feat(gateway): wire bridge.SetPendingReplayer(handler)"
+```
+
+---
+
+## Task 10: 三渠道 conn 识别 `supplement_mode` 发文案
+
+**Files:**
+- Modify: `internal/messaging/feishu/conn.go`（message 处理，`WriteCtx:238` 附近）
+- Modify: `internal/messaging/slack/conn_events.go`（`handleDefaultText:137` 或 message 分发处）
+- Modify: `internal/messaging/yuanxin/adapter.go`（`WriteCtx:585` message case）
+- Test: 各渠道 `*_test.go`
+
+**Interfaces:**
+- Consumes: `env.Metadata["supplement_mode"]`、各渠道文案方法（feishu `sendTextMessage:257` / slack `writeWithPostMessage:956` / yuanxin `SendResponse:507`）
+
+- [ ] **Step 1: 飞书 — 在 `WriteCtx` 的 message 分支前检查 mode**
+
+在 feishu `conn.go` message 事件处理入口（展示 text 之前）加：
+```go
+if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+	text := feishuSupplementText(mode) // injected/buffered 文案
+	_ = c.adapter.sendTextMessage(ctx, c.chatID, text)
+	return nil
+}
+```
+文案常量（feishu 包内）：
+```go
+func feishuSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ 已收到，正在当前任务中一并处理"
+	}
+	return "⏳ 已收到，当前任务完成后会自动处理"
+}
+```
+
+- [ ] **Step 2: Slack — 在 `handleDefaultText`（或 message 展示入口）前检查 mode**
+
+```go
+if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+	_ = c.writeWithPostMessage(ctx, slackSupplementText(mode), false)
+	return nil
+}
+```
+```go
+func slackSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ Got it — processing within the current task."
+	}
+	return "⏳ Got it — will process automatically once the current task finishes."
+}
+```
+
+- [ ] **Step 3: yuanxin — 在 `WriteCtx` 的 message case 前检查 mode**
+
+```go
+if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+	return c.adapter.SendResponse(ctx, c, yuanxinSupplementText(mode))
+}
+```
+```go
+func yuanxinSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ 已收到，正在当前任务中一并处理"
+	}
+	return "⏳ 已收到，当前任务完成后会自动处理"
+}
+```
+
+- [ ] **Step 4: 各渠道写测试**（mock envelope 带 `supplement_mode=injected|buffered`，断言文案方法被调用、展示路径不被触发）
+
+示例（feishu）：
+```go
+func TestWriteCtx_SupplementMode_RendersI18nText(t *testing.T) {
+	t.Parallel()
+	c, adapter := newTestFeishuConn(t)
+	for _, mode := range []string{"injected", "buffered"} {
+		env := &events.Envelope{SessionID: "s", Event: events.Event{Type: events.Message},
+			Metadata: map[string]any{"supplement_mode": mode}}
+		require.NoError(t, c.WriteCtx(t.Context(), env))
+		require.Contains(t, adapter.lastSentText, "⏳ 已收到")
+	}
+}
+```
+（slack/yuanxin 同模式，跟随各自现有 `WriteCtx`/`handleDefaultText` 测试 helper。）
+
+- [ ] **Step 5: 运行测试**
+
+Run: `go test ./internal/messaging/feishu/ ./internal/messaging/slack/ ./internal/messaging/yuanxin/ -run Supplement -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/messaging/feishu/conn.go internal/messaging/slack/conn_events.go internal/messaging/yuanxin/adapter.go internal/messaging/*/conn*_test.go
+git commit -m "feat(messaging): recognize supplement_mode metadata, render i18n busy text"
+```
+
+---
+
+## Task 11: 清理路径（conn.Close / CloseSharedState）
+
+**Files:**
+- Modify: `internal/messaging/feishu/conn.go`（`Close`）
+- Modify: `internal/messaging/slack/conn_events.go` 或 `adapter.go`（`Close`）
+- Modify: `internal/messaging/yuanxin/adapter.go`（`Close`）
+- Modify: `internal/messaging/platform_adapter.go`（`CloseSharedState:72`）
+- Test: 相关 `*_test.go`
+
+**Interfaces:**
+- Consumes: `bridge.ClearPending(sessionID)`、`bridge.ClearAllPending()`（Task 6）—— messaging 层调 gateway Bridge 需通过其 HubInterface/现有 bridge 句柄；若 messaging PlatformAdapter 不持有 gateway Bridge，则清理由 gateway 侧 session 生命周期触发（见 Step 1 注）。
+
+- [ ] **Step 1: 确认清理触发点**
+
+> **先勘察**：messaging `PlatformAdapter` 持有的是 messaging `*Bridge`（`platform_adapter.go:14`），不是 gateway Bridge。gateway Bridge 的 `ClearPending`/`ClearAllPending` 无法从 messaging 层直接调。
+>
+> 因此清理挂在 **gateway 侧 session 生命周期**：
+> - `sessionID` 级清理（conn.Close 对应）：gateway 在 session `terminated/deleted` 时调 `bridge.ClearPending(sessionID)`。
+> - 全局清理：gateway 关闭时 `bridge.ClearAllPending()`。
+>
+> 在 `internal/gateway` 找 session 终止/删除路径（session manager delete、bridge shutdown），插入 `ClearPending`/`ClearAllPending`。若现有 session 删除已有 cleanup outbox/钩子，跟随该模式。
+
+在 gateway session 删除/终止路径加：
+```go
+	h.bridge.ClearPending(sessionID)  // 或 b.ClearPending 在 bridge 内部钩子
+```
+在 bridge shutdown（`Close`/`shutdown`）加：
+```go
+	b.ClearAllPending()
+```
+
+- [ ] **Step 2: 写测试**（session 删除后 pending 被清空；bridge shutdown 清空全部）
+
+```go
+func TestPendingClearedOnSessionEnd(t *testing.T) {
+	t.Parallel()
+	b := newTestBridge(t)
+	b.pending.Append("s1", "x", newInputEnvelope(t, "s1", "x"))
+	b.ClearPending("s1")
+	_, _, ok := b.pending.DrainAndMerge("s1")
+	require.False(t, ok)
+}
+```
+
+- [ ] **Step 3: 运行测试 + 编译**
+
+Run: `go test ./internal/gateway/ -run TestPendingCleared -count=1 -race && go build ./...`
+Expected: PASS + 无错误。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/gateway/*.go
+git commit -m "feat(gateway): clear pending buffer on session end and bridge shutdown"
+```
+
+---
+
+## Task 12: 全量验证 + 文档
+
+- [ ] **Step 1: 全量测试（含 race）**
+
+Run: `go test ./... -count=1 -race -timeout 300s`
+Expected: 全绿。
+
+- [ ] **Step 2: 质量门禁**
+
+Run: `make check`（或 `make lint && make test-short`，跟随仓库 `make help`）
+Expected: 通过。
+
+- [ ] **Step 3: 确认设计文档/计划与实现一致**（无残留 `SupplementNotifier` 引用）
+
+Run: `grep -rn "SupplementNotifier\|NotifySupplementAccepted" internal/ cmd/ docs/`
+Expected: 仅 docs/specs 历史段（若有），代码无引用。
+
+- [ ] **Step 4: Commit 收尾**（若有文档微调）
+
+```bash
+git add docs/
+git commit -m "docs(mid-turn): finalize spec/plan after implementation"
+```
+
+---
+
+## Self-Review 结果
+
+**Spec coverage**：设计文档各节均有任务覆盖——MidTurnInjector（T2）、CC/codex 实现（T3/T4）、PendingBuffer（T5）、busy 决策+文案+重投（T6/T7/T8/T9）、三渠道文案（T10）、清理（T11）、metrics（T1）。typed-error 不做（设计已定，无任务，正确）。acp/ocs 不实现 MidTurnInjector → 自动兜底（T7 的 else 分支）。
+
+**Placeholder 风险**：T3/T4/T10 的测试 helper（`newTestWorkerWithPipeConn`/`newTestAppServerWorker`/`newTestFeishuConn` 等）标注"复用现有模式"——这些 helper 在各自 `*_test.go` 已存在（`Input`/`StopCurrentTurn`/`WriteCtx` 已有测试），实施时按现有 mock 跟随；若不存在则按现有同模式创建。T11 Step 1 标"先勘察"——因为 messaging 层不持有 gateway Bridge，清理点的精确位置需实施时确认（设计已锁定挂 gateway session 生命周期）。
+
+**类型一致性**：`MidTurnInjector.InjectMidTurn(ctx, content, metadata)` 签名（T2）== CC/codex 实现（T3/T4）；`PendingReplayer.DeliverReplay(ctx, env)`（T6）== Handler 实现（T7）== bridge_forward 调用（T8）；`PendingBuffer.Append/DrainAndMerge/Clear/ClearAll`（T5）== bridge 代理（T6）== bridge_forward 调用（T8）；`cloneForReplay(env, content)`（T5）== bridge_forward 调用（T8）。一致。

--- a/docs/superpowers/specs/2026-07-25-session-busy-midturn-design.md
+++ b/docs/superpowers/specs/2026-07-25-session-busy-midturn-design.md
@@ -1,0 +1,311 @@
+# IM 渠道 SESSION_BUSY 的 mid-turn 透传 + 兜底设计
+
+**日期：** 2026-07-25
+**状态：** 草案，待 review
+**范围：** `internal/worker`（`MidTurnInjector` 接口 + CC/codex adapter）、`internal/gateway`（busy 决策、`PendingBuffer`、done 重投）、`internal/messaging`（三渠道文案回调）
+**关联：**
+- 演进自 [`2026-07-25-session-busy-pending-replay-design.md`](./2026-07-25-session-busy-pending-replay-design.md)（其兜底部分保留为本设计的 fallback）
+- 不冲突 [`2026-07-16-webchat-follow-up-queue-design.md`](./2026-07-16-webchat-follow-up-queue-design.md)（webchat 前端队列 vs IM gateway 层，范围不重叠）
+- 遵守 [`2026-07-14-durable-ingress-reliability-closure-design.md`](./2026-07-14-durable-ingress-reliability-closure-design.md)（active gate 单活跃约束不动）
+
+---
+
+## 决策摘要
+
+前置设计 `pending-replay` 的核心前提——"SESSION_BUSY 时 gateway 只能暂存 + 合并重投"——**被实测推翻**：hotplex 的 CC worker 跑的是 `claude --print --input-format stream-json`（headless），而该模式**原生支持 mid-turn 注入**——turn 进行中向 stdin 写第二条 user 消息，CC 会把它纳入当前 running turn 消化（随下一个 tool result 体现），而非排队成独立的下一个 turn。codex 则有协议级 `turn/steer` 原语。
+
+因此采用**混合方案**，由 gateway 在 busy 时按 worker 能力分流：
+
+1. **worker 支持 mid-turn（CC、codex）→ 透传**：把追问直接注入当前 running turn（写 worker stdin / 调 `turn/steer`），不创建新 execution、不占 active gate 槽、不暂存。worker 自决如何在当前 turn 内处理——符合"hotplex 不做 input 控制、由 worker 自身决定"的原则。
+2. **worker 不支持（ocs 待定、acp 协议层不可能）→ 兜底**：gateway 暂存 + done 后合并重投（即 `pending-replay` 设计，保留为 fallback）。
+
+**不修改 active gate 单活跃约束**（partial unique index 不动），**不修改 AEP wire contract**。
+
+## 背景与已证实问题
+
+### 黑洞效应（沿用 pending-replay 背景）
+
+PR #890 引入 active gate 后，每 session 同时只允许一个 `pending/running` execution。用户在长任务执行中追问，新消息撞 `SESSION_BUSY` 被直接丢弃，各 IM 渠道用通用兜底文案通知用户，造成黑洞效应与误判故障（飞书 `handler.go:242`、Slack `conn_events.go:86`、yuanxin 仅 `Log.Error`）。
+
+### pending-replay 设计的局限
+
+`pending-replay` 假设"busy 时只能 gateway 暂存合并重投"，方案是 `SESSION_BUSY → 存 PendingBuffer → done 后合并为一条 input 重投`。它把追问**延后到下一个 turn** 处理，而非让 worker 在**当前 turn** 内消化。这在 worker 原生支持 mid-turn 注入时是次优的——多了一次 turn 往返、丢失了"并入当前推理"的自然语义。
+
+### 方向转变的依据：CC mid-turn 能力实测
+
+在 headless `--print --input-format stream-json --output-format stream-json --verbose` 模式下实测（CC 2.1.212）：
+
+- **t=0** 发 prompt1："用 Bash 跑 `sleep 12`，完成后只回 SLEEP_DONE"
+- CC 决定调 Bash sleep（`tool_use` 1 次），turn 进入工具执行窗口
+- **t=7**（sleep 仍在跑）注入 prompt2："BONUS: 7+8=? 必须在回复里包含 BONUS=15"
+- CC 在 sleep 完成后生成最终回复，**同时含 `SLEEP_DONE` 与 `BONUS=15`**
+- **只有 1 个 `result` 事件**，`num_turns:2`，`stop_reason:end_turn`，`duration_ms:29938`
+
+最硬的证据是 CC 自己的 thinking 原文：
+
+> "Now a new message came in... **In Claude Code, these mid-turn messages are genuinely from the user** and represent legitimate instructions."
+
+**结论**：CC 客户端在工具执行期间持续读 stdin，把中途注入的 user message 纳入**当前 agentic turn**（turn1 调 sleep → turn2 收 tool_result + BONUS → 同一个 result 输出两者），**而非排队成独立的下一个 result**。hotplex 现有架构（`--print --input-format stream-json` + 常驻 stdin）物理通道已具备，仅被 gateway 的 active gate 在 execution 层挡住。
+
+**两个诚实的 caveat**：
+1. 实测后端为 glm-5.2（代理），但"mid-turn 读 stdin"是 CC 客户端行为，与后端模型无关，结论对 CC 客户端成立。
+2. 实测覆盖"工具执行期间"的 mid-turn（最常见追问时机）；纯文本 streaming 期间的注入未单独测，但 control 协议（`internal/worker/claudecode/control.go` 双向 control_request/response）证明 CC 在 turn 进行中持续读 stdin，机制应一致。
+
+## 错误识别：不引入 typed error（与 pending-replay 的关键差异）
+
+`pending-replay` 计划新增 `pkg/events.CodedError` 让各渠道 `errors.As` 识别 `SESSION_BUSY`。**本设计不做**：混合方案下，busy 时 gateway 内部完成透传或兜底，**不再向渠道返回 `SESSION_BUSY` error**（透传/兜底均视为"已处理"，不报错）。渠道改通过 bridge→adapter 回调（见下）得知"追问已被接收"，无需 catch error。故：
+
+- `sendErrorf`（`internal/gateway/errors.go:14`）**不改**，继续用于真正的 internal error / 真正需要拒绝的场景。
+- `pkg/events` 不新增 `CodedError`，无 AEP wire contract 变动。
+
+> 透传失败回退兜底时，错误在 gateway 内部处理（log + 走兜底），也不冒泡到渠道。
+
+## 架构：gateway 统一 busy 决策
+
+busy 决策集中在 `internal/gateway/handler.go` 的 `deliverToWorker`（`:536` 当前 `ErrSessionBusy` 拒绝点）。改造后：
+
+```
+deliverToWorker → acceptInputExecutionWithRetry 返回 ErrSessionBusy
+  └─ w := sm.GetWorker(env.SessionID)
+     ├─ w 实现 MidTurnInjector（且 worker 未 stopped）
+     │    → 透传：err := w.InjectMidTurn(ctx, content, md)
+     │       ├─ err == nil：
+     │       │    observability.MidTurnInjected().Add(ctx, 1)
+     │       │    bridge.CaptureInboundEvent(sid, seq, Input, data)  // 最低可观测
+     │       │    h.notifySupplement(sid, "injected")   // hub 发 message(metadata mode)→ conn 发"正在处理"文案
+     │       │    return nil（透传成功，不报错）
+     │       └─ err != nil（极小竞态：done 与 inject 同时，turn 已结束）：
+     │            落入兜底分支（见下）
+     └─ else（acp/ocs 不实现 MidTurnInjector，或透传失败回退）
+          → 兜底：bridge.BufferPending(env.SessionID, env, content)
+            observability.SupplementBuffered().Add(ctx, 1)
+            h.notifySupplement(sid, "buffered")   // hub 发 message(metadata mode)→ conn 发"完成后处理"文案
+            return nil（已暂存，不报错）
+```
+
+三处接入点均已确认：
+- busy 分支：`handler.go:536`（现 `return sendErrorf(... SESSION_BUSY)`）
+- 透传蓝本：`tryInteractionResponse`（`handler.go:405`）直接 `w.Input()` 绕 execution + `CaptureInboundEvent`（`:412`）
+- done 重投：`bridge_forward.go:507`（`FinishRuntime` 成功后，active gate 已释放）
+
+## Worker 能力声明（新增可选接口）
+
+仿现有可选接口模式（`PermissionCeilingReporter` `worker.go:166`、`ControlRequester`），新增 duck-type 接口，实现即声明支持：
+
+```go
+// internal/worker/worker.go
+
+// MidTurnInjector is implemented by workers that can accept a user message
+// mid-turn — injecting it into the currently running turn rather than starting
+// a new one. Gateway probes this via type assertion at the SESSION_BUSY branch;
+// workers that don't implement it fall back to pending-buffer replay.
+type MidTurnInjector interface {
+    // InjectMidTurn delivers a user message into the active turn of the worker.
+    // It must return an error if the turn is no longer active (caller falls back).
+    InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error
+}
+```
+
+gateway 探测：
+
+```go
+inj, ok := w.(worker.MidTurnInjector)
+if ok && !w.IsStopped() {
+    // 透传
+}
+```
+
+| Worker | 实现 | 说明 |
+|---|---|---|
+| **CC** | `InjectMidTurn` = 写 stdin 同一 stream-json user 消息（复用 `writeStreamInputLocked` `input.go:43` 的内核） | 实测证明 turn 进行中写 → CC 当 mid-turn 吸收。**无需新协议、无需新方法实质逻辑**，仅包一层以满足接口 |
+| **codex** | `InjectMidTurn` = `manager.SteerTurn(threadID, turnID, content)` | `SteerTurn` 已实现（`codexcli/manager.go:1093`），`threadID`（`worker.go:104`）/`turnID`（`worker.go:105`）已跟踪。照抄 `StopCurrentTurn`（`worker.go:529`）模式 |
+| **ocs / acp** | 不实现 | acp `call` 阻塞到 turn 结束（`acp/client.go:279`），协议层不可能 mid-turn → 兜底。ocs 行为由 `opencode serve` 决定，本轮按不支持处理（兜底），未来可加 |
+
+### codex 过期 turnID 竞态处理
+
+`w.turnID` 在 turn 结束（`turn/completed`/`turn/failed`）时**不会被清除**（mapper `mapNotifTurnCompleted`/`mapTurnFailed` 不碰 turnID）。若 `InjectMidTurn` 在 turn 已结束后调用，`SteerTurn` 传旧 `expectedTurnID` 会被上游拒绝（`manager.go:1091` 注释："the request fails if it does not match"）。
+
+**处理（最小改动，不在 worker 内清 turnID）**：
+- busy 时 session 必然 active（有 running execution 才会 busy），故 turn 活跃，`InjectMidTurn` 安全。
+- 极小竞态窗口（done 与 inject 同时）：`InjectMidTurn` 返回 error → gateway **自动回退兜底**（见架构流程图的 `err != nil` 分支）。
+- 无需新增 mapper→worker 信号路径、无需 activeTurn bool 字段。
+
+> codex 的 `turn/steer` 能力目前**全仓库零 caller**（预留），本设计首次接线。建议实施时补 codex steer 集成测试（CC 已实测，codex 基于代码分析 + 协议原语存在）。
+
+## 兜底路径（保留 pending-replay，仅对不支持 worker）
+
+`PendingBuffer` 放 **gateway/Bridge 层**（不放 messaging——done 触发点 `finishRuntimeOnDone` 在 bridge，放这避免跨层）。bridge 持有：
+
+```go
+// internal/gateway/bridge.go
+type Bridge struct {
+    ...
+    pendingMu sync.Mutex
+    pending   map[string][]pendingEntry  // sessionID → 追问条目
+}
+
+type pendingEntry struct {
+    content    string
+    envelope   *events.Envelope  // 原消息 envelope（含 sessionID/owner/metadata）
+    receivedAt int64
+}
+```
+
+方法（沿用 pending-replay 设计）：
+
+| 方法 | 行为 |
+|---|---|
+| `BufferPending(sid, env, content)` | 追加；相邻完全相同 content 去重；超 `maxPendingPerSession`（默认 20）丢最旧保最新 |
+| `DrainAndMerge(sid) (merged string, repr *Envelope, ok bool)` | 原子取出并清空；单条原样、多条加合并头+编号；repr 取最后一条 envelope 作重投模板 |
+| `Clear(sid)` / `ClearAll()` | 清理 |
+
+**done 时重投**（`bridge_forward.go:527` `FinishRuntime` 成功后）：
+
+Bridge 不持有 Handler 引用（Bridge 先于 Handler 构造），故新增 narrow 接口 + late setter（仿 `SetAuditCollector:227`），在 `gateway_run.go:557` 注入 `bridge.SetPendingReplayer(handler)`：
+
+```go
+// internal/gateway/bridge.go
+type PendingReplayer interface {
+    DeliverReplay(ctx context.Context, env *events.Envelope) error
+}
+```
+
+`finishRuntimeOnDone` success 后（注意该方法运行在**已持有的 seq lease** 下，重投必须 goroutine 异步、不重入 `BeginSeqOperation`）：
+
+```go
+if merged, repr, ok := b.pending.DrainAndMerge(sessionID); ok && b.replayer != nil {
+    replayEnv := cloneForReplay(repr, merged)  // gateway 私有 helper
+    go func() { _ = b.replayer.DeliverReplay(context.Background(), replayEnv) }()
+}
+```
+
+`Handler.DeliverReplay` 实现走 `deliverToWorker`（重新 accept，此时 active gate 已释放、不会 busy）。
+
+- 重投用**新 `client_message_id`**：`cloneForReplay` 调 `events.Clone`（深拷贝 Data/Metadata）+ 换 `env.ID`=`aep.NewID()` + 写 `data["client_message_id"]=aep.NewID()`，避免 `UNIQUE(session_id, client_message_id)` 去重误判。
+- 重投又 busy（done 后瞬间被占，极端）：递归 `BufferPending` 回去，等下一个 done。
+- `cloneForReplay` 放 **gateway 内部**（`pending_buffer.go`）：`pkg/events` 不能 import `pkg/aep`（循环依赖），故 helper 不放公共包。
+
+### 合并格式
+
+- **单条**：原样，不注入框架文本。
+- **多条**（`DrainAndMerge` 输出）：
+
+```
+（以下是上一轮执行期间追加的 3 条消息，请一并处理）
+1. 继续
+2. 补充：重点关注金融领域
+3. 换个角度
+```
+
+条目按收到时序编号；content 原文忠实保留，仅 `SanitizeText` 清洗。
+
+## 文案与即时反馈机制（不改 AEP）
+
+**基于代码勘察的简化**：当前 busy 信号已经有一条现成的 hub→conn 通道——gateway `sendErrorf` 发 Error envelope → hub `SendToSession` → 各 conn `handleError`（feishu `conn.go:363` / slack `conn_events.go:73` / yuanxin `adapter.go:606`）用 `ExtractErrorMessage` 取文案、走**通用错误兜底**（这正是误导文案的来源）。三 conn 均不区分 Error Code。
+
+注意：gateway `Bridge` 与 messaging `Bridge` 是两层不同对象，gateway Bridge **不持有** messaging platform adapter。因此原草案的 `SupplementNotifier`/`NotifySupplementAccepted`/bridge→adapter 反向持有不可行且多余——**去掉**。
+
+正确做法：复用 hub 广播，但用 `message` envelope + metadata 标记（非 error，避免误终端态）：
+
+- gateway busy 透传/兜底后，发一个 `message` envelope via `h.hub.SendToSession`，`Metadata["supplement_mode"] = "injected"|"buffered"`，Content 空。
+- 三渠道 conn 的 message 处理入口（feishu `WriteCtx` `conn.go:238` / slack `handleDefaultText` `conn_events.go:137` / yuanxin `WriteCtx` `adapter.go:585`）先检查 `env.Metadata["supplement_mode"]`：非空则调各渠道文案发送（feishu `sendTextMessage:257` / slack `writeWithPostMessage:956` / yuanxin `SendResponse:507`），用自己的 i18n 文案、不展示空 Content；否则正常展示 worker 输出。
+- 文案在各 messaging 渠道（符合 i18n 规范）：
+  - injected：`⏳ 已收到，正在当前任务中一并处理`
+  - buffered：`⏳ 已收到，当前任务完成后会自动处理`
+- gateway 不硬编码渠道文案，不新增 AEP wire event（复用 `message` + metadata key）。
+- webchat 不撞 busy（前端 follow-up queue 管控），收不到该 envelope；多 conn 场景若收到，显示空 Content（可接受，webchat 前端优化留 follow-up）。
+
+## 各渠道接入（每渠道一处）
+
+三渠道（`feishu`/`slack`/`yuanxin`）只需实现 `NotifySupplementAccepted` 回调，按 mode 发对应文案。**不再各自 `errors.As` 检测 `SESSION_BUSY`**（混合方案下渠道收不到 busy error）。
+
+- busy 分支与 done 重投全在 gateway 层，渠道零决策逻辑。
+- yuanxin 当前 busy 只 `Log.Error`（无用户提示），本改动补上提示，顺带消除其黑洞。
+
+## 清理
+
+| 时机 | 动作 |
+|---|---|
+| 透传 | 无状态，无需清理 |
+| `ReplayPendingIfNeeded`（done 重投）后 | `DrainAndMerge` 已清空 |
+| 各渠道 `conn.Close` | `Clear(sessionID)` |
+| `PlatformAdapter.CloseSharedState` | `ClearAll()` |
+| reset | sessionID 变更，旧 buffer 随旧 conn.Close 清理；新 session 天然隔离 |
+
+**不主动超时**：长任务不应丢消息；生命周期由 session 兜底。
+
+## 边界与异常
+
+- **透传 mid-turn input 不进 execution ledger**（不占 active gate 槽），但加 metric（`mid_turn_injected_total` / `supplement_buffered_total`）+ `CaptureInboundEvent` 保最低可观测。重启时透传 mid-turn 状态无持久化（CC 自身 agentic loop 持有），可接受。
+- **透传不污染崩溃恢复 lastInput**：CC `InjectMidTurn` 必须复用 `writeStreamInputLocked`（`input.go:43`）的 stdin 写内核，**不得调完整 `w.Input`**——否则 `SetLastInput` 会把 mid-turn 内容写入 lastInput，崩溃恢复（`bridge_worker.go` 重投 lastInput）将误重投 mid-turn 而非原 turn input。codex `InjectMidTurn` 走 `SteerTurn`、不经 `turn/start`，同样不更新 lastInput。
+- **重投用新 id**：`events.CloneForReplay` 生成新 `client_message_id`，避免去重误判。
+- **多 session 隔离**：buffer 按 `sessionID`，天然隔离。
+- **重投又 busy**：递归 `BufferPending`，等下一个 done。
+- **透传失败回退**（codex 极小竞态、CC stdin 写失败）：`InjectMidTurn` 返回 error → gateway 落入兜底。
+- **reset 期间**：旧 buffer 随旧 conn.Close 清理；新 session 无 pending。
+- **合并后 Worker 处理失败**：属正常 turn 错误，走各渠道现有 error 展示，不影响 pending 机制。
+- **Worker 卡死永不 done**：lease 过期 → fence → fresh worker；兜底 buffer 残留由 `conn.Close`/`CloseSharedState` 兜底清理。
+
+## 测试要点
+
+- **CC 透传**：busy → `InjectMidTurn` 写 stdin → CC 在当前 turn 消化（mock CC 进程或集成实测）。
+- **codex 透传**：busy → `SteerTurn` 调用，`threadID`/`turnID` 正确；`SteerTurn` 失败（过期 turnID）→ 回退兜底。
+- **透传失败回退**：`InjectMidTurn` 返回 error → 落入 `BufferPending`。
+- **兜底完整链路**：busy → buffer → done → `DrainAndMerge` → 合并重投（基座单测，mock worker 不实现 `MidTurnInjector`）。
+- **合并顺序与编号格式**；单条原样（无合并头）。
+- **上限 20 截断**（保最新）；相邻完全相同 content 去重；不同 content 不去重。
+- **重投新 id**；`seq` 由 Handle 重分配。
+- **worker 能力探测**：实现 `MidTurnInjector` 走透传；不实现走兜底。
+- **并发**：`BufferPending` 与 `DrainAndMerge` 并发安全（`-race`）；透传 stdin 写与 control 写的锁复用。
+- **三渠道文案**：injected / buffered 两 mode 各发对应文案；yuanxin 不再黑洞。
+- **清理**：reset / `conn.Close` / `CloseSharedState`。
+
+## 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `internal/worker/worker.go` | 新增 `MidTurnInjector` 接口 |
+| `internal/worker/claudecode/worker.go` | 实现 `InjectMidTurn`（复用 `writeStreamInputLocked`） |
+| `internal/worker/codexcli/worker.go` | 实现 `InjectMidTurn`（调 `manager.SteerTurn`） |
+| `internal/gateway/handler.go` | `:536` busy 分支改造：透传/兜底决策；`notifySupplement`（hub 发 message+metadata）；`DeliverReplay`（实现 `PendingReplayer`） |
+| `internal/gateway/pending_buffer.go`（新） | `pendingEntry` + `PendingBuffer`：`BufferPending`/`DrainAndMerge`/`Clear`/`ClearAll`（去重+上限20）；私有 `cloneForReplay`（`events.Clone`+`aep.NewID`，写新 `client_message_id`） |
+| `internal/gateway/bridge.go` | `pending *PendingBuffer` 字段；`PendingReplayer` 接口 + `SetPendingReplayer` late setter（仿 `SetAuditCollector:227`）；`Clear`/`ClearAll` 代理 |
+| `internal/gateway/bridge_forward.go` | `:527` done 成功后 `DrainAndMerge` + goroutine 异步 `replayer.DeliverReplay`（避开 seq lease） |
+| `cmd/hotplex/gateway_run.go` | `:557` 注入 `bridge.SetPendingReplayer(handler)` |
+| `internal/messaging/{feishu,slack,yuanxin}/conn*.go` | message 处理入口识别 `Metadata["supplement_mode"]`，调各自文案方法（feishu `sendTextMessage:257` / slack `writeWithPostMessage:956` / yuanxin `SendResponse:507`） |
+| 对应 `*_test.go` | 透传单测、兜底单测、codex steer、竞态回退、三渠道 mode 文案识别、`-race` |
+
+## 关键决策与理由
+
+| 决策 | 选择 | 理由 |
+|---|---|---|
+| 总体策略 | 混合：透传优先 + 不支持兜底 | CC/codex 原生支持 mid-turn，透传最自然；acp 不可能，兜底保底 |
+| 透传位置 | gateway 层统一决策 | busy 检测、worker 接口、active gate 都在 gateway；messaging 只管文案 |
+| Worker 能力声明 | 可选接口 `MidTurnInjector`（duck-type） | 符合现有 `PermissionCeilingReporter` 模式；不实现者自动兜底，零特判 |
+| CC 透传实现 | 复用 stdin stream-json 写 | 实测证明 turn 进行中写 = mid-turn 吸收，无需新协议 |
+| codex 透传实现 | 调已有 `SteerTurn` | 协议级 mid-turn 原语已存在，仅需接线（首次 caller） |
+| codex 过期 turnID | 不清，靠 busy 必 active + 失败回退 | 最小改动；竞态由兜底覆盖 |
+| 兜底位置 | gateway/Bridge 层 | done 触发点在 bridge，避免跨层（pending-replay 放 messaging 的改进） |
+| typed error（CodedError） | **不做** | 混合方案 busy 不返回渠道，无消费者；简化 |
+| 文案机制 | hub 广播 `message` + `Metadata["supplement_mode"]`，三 conn 识别发文案 | 复用现有 hub→conn 通道，不改 AEP，文案留 messaging 层；gateway Bridge 无需反向持有 messaging adapter |
+| done 重投回桥 | `PendingReplayer` narrow 接口 + late setter（仿 `SetAuditCollector`） | Bridge 先于 Handler 构造、无 handler 引用；用接口避免循环耦合 |
+| 透传即时反馈 | 发提示 | IM 渠道 worker 回复可能很久，用户需即时确认追问没丢 |
+| 透传 ledger | 不进（仅 metric） | 不占 active gate；mid-turn 状态由 worker agentic loop 持有 |
+| 超时 | 不主动超时 | 随 session 清理；长任务不应丢消息 |
+| 单 session 上限 | 20 条（兜底） | 防滥用与内存；超出保留最新 |
+
+## 非目标
+
+- 不改 active gate 单活跃约束与 partial unique index。
+- 不引入 gateway 层 `ExecutionQueue`（issue #868）。
+- 不做交互式卡片（pending-replay 方案 C，未来可选）。
+- 不自动重投 delivery `unknown` 的输入。
+- 不持久化兜底 pending（仅内存；gateway 重启时 in-flight 暂存丢失，可接受——用户会重发）。
+- 不为 ocs 本轮实现 mid-turn（本轮按兜底；未来 `opencode serve` 若支持可加）。
+- WebChat 不涉及：前端已有 follow-up queue（`2026-07-16-webchat-follow-up-queue-design.md`，stop-and-send + 可编辑 FIFO 队列），范围不重叠。
+
+## 与现有设计的关系
+
+- **演进 `2026-07-25-session-busy-pending-replay-design.md`**：其兜底（PendingBuffer / 合并重投）保留为本设计对不支持 worker 的 fallback；新增 mid-turn 透传为主路径。两者不矛盾，pending-replay 的合并格式、上限、去重逻辑直接复用。
+- **不冲突 `2026-07-16-webchat-follow-up-queue-design.md`**：该设计是 webchat **前端**页面级 FIFO 队列（stop-and-send），明确边界"不修改 Slack/飞书/Cron 入站行为"；本设计是 **gateway/messaging 层** mid-turn，聚焦 IM 渠道。该设计 :98 "不引入 Worker 原生 mid-turn steering" 是其前端设计的边界选择（彼时未验证 CC 支持），不约束 IM 层——本设计以 CC 实测为据，在 IM 层引入 mid-turn。
+- **遵守 `2026-07-14-durable-ingress-reliability-closure-design.md`**：active gate 单活跃不变；透传注入当前 turn（不开第二个 execution），不触发"避免重复副作用"（该不变量针对重投，非注入）。

--- a/docs/superpowers/specs/2026-07-25-session-busy-pending-replay-design.md
+++ b/docs/superpowers/specs/2026-07-25-session-busy-pending-replay-design.md
@@ -1,0 +1,246 @@
+# IM 渠道 SESSION_BUSY 暂存与合并重投设计
+
+**日期：** 2026-07-25
+**状态：** 已批准，待实施
+**范围：** `internal/messaging`（共享基座 + 飞书/Slack/yuanxin 三渠道接入）、`pkg/events`（typed error）、`internal/gateway/errors.go`（小改）
+**关联：** [Durable Ingress 可靠性闭环设计](./2026-07-14-durable-ingress-reliability-closure-design.md)（PR #890，引入 active gate）；issue #868（ExecutionQueue，本轮非目标）
+
+## 决策摘要
+
+PR #890 引入 active gate 后，每个 session 同时只允许一个 `pending/running` execution。
+当用户在长任务执行中追问，新消息撞 `SESSION_BUSY` 被直接丢弃，且各 IM 渠道用通用兜底文案
+通知用户，造成**黑洞效应**与**误判故障**。该问题**跨渠道**：飞书（`handler.go:242`
+“抱歉，处理您的请求时遇到问题”）、Slack（`conn_events.go:86` “An internal error occurred.
+Please try again or use /reset.”）、yuanxin（消息处理只 `Log.Error` 后返回）均有。
+
+本设计**不修改 gateway 的 active gate 单活跃约束**（durable ingress 设计刻意保留的底线），
+在 messaging 共享基座做“暂存 + 合并重投”，三渠道统一复用：
+
+1. `SESSION_BUSY` 时，把追问（content + 原 envelope）append 到 `PlatformAdapter` 的
+   per-session pending 列表，回复渠道各自的静默提示。
+2. 当前 turn `done` 后，合并列表所有条目为一条 input，一次性投递给 Worker。
+3. 不主动超时，pending 随 session 销毁 / reset / close 清理。
+
+**合并而非逐条**：用户连发多条追问时合并成一个 turn，避免逐条串行慢队列，仍单活跃。
+**共享基座**：`PendingBuffer` 与重投逻辑放 `internal/messaging`，三渠道仅各接两个点
+（busy 时 append + 提示文案、done 时触发重投），重投逻辑零重复——得益于通用的
+`Bridge.MakeEnvelope`。
+
+## 背景与已证实问题
+
+### 行为变更溯源
+
+- v1.34.x 及更早：`deliverToWorker` 无 active gate，新消息直接投 `Worker.Input`。
+- v1.35.0（PR #890）：`idx_execution_one_active_per_session` partial unique index 强制
+  每 session 单活跃，`ErrSessionBusy` 硬拒绝；队列被有意列为非目标。
+
+### 黑洞效应三重成因
+
+1. **消息丢弃**：`SESSION_BUSY` 时不排队、不暂存，直接拒绝。
+2. **文案误导**：各渠道无 `SESSION_BUSY` 专门处理，走通用兜底，用户误判故障。
+3. **时机矛盾**：typing indicator / placeholder card 在报错前已发出。
+
+### 运行时佐证（2026-07-25）
+
+session `9b1aae6d` 的“执行”任务 `running` 30+ 分钟，用户 11:56/11:57/12:03 连续追问 3 次
+全部 `SESSION_BUSY`（`feishu/chat_queue.go:113` 记录 `err="SESSION_BUSY: ..."`）。
+
+## 错误识别（唯一的 gateway 接触点）
+
+`sendErrorf`（`internal/gateway/errors.go:14`）当前返回 `fmt.Errorf("%s: %s", code, msg)`，
+错误码仅在字符串前缀。改为返回 `pkg/events.CodedError`，各渠道 `errors.As` 识别：
+
+```go
+// pkg/events
+type CodedError struct {
+    Code ErrorCode
+    Err  error
+}
+func (e *CodedError) Error() string { return string(e.Code) + ": " + e.Err.Error() }
+func (e *CodedError) Unwrap() error { return e.Err }
+```
+
+放 `pkg/events` 避免循环依赖。仅类型化，不动 active gate 控制流，不改 error event 发送
+（event 已携带 `Code`）。
+
+## 共享设计（internal/messaging）
+
+### PendingBuffer（新增 `pending_buffer.go`）
+
+挂在 `PlatformAdapter`，按 `sessionID` 索引。
+
+```go
+type pendingEntry struct {
+    content    string             // 追问原文
+    envelope   *events.Envelope   // 原消息 envelope 副本（含 sessionID/owner/metadata）
+    receivedAt int64              // unix milli
+}
+
+type PendingBuffer struct {
+    mu    sync.Mutex
+    items map[string][]pendingEntry
+    log   *slog.Logger
+}
+```
+
+**存原 envelope 而非 pctx**：envelope 已含重投所需的全部信息（sessionID、OwnerID、
+metadata），各渠道 append 时直接传手里已构造好的 envelope，零额外上下文组装。
+
+方法：
+
+| 方法 | 行为 |
+|---|---|
+| `Append(sessionID, content, env)` | 追加；**相邻完全相同 content 去重**；超 `maxPendingPerSession`（默认 20）则丢最旧保最新 |
+| `DrainAndMerge(sessionID) (mergedContent string, repr *events.Envelope, ok bool)` | 原子取出并清空；单条原样、多条加合并头+编号；`repr` 取最后一条 entry 的 envelope 作为重投模板 |
+| `Clear(sessionID)` / `ClearAll()` | 清理 |
+
+### PlatformAdapter 接入方法
+
+```go
+// busy 时调用：存追问 + 由渠道发自己的提示文案
+func (a *PlatformAdapter) AppendPendingInput(sessionID, content string, env *events.Envelope)
+
+// done 时调用：drain + 合并 + 用通用 MakeEnvelope 重投；返回是否发生重投
+func (a *PlatformAdapter) ReplayPendingIfNeeded(ctx context.Context, sessionID string, pc PlatformConn) bool
+```
+
+`ReplayPendingIfNeeded` 实现（**完全共享，渠道无关**）：
+
+```go
+merged, repr, ok := a.pendingBuffer.DrainAndMerge(sessionID)
+if !ok { return false }
+// 基于 repr 构造新 envelope：新 id + merged content，复用 sessionID/owner/metadata
+replayEnv := events.CloneForReplay(repr, merged)   // pkg/events helper
+if err := a.bridge.Handle(ctx, replayEnv, pc); err != nil {
+    // 重投又 busy（done 后瞬间被占，极端）：递归 append 回去，等下一个 done
+    var coded *events.CodedError
+    if errors.As(err, &coded) && coded.Code == events.ErrCodeSessionBusy {
+        a.pendingBuffer.Append(sessionID, merged, replayEnv)
+    }
+}
+return true
+```
+
+- 重投用**新 `client_message_id` / id**（`events.CloneForReplay` 生成），彻底避免
+  `UNIQUE(session_id, client_message_id)` 去重误判。
+- `seq` 由 `Bridge.Handle`（`bridge.go:130`）重新分配，无需关心。
+- `pc`（PlatformConn）由各渠道 handleDone 传入自己的 conn，三渠道 conn 均实现该接口。
+
+### 清理（随 session）
+
+| 时机 | 动作 |
+|---|---|
+| `ReplayPendingIfNeeded` 后 | `DrainAndMerge` 已清空 |
+| 各渠道 `conn.Close` | `Clear(sessionID)` |
+| `PlatformAdapter.CloseSharedState` | `ClearAll()` |
+| reset | sessionID 变更，旧 buffer 由旧 conn.Close 清理；新 session 天然隔离 |
+
+**不主动超时**：长任务不应丢消息；生命周期由 session 兜底。
+
+## 各渠道接入（每渠道两个点）
+
+### 飞书 `internal/messaging/feishu`
+
+- **消息处理**（`handler.go` `handleTextMessage`，`Bridge().Handle` 返回 err 后）：
+  ```go
+  var coded *events.CodedError
+  if errors.As(err, &coded) && coded.Code == events.ErrCodeSessionBusy {
+      a.AppendPendingInput(env.SessionID, text, envelope)
+      _ = a.sendTextMessage(context.Background(), channelID,
+          "⏳ 已收到，当前任务完成后会自动处理")
+      return nil
+  }
+  // 非 busy：保持原通用报错
+  ```
+- **done**（`conn.go` `handleDone`）：`go a.ReplayPendingIfNeeded(ctx, env.SessionID, c)`。
+- 提示文案：飞书中文（见上）。
+
+### Slack `internal/messaging/slack`
+
+- **消息处理**（`Bridge().Handle` 返回 err 处）：同模式，`AppendPendingInput` + 英文提示
+  `"⏳ Got it — will process automatically once the current task finishes."`。
+- **done**（`conn_events.go:46` `handleDone`）：`go a.ReplayPendingIfNeeded(...)`。
+- 提示文案：Slack 英文。
+
+### yuanxin `internal/messaging/yuanxin`
+
+- **消息处理**（`adapter.go:403` `Bridge().Handle` 返回 err 处）：同模式，
+  `AppendPendingInput(env.SessionID, text, envelope)` + 提示。
+- **done**（`adapter.go:596` `case events.Done`）：`go a.ReplayPendingIfNeeded(...)`。
+- yuanxin 当前 busy 只 `Log.Error` 返回（无用户提示），本改动补上提示，顺带消除其黑洞。
+
+## 合并格式
+
+- **单条**：原样投递，不注入框架文本。
+- **多条**（`DrainAndMerge` 输出）：
+
+```
+（以下是上一轮执行期间追加的 3 条消息，请一并处理）
+1. 继续
+2. 补充：重点关注金融领域
+3. 换个角度
+```
+
+条目按收到时序编号；content 原文忠实保留，仅做 `SanitizeText` 清洗。
+
+## 关键决策与理由
+
+| 决策 | 选择 | 理由 |
+|---|---|---|
+| 渠道范围 | 飞书 + Slack + yuanxin（共享基座） | 黑洞跨渠道；共享基座避免重复，未来加渠道零成本 |
+| 重投逻辑位置 | 共享于 `PlatformAdapter` | `Bridge.MakeEnvelope` 通用，渠道无需各自实现 |
+| 暂存内容 | content + 原 envelope | envelope 已含重投全部信息，渠道 append 零额外组装 |
+| 暂存容量 | 多条列表 | 用户边想边发，需保留全部追加意图 |
+| 投递方式 | 合并为一条 | 避免逐条串行慢队列，一个 turn 处理，仍单活跃 |
+| 超时 | 不主动超时 | 随 session 清理；长任务不应丢消息 |
+| 用户反馈 | 各渠道静默文本 | 轻量；交互按钮留作未来方案 C |
+| 单 session 上限 | 20 条 | 防滥用与内存；超出保留最新 |
+| 错误识别 | typed error（`pkg/events.CodedError`） | 健壮，符合 `errors.As` 惯例 |
+
+## 非目标
+
+- 不引入 gateway 层 `ExecutionQueue`（issue #868，durable ingress 设计已列为非目标）。
+- 不改 active gate 单活跃约束与 partial unique index。
+- 不做交互式卡片（方案 C，未来可选增强）。
+- 不自动重投 delivery `unknown` 的输入。
+- 不持久化 pending（仅内存；gateway 重启时 in-flight 暂存丢失，可接受——用户会重发）。
+- WebChat 不涉及：前端已对 `SESSION_BUSY` 做友好终端态提示（CHANGELOG）。
+
+## 边界与异常
+
+- **重投用新 id**：`events.CloneForReplay` 生成新 `client_message_id`，避免去重误判。
+- **多 session 隔离**：buffer 按 `sessionID`，天然隔离。
+- **Worker 卡死永不 done**：lease 过期 → fence → fresh worker；buffer 残留由
+  `conn.Close` / `CloseSharedState` 兜底清理。
+- **重投又 busy**：递归 `Append` 回列表，等下一个 done。
+- **busy 时新建的 placeholder card**（飞书）：常见情况前一个任务 streaming 已 active，
+  `handler.go:223` 自动跳过本次新建；少数情况（busy 但 streaming 未 active）本次新建
+  `streamCtrl` + placeholder，busy 分支需 `SetTerminalContent("已收到待处理")` 后 `Close`，
+  避免空占位卡残留。
+- **reset 期间**：旧 buffer 随旧 conn.Close 清理；新 session 无 pending。
+- **合并后 Worker 处理失败**：属正常 turn 错误，走各渠道现有 error 展示，不影响 pending 机制。
+
+## 测试要点
+
+- 共享：busy → append → done → `DrainAndMerge` → 合并重投完整链路（基座单测，mock Bridge）。
+- 合并顺序与编号格式；单条原样（无合并头）。
+- 上限 20 条截断（保留最新）；相邻完全相同 content 去重；不同 content 不去重。
+- 重投用新 id；`seq` 由 Handle 重分配。
+- typed error 识别：非 busy 错误（`INTERNAL_ERROR`）不进 pending。
+- 重投又 busy 的递归暂存。
+- 并发：`Append` 与 `DrainAndMerge` 并发安全（`-race`）。
+- 各渠道集成：飞书/Slack/yuanxin 各自的 busy 分支与 handleDone 触发重投；提示文案正确。
+- reset / `conn.Close` / `CloseSharedState` 清理。
+
+## 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `pkg/events/errors.go`（或 events.go） | 新增 `CodedError`；`CloneForReplay(env, content)` helper |
+| `internal/gateway/errors.go` | `sendErrorf` 返回 `*events.CodedError` |
+| `internal/messaging/pending_buffer.go` | 新增 `PendingBuffer` + `pendingEntry` + 合并/上限/去重 |
+| `internal/messaging/platform_adapter.go` | `pendingBuffer` 字段；`InitSharedState` 初始化 / `CloseSharedState` 清理；`AppendPendingInput` / `ReplayPendingIfNeeded` |
+| `internal/messaging/feishu/{handler,conn}.go` | busy 分支 + 提示文案；`handleDone` 重投 |
+| `internal/messaging/slack/{adapter,conn_events}.go` | busy 分支 + 提示文案；`handleDone` 重投 |
+| `internal/messaging/yuanxin/adapter.go` | `:403` busy 分支 + 提示；`:596` done 重投 |
+| 对应 `*_test.go` | 基座单测 + 三渠道集成测试 + `-race` |

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -930,6 +930,13 @@ func (b *Bridge) Shutdown(ctx context.Context) {
 		b.compressCache.Delete(key)
 		return true
 	})
+	// Drop any buffered mid-turn supplements so stale entries don't survive
+	// shutdown. The buffer is in-memory (not persisted), but clearing here
+	// keeps the Bridge's post-Shutdown state coherent if anything re-enters
+	// the Bridge during the tear-down tail (e.g. a late handler callback).
+	// Task 11 cleanup path; runs after forwarders drain so a racing
+	// DrainAndMerge in replay completes first.
+	b.ClearAllPending()
 }
 
 // MarkClosed sets the closed flag and cancels the shutdown context so that:

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -81,6 +81,13 @@ type Bridge struct {
 	// fast path; write lock is used for create/delete/reset operations.
 	accumMu sync.RWMutex
 
+	// pending buffers user supplements that arrived while a session was busy,
+	// for workers that lack mid-turn support (acp/ocs fallback). PendingBuffer
+	// has its own internal mu, so no separate guard here. Initialized in
+	// NewBridge; nil-safe proxy methods (BufferPending/ClearPending/...).
+	pending  *PendingBuffer
+	replayer PendingReplayer // late-injected (Bridge built before Handler)
+
 	crashTracker   map[string]*crashHistory // per-session crash loop detection
 	crashTrackerMu sync.Mutex
 
@@ -140,6 +147,7 @@ func NewBridge(deps BridgeDeps) *Bridge {
 		executionStore:     deps.ExecutionStore,
 		repairer:           deps.Repairer,
 		turnTTFT:           newTurnTTFTTracker(),
+		pending:            NewPendingBuffer(),
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
 	b.defaultPermissionMode.Store(worker.NormalizePermissionMode(deps.DefaultPermissionMode))
@@ -226,6 +234,40 @@ func (b *Bridge) GetWorkspaceByID(ctx context.Context, id string) (*session.Work
 // (issue #833 P2, spec §5.2). Optional: nil leaves tool-call audit disabled.
 func (b *Bridge) SetAuditCollector(ac *audit.Collector) {
 	b.auditCollector = ac
+}
+
+// PendingReplayer replays a buffered supplement as a fresh input turn.
+// Implemented by Handler (which owns deliverToWorker); injected after Bridge
+// construction via SetPendingReplayer because Bridge is built before Handler.
+type PendingReplayer interface {
+	DeliverReplay(ctx context.Context, env *events.Envelope) error
+}
+
+// SetPendingReplayer late-injects the replay target (Handler). Optional: nil
+// leaves done-time replay disabled (supplements buffered but not replayed).
+func (b *Bridge) SetPendingReplayer(r PendingReplayer) { b.replayer = r }
+
+// BufferPending appends a busy-supplement for the fallback path (worker lacks
+// mid-turn support). Called from Handler's SESSION_BUSY branch.
+func (b *Bridge) BufferPending(sessionID string, env *events.Envelope, content string) {
+	if b.pending != nil {
+		b.pending.Append(sessionID, content, env)
+	}
+}
+
+// ClearPending drops buffered supplements for one session. Called when the
+// session is reset/deleted.
+func (b *Bridge) ClearPending(sessionID string) {
+	if b.pending != nil {
+		b.pending.Clear(sessionID)
+	}
+}
+
+// ClearAllPending drops all buffered supplements. Called on bridge shutdown.
+func (b *Bridge) ClearAllPending() {
+	if b.pending != nil {
+		b.pending.ClearAll()
+	}
 }
 
 // StartSession creates a new session and starts a worker.

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -529,6 +529,28 @@ func (b *Bridge) finishRuntimeOnDone(sessionID string, fc *forwardContext, env *
 		return
 	}
 
+	// Replay buffered supplements now that the active gate is released. This
+	// method runs UNDER processForwardedEvent's held seq lease (see comment at
+	// the NextSeqHeld call below about self-deadlock if we re-enter
+	// BeginSeqOperation), so the replay MUST run async — DeliverReplay →
+	// deliverToWorker → acceptInputExecution re-enters the seq barrier in its
+	// own context. cloneForReplay sets seq=0 so the hub reassigns it.
+	if b.pending != nil && b.replayer != nil {
+		if merged, repr, ok := b.pending.DrainAndMerge(sessionID); ok {
+			replayEnv := cloneForReplay(repr, merged)
+			go func() {
+				if err := b.replayer.DeliverReplay(context.Background(), replayEnv); err != nil {
+					b.log.Warn("bridge: supplement replay failed",
+						"session_id", sessionID, "err", err)
+					// Replay collided with a fresh input that re-occupied the
+					// gate between Done and the async dispatch. Re-buffer for
+					// the next Done so the supplement is not lost.
+					b.pending.Append(sessionID, merged, replayEnv)
+				}
+			}()
+		}
+	}
+
 	observability.ExecutionRuntimeOutcome().Add(context.Background(), 1,
 		metric.WithAttributes(attribute.String("runtime_status", string(rtStatus))))
 	if rec.StartedAt != nil {

--- a/internal/gateway/bridge_forward_test.go
+++ b/internal/gateway/bridge_forward_test.go
@@ -1,0 +1,109 @@
+package gateway
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/execution"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// fakeReplayer is a test double for PendingReplayer. calls counts
+// DeliverReplay invocations; lastContent captures the content of the most
+// recent replay envelope. When callCh is non-nil, it is closed on the first
+// call so the negative test can detect a spurious replay from a t.Cleanup
+// select — without any time.Sleep.
+type fakeReplayer struct {
+	calls       atomic.Int32
+	lastContent atomic.Value // string
+	callCh      chan struct{}
+}
+
+func (r *fakeReplayer) DeliverReplay(_ context.Context, env *events.Envelope) error {
+	r.calls.Add(1)
+	if data, ok := env.Event.Data.(map[string]any); ok {
+		if c, _ := data["content"].(string); c != "" {
+			r.lastContent.Store(c)
+		}
+	}
+	if r.callCh != nil {
+		select {
+		case <-r.callCh:
+		default:
+			close(r.callCh)
+		}
+	}
+	return nil
+}
+
+// newDoneBridgeWithOpenExec builds a Bridge + forwardContext + Done envelope
+// backed by a fake execution store returning an open Delivered record that
+// FinishRuntime accepts. Mirrors the harness in
+// TestFinishRuntimeOnDone_UsesEmittingForwarderRunID; the pending buffer is
+// initialized (the production Bridge literal leaves it nil).
+func newDoneBridgeWithOpenExec(t *testing.T, sessionID string) (*Bridge, *forwardContext, *events.Envelope, *fakeExecutionStore) {
+	t.Helper()
+	rec := testExecutionRecord(execution.StatusDelivered)
+	rec.SessionID = sessionID
+	rec.WorkerRunID = "run-current"
+	store := &fakeExecutionStore{openRecord: rec}
+	b := &Bridge{
+		executionStore: store,
+		hub:            newTestHub(t),
+		log:            testLogger(t),
+		pending:        NewPendingBuffer(),
+	}
+	fc := &forwardContext{sessionID: sessionID, workerRunID: "run-current"}
+	env := events.NewEnvelope("evt-done", sessionID, 1, events.Done, events.DoneData{Success: true})
+	return b, fc, env, store
+}
+
+// TestFinishRuntimeOnDone_ReplaysPending verifies that when Done arrives and
+// the active gate is released, a buffered supplement is drained, merged, and
+// replayed exactly once via the PendingReplayer. The replay goroutine runs
+// async (seq-lease safety), so we poll via require.Eventually — no sleep.
+func TestFinishRuntimeOnDone_ReplaysPending(t *testing.T) {
+	t.Parallel()
+	b, fc, env, _ := newDoneBridgeWithOpenExec(t, "s-replay")
+	rp := &fakeReplayer{}
+	b.SetPendingReplayer(rp)
+	// Buffer a supplement that the Done path must drain + replay.
+	b.pending.Append("s-replay", "追问", newInputEnvelope(t, "s-replay", "x"))
+
+	b.finishRuntimeOnDone("s-replay", fc, env)
+
+	require.Eventually(t, func() bool { return rp.calls.Load() == 1 },
+		time.Second, 10*time.Millisecond)
+	require.Equal(t, "追问", rp.lastContent.Load())
+}
+
+// TestFinishRuntimeOnDone_NoPendingNoReplay verifies that with an empty
+// pending buffer, finishRuntimeOnDone does NOT spawn a replay goroutine.
+// Detection uses NO time.Sleep: the fakeReplayer closes callCh if ever
+// invoked, and t.Cleanup's select catches the spurious call. A runtime.Gosched
+// yields the test goroutine so any spawned replay has a chance to fire before
+// cleanup runs — this is a scheduler hint, not a sleep.
+func TestFinishRuntimeOnDone_NoPendingNoReplay(t *testing.T) {
+	t.Parallel()
+	b, fc, env, _ := newDoneBridgeWithOpenExec(t, "s-nopending")
+	rp := &fakeReplayer{callCh: make(chan struct{})}
+	b.SetPendingReplayer(rp)
+
+	b.finishRuntimeOnDone("s-nopending", fc, env)
+	// Yield so a (buggy) spawned goroutine can fire and close callCh before
+	// cleanup's select. Not a sleep — just a scheduling hint.
+	runtime.Gosched()
+
+	t.Cleanup(func() {
+		select {
+		case <-rp.callCh:
+			t.Errorf("unexpected replay call")
+		default:
+		}
+	})
+}

--- a/internal/gateway/bridge_forward_test.go
+++ b/internal/gateway/bridge_forward_test.go
@@ -77,9 +77,16 @@ func TestFinishRuntimeOnDone_ReplaysPending(t *testing.T) {
 
 	b.finishRuntimeOnDone("s-replay", fc, env)
 
-	require.Eventually(t, func() bool { return rp.calls.Load() == 1 },
-		time.Second, 10*time.Millisecond)
-	require.Equal(t, "追问", rp.lastContent.Load())
+	// Poll the actual asserted condition (call count AND replayed content) in a
+	// single predicate, rather than checking calls then content separately:
+	// calls.Add(1) happens before lastContent.Store inside DeliverReplay, so a
+	// standalone calls==1 gate can observe the call before the Store is visible,
+	// racing the subsequent content assertion under -race load.
+	require.Eventually(t, func() bool {
+		c, _ := rp.lastContent.Load().(string)
+		return rp.calls.Load() == 1 && c == "追问"
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, "追问", rp.lastContent.Load().(string))
 }
 
 // TestFinishRuntimeOnDone_NoPendingNoReplay verifies that with an empty

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -514,6 +514,64 @@ func (h *Handler) tryCommandDispatch(ctx context.Context, env *events.Envelope, 
 	return false, nil
 }
 
+// handleSupplementOnBusy routes a SESSION_BUSY input to mid-turn passthrough
+// (when the worker implements MidTurnInjector and the turn is still live) or
+// the fallback pending buffer. Falls back to the legacy SESSION_BUSY error
+// only when bridge buffering is unavailable.
+//
+// Decision order:
+//  1. Worker implements MidTurnInjector AND !IsStopped → InjectMidTurn.
+//     Success → metric + capture + "injected" notify + return nil.
+//     Failure → log and fall through to buffer.
+//  2. bridge != nil → BufferPending + metric + "buffered" notify + return nil.
+//  3. Otherwise → legacy sendErrorf SESSION_BUSY.
+func (h *Handler) handleSupplementOnBusy(ctx context.Context, env *events.Envelope, content string) error {
+	if w := h.sm.GetWorker(env.SessionID); w != nil {
+		if inj, ok := w.(worker.MidTurnInjector); ok && !w.IsStopped() {
+			if err := inj.InjectMidTurn(ctx, content, nil); err == nil {
+				observability.MidTurnInjected().Add(ctx, 1)
+				if h.bridge != nil {
+					h.bridge.CaptureInboundEvent(env.SessionID, env.Seq, events.Input, env.Event.Data)
+				}
+				h.notifySupplement(ctx, env.SessionID, "injected")
+				return nil
+			} else {
+				h.log.Warn("gateway: mid-turn inject failed, falling back to buffer",
+					"session_id", env.SessionID, "err", err)
+			}
+		}
+	}
+	if h.bridge != nil {
+		h.bridge.BufferPending(env.SessionID, env, content)
+		observability.SupplementBuffered().Add(ctx, 1)
+		h.notifySupplement(ctx, env.SessionID, "buffered")
+		return nil
+	}
+	return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session has an active execution")
+}
+
+// notifySupplement broadcasts a marker `message` envelope so platform conns
+// (Slack/Feishu/Webchat) can render their own i18n "supplement accepted"
+// text. Metadata["supplement_mode"] carries the mode ("injected"|"buffered");
+// Content is empty — conns substitute their own localized text (Task 10).
+// Best-effort: delivery failures are not surfaced to the user.
+func (h *Handler) notifySupplement(ctx context.Context, sessionID, mode string) {
+	env := events.NewEnvelope(aep.NewID(), sessionID, h.hub.NextSeq(sessionID),
+		events.Message, events.MessageData{Content: ""})
+	env.Metadata = map[string]any{"supplement_mode": mode}
+	_ = h.hub.SendToSession(ctx, env)
+}
+
+// DeliverReplay replays a buffered supplement as a fresh input turn.
+// Implements bridge.PendingReplayer; the active gate is already released by
+// the prior done, so deliverToWorker's accept path will succeed. The content
+// is extracted from the envelope's Data map (preserved by cloneForReplay).
+func (h *Handler) DeliverReplay(ctx context.Context, env *events.Envelope) error {
+	data, _ := env.Event.Data.(map[string]any)
+	content, _ := data["content"].(string)
+	return h.deliverToWorker(ctx, env, content)
+}
+
 // deliverToWorker validates session state, handles IDLE→RUNNING transition,
 // and delivers user input to the worker process.
 func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, content string) error {
@@ -536,7 +594,7 @@ func (h *Handler) deliverToWorker(ctx context.Context, env *events.Envelope, con
 		if errors.Is(err, execution.ErrSessionBusy) {
 			observability.ExecutionSessionBusy().Add(ctx, 1)
 			h.cancelRetryIfNeeded(env.SessionID)
-			return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "session has an active execution")
+			return h.handleSupplementOnBusy(ctx, env, content)
 		}
 		h.log.Error("gateway: persist input acceptance failed", "err", err, "session_id", env.SessionID)
 		// A genuine new input failed to durably register; cancel any in-flight
@@ -1269,3 +1327,7 @@ func interactionResponseMetadata(kind events.Kind, data any) (map[string]any, er
 
 	return metadata, nil
 }
+
+// Compile-time assertion: *Handler satisfies bridge.PendingReplayer so the
+// bridge can late-inject it via SetPendingReplayer for done-time replay.
+var _ PendingReplayer = (*Handler)(nil)

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -528,6 +528,23 @@ func (h *Handler) tryCommandDispatch(ctx context.Context, env *events.Envelope, 
 func (h *Handler) handleSupplementOnBusy(ctx context.Context, env *events.Envelope, content string) error {
 	if w := h.sm.GetWorker(env.SessionID); w != nil {
 		if inj, ok := w.(worker.MidTurnInjector); ok && !w.IsStopped() {
+			// Re-check the active gate immediately before injecting. A race
+			// window exists between the SESSION_BUSY detection (in
+			// acceptInputExecutionWithRetry above) and this inject: if the
+			// running turn's Done arrived in between and released the gate,
+			// injecting now would write the supplement as the PRIMARY input of
+			// a new unsolicited CC turn — CC headless stays alive reading stdin
+			// after Done — producing a ghost turn with no execution record. If
+			// the gate is already released, route to the normal delivery path so
+			// the supplement becomes a proper new turn. (Codex avoids this via
+			// SteerTurn's expectedTurnID; CC has no turn-liveness signal, so we
+			// re-check here. A residual sub-millisecond window between this check
+			// and the stdin write remains by design.)
+			if h.executionStore != nil {
+				if _, aerr := h.executionStore.ActiveBySession(ctx, env.SessionID); errors.Is(aerr, execution.ErrNotFound) {
+					return h.deliverToWorker(ctx, env, content)
+				}
+			}
 			if err := inj.InjectMidTurn(ctx, content, nil); err == nil {
 				observability.MidTurnInjected().Add(ctx, 1)
 				if h.bridge != nil {

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1278,3 +1278,90 @@ func TestHandleInput_NormalInput_CaptureInbound(t *testing.T) {
 	require.Equal(t, "inbound", page.Events[0].Direction)
 	require.Equal(t, int64(7), page.Events[0].Seq)
 }
+
+// ─── handleSupplementOnBusy (SESSION_BUSY mid-turn) tests ────────────────────
+
+// mockMidTurnWorker extends mockWorkerForHandler with InjectMidTurn, satisfying
+// worker.MidTurnInjector so the handler's SESSION_BUSY branch takes the
+// passthrough path.
+type mockMidTurnWorker struct {
+	mockWorkerForHandler
+	injectErr   error
+	injected    string
+	injectCount int
+}
+
+func (m *mockMidTurnWorker) InjectMidTurn(_ context.Context, content string, _ map[string]any) error {
+	m.injectCount++
+	m.injected = content
+	return m.injectErr
+}
+
+// newBusyTestHandler wires a Handler with a mock SessionManager, a real Hub
+// (so NextSeq/SendToSession work without Run()), and a real Bridge (so the
+// PendingBuffer is exercised). The returned sm is pre-set to return the given
+// worker from GetWorker; callers can substitute it via sm.Mock expectations.
+func newBusyTestHandler(t *testing.T, w worker.Worker) (*Handler, *mockInputSM, *Hub, *Bridge) {
+	t.Helper()
+	sm := new(mockInputSM)
+	sm.Test(t)
+	if w != nil {
+		sm.On("GetWorker", mock.Anything).Return(w).Maybe()
+	}
+	hub := newCtrlHub(t)
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: sm})
+	h := &Handler{
+		log:    slog.Default(),
+		hub:    hub,
+		sm:     sm,
+		bridge: bridge,
+	}
+	return h, sm, hub, bridge
+}
+
+func TestHandleSupplementOnBusy_Passthrough(t *testing.T) {
+	t.Parallel()
+	mw := &mockMidTurnWorker{}
+	h, _, _, bridge := newBusyTestHandler(t, mw)
+	env := newInputEnvelope(t, "s", "追问")
+	env.Seq = 5
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+	require.Equal(t, "追问", mw.injected, "InjectMidTurn must receive the supplement")
+	require.Equal(t, 1, mw.injectCount, "InjectMidTurn must be called exactly once")
+
+	// Passthrough must NOT buffer the supplement.
+	_, _, ok := bridge.pending.DrainAndMerge("s")
+	require.False(t, ok, "passthrough path must not buffer")
+}
+
+func TestHandleSupplementOnBusy_FallbackBuffer(t *testing.T) {
+	t.Parallel()
+	// mockWorkerForHandler does NOT implement worker.MidTurnInjector, so the
+	// handler must fall back to the pending buffer.
+	w := new(mockWorkerForHandler)
+	h, _, _, bridge := newBusyTestHandler(t, w)
+	env := newInputEnvelope(t, "s", "追问")
+	env.Seq = 5
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+
+	merged, _, ok := bridge.pending.DrainAndMerge("s")
+	require.True(t, ok, "fallback path must buffer the supplement")
+	require.Equal(t, "追问", merged)
+}
+
+func TestHandleSupplementOnBusy_InjectFailureFallsBack(t *testing.T) {
+	t.Parallel()
+	mw := &mockMidTurnWorker{injectErr: errors.New("turn ended")}
+	h, _, _, bridge := newBusyTestHandler(t, mw)
+	env := newInputEnvelope(t, "s", "追问")
+	env.Seq = 5
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+	require.Equal(t, 1, mw.injectCount, "InjectMidTurn must be attempted")
+
+	merged, _, ok := bridge.pending.DrainAndMerge("s")
+	require.True(t, ok, "failed inject must fall back to buffer")
+	require.Equal(t, "追问", merged)
+}

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1365,3 +1365,50 @@ func TestHandleSupplementOnBusy_InjectFailureFallsBack(t *testing.T) {
 	require.True(t, ok, "failed inject must fall back to buffer")
 	require.Equal(t, "追问", merged)
 }
+
+// TestHandleSupplementOnBusy_RaceGateStillHeld is the complement: the active
+// gate is still held (Done did NOT win the race), so the re-check passes and
+// InjectMidTurn proceeds normally.
+func TestHandleSupplementOnBusy_RaceGateStillHeld(t *testing.T) {
+	t.Parallel()
+	mw := &mockMidTurnWorker{}
+	h, _, _, bridge := newBusyTestHandler(t, mw)
+	h.executionStore = &fakeExecutionStore{activeRecord: testExecutionRecord(execution.StatusDelivered)}
+
+	env := newInputEnvelope(t, "s", "追问")
+	env.Seq = 5
+
+	require.NoError(t, h.handleSupplementOnBusy(t.Context(), env, "追问"))
+	require.Equal(t, 1, mw.injectCount, "gate held → InjectMidTurn must run")
+	require.Equal(t, "追问", mw.injected)
+
+	_, _, ok := bridge.pending.DrainAndMerge("s")
+	require.False(t, ok, "successful inject must not buffer")
+}
+
+// TestHandleSupplementOnBusy_GateReleasedBeforeInject covers the TOCTOU race
+// where the running turn's Done arrives between the SESSION_BUSY detection
+// (acceptInputExecutionWithRetry) and the mid-turn inject. CC headless stays
+// alive reading stdin after Done, so injecting then would start a ghost turn
+// with no execution record. The ActiveBySession re-check must route the
+// supplement to the normal delivery path (a proper new turn) instead. Here
+// sm.Get fails, so delegation is observed as an error — the key assertion is
+// that InjectMidTurn is never called once the gate is released.
+func TestHandleSupplementOnBusy_GateReleasedBeforeInject(t *testing.T) {
+	t.Parallel()
+	mw := &mockMidTurnWorker{}
+	h, sm, _, _ := newBusyTestHandler(t, mw)
+	// ActiveBySession reports the gate as released (ErrNotFound): Done won the
+	// race between SESSION_BUSY detection and the inject.
+	h.executionStore = &fakeExecutionStore{}
+	// deliverToWorker's first step is sm.Get; fail it so delegation is observed
+	// as an error without standing up a full delivery pipeline.
+	sm.On("Get", "s").Return(nil, errors.New("session gone")).Maybe()
+
+	env := newInputEnvelope(t, "s", "追问")
+	env.Seq = 5
+
+	err := h.handleSupplementOnBusy(t.Context(), env, "追问")
+	require.Error(t, err, "released gate must route to deliverToWorker")
+	require.Equal(t, 0, mw.injectCount, "must NOT inject once the active gate is released")
+}

--- a/internal/gateway/input_execution_test.go
+++ b/internal/gateway/input_execution_test.go
@@ -27,6 +27,7 @@ type fakeExecutionStore struct {
 	errorCode    string
 	statusCalls  int
 	openRecord   *execution.Record
+	activeRecord *execution.Record // when set, ActiveBySession reports the gate as held
 	markRunID    string
 	markErr      error
 	finishRunID  string
@@ -73,6 +74,9 @@ func (s *fakeExecutionStore) FinishRuntime(_ context.Context, _ string, runID st
 	return s.finishErr
 }
 func (s *fakeExecutionStore) ActiveBySession(context.Context, string) (*execution.Record, error) {
+	if s.activeRecord != nil {
+		return s.activeRecord, nil
+	}
 	return nil, execution.ErrNotFound
 }
 func (s *fakeExecutionStore) OpenBySession(context.Context, string) (*execution.Record, error) {

--- a/internal/gateway/pending_buffer.go
+++ b/internal/gateway/pending_buffer.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hrygo/hotplex/pkg/aep"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// maxPendingPerSession caps buffered supplements per session to bound memory.
+const maxPendingPerSession = 20
+
+type pendingEntry struct {
+	content    string
+	envelope   *events.Envelope
+	receivedAt int64
+}
+
+// PendingBuffer holds user supplements that arrived while a session was busy,
+// keyed by sessionID. Only used for workers that do NOT implement
+// MidTurnInjector (acp/ocs fallback); mid-turn-capable workers inject directly.
+type PendingBuffer struct {
+	mu    sync.Mutex
+	items map[string][]pendingEntry
+}
+
+func NewPendingBuffer() *PendingBuffer {
+	return &PendingBuffer{items: make(map[string][]pendingEntry)}
+}
+
+// Append adds a supplement. Adjacent identical content is deduped; over the
+// per-session cap the oldest are dropped to keep the newest.
+func (p *PendingBuffer) Append(sessionID, content string, env *events.Envelope) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	items := p.items[sessionID]
+	if n := len(items); n > 0 && items[n-1].content == content {
+		return
+	}
+	items = append(items, pendingEntry{content: content, envelope: events.Clone(env), receivedAt: time.Now().UnixMilli()})
+	if len(items) > maxPendingPerSession {
+		items = items[len(items)-maxPendingPerSession:]
+	}
+	p.items[sessionID] = items
+}
+
+// DrainAndMerge atomically removes and returns the merged supplement for a
+// session. A single entry is returned verbatim; multiple are joined with a
+// header and 1-based numbering. repr is the last entry's envelope (template
+// for replay). ok is false if nothing was buffered.
+func (p *PendingBuffer) DrainAndMerge(sessionID string) (string, *events.Envelope, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	items := p.items[sessionID]
+	if len(items) == 0 {
+		delete(p.items, sessionID)
+		return "", nil, false
+	}
+	delete(p.items, sessionID)
+	repr := items[len(items)-1].envelope
+	if len(items) == 1 {
+		return items[0].content, repr, true
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "（以下是上一轮执行期间追加的 %d 条消息，请一并处理）\n", len(items))
+	for i, it := range items {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, strings.TrimSpace(it.content))
+	}
+	return b.String(), repr, true
+}
+
+func (p *PendingBuffer) Clear(sessionID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, sessionID)
+}
+
+func (p *PendingBuffer) ClearAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items = make(map[string][]pendingEntry)
+}
+
+// cloneForReplay builds a fresh Input envelope for replay: new id + new
+// client_message_id (avoids UNIQUE(session_id, client_message_id) dedup),
+// replaced content, reused session/owner/metadata, seq=0 (re-assigned by hub).
+// Lives in gateway (not pkg/events) because it needs aep.NewID and pkg/events
+// cannot import pkg/aep (cycle).
+func cloneForReplay(env *events.Envelope, content string) *events.Envelope {
+	c := events.Clone(env) // deep-copies Event.Data map + Metadata
+	c.ID = aep.NewID()
+	c.Seq = 0
+	if data, ok := c.Event.Data.(map[string]any); ok {
+		data["content"] = content
+		data["client_message_id"] = aep.NewID()
+	}
+	return c
+}

--- a/internal/gateway/pending_buffer_test.go
+++ b/internal/gateway/pending_buffer_test.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -98,4 +100,88 @@ func TestCloneForReplay_NewIDs(t *testing.T) {
 	require.Equal(t, "new content", c.Event.Data.(map[string]any)["content"])
 	require.Equal(t, "s", c.SessionID) // 复用 session
 	require.Zero(t, c.Seq)             // 由 hub 重分配
+}
+
+// newTestBridgeForPending builds a minimal Bridge for pending-buffer cleanup
+// tests. Only Log is needed — ClearPending/ClearAllPending are pure in-memory
+// operations and don't touch Hub/SM.
+func newTestBridgeForPending(t *testing.T) *Bridge {
+	t.Helper()
+	return NewBridge(BridgeDeps{Log: slog.Default()})
+}
+
+// TestPendingClearedOnSessionEnd verifies the per-session cleanup contract:
+// after Bridge.ClearPending(sid), a subsequent DrainAndMerge(sid) returns
+// ok=false so stale supplements cannot replay into a dead session. Mirrors
+// the contract called from sm.OnTerminate in cmd/hotplex/gateway_run.go.
+func TestPendingClearedOnSessionEnd(t *testing.T) {
+	t.Parallel()
+	b := newTestBridgeForPending(t)
+	env := newInputEnvelope(t, "s1", "x")
+	b.pending.Append("s1", "x", env)
+	// Sanity: buffer holds one entry before clear.
+	_, _, ok := b.pending.DrainAndMerge("s1")
+	require.True(t, ok, "pre-clear: expected one buffered supplement")
+
+	// Repopulate (drain removed it) and clear via the Bridge-level method.
+	b.pending.Append("s1", "x", env)
+	b.ClearPending("s1")
+	_, _, ok = b.pending.DrainAndMerge("s1")
+	require.False(t, ok, "post-clear: expected buffer empty for s1")
+}
+
+// TestPendingClearedOnSessionEnd_OnlyTargetSession verifies ClearPending(sid)
+// does not disturb other sessions' buffers.
+func TestPendingClearedOnSessionEnd_OnlyTargetSession(t *testing.T) {
+	t.Parallel()
+	b := newTestBridgeForPending(t)
+	env := newInputEnvelope(t, "s", "x")
+	b.pending.Append("s1", "x", env)
+	b.pending.Append("s2", "y", env)
+
+	b.ClearPending("s1")
+
+	_, _, ok := b.pending.DrainAndMerge("s1")
+	require.False(t, ok, "s1 should be cleared")
+	_, _, ok = b.pending.DrainAndMerge("s2")
+	require.True(t, ok, "s2 should be untouched")
+}
+
+// TestClearAllPendingOnShutdown verifies the global cleanup contract: after
+// Bridge.ClearAllPending(), every session's buffer is empty. This mirrors the
+// call made in Bridge.Shutdown so stale supplements don't survive a gateway
+// restart's in-memory state (buffer is not persisted).
+func TestClearAllPendingOnShutdown(t *testing.T) {
+	t.Parallel()
+	b := newTestBridgeForPending(t)
+	env := newInputEnvelope(t, "s", "x")
+	b.pending.Append("s1", "a", env)
+	b.pending.Append("s2", "b", env)
+	b.pending.Append("s3", "c", env)
+
+	b.ClearAllPending()
+
+	for _, sid := range []string{"s1", "s2", "s3"} {
+		_, _, ok := b.pending.DrainAndMerge(sid)
+		require.False(t, ok, "post-ClearAllPending: %s should be empty", sid)
+	}
+}
+
+// TestBridge_ShutdownClearsAllPending drives Bridge.Shutdown (the real hook)
+// and verifies it clears the buffer via the internal ClearAllPending call.
+func TestBridge_ShutdownClearsAllPending(t *testing.T) {
+	t.Parallel()
+	b := newTestBridgeForPending(t)
+	env := newInputEnvelope(t, "s", "x")
+	b.pending.Append("s1", "a", env)
+	b.pending.Append("s2", "b", env)
+
+	// Shutdown uses context.Background for the test; no forwarders are
+	// registered so WaitForwarders returns immediately.
+	b.Shutdown(context.Background())
+
+	for _, sid := range []string{"s1", "s2"} {
+		_, _, ok := b.pending.DrainAndMerge(sid)
+		require.False(t, ok, "post-Shutdown: %s should be empty", sid)
+	}
 }

--- a/internal/gateway/pending_buffer_test.go
+++ b/internal/gateway/pending_buffer_test.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func newInputEnvelope(t *testing.T, sid, content string) *events.Envelope {
+	t.Helper()
+	return events.NewEnvelope("evt_orig", sid, 0, events.Input, map[string]any{
+		"content":           content,
+		"client_message_id": "cmid_orig",
+	})
+}
+
+func TestPendingBuffer_DrainAndMerge(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		inputs  []string
+		wantSub []string // merged 中应包含的子串
+		single  bool
+	}{
+		{"single passthrough", []string{"继续"}, []string{"继续"}, true},
+		{"multi merged numbered", []string{"继续", "补充", "换角度"},
+			[]string{"3 条消息", "1. 继续", "2. 补充", "3. 换角度"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pb := NewPendingBuffer()
+			env := newInputEnvelope(t, "sess_1", "orig")
+			for _, c := range tc.inputs {
+				pb.Append("sess_1", c, env)
+			}
+			merged, repr, ok := pb.DrainAndMerge("sess_1")
+			require.True(t, ok)
+			require.NotNil(t, repr)
+			if tc.single {
+				require.Equal(t, tc.inputs[0], merged)
+			} else {
+				for _, s := range tc.wantSub {
+					require.Contains(t, merged, s)
+				}
+			}
+			// drain 后清空
+			_, _, ok2 := pb.DrainAndMerge("sess_1")
+			require.False(t, ok2)
+		})
+	}
+}
+
+func TestPendingBuffer_DedupAdjacentAndCap(t *testing.T) {
+	t.Parallel()
+	pb := NewPendingBuffer()
+	env := newInputEnvelope(t, "s", "x")
+	// 相邻完全相同去重
+	pb.Append("s", "同", env)
+	pb.Append("s", "同", env)
+	merged, _, _ := pb.DrainAndMerge("s")
+	require.Equal(t, "同", merged) // 只剩一条
+
+	// 上限 20：塞 25 条，只保留最新 20，合并后编号 1..20
+	for i := 0; i < 25; i++ {
+		pb.Append("s", fmt.Sprintf("m%d", i), env)
+	}
+	merged, _, _ = pb.DrainAndMerge("s")
+	require.Contains(t, merged, "20 条消息")
+	require.Contains(t, merged, "1. m5") // 最旧保留的是 m5（丢 m0..m4）
+	require.Contains(t, merged, "20. m24")
+}
+
+func TestPendingBuffer_Concurrent(t *testing.T) {
+	t.Parallel()
+	pb := NewPendingBuffer()
+	env := newInputEnvelope(t, "s", "x")
+	done := make(chan struct{})
+	for i := 0; i < 50; i++ {
+		go func() { pb.Append("s", "c", env); done <- struct{}{} }()
+		go func() { pb.DrainAndMerge("s"); done <- struct{}{} }()
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+}
+
+func TestCloneForReplay_NewIDs(t *testing.T) {
+	t.Parallel()
+	orig := newInputEnvelope(t, "s", "old")
+	orig.Event.Data.(map[string]any)["client_message_id"] = "cmid_orig"
+	c := cloneForReplay(orig, "new content")
+	require.NotEqual(t, orig.ID, c.ID)
+	require.NotEqual(t, "cmid_orig", c.Event.Data.(map[string]any)["client_message_id"])
+	require.Equal(t, "new content", c.Event.Data.(map[string]any)["content"])
+	require.Equal(t, "s", c.SessionID) // 复用 session
+	require.Zero(t, c.Seq)             // 由 hub 重分配
+}

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -450,6 +450,17 @@ func (c *FeishuConn) handleStatusEvent(ctx context.Context, env *events.Envelope
 }
 
 func (c *FeishuConn) handleMessageEvent(ctx context.Context, env *events.Envelope) error {
+	// Supplement path: gateway accepted a mid-turn supplement and signals via
+	// metadata. Render the i18n busy text and return before the normal display
+	// path, which would silently drop the (empty) Content.
+	if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+		text := feishuSupplementText(mode)
+		c.mu.RLock()
+		chatID := c.chatID
+		c.mu.RUnlock()
+		return c.adapter.sendTextMessage(ctx, chatID, text)
+	}
+
 	var content string
 	if msgData, ok := env.Event.Data.(events.MessageData); ok {
 		content = msgData.Content
@@ -460,6 +471,19 @@ func (c *FeishuConn) handleMessageEvent(ctx context.Context, env *events.Envelop
 		return nil
 	}
 	return c.sendOrReply(ctx, OptimizeMarkdownStyle(SanitizeForCard(messaging.SanitizeText(content))))
+}
+
+// feishuSupplementText returns the Chinese i18n text for a mid-turn supplement
+// accepted by the gateway's busy branch. `injected` means the supplement was
+// merged into the running turn; any other mode (typically `buffered`) means it
+// was queued for the next turn. The fallback is the buffered text — promising
+// future handling — so an unexpected mode never falsely implies the supplement
+// is already being processed.
+func feishuSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ 已收到，正在当前任务中一并处理"
+	}
+	return "⏳ 已收到，当前任务完成后会自动处理"
 }
 
 func (c *FeishuConn) Close() error {

--- a/internal/messaging/feishu/supplement_test.go
+++ b/internal/messaging/feishu/supplement_test.go
@@ -1,0 +1,83 @@
+package feishu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TestFeishuSupplementText verifies the i18n text mapping per supplement mode.
+// injected: supplement was merged into the running turn.
+// buffered: supplement was queued for the next turn.
+// Any other mode falls back to the buffered text (safe default — promises
+// future handling rather than implying immediate processing).
+func TestFeishuSupplementText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"injected merged into current turn", "injected", "⏳ 已收到，正在当前任务中一并处理"},
+		{"buffered for next turn", "buffered", "⏳ 已收到，当前任务完成后会自动处理"},
+		{"unknown mode falls back to buffered text", "unknown", "⏳ 已收到，当前任务完成后会自动处理"},
+		{"empty mode falls back to buffered text", "", "⏳ 已收到，当前任务完成后会自动处理"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, feishuSupplementText(tt.mode))
+		})
+	}
+}
+
+// TestWriteCtx_SupplementMode_RendersI18nText verifies that a `message` envelope
+// carrying supplement_mode metadata triggers the i18n supplement text send
+// instead of the normal display path (which would silently drop empty Content).
+//
+// Detection is verified by the sendTextMessage error ("lark client not
+// initialized" in the test harness). Without the early return, handleMessageEvent
+// would see empty Content and return nil silently.
+func TestWriteCtx_SupplementMode_RendersI18nText(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestAdapter(t)
+	conn := newTestConn(adapter, "") // no replyToMsgID → sendTextMessage path
+
+	for _, mode := range []string{"injected", "buffered"} {
+		env := &events.Envelope{
+			SessionID: "s-test",
+			Event:     events.Event{Type: events.Message},
+			Metadata:  map[string]any{"supplement_mode": mode},
+		}
+		err := conn.WriteCtx(context.Background(), env)
+		// The supplement path reaches sendTextMessage, which fails predictably
+		// with "lark client not initialized" in the test harness. Without the
+		// supplement check, WriteCtx would return nil (empty Content dropped).
+		require.Error(t, err, "mode=%s should reach sendTextMessage", mode)
+		require.Contains(t, err.Error(), "lark client not initialized",
+			"mode=%s should trigger sendTextMessage via supplement path", mode)
+	}
+}
+
+// TestWriteCtx_SupplementMode_NoMetadataFallsThrough confirms that a Message
+// envelope WITHOUT supplement_mode metadata is handled by the normal display
+// path (returns nil for empty Content, does not call sendTextMessage).
+func TestWriteCtx_SupplementMode_NoMetadataFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestAdapter(t)
+	conn := newTestConn(adapter, "")
+
+	// Empty Content, no supplement metadata → silent no-op (existing behavior).
+	env := &events.Envelope{
+		SessionID: "s-test",
+		Event:     events.Event{Type: events.Message},
+	}
+	err := conn.WriteCtx(context.Background(), env)
+	require.NoError(t, err, "Message without supplement_mode and empty Content returns nil")
+}

--- a/internal/messaging/slack/conn_events.go
+++ b/internal/messaging/slack/conn_events.go
@@ -116,6 +116,15 @@ func (c *SlackConn) handleSkillsList(ctx context.Context, env *events.Envelope) 
 }
 
 func (c *SlackConn) handleStandaloneMessage(ctx context.Context, env *events.Envelope) error {
+	// Supplement path: gateway accepted a mid-turn supplement and signals via
+	// metadata. Render the i18n busy text synchronously and return before the
+	// normal display path, which would silently drop the (empty) Content.
+	// Synchronous (not goroutine-launch) so callers see send failures and tests
+	// can observe the reached path; the supplement text is a one-shot short msg.
+	if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+		return c.writeWithPostMessage(ctx, slackSupplementText(mode), false)
+	}
+
 	var text string
 	if msgData, ok := env.Event.Data.(events.MessageData); ok && msgData.Content != "" {
 		text = messaging.SanitizeText(msgData.Content)
@@ -132,6 +141,19 @@ func (c *SlackConn) handleStandaloneMessage(ctx context.Context, env *events.Env
 		}()
 	}
 	return nil
+}
+
+// slackSupplementText returns the English i18n text for a mid-turn supplement
+// accepted by the gateway's busy branch. `injected` means the supplement was
+// merged into the running turn; any other mode (typically `buffered`) means it
+// was queued for the next turn. The fallback is the buffered text — promising
+// future handling — so an unexpected mode never falsely implies the supplement
+// is already being processed.
+func slackSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ Got it — processing within the current task."
+	}
+	return "⏳ Got it — will process automatically once the current task finishes."
 }
 
 func (c *SlackConn) handleDefaultText(ctx context.Context, env *events.Envelope) error {

--- a/internal/messaging/slack/supplement_test.go
+++ b/internal/messaging/slack/supplement_test.go
@@ -1,0 +1,88 @@
+package slack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TestSlackSupplementText verifies the English i18n text mapping per supplement
+// mode. injected: merged into the running turn. buffered: queued for next turn.
+// Any other mode falls back to the buffered text (safe default).
+func TestSlackSupplementText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"injected merged into current turn", "injected", "⏳ Got it — processing within the current task."},
+		{"buffered for next turn", "buffered", "⏳ Got it — will process automatically once the current task finishes."},
+		{"unknown mode falls back to buffered text", "unknown", "⏳ Got it — will process automatically once the current task finishes."},
+		{"empty mode falls back to buffered text", "", "⏳ Got it — will process automatically once the current task finishes."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, slackSupplementText(tt.mode))
+		})
+	}
+}
+
+// TestWriteCtx_SupplementMode_RendersI18nText verifies that a `message` envelope
+// carrying supplement_mode metadata triggers the i18n supplement text send
+// (synchronously) instead of the normal display path (which would silently drop
+// empty Content).
+//
+// Detection is verified by the writeWithPostMessage error ("slack: client not
+// initialized" in the test harness). Without the early return, the message
+// path returns nil silently for empty Content.
+func TestWriteCtx_SupplementMode_RendersI18nText(t *testing.T) {
+	t.Parallel()
+
+	conn := &SlackConn{
+		adapter:   &Adapter{},
+		channelID: "C123",
+		threadTS:  "123.456",
+	}
+
+	for _, mode := range []string{"injected", "buffered"} {
+		env := &events.Envelope{
+			SessionID: "s-test",
+			Event:     events.Event{Type: events.Message},
+			Metadata:  map[string]any{"supplement_mode": mode},
+		}
+		err := conn.WriteCtx(context.Background(), env)
+		// The supplement path reaches writeWithPostMessage, which fails
+		// predictably with "slack: client not initialized" in the test harness.
+		// Without the supplement check, WriteCtx would return nil (empty
+		// Content dropped by handleStandaloneMessage).
+		require.Error(t, err, "mode=%s should reach writeWithPostMessage", mode)
+		require.Contains(t, err.Error(), "client not initialized",
+			"mode=%s should trigger writeWithPostMessage via supplement path", mode)
+	}
+}
+
+// TestWriteCtx_SupplementMode_NoMetadataFallsThrough confirms that a Message
+// envelope WITHOUT supplement_mode metadata is handled by the normal display
+// path (returns nil for empty Content, does not call writeWithPostMessage).
+func TestWriteCtx_SupplementMode_NoMetadataFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	conn := &SlackConn{
+		adapter:   &Adapter{},
+		channelID: "C123",
+		threadTS:  "123.456",
+	}
+
+	env := &events.Envelope{
+		SessionID: "s-test",
+		Event:     events.Event{Type: events.Message},
+	}
+	err := conn.WriteCtx(context.Background(), env)
+	require.NoError(t, err, "Message without supplement_mode and empty Content returns nil")
+}

--- a/internal/messaging/yuanxin/adapter.go
+++ b/internal/messaging/yuanxin/adapter.go
@@ -538,6 +538,19 @@ func (a *Adapter) SendResponse(ctx context.Context, conn *YuanxinConn, content s
 	return err
 }
 
+// yuanxinSupplementText returns the Chinese i18n text for a mid-turn supplement
+// accepted by the gateway's busy branch. `injected` means the supplement was
+// merged into the running turn; any other mode (typically `buffered`) means it
+// was queued for the next turn. The fallback is the buffered text — promising
+// future handling — so an unexpected mode never falsely implies the supplement
+// is already being processed.
+func yuanxinSupplementText(mode string) string {
+	if mode == "injected" {
+		return "⏳ 已收到，正在当前任务中一并处理"
+	}
+	return "⏳ 已收到，当前任务完成后会自动处理"
+}
+
 const maxTextBuilderSize = 1 << 20
 
 type YuanxinConn struct {
@@ -585,6 +598,15 @@ func (c *YuanxinConn) GetMetadata() map[string]any {
 func (c *YuanxinConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 	if env == nil {
 		return fmt.Errorf("yuanxin: nil envelope")
+	}
+
+	// Supplement path: gateway accepted a mid-turn supplement and signals via
+	// metadata. Render the i18n busy text and return before the normal display
+	// path. The gateway only sets supplement_mode on `message` envelopes with
+	// empty Content, so the metadata alone is the signal — no event-type gate
+	// needed. Checked before the switch since Message has no dedicated case.
+	if mode, _ := env.Metadata["supplement_mode"].(string); mode != "" {
+		return c.adapter.SendResponse(ctx, c, yuanxinSupplementText(mode))
 	}
 
 	c.adapter.Log.Debug("yuanxin: WriteCtx called",

--- a/internal/messaging/yuanxin/supplement_test.go
+++ b/internal/messaging/yuanxin/supplement_test.go
@@ -1,0 +1,80 @@
+package yuanxin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TestYuanxinSupplementText verifies the Chinese i18n text mapping per supplement
+// mode. injected: merged into the running turn. buffered: queued for next turn.
+// Any other mode falls back to the buffered text (safe default).
+func TestYuanxinSupplementText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"injected merged into current turn", "injected", "⏳ 已收到，正在当前任务中一并处理"},
+		{"buffered for next turn", "buffered", "⏳ 已收到，当前任务完成后会自动处理"},
+		{"unknown mode falls back to buffered text", "unknown", "⏳ 已收到，当前任务完成后会自动处理"},
+		{"empty mode falls back to buffered text", "", "⏳ 已收到，当前任务完成后会自动处理"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, yuanxinSupplementText(tt.mode))
+		})
+	}
+}
+
+// TestWriteCtx_SupplementMode_RendersI18nText verifies that an envelope carrying
+// supplement_mode metadata triggers the i18n supplement text send instead of the
+// normal display path (which would silently drop empty Content).
+//
+// Detection is verified by the SendResponse error ("producer not initialized"
+// in the test harness). Without the early return, WriteCtx would return nil
+// silently (empty Content → ExtractResponseText returns ok=false).
+func TestWriteCtx_SupplementMode_RendersI18nText(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter()
+	conn := NewYuanxinConn(a, "ch-test", "th-test", "/tmp")
+
+	for _, mode := range []string{"injected", "buffered"} {
+		env := &events.Envelope{
+			SessionID: "s-test",
+			Event:     events.Event{Type: events.Message},
+			Metadata:  map[string]any{"supplement_mode": mode},
+		}
+		err := conn.WriteCtx(context.Background(), env)
+		// The supplement path reaches SendResponse, which fails predictably
+		// with "producer not initialized" in the test harness. Without the
+		// supplement check, WriteCtx would return nil (empty Content).
+		require.Error(t, err, "mode=%s should reach SendResponse", mode)
+		require.Contains(t, err.Error(), "producer not initialized",
+			"mode=%s should trigger SendResponse via supplement path", mode)
+	}
+}
+
+// TestWriteCtx_SupplementMode_NoMetadataFallsThrough confirms that an envelope
+// WITHOUT supplement_mode metadata is handled by the normal display path
+// (returns nil for empty Content, does not call SendResponse).
+func TestWriteCtx_SupplementMode_NoMetadataFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter()
+	conn := NewYuanxinConn(a, "ch-test", "th-test", "/tmp")
+
+	env := &events.Envelope{
+		SessionID: "s-test",
+		Event:     events.Event{Type: events.Message},
+	}
+	err := conn.WriteCtx(context.Background(), env)
+	require.NoError(t, err, "Message without supplement_mode and empty Content returns nil")
+}

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -1034,6 +1034,12 @@ var (
 	executionSessionBusy     metric.Int64Counter
 	executionSessionBusyInit sync.Once
 
+	midTurnInjected     metric.Int64Counter
+	midTurnInjectedInit sync.Once
+
+	supplementBuffered     metric.Int64Counter
+	supplementBufferedInit sync.Once
+
 	executionDeliveryOutcome     metric.Int64Counter
 	executionDeliveryOutcomeInit sync.Once
 
@@ -1131,6 +1137,38 @@ func ExecutionSessionBusy() metric.Int64Counter {
 		}
 	})
 	return executionSessionBusy
+}
+
+// MidTurnInjected counts user supplements injected into a running turn
+// (worker implements MidTurnInjector; CC headless stream-json / codex turn-steer).
+func MidTurnInjected() metric.Int64Counter {
+	midTurnInjectedInit.Do(func() {
+		var err error
+		midTurnInjected, err = Meter().Int64Counter(
+			"hotplex.execution.mid_turn_injected",
+			metric.WithDescription("User supplements injected into a running turn (mid-turn passthrough)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.execution.mid_turn_injected", err)
+		}
+	})
+	return midTurnInjected
+}
+
+// SupplementBuffered counts user supplements buffered for replay when the
+// worker does not support mid-turn injection (acp/ocs fallback).
+func SupplementBuffered() metric.Int64Counter {
+	supplementBufferedInit.Do(func() {
+		var err error
+		supplementBuffered, err = Meter().Int64Counter(
+			"hotplex.execution.supplement_buffered",
+			metric.WithDescription("User supplements buffered for replay (worker lacks mid-turn support)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.execution.supplement_buffered", err)
+		}
+	})
+	return supplementBuffered
 }
 
 func ExecutionDeliveryOutcome() metric.Int64Counter {

--- a/internal/observability/instruments_audit_test.go
+++ b/internal/observability/instruments_audit_test.go
@@ -37,3 +37,21 @@ func TestAuditInstruments(t *testing.T) {
 		require.NotNil(t, m)
 	})
 }
+
+// TestMidTurnInstruments verifies the two mid-turn counter accessors added for
+// SESSION_BUSY passthrough observability return non-nil instruments. Same shape
+// as TestAuditInstruments — Meter() falls back to a noop meter before Init, so
+// instrument creation succeeds without side effects.
+func TestMidTurnInstruments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MidTurnInjected", func(t *testing.T) {
+		m := MidTurnInjected()
+		require.NotNil(t, m)
+	})
+
+	t.Run("SupplementBuffered", func(t *testing.T) {
+		m := SupplementBuffered()
+		require.NotNil(t, m)
+	})
+}

--- a/internal/worker/claudecode/input_test.go
+++ b/internal/worker/claudecode/input_test.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"os"
 	"sync"
@@ -102,4 +103,46 @@ func TestConn_Stdin_SetLastInput_Integration(t *testing.T) {
 
 	// Drain pipe.
 	_, _ = r.Read(make([]byte, 4096))
+}
+
+// TestInjectMidTurn_WritesStdinWithoutSetLastInput verifies the two defining
+// properties of (*Worker).InjectMidTurn:
+//
+//  1. It writes the same stream-json user frame to stdin that Input would
+//     (so Claude Code headless --print --input-format stream-json absorbs it
+//     into the running turn rather than queuing a new one).
+//  2. It does NOT update crash-recovery lastInput — bridge_worker.go replays
+//     lastInput on resume failure, and a mid-turn supplement must never be
+//     re-delivered as the turn's primary input.
+//
+// The pipe-backed *base.Conn triggers the production stdin-write path (the
+// mock-conn fallback in Input is for non-base connections). Pattern mirrors
+// TestCompact_ProcessNotRunning in worker_coverage_test.go.
+func TestInjectMidTurn_WritesStdinWithoutSetLastInput(t *testing.T) {
+	t.Parallel()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	baseConn := base.NewConn(slog.Default(), w, "user1", "sess1")
+	ww := New()
+	ww.testConn = baseConn
+
+	content := "BONUS: tell me 7+8"
+	require.NoError(t, ww.InjectMidTurn(t.Context(), content, nil))
+
+	// Close the write end so io.ReadAll returns; the conn's stdin field is
+	// left pointing at the closed fd, which is fine — the test is done.
+	require.NoError(t, w.Close())
+
+	frame, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NotEmpty(t, frame)
+
+	require.Contains(t, string(frame), content)
+	require.Contains(t, string(frame), `"type":"user"`)
+
+	// Critical correctness invariant: InjectMidTurn must NOT update lastInput.
+	require.Empty(t, baseConn.LastInput(), "InjectMidTurn must not SetLastInput")
 }

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -30,6 +30,7 @@ import (
 var _ worker.Worker = (*Worker)(nil)
 var _ worker.WorkerCommander = (*Worker)(nil)
 var _ worker.PermissionCeilingReporter = (*Worker)(nil)
+var _ worker.MidTurnInjector = (*Worker)(nil)
 var _ base.MetadataHandler = (*Worker)(nil)
 
 // trySender is a named interface for non-blocking envelope send.
@@ -586,6 +587,47 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 		}
 	}
 
+	w.SetLastIO(time.Now())
+	return nil
+}
+
+// InjectMidTurn delivers a user message into the active turn by writing the
+// same stream-json user frame to stdin. Claude Code (headless --print
+// --input-format stream-json) absorbs it into the running turn rather than
+// queuing a new one (verified by mid-turn injection probe, 2026-07-25).
+//
+// Unlike Input, it MUST NOT call SetLastInput: this is a supplemental inject,
+// not the turn's primary input — crash recovery (bridge_worker.go) replays
+// lastInput and must not replay a mid-turn supplement.
+func (w *Worker) InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error {
+	conn := w.Conn()
+	if conn == nil {
+		return fmt.Errorf("claudecode: not started")
+	}
+	baseConn, ok := conn.(*base.Conn)
+	if !ok {
+		return fmt.Errorf("claudecode: inject requires base conn")
+	}
+	stdin, mu := baseConn.StdinUnlocked()
+	if stdin == nil {
+		return &worker.WorkerError{Kind: worker.ErrKindUnavailable, Message: "claudecode: stdin closed"}
+	}
+	// Mutex acquired inside the closure for the same orphan-write reason as Input
+	// (see Input comment, worker.go:544-554).
+	if err := base.WriteWithCtxBounded(ctx, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		return writeStreamInputLocked(stdin, content)
+	}); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return &worker.WorkerError{
+				Kind:    worker.ErrKindUnavailable,
+				Message: "claudecode: stdin write stalled (worker not reading input)",
+				Cause:   err,
+			}
+		}
+		return fmt.Errorf("claudecode: inject mid-turn: %w", err)
+	}
 	w.SetLastIO(time.Now())
 	return nil
 }

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -87,6 +87,7 @@ var _ worker.WorkerCommander = (*AppServerWorker)(nil)
 var _ worker.ControlRequester = (*AppServerWorker)(nil)
 var _ worker.SystemPromptUpdater = (*AppServerWorker)(nil)
 var _ worker.PermissionCeilingReporter = (*AppServerWorker)(nil)
+var _ worker.MidTurnInjector = (*AppServerWorker)(nil)
 
 type appState int
 
@@ -536,6 +537,30 @@ func (w *AppServerWorker) StopCurrentTurn(ctx context.Context) error {
 	}
 	w.MarkStopped()
 	return w.manager.InterruptTurn(tid, turnID)
+}
+
+// InjectMidTurn steers the active turn with supplemental user input via the
+// app-server turn/steer RPC. Unlike Input (turn/start), it does not start a
+// new turn and does not update lastInput. Returns an error if no turn is
+// active so the gateway can fall back to pending-buffer replay.
+//
+// SteerTurn is the first caller of the already-implemented manager RPC
+// (manager.go:1093); this method is the SESSION_BUSY mid-turn wiring point
+// probed by the gateway via the worker.MidTurnInjector interface assertion.
+// Lock pattern mirrors StopCurrentTurn: snapshot threadID/turnID under w.mu,
+// release the lock, empty-check, then call SteerTurn outside the lock. Does
+// NOT call SetLastIO — a mid-turn inject is supplemental, not the turn's
+// primary input (crash recovery must not replay it).
+func (w *AppServerWorker) InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error {
+	w.mu.Lock()
+	tid := w.threadID
+	turnID := w.turnID
+	w.mu.Unlock()
+	if tid == "" || turnID == "" {
+		return fmt.Errorf("codexcli: no active turn to steer")
+	}
+	_, err := w.manager.SteerTurn(tid, turnID, content)
+	return err
 }
 
 func (w *AppServerWorker) Kill() error {

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -707,6 +707,72 @@ func TestAppServerWorkerInputNoThreadID(t *testing.T) {
 	require.Contains(t, err.Error(), "not started")
 }
 
+// ─── InjectMidTurn Tests (SESSION_BUSY mid-turn passthrough) ──────────────
+
+// TestInjectMidTurn_SteersActiveTurn verifies InjectMidTurn delegates to
+// manager.SteerTurn with the worker's snapshot threadID + turnID and the
+// injected text. The codex package has no mock manager — manager is a concrete
+// *CodexAppServerManager — so we mirror the real-manager + fake-stdin pattern
+// used by TestInputCallsTurnStart / TestRespondServerRequest: SteerTurn's Call
+// writes the JSON-RPC frame to stdin (captured in a strings.Builder) and then
+// times out waiting for a response. The captured frame proves SteerTurn was
+// invoked with the right args; the surfaced error proves InjectMidTurn
+// delegates the RPC (and does not swallow it).
+func TestInjectMidTurn_SteersActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{
+		IdleDrainPeriod: time.Minute,
+		CallTimeout:     20 * time.Millisecond,
+	})
+	var buf strings.Builder
+	mgr.stdin = struct {
+		io.Writer
+		io.Closer
+	}{
+		Writer: &buf,
+		Closer: io.NopCloser(nil),
+	}
+	mgr.mu.Lock()
+	mgr.refs = 1
+	mgr.state = stateRunning
+	mgr.mu.Unlock()
+
+	wk := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thr_1",
+		turnID:     "turn_1",
+	}
+
+	err := wk.InjectMidTurn(context.Background(), "more info", nil)
+	// SteerTurn's Call times out (no real codex process responds), proving the
+	// RPC path was taken. InjectMidTurn must surface — not swallow — the error.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "turn/steer")
+
+	// The JSON-RPC request written to stdin is the observable proof that
+	// SteerTurn was called with the worker's snapshot IDs and injected text.
+	written := buf.String()
+	require.Contains(t, written, `"method":"turn/steer"`)
+	require.Contains(t, written, `"threadId":"thr_1"`)
+	require.Contains(t, written, `"expectedTurnId":"turn_1"`)
+	require.Contains(t, written, `"more info"`)
+}
+
+// TestInjectMidTurn_NoActiveTurn verifies InjectMidTurn returns an error when
+// no turn is active (threadID/turnID empty), so the gateway falls back to
+// pending-buffer replay. Mirrors StopCurrentTurn's empty-turn guard.
+func TestInjectMidTurn_NoActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	w := newTestAppServerWorker(t)
+	// threadID/turnID left empty — no active turn to steer.
+	err := w.InjectMidTurn(context.Background(), "x", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no active turn")
+}
+
 // ─── appConn tests ────────────────────────────────────────────────────────
 
 func TestAppConnSendRecvClose(t *testing.T) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -167,6 +167,20 @@ type PermissionCeilingReporter interface {
 	PermissionCeiling() (string, bool)
 }
 
+// MidTurnInjector is implemented by workers that can accept a user message
+// mid-turn — injecting it into the currently running turn rather than starting
+// a new one. Gateway probes this via type assertion at the SESSION_BUSY branch;
+// workers that don't implement it fall back to pending-buffer replay.
+//
+// Implementations MUST NOT update crash-recovery lastInput: a mid-turn inject
+// is supplemental, not the turn's primary input.
+type MidTurnInjector interface {
+	// InjectMidTurn delivers a user message into the active turn of the worker.
+	// It must return an error if the turn is no longer active (caller falls back
+	// to pending-buffer replay).
+	InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error
+}
+
 // ResetResult describes the outcome of a ResetContext call.
 // Gateway reads this to decide orchestration without knowing Worker internals.
 type ResetResult struct {


### PR DESCRIPTION
Resolves #931 · Related #851 · Related #878 · Related #902

## 概述

会话繁忙(SESSION_BUSY)时的混合输入处理方案。此前网关对活跃 turn 期间的任何输入硬拒绝;现在按 worker 能力分支:

- **中途注入(Mid-turn passthrough)**:支持中途注入的 worker(Claude Code / Codex)实现新的可选 `MidTurnInjector` 接口(`InjectMidTurn(ctx, content, metadata)`)。SESSION_BUSY 时直接把 supplement 注入运行中的 turn。
- **缓冲兜底(Buffer fallback)**:不支持的 worker(Open Code Server / ACP)→ 网关暂存 `PendingBuffer`,turn `done` 释放 active gate 后 drain + merge + replay(`PendingReplayer.DeliverReplay`)。
- **文本反馈**:两条路径都广播携带 `Metadata["supplement_mode"]` 的空内容 `message` 信封;三渠道(feishu/slack/yuanxin)检测该 metadata 并渲染各自的 i18n 文案。
- **清理**:`OnTerminate`(TERMINATED + DELETED)与 `Bridge.Shutdown` 清空 pending buffer,避免 session 结束后误重放。
- **指标**:`mid_turn_injected` + `supplement_buffered` counter。

**设计不变**:active gate 单次活跃约束(DB 部分唯一索引)、AEP 线协议(无新事件 kind,`supplement_mode` 复用 `message` metadata)。

## 设计文档

- spec:`docs/superpowers/specs/2026-07-25-session-busy-midturn-design.md`
- plan:`docs/superpowers/plans/2026-07-25-session-busy-midturn.md`(12 任务 TDD)

## 关键约束(全分支审查已验证)

- **CC `InjectMidTurn` 不调用 `SetLastInput`** —— 崩溃恢复(`bridge_worker.go`)重放 `lastInput`,supplement 非主输入,复用 `writeStreamInputLocked` 路径。
- **CC TOCTOU** —— CC headless(`--print --input-format stream-json`)在 Done 后仍读 stdin。done 在 SESSION_BUSY 检测与 inject 之间到达时,`ActiveBySession` 重检查发现 gate 已释放 → 走 `deliverToWorker`(正规新 turn,有 execution record),避免幽灵 turn。Codex 通过 `SteerTurn` 的 `expectedTurnID` 对称处理。
- **Replay lease-safe** —— 重放 goroutine 在 `FinishRuntime` 成功(active gate 释放)后异步启动,`cloneForReplay` 重置 seq。
- Mutex 显式 `mu` 字段;测试无 `time.Sleep` 等待异步(`require.Eventually` / channel 信号)。

## 测试

`go test ./... -count=1 -race` 全绿。覆盖:CC/codex `InjectMidTurn`(含 lastInput 不被触碰)、`PendingBuffer`(相邻去重 / cap 20 / 并发 / cloneForReplay 新 id)、handler busy 分支(inject 成功 / inject 失败回退 / gate 释放走新 turn)、`finishRuntimeOnDone` replay(flaky 已修)、三渠道 supplement 文案、清理路径、CC TOCTOU 重检查(`GateReleasedBeforeInject` / `RaceGateStillHeld`)。

## Review

全分支审查(15 commit / 25 文件 / +2870 行,rebase onto #929 AEP canonical schema 后)verdict:**Ready to merge**,0 Critical,Important(CC TOCTOU + 对应测试)已修,Minor 已 triage(#4 already present、#3 kept、#5/#6/#7 低价值)。rebase 后 `go test ./... -count=1 -race` 再次全绿,`7055d2b0` 的 seq 单一权威改动与本分支 replay block 自动合并且无冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
