### PR TITLE
docs(patrol): 2026-07-27 文档维护

### DIFF
--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -164,6 +164,25 @@ type RuntimeExecutionData struct {
 发送。`runtime.execution.completed` 或 `runtime.execution.failed` 在 `done` 之后
 发送（作为 execution 账本的终态通知，与 run 结果分离）。
 
+#### `internal_reset` — Worker 原地重置通知
+
+`additive` 的 worker→gateway **内部协调事件，绝不转发给客户端**（`bridge_forward.go`
+拦截消费）。In-place-reset Worker（OCS、ACP）通过 API/RPC 完成原地状态重置后发出，
+Gateway accumulator 据此递增 generation、清零 turn 计数与 turn 文本缓冲。
+
+```go
+type InternalResetData struct {
+    Generation int64 `json:"generation"` // Worker 侧 reset generation 序号
+}
+```
+
+- **方向**：S → C（仅 Gateway 内部消费，客户端不可见）
+- **稳定性**：`additive`（未知消费者静默忽略）
+- **背压**：**不丢弃** — `base/conn.go` 的 `InjectWithTimeout` 提供 2s 超时，保证 normal load 下不被静默丢弃
+- **发送方**：OCS（`opencodeserver/worker.go`）、ACP（`acp/worker.go`）经 `LoadResetGeneration()` 读取后发出
+
+> **与 fork-based 重置的区别**：Claude Code 等 fork-based Worker 重置时 fork 新进程并替换 Conn；in-place Worker（OCS/ACP）复用同一进程，仅通过 `internal_reset` 向 Gateway 回执新 generation（`ConnReplaced=false`），用于同步内部统计。
+
 #### `state` — 状态变更
 
 ```go


### PR DESCRIPTION
## Summary

自基线 `53212a10`（PR #928，2026-07-24）以来 main 上的 1 个提交（PR #929 AEP canonical schema + cross-SDK conformance）触发的文档巡逻维护。

### 修复

- **`docs/reference/events.md`**：补全遗漏的 `internal_reset` 事件章节。events.md 逐 Kind 覆盖 AEP v1 全部 35 个事件，唯独缺 `internal_reset`（由 in-place-reset Worker OCS/ACP 发出、Gateway 内部消费、绝不转发客户端）。PR #929 已将该类型补全给 TS/Python/Java SDK，文档需同步。修复后覆盖度 35/35。

### 评估后未改动

- `aep-protocol.md`：PR #929 已自带 Canonical Schema 章节，准确完整
- events.md Seq 编号规则：fix(acp) #879 改的是 seq 分配者（mapper 本地计数器 → bridge 统一 Hub SeqGen），非编号规则本身，现有描述仍准确
- `docs/architecture/`：index.md BFS 不可达，不在巡逻维护范围

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)