### PR TITLE
docs(patrol): 2026-07-28 同步 #934 SESSION_BUSY mid-turn 文档影响

### DIFF
--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -580,7 +580,14 @@ const tabId = `sess_${crypto.randomUUID()}`;
 
 > `session_id` 由 Gateway 覆盖为 init_ack 返回的 Gateway Session ID，`seq` 覆盖为 per-session 单调递增序列号——客户端填空字符串、真实 ID 或省略该字段效果完全相同。`session_id` 仅在 init 握手时有语义（参与 Session ID 派生），后续所有消息中该字段被忽略。
 
-**限制**：Session 必须处于 Active 状态（created / running / idle），非 Active 状态下发送 input 返回 `SESSION_BUSY` 或 `SESSION_TERMINATED` 错误。
+**状态限制**：Session 必须处于 Active 状态（created / running / idle）；处于 TERMINATED/DELETED 时发送 input 返回 `SESSION_TERMINATED`。
+
+**会话繁忙时的输入（SESSION_BUSY 分支）**：若 session 正在执行一个 turn（active gate 被占用），新 input 进入 SESSION_BUSY 分支，但**不会被丢弃或硬拒绝**，而是按 Worker 能力分流：
+
+- 支持 mid-turn 注入的 Worker（`claude_code`、`codex_cli`）：追问被透传并入当前 turn，结果随当前回复一起产出。
+- 其余 Worker（`acp`、`opencode_server`）：追问被暂存，当前 turn 完成后合并重投为一个新 input。
+
+仅当 Bridge 不可用等异常情况才会向客户端返回 `SESSION_BUSY` 错误。客户端可通过 `message` 事件的 `metadata.supplement_mode`（`injected` / `buffered`）感知追问已被接收。
 
 ### 6.2 接收流式响应
 
@@ -768,7 +775,7 @@ Worker 执行过程中还可能产生：
 
 Gateway 对**所有直接连接 `/ws` 的客户端**实行每个 session 单连接限制；这不仅适用于内置 WebChat，也适用于企业自建前端、SDK 和其他 WebSocket Gateway 集成。首个完成 `init` 的连接成为该 session 的 owner；在它关闭前，后续使用同一 session 的 `init` 会收到 `init_ack` 错误，`code` 为 `SESSION_ALREADY_CONNECTED`，随后连接关闭。
 
-这与 `SESSION_BUSY` 不同：`SESSION_BUSY` 表示同一已建立连接上的 session 正在执行，拒绝新的 `input`；`SESSION_ALREADY_CONNECTED` 表示握手阶段已有另一条直接 WebSocket 连接。
+这与 `SESSION_BUSY` 不同：`SESSION_BUSY` 表示同一已建立连接上的 session 正在执行一个 turn，此时新的 `input` 不再被拒绝，而是按 Worker 能力透传并入当前 turn 或暂存待完成后重投（见 §6.1）；`SESSION_ALREADY_CONNECTED` 表示握手阶段已有另一条直接 WebSocket 连接。
 
 企业客户端应按以下方式处理：
 
@@ -1370,7 +1377,7 @@ direction=after&cursor=142    # 向后追赶：id > 142
 | 错误码                | 说明           | 建议           |
 | --------------------- | -------------- | -------------- |
 | `SESSION_NOT_FOUND`   | Session 不存在 | 重新 init      |
-| `SESSION_BUSY`        | Session 非活跃 | 等待或重连     |
+| `SESSION_BUSY`        | 会话繁忙，正常情况自动透传/暂存（仅异常回退返回此码） | 见 §6.1 |
 | `SESSION_EXPIRED`     | 已过期         | 创建新会话     |
 | `SESSION_TERMINATED`  | Session 已终止 | 重连恢复或新建 |
 | `SESSION_INVALIDATED` | Session 已失效 | 重新 init      |

--- a/docs/guides/enterprise/observability.md
+++ b/docs/guides/enterprise/observability.md
@@ -57,7 +57,7 @@ HotPlex 使用 `log/slog` JSON Handler 输出结构化日志，兼容 OTel Log D
 
 ## 2. OTel 原生指标体系
 
-HotPlex 使用统一的 `internal/observability/` 包，通过 OTel Meter API 注册 58+ 个指标，前缀为 `hotplex.`。应用代码零直接依赖 `prometheus/client_golang`。
+HotPlex 使用统一的 `internal/observability/` 包，通过 OTel Meter API 注册 60+ 个指标，前缀为 `hotplex.`。应用代码零直接依赖 `prometheus/client_golang`。
 
 指标通过 OTel Prometheus Exporter 以标准 Prometheus 格式暴露于 `GET /admin/metrics`，同时支持通过 OTLP gRPC 导出到 OTel Collector。
 
@@ -150,7 +150,9 @@ Durable ingress 的输入账本、owner lease 续约与终态修复子系统。
 | `hotplex.execution.accept` | Counter | — | 新输入被持久化接受 |
 | `hotplex.execution.duplicate` | Counter | — | 幂等去重（相同 ID + payload） |
 | `hotplex.execution.conflict` | Counter | — | Payload 冲突（相同 ID，不同 hash） |
-| `hotplex.execution.session_busy` | Counter | — | Active gate 拒绝（session 忙于此前 execution） |
+| `hotplex.execution.session_busy` | Counter | — | Active gate 拒绝（session 忙于此前 execution），转入 mid-turn 透传或暂存兜底 |
+| `hotplex.execution.mid_turn_injected` | Counter | — | busy 时追问被透传注入当前 turn（worker 支持 mid-turn，如 claude_code/codex_cli） |
+| `hotplex.execution.supplement_buffered` | Counter | — | busy 时追问被暂存，待 turn 完成后重投（worker 不支持 mid-turn 的兜底） |
 | `hotplex.execution.delivery_outcome` | Counter | `delivery_status` | Worker 投递结果（delivered/unknown/failed） |
 | `hotplex.execution.runtime_outcome` | Counter | `runtime_status` | Worker 运行终态（completed/failed/unknown） |
 | `hotplex.execution.delivery_latency` | Histogram | — | accept 到 delivery outcome 耗时 |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -238,6 +238,8 @@ type MessageData struct {
 
 Turn 结束时的完整消息聚合，兼容非流式场景。
 
+> **busy 追问通知 marker**：当 session 繁忙（SESSION_BUSY 分支）时收到用户追问，Gateway 会广播一个空 `content` 的 `message` 事件作为通知 marker，`metadata.supplement_mode` 标记处理方式——`injected`（透传并入当前 turn，结果随当前回复产出）或 `buffered`（暂存待 turn 完成后重投）。客户端应据此感知追问已被接收，而非将其当作空消息展示。
+
 #### `tool_call` — 工具调用通知
 
 ```go


### PR DESCRIPTION
Closes #935

#934 将 SESSION_BUSY 从硬拒绝改为按 Worker 能力分流（mid-turn 透传注入 / 暂存待 turn 完成后重投），新增 `mid_turn_injected` / `supplement_buffered` 指标。同步受影响文档：

- **websocket-integration.md**：§6.1 状态限制、§8.3 所有权对比、§13.2 错误表三处 SESSION_BUSY 更新为透传/暂存语义，移除「硬拒绝 / Session 非活跃」
- **observability.md**：2.9 Execution 指标表补 `mid_turn_injected` + `supplement_buffered`，与 metrics.md 对齐（总数 58+ → 60+）
- **events.md**：`message` 事件补充 `supplement_mode` marker（busy 追问通知）说明

纯文档变更，无代码/协议改动。