### PR TITLE
fix(feishu): 加固 Claude Code 端到端消息链

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -808,16 +808,10 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		log.Warn("Brain initialization failed (fail-open)", "err", err)
 	}
 
-	// Effective events/turns retention: when audit is enabled, extend the TTL
-	// to max(events.retention, audit.full_content_retention) so audit event_ref
-	// drill-down stays valid for the full-content window (spec §5.3). Hot-reload
-	// of this effective value requires a gateway restart (the GC goroutine
-	// captures the value at startup), consistent with audit.collector.batch_interval.
+	// Events and turns retain only their configured events.retention window.
+	// Audit plaintext has an independent retention policy. The GC captures this
+	// value at startup, so changing events.retention requires a gateway restart.
 	eventsRetention := config.EffectiveEventsRetention(cfg)
-	if eventsRetention != cfg.Events.Retention {
-		log.Info("audit: extending events/turns retention for full-content drill-down",
-			"original", cfg.Events.Retention, "effective", eventsRetention)
-	}
 	go runEventsGC(ctx, stores, log, eventsRetention)
 
 	leaseMgr.Start(ctx)

--- a/docs/.../plans/2026-08-03-feishu-claude-e2e-hardening.md
+++ b/docs/.../plans/2026-08-03-feishu-claude-e2e-hardening.md
@@ -1,0 +1,135 @@
+# 飞书 × Claude Code 消息链加固实施计划
+
+> **执行方式**：按 subagent-driven-development 流程逐任务执行；每个任务先红测、再最小实现、再绿测、提交、自审和独立任务审查。Epic：[#941](https://github.com/hrygo/hotplex/issues/941)。
+
+**目标**：在保留 audit 原文明文的前提下，修复飞书 × Claude Code 端到端消息链的六类可靠性和安全风险。
+
+**架构边界**：audit 是长期原文真相源，event store 是短期运行副本，INFO 日志仅留元数据/指纹。平台命令统一转换为 AEP control；队列承担单 chat 串行和安全生命周期；终态控制器返回真实投递结果，由连接层负责静态兜底。
+
+**技术栈**：Go、AEP v1、Feishu Go SDK、OpenTelemetry、testify、GitHub Actions。
+
+---
+
+### Task 1：数据副本分层与正文日志消除
+
+**文件**：
+- 修改：`internal/gateway/handler.go`
+- 修改：`internal/gateway/handler_test.go`
+- 修改：`internal/config/config_types.go`
+- 修改：`internal/config/effective_events_retention_test.go`
+- 修改：`docs/reference/configuration.md`
+
+**步骤**：
+1. 新增红测：INFO handler 日志不包含输入原文，但包含 `data_size` 和 `data_sha256`；`emitAudit` 仍保留完整 `content`。
+2. 新增红测：audit enabled 且 full-content retention 更长时，`EffectiveEventsRetention` 仍返回 `events.retention`。
+3. 运行：`rtk go test ./internal/gateway ./internal/config -run 'Test.*(Audit|ReceivedEvent|EffectiveEventsRetention)' -count=1`，确认失败原因符合预期。
+4. 实现稳定的 envelope 数据编码、大小和 SHA-256 短指纹日志，移除 INFO 的 `data` 字段。
+5. 解耦 event retention 与 audit full-content retention；更新注释和配置文档。
+6. 运行：`rtk go test ./internal/gateway ./internal/config -count=1 -race`。
+7. 提交：`fix(gateway): separate plaintext audit from operational copies`
+
+### Task 2：停止指令进入 AEP `control.stop`
+
+**文件**：
+- 修改：`internal/messaging/control_command.go`
+- 修改：`internal/messaging/control_command_test.go`
+- 修改：`internal/messaging/pipeline.go`
+- 修改：`internal/messaging/feishu/handler.go`
+- 修改：`internal/messaging/feishu/adapter_flow_test.go`
+- 修改：`internal/messaging/slack/adapter.go`
+- 修改：相关 Slack 测试
+
+**步骤**：
+1. 新增红测：`stop`、`停止`、`/stop` 被检测为 `CmdControl` 且 action 为 `ControlActionStop`。
+2. 新增飞书/Slack 红测：abort 文本调用 control handler，而非仅本地返回或仅取消 queue。
+3. 运行相关消息包定向测试，确认红测。
+4. 将 abort trigger 统一映射为 control result；平台路由复用既有 control envelope 和 Gateway stop 实现。
+5. 确保 stop 不新建错误 session、不触发 reset/terminate 语义。
+6. 运行：`rtk go test ./internal/messaging/... ./internal/gateway -count=1 -race`。
+7. 提交：`fix(messaging): route abort commands through control stop`
+
+### Task 3：ChatQueue 生命周期与去重回滚
+
+**文件**：
+- 修改：`internal/messaging/feishu/chat_queue.go`
+- 修改：`internal/messaging/feishu/chat_queue_test.go`
+- 修改：`internal/messaging/dedup.go`
+- 修改：`internal/messaging/dedup_test.go`
+- 修改：`internal/messaging/feishu/handler.go`
+- 修改：`internal/messaging/feishu/adapter_flow_test.go`
+
+**步骤**：
+1. 新增红测：Close 与 Enqueue 并发无 panic；Close 后返回 `ErrChatQueueClosed`；idle 退出边界不会接收孤儿任务。
+2. 新增红测：queue full 时 handler 回滚 message ID，平台重试可再次进入；成功入队仍去重。
+3. 新增 Dedup 条件删除红测。
+4. 运行定向测试和 `-race`，确认红测或竞态。
+5. 在队列锁内完成 worker 选择和 channel send，使用 closed 状态与实例条件删除。
+6. handler 用提交/回滚语义管理 dedup 记录。
+7. 运行：`rtk go test ./internal/messaging ./internal/messaging/feishu -count=1 -race`。
+8. 提交：`fix(feishu): make queue admission and dedup retry-safe`
+
+### Task 4：媒体有界读取与最小权限
+
+**文件**：
+- 修改：`internal/messaging/feishu/media.go`
+- 修改：`internal/messaging/feishu/media_test.go`
+
+**步骤**：
+1. 新增红测：恰好 10 MiB 成功、10 MiB + 1 失败、超限 reader 不被完整读取。
+2. 新增 Unix 权限红测：目录 `0700`、文件 `0600`；Windows 跳过 mode 位断言。
+3. 运行定向测试确认红测。
+4. 使用 `io.LimitReader(mediaMaxSize+1)` 有界读取，收紧 `MkdirAll`/`WriteFile` 权限。
+5. 运行：`rtk go test ./internal/messaging/feishu -run 'Test.*Media' -count=1 -race`。
+6. 提交：`fix(feishu): bound media reads and restrict temp files`
+
+### Task 5：终态投递错误、指标与静态兜底
+
+**文件**：
+- 修改：`internal/messaging/feishu/streaming.go`
+- 修改：`internal/messaging/feishu/streaming_test.go`
+- 修改：`internal/messaging/feishu/conn.go`
+- 修改：`internal/messaging/feishu/conn_test.go`
+- 修改：`internal/observability/instruments.go`
+- 修改：`internal/observability/instruments_test.go`
+- 修改：`docs/reference/metrics.md`
+
+**步骤**：
+1. 新增红测：final CardKit 和 IM Patch 均失败时 `Close` 返回错误；header update 失败可见。
+2. 新增红测：连接层收到 Close 错误后发送静态终态兜底；兜底失败可计量。
+3. 新增 lazy `sync.Once` 指标 accessor 测试。
+4. 运行定向测试确认红测。
+5. 用 `errors.Join` 聚合终态错误，保持成功降级路径；增加 `hotplex.streaming.terminal_failures` 与兜底结果属性。
+6. 连接层只发送简短静态说明，不重复完整正文。
+7. 更新 metrics 文档并运行：`rtk go test ./internal/messaging/feishu ./internal/observability -count=1 -race`。
+8. 提交：`fix(feishu): surface terminal delivery failures`
+
+### Task 6：Claude Code bypass doctor 风险告警
+
+**文件**：
+- 修改：`internal/cli/checkers/permission_mode.go`
+- 修改：`internal/cli/checkers/permission_mode_test.go`
+- 修改：`docs/reference/configuration.md`
+- 修改：`docs/guides/production.md`
+
+**步骤**：
+1. 新增红测：有效 permission mode 为 bypass 时 Warn，workspace 时 Pass，配置不可读时 Warn 且有 FixHint。
+2. 覆盖 `HOTPLEX_WORKER_DEFAULT_PERMISSION_MODE` 环境覆盖和 YAML 默认值。
+3. 运行定向测试确认红测。
+4. 实现只读 checker，不提供 FixFunc，不修改配置。
+5. 文档说明 bypass 的信任边界、allowlist 不能替代 Worker 权限和收紧方法。
+6. 运行：`rtk go test ./internal/cli/checkers -count=1 -race`。
+7. 提交：`feat(doctor): warn on claude bypass permission mode`
+
+### Task 7：全局回归、最终审查与 PR
+
+**文件**：
+- 检查：本计划涉及的全部文件
+
+**步骤**：
+1. 对 `main...HEAD` 生成最终 review package，并由独立高能力 reviewer 审查设计一致性、并发、安全和跨平台风险。
+2. 修复全部 Critical/Important，重复审查直至通过。
+3. 运行：`rtk go test ./internal/messaging/... ./internal/gateway ./internal/config ./internal/cli/checkers ./internal/observability -count=1 -race`。
+4. 运行：`rtk make check`。
+5. 检查：`rtk git diff --check`、`rtk git status --short`、Issue/Spec/测试可追溯性。
+6. 删除 SDD scratch workspace，推送 `agent/feishu-claude-e2e-hardening`。
+7. 创建关联 `Closes #941` 的 Draft PR，写入测试证据和剩余现场验证边界。

--- a/docs/.../specs/2026-08-03-feishu-claude-e2e-hardening-design.md
+++ b/docs/.../specs/2026-08-03-feishu-claude-e2e-hardening-design.md
@@ -1,0 +1,92 @@
+# 飞书 × Claude Code 消息链可靠性、数据治理与安全加固设计
+
+**状态**：Approved  
+**日期**：2026-08-03  
+**Epic**：[#941](https://github.com/hrygo/hotplex/issues/941)
+
+## 1. 目标
+
+加固飞书消息从接入、排队、Gateway 投递、Claude Code 执行到飞书终态展示的完整链路，同时保留审计原文明文，降低无治理的数据副本、消息丢失、停止失效、资源耗尽、终态不可见和高权限误用风险。
+
+## 2. 已批准决策
+
+1. 审计存储继续保留消息原文明文，作为长期合规与追溯真相源。
+2. 飞书停止指令必须进入 AEP `control.stop`，只停止当前 turn，不销毁 session。
+3. ChatQueue 的 worker 生命周期与任务入队必须原子化；入队失败必须回滚本次去重登记。
+4. 媒体下载必须在流式读取中执行 10 MiB 硬限制，临时目录和文件采用最小权限。
+5. 最终 CardKit、IM Patch、header update 失败必须对上游可见、可计量，并尝试静态文本兜底。
+6. Claude Code `bypass` 权限模式增加显式 doctor 风险检查与文档，不自动修改现网配置。
+
+## 3. 数据副本模型
+
+### 3.1 允许的受控副本
+
+| 存储层 | 职责 | 原文明文 | 默认时限 |
+| --- | --- | --- | --- |
+| Audit user activity | 合规、追责、完整原文查询 | 保留 | `audit.retention` |
+| Event store | 会话历史、恢复、协议重放 | 保留 | `events.retention` |
+
+两者不是同一用途：audit 是长期治理记录，event store 是短期运行事实。它们必须分别执行自己的留存策略。
+
+### 3.2 禁止的无治理副本
+
+INFO 日志不得输出 `Envelope.Event.Data`、prompt 或消息正文。日志只记录：事件类型、session、seq、数据大小和正文 SHA-256 短指纹。这样既能关联排障，又不会形成第三份无独立留存策略的正文。
+
+### 3.3 留存解耦
+
+现有 `EffectiveEventsRetention` 以 `max(events.retention, audit.full_content_retention)` 延长事件存储，但消息审计记录本身已经包含原文，且当前 `message.inbound` 没有依赖 event reference 才能读取正文。新语义只使用 `events.retention`；`audit.full_content_retention` 保留为兼容配置字段，但不再延长事件/turn 副本。
+
+该变更不删除或脱敏 audit 原文，也不批量修改历史数据；只影响后续 GC 的事件/turn 留存窗口。
+
+## 4. 停止链路
+
+`DetectCommand` 将所有 abort trigger 规范化为 `ControlActionStop`。飞书和 Slack 均通过既有 `handleTextControlCommand` 建立 control envelope，由 Gateway 完成 ownership 校验、`Worker.StopCurrentTurn`、execution runtime 收敛，并发出 `done.reason=stopped_by_user`。
+
+平台本地的流式任务取消仍由收到 terminal/done 后的连接逻辑负责，不能替代 Worker stop。
+
+## 5. ChatQueue 与去重
+
+- `ChatQueue` 增加 closed 状态。
+- 查找/创建 worker、确认 worker 可接收、非阻塞入队在同一队列锁保护下完成。
+- idle worker 只能在持有队列锁且确认自己仍是 map 当前实例后删除。
+- `Close` 在锁内标记关闭并关闭每个 worker channel，后续 Enqueue 返回稳定哨兵错误，不 panic。
+- dedup 提供条件删除：仅当记录仍对应本次登记时回滚，避免误删后续记录。
+- 飞书 handler 在转换、gate 或 enqueue 失败时回滚本次去重登记；成功入队后保持去重。
+
+## 6. 媒体边界
+
+- 使用 `io.LimitReader(mediaMaxSize+1)` 或等价有界读取，超过上限立即返回明确错误。
+- 媒体目录权限 `0700`，文件权限 `0600`。
+- 文件名继续使用 `filepath.Base` 和资源 key 组合，禁止路径穿越。
+- 失败路径不留下部分文件。
+
+## 7. 终态投递
+
+- `StreamingCardController.Close` 聚合最终 flush、disable streaming、header update 错误。
+- CardKit 失败后继续 IM Patch；两者都失败时增加终态失败指标并返回错误。
+- 上层连接收到 Close 错误后使用独立静态文本消息发送简短终态兜底；兜底失败也记录指标和结构化日志。
+- 成功呈现内容但仅 header 修饰失败时仍返回可识别错误，让上层计量但避免重复完整正文。
+- 新指标必须通过 observability 的 lazy `sync.Once` accessor 注册并写入 metrics 文档。
+
+## 8. `bypass` 风险检查
+
+新增 `worker.claude_bypass_mode` doctor checker：解析有效配置及环境覆盖，若 Claude Code 的有效默认或平台 worker 配置为 `bypass`，输出 Warn、风险说明和收紧建议。检查只读，不提供自动修复，不修改生产配置。
+
+## 9. 兼容性与非目标
+
+- 不改变 AEP wire contract。
+- 不迁移、不删除、不脱敏历史 audit 原文。
+- 不自动切换现网 permission mode。
+- 不把 `unknown` 输入状态视作可安全重投。
+- Linux、macOS、Windows 都不得引入平台专属路径或信号假设。
+
+## 10. 验收
+
+- audit 测试证明原文明文仍保留；日志测试证明正文不出现。
+- event retention 测试证明不再被 audit full-content window 延长。
+- stop 解析、飞书路由和 Gateway `stopped_by_user` 闭环测试通过。
+- ChatQueue queue-full、idle、Close、并发 race 和 dedup rollback 测试通过。
+- 10 MiB 边界、超限流式终止、`0700/0600` 权限测试通过。
+- CardKit/IM Patch/header/兜底失败注入测试与指标测试通过。
+- bypass checker 在 bypass/workspace/无配置场景下结果正确。
+- 相关包 `go test -count=1 -race` 与全量 `make check` 通过。

--- a/docs/guides/enterprise/audit.md
+++ b/docs/guides/enterprise/audit.md
@@ -96,7 +96,7 @@ grep "audit" ~/.hotplex/logs/gateway.log | head -5
 audit:
   enabled: true
   retention: 26280h       # 3 年（默认值）
-  full_content_retention: 2160h  # 90 天（默认值）
+  full_content_retention: 2160h  # 90 天兼容字段；不影响 events/turns GC
   collector:
     channel_cap: 4096     # 内存缓冲区
     batch_interval: 1s     # 刷写间隔
@@ -118,9 +118,9 @@ audit:
 |--------|------|--------|----------|------|
 | `audit.enabled` | bool | `true` | `AUDIT_ENABLED` | 是否启用审计系统 |
 | `audit.retention` | duration | `26280h`（3 年） | `AUDIT_RETENTION` | 审计记录保留时长 |
-| `audit.full_content_retention` | duration | `2160h`（90 天） | `AUDIT_FULL_CONTENT_RETENTION` | 事件 drill-down 引用有效窗口 |
+| `audit.full_content_retention` | duration | `2160h`（90 天） | `AUDIT_FULL_CONTENT_RETENTION` | 兼容配置字段；不影响 event store 或 turns 的留存 |
 
-**有效事件保留期**：当审计启用时，实际的事件保留期为 `max(events.retention, audit.full_content_retention)`，确保审计引用在 90 天内可回溯。
+**事件与审计留存相互独立**：event store 与 turns 只按 `events.retention` 清理；入站消息原文由 audit 记录保留并按 `audit.retention` 独立清理。`audit.full_content_retention` 为兼容字段，不会延长 event/turn 副本或 `event_ref` 的可用时间。
 
 ### 3.2 Collector 调优
 
@@ -172,7 +172,7 @@ audit:
 | `audit.collector.batch_size` | **热重载** | 立即应用 |
 | `audit.collector.batch_interval` | **热重载**（⚠️ 实际需重启） | 变更会被记录，但刷写器需重启才能生效 |
 | `audit.enabled` | **需重启** | 禁止热关闭，防止管理员在审计盲区操作 |
-| `audit.full_content_retention` | **需重启** | 事件 TTL 变更需重启 |
+| `audit.full_content_retention` | **需重启** | 兼容字段变更会被审计记录，但不会改变 event/turn GC 留存 |
 | `audit.collector.channel_cap` | **需重启** | Channel 容量在创建时确定 |
 | `audit.collector.spill_dir` | **需重启** | Spill 路径在启动时确定 |
 
@@ -838,7 +838,7 @@ groups:
 - [ ] **审计系统**：确认 `audit.enabled: true`（默认开启），生产环境**禁止关闭**
 - [ ] **Hash Chain 告警**：配置 `AuditChainBroken` 告警规则，确保链断裂在 5 分钟内通知
 - [ ] **Spill 监控**：配置 `AuditSpillRateHigh` 告警，高并发场景适当调大 `channel_cap`
-- [ ] **保留期**：根据合规要求调整 `audit.retention`（默认 3 年）和 `audit.full_content_retention`（默认 90 天）
+- [ ] **保留期**：根据合规要求分别调整 `audit.retention`（默认 3 年）与 `events.retention`（默认 30 天）；`audit.full_content_retention`（默认 90 天）仅为兼容字段
 - [ ] **身份链接**：为跨平台用户创建 Identity Link，确保跨渠道审计查询完整
 - [ ] **Sink 投递**：生产环境配置 Webhook Sink 接入 SIEM，不要使用 noop 默认值
 - [ ] **导出归档**：定期导出审计数据（JSON/CSV）并归档，满足合规审查要求

--- a/docs/guides/enterprise/audit.md
+++ b/docs/guides/enterprise/audit.md
@@ -389,7 +389,8 @@ Tool Call 的敏感工具输入在写入审计表前，自动进行凭证遮罩�
 
 | 事件类型 | detail_json 内容 | drill-down |
 |----------|-----------------|------------|
-| 标准事件 | 摘要 + SHA-256 | 通过 `event_ref` 回溯 events/turns（90 天有效） |
+| `message.inbound` | `content` 保留消息原文，按 `audit.retention` 独立留存 | `event_ref` 若存在仅关联 events/turns，并只在 `events.retention` 窗口内可用 |
+| 其他标准事件 | 摘要 + SHA-256 | `event_ref` 若存在仅作短期运行事实关联 |
 | 敏感行为 | 完整上下文直接存储 | 无需 drill-down |
 
 **敏感行为**（直接存储完整上下文）包括：认证失败、敏感工具调用、权限拒绝、Worker 崩溃/超时。

--- a/docs/guides/enterprise/deployment.md
+++ b/docs/guides/enterprise/deployment.md
@@ -121,6 +121,19 @@ Docker/K8s 环境建议用 NetworkPolicy 替代，避免 NAT 后 IP 失真。
 | XML Sanitizer | 强制开启，防注入 |
 | 路径安全 | `work_dir` 限制在允许目录树内 |
 
+### 2.6 Claude Code Worker 权限
+
+飞书机器人使用 Claude Code 时，生产基线应同时把 workspace 默认和 Claude Code operator ceiling 收紧为 `workspace`（或按业务需要收紧为 `read-only`）：
+
+```yaml
+worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: workspace
+```
+
+`bypass` 会跳过常规 Claude Code 权限提示；仅应在隔离、短期且由运维人员明确批准的场景使用。飞书的 `allow_from`、`allow_dm_from` 和 `allow_group_from` 是入口身份限制，不是 Worker 工具权限边界：白名单用户的消息仍可能驱动 Worker 执行高权限工具。部署变更后运行 `hotplex doctor`，确认 `worker.claude_bypass_mode` 没有 Warn，再使用 `hotplex service restart` 原子重启服务。
+
 ---
 
 ## 3. 网络配置

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -31,6 +31,7 @@ description: "HotPlex Worker Gateway 所有配置项的权威参考，覆盖配�
    - [webchat — Web Chat UI](#313-webchat--web-chat-ui)
    - [oauth — WebChat 企业 SSO（OIDC）](#314-oauth--webchat--ssooidc)
    - [inherits — 配置继承](#315-inherits--)
+   - [events 和 audit — 事件与审计留存](#316-events-和-audit--事件与审计留存)
 4. [热重载](#4-热重载)
 5. [环境变量速查](#5-环境变量速查)
 
@@ -681,6 +682,20 @@ log:
 2. 递归加载父配置文件（含环检测）
 3. 子配置文件值覆盖父配置值
 4. 环境变量覆盖所有文件配置
+
+---
+
+### 3.16 events 和 audit — 事件与审计留存
+
+运行期 event store 与合规 audit store 是职责不同的两类数据副本：前者支持会话恢复和协议重放，后者保存可追溯的用户活动原文。两者按各自配置独立清理；延长审计原文留存**不会**延长 event store 或 turn 的留存。
+
+| 字段 | 类型 | 默认值 | 环境变量 | 说明 |
+|------|------|--------|----------|------|
+| `events.retention` | duration | `720h` (30天) | `HOTPLEX_EVENTS_RETENTION` | Event store 和 turns 的运行期留存窗口。到期后由事件 GC 清理 |
+| `audit.retention` | duration | `26280h` (3年) | `HOTPLEX_AUDIT_RETENTION` | 审计记录的基础留存窗口，由 audit GC 独立执行 |
+| `audit.full_content_retention` | duration | `2160h` (90天) | `HOTPLEX_AUDIT_FULL_CONTENT_RETENTION` | 审计原文的兼容配置字段；不再影响 event store 或 turns 留存 |
+
+> 网关 INFO 日志不会记录消息正文、prompt 或 `Envelope.Event.Data`。为支持关联排障，日志仅包含事件类型、session、seq、`data_size` 与 `data_sha256`（SHA-256 的短指纹）。
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -290,6 +290,21 @@ LLM Provider 返回临时错误（429、529、400 等）时的自动重试配置
 | `permission_auto_approve` | []string | `["ExitPlanMode"]` | — | 自动批准的工具名称列表（无需转发用户交互 UI） |
 | `mcp_servers` | map | `{}` | — | 用户配置的 MCP Server。空值 = 使用默认发现机制 |
 
+##### Claude Code 权限边界与 Doctor
+
+`bypass` 会让 Claude Code 使用跳过常规权限提示的执行路径；它只应出现在受控、短期、已隔离的运维场景，不能作为飞书生产机器人的常规默认值。`messaging.*.allow_from`、`allow_dm_from` 和 `allow_group_from` 仅限制**谁能向机器人发消息**，不能限制获准请求在 Worker 内可调用的工具，也不能替代 Worker 权限模式。
+
+对启用的飞书 `claude_code` Worker，`hotplex doctor` 的 `worker.claude_bypass_mode` 会按运行时同一规则检查两类有效模式：平台会话的空 `sessionMode` 使用 `worker.claude_code.permission_mode`（空值仍是兼容性的 `bypass`）；workspace 会话使用 `worker.default_permission_mode`，再被前者作为 permissiveness ceiling 收紧。发现任一路径为 `bypass` 时只输出 Warn 和收紧建议，**不会修改配置，也没有自动修复**。
+
+`HOTPLEX_WORKER_CLAUDE_CODE_PERMISSION_MODE` 可覆盖 Claude Code operator 模式。相对地，`HOTPLEX_WORKER_DEFAULT_PERMISSION_MODE` 当前**没有**运行时环境变量绑定；该变量不会覆盖 YAML 的 `worker.default_permission_mode`，请在配置文件中设置该字段。收紧到 workspace 的生产基线示例：
+
+```yaml
+worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: workspace
+```
+
 #### 3.7.4 opencode_server — OpenCode Server Worker
 
 | 字段 | 类型 | 默认值 | 环境变量 | 说明 |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -266,6 +266,7 @@ rate(hotplex_cron_duration_sum[5m]) / rate(hotplex_cron_duration_count[5m])
 | `hotplex.streaming.card.rotations` | Counter | Streaming Card TTL 触发的旋转次数 |
 | `hotplex.streaming.card.rotation_failures` | Counter | 旋转失败数，label: `phase` |
 | `hotplex.streaming.card.flush_fallbacks` | Counter | CardKit 降级到 IM Patch 的次数 |
+| `hotplex.streaming.terminal_failures` | Counter | 终态 CardKit/IM Patch 或收尾装饰失败次数，label: `fallback_result`（`pending` / `sent` / `failed` / `skipped_body_presented`） |
 
 ## ACP 指标
 

--- a/docs/specs/User-Behavior-Audit-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Spec.md
@@ -223,7 +223,7 @@ type AlertSink interface {
 - `detail_json` 字段白名单(结构化)
 - **禁录**:凭证、password、API key 明文、session token、完整 PII(身份证/手机号)
 - API key 记前缀 + 掩码(`hpk_a4c1…`)
-- 消息正文:摘要(前 N 字 + PII 脱敏)+ sha256;全量靠 `event_ref` 或敏感行为路径
+- 消息正文：`message.inbound` 的 `detail_json.content` 直接保留原文，并按 `audit.retention` 独立留存；`event_ref` 若存在只关联 events/turns，且仅在 `events.retention` 窗口内可用
 - 符合 OWASP Logging Cheat Sheet "What Not to Log"
 
 ### 5.10 性能与背压(补 events 静默丢弃缺口)

--- a/docs/specs/User-Behavior-Audit-Spec.md
+++ b/docs/specs/User-Behavior-Audit-Spec.md
@@ -32,7 +32,7 @@ hotplex 需要审计每个用户的行为,支撑**内部调查**与**合规/取�
 |---|---|
 | 驱动 | 内部调查 + 合规/取证 |
 | 归因维度 | 平台原生 ID(`ou_…`/`U…`/UUID 各自独立审计) |
-| 消息内容 | 独立审计表存摘要+sha256;全量靠 `event_ref` 引用 events/turns;敏感行为全量直存 |
+| 消息内容 | `message.inbound` 在独立审计表保留原文；`event_ref` 仅为 events/turns 的可选关联，不承担审计正文留存 |
 | 保留期 | 3 年 |
 | 不可变性 | append-only + hash chain(不需 WORM/外部存储) |
 | 实时告警 | 需要(本 spec 只定义可扩展 `AlertSink` 接口,不实现具体规则/通道) |
@@ -118,16 +118,16 @@ CREATE INDEX idx_ua_action_ts ON user_activity(action, ts);
 
 > **注**:每请求的 cookie 重新校验(`AuthenticateRequest` cookie 成功分支、WS 升级成功分支)**不发审计行**——归因交给领域动作。`auth.token_validated` 常量保留未用(预留)。
 
-### 5.3 内容策略(摘要 + 引用复用全量)
+### 5.3 内容策略（审计原文与运行副本分离）
 
-呼应决策 3(独立表则摘要+hash):
+呼应消息内容决策：审计是长期治理记录，events/turns 是短期运行副本。
 
-- 审计表 `detail_json` 存**摘要 + sha256**(永久可查,3 年)
-- `event_ref` → `events.id` / `turns.id`,session 存活时下钻**复用** events/turns 完整内容(不在审计表重存全量)
+- `message.inbound` 的 `detail_json.content` 保存消息原文，并按 `audit.retention`（默认 3 年）独立留存
+- 其他审计记录仍按其数据最小化策略保存摘要、SHA-256 或必要上下文
+- `event_ref` → `events.id` / `turns.id` 仅用于关联运行事实；审计正文读取不依赖它
 - **敏感行为**(失败认证、敏感工具调用、denied、crash/timeout)在 `detail_json` 内**直接存全量上下文**(量小且重要,不依赖 events)
-- 权衡:events/turns 现 retention 30 天,到期后普通消息只剩摘要。新增 `audit.full_content_retention` 把 events/turns 延长(默认 90 天)供下钻;敏感行为已全量入审计表,不受影响
-- **wiring**:`effective events retention = max(events.retention, audit.full_content_retention)`(audit 启用时);注意此延长会同时影响**非审计用途**的 events(副作用已接受,换取下钻完整性)
-- `event_ref` 预期会随 events/turns TTL(90 天)后**悬空**——届时审计行只剩摘要 + sha256(仍满足"是否做过某行为"的审计);需长期全量回溯的敏感行为已全量直存 `detail_json`,不依赖 `event_ref`。悬空是设计预期,非异常
+- `events.retention`（默认 30 天）独立控制 events/turns GC；`audit.full_content_retention` 保留为兼容字段，绝不延长运行副本
+- `event_ref` 可以在 events/turns 到期后悬空；这不影响已存入 audit 的消息原文或敏感行为上下文。悬空是设计预期，非异常
 
 ### 5.4 归因
 
@@ -261,7 +261,7 @@ type AlertSink interface {
 audit:
   enabled: true
   retention: 26280h              # 3 年
-  full_content_retention: 2160h  # events/turns 延长(90 天)供下钻
+  full_content_retention: 2160h  # 兼容字段；不延长 events/turns
   chain_verify_interval: 1h
   collector:
     channel_cap: 4096
@@ -342,7 +342,7 @@ audit:
 - `tool.call` 工具调用审计(spec §5.2)
 - 现有 `internal/admin/audit.go` AdminAudit slog 路径迁移为双写 `user_activity`
 - 外部 `RegisterSink` 机制 + `WebhookSink`
-- `full_content_retention` 延长 events/turns TTL(默认 90 天)
+- `full_content_retention` 保留为兼容字段，不影响 events/turns TTL
 - `system.audit_config_changed` meta-audit
 - sinks↔audit 单向导入清理
 
@@ -434,7 +434,7 @@ audit:
 |---|---|
 | 双写性能开销 | 异步批量 + spill;审计点轻量(摘要) |
 | hash chain 写入序列化瓶颈 | SQLite 单进程 mutex + 批量足够;**PG 多 pod 共享 advisory lock 是全局串行化点**——高吞吐场景按 `user_id` hash 分片多链(见 §14 分区) |
-| events 到期后普通消息只剩摘要 | `full_content_retention` 延长;敏感行为全量入审计表 |
+| events 到期后 `event_ref` 悬空 | 入站消息原文与敏感行为上下文已独立保存在审计表；按需要调整 `events.retention` |
 | 平台原生 ID 不归一 → 同人跨通道分散 | v1 接受;v2 建映射(§13) |
 | 审计表 3 年膨胀 | TTL GC + 索引 + 可选冷归档 |
 | spill 磁盘故障丢审计 | WAL + fsync;失败告警 |

--- a/docs/superpowers/specs/2026-07-06-audit-p2-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-06-audit-p2-review-fixes-design.md
@@ -35,7 +35,7 @@ The change covers credential-safe audit serialization, tool-input redaction, sin
 
 ### Retention and config audit
 
-- Treat `audit.full_content_retention` as static/restart-required because the event GC captures its TTL at startup. This matches actual runtime behavior and prevents a false “applied” signal.
+- Keep `audit.full_content_retention` static/restart-required as a compatibility field. Its changes remain auditable, but it no longer changes the event GC TTL.
 - Add `audit.full_content_retention` to `auditConfigDiff` so attempted changes are still recorded in the tamper-evident trail.
 
 ## Compatibility
@@ -43,7 +43,7 @@ The change covers credential-safe audit serialization, tool-input redaction, sin
 - Existing `sinks.Sink` implementations remain source-compatible; lifecycle support is optional.
 - Existing YAML fields and defaults do not change.
 - External sink delivery remains best-effort and non-blocking. Database audit persistence remains the source of truth.
-- `full_content_retention` changes now explicitly require restart; startup behavior is unchanged.
+- `full_content_retention` changes remain restart-required for compatibility and are recorded, but no longer affect event/turn retention at startup.
 
 ## Testing
 

--- a/internal/cli/checkers/permission_mode.go
+++ b/internal/cli/checkers/permission_mode.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
 )
 
 // claudeAutoModeChecker verifies the installed Claude Code CLI advertises the
@@ -62,6 +63,120 @@ func (c claudeAutoModeChecker) Check(ctx context.Context) cli.Diagnostic {
 	}
 }
 
+// claudeBypassModeChecker reports the risk of a configured Feishu Claude Code
+// worker running with bypass permissions. It is intentionally read-only: a
+// permission change needs an operator decision and a restart.
+type claudeBypassModeChecker struct{}
+
+func (c claudeBypassModeChecker) Name() string     { return "worker.claude_bypass_mode" }
+func (c claudeBypassModeChecker) Category() string { return "worker" }
+
+func (c claudeBypassModeChecker) Check(ctx context.Context) cli.Diagnostic {
+	cfg, err := loadConfig()
+	if cfg == nil && err == nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "Config path not set; skipping Claude Code bypass permission check",
+		}
+	}
+	if err != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot load config for Claude Code bypass permission check",
+			Detail:   err.Error(),
+			FixHint:  "Fix the configuration file, then run hotplex doctor again",
+		}
+	}
+
+	if !hasFeishuClaudeCodeWorker(cfg) {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "No Claude Code Feishu worker configured",
+		}
+	}
+
+	workspaceMode := resolveClaudePermissionMode(cfg.Worker.DefaultPermissionMode, cfg.Worker.ClaudeCode.PermissionMode)
+	platformMode := resolveClaudePermissionMode("", cfg.Worker.ClaudeCode.PermissionMode)
+	if workspaceMode == permissionModeBypass || platformMode == permissionModeBypass {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Claude Code bypass permission mode is active for Feishu",
+			Detail:   "Bypass skips normal Claude Code permission prompts for at least one effective Feishu session mode.",
+			FixHint:  "Set worker.claude_code.permission_mode and worker.default_permission_mode to workspace or read-only, then restart HotPlex.",
+		}
+	}
+
+	return cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusPass,
+		Message:  "Configured Feishu Claude Code workers use restricted permission modes",
+	}
+}
+
+const (
+	permissionModeReadOnly  = "read-only"
+	permissionModeWorkspace = "workspace"
+	permissionModeAutoEdit  = "auto-edit"
+	permissionModeBypass    = "bypass"
+)
+
+// resolveClaudePermissionMode mirrors Claude Code's runtime resolution: a
+// platform session has no session mode and therefore uses the operator mode;
+// an explicit workspace default is clamped to that operator ceiling. Empty
+// operator mode preserves the legacy Claude Code bypass default.
+func resolveClaudePermissionMode(sessionMode, operatorMode string) string {
+	effectiveMode := sessionMode
+	if effectiveMode == "" {
+		effectiveMode = operatorMode
+	}
+	if operatorMode != "" && permissionModeRank(effectiveMode) > permissionModeRank(operatorMode) {
+		effectiveMode = operatorMode
+	}
+	if effectiveMode == "" {
+		return permissionModeBypass
+	}
+	return effectiveMode
+}
+
+func permissionModeRank(mode string) int {
+	switch mode {
+	case permissionModeReadOnly:
+		return 0
+	case permissionModeWorkspace:
+		return 1
+	case permissionModeAutoEdit:
+		return 2
+	case permissionModeBypass:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func hasFeishuClaudeCodeWorker(cfg *config.Config) bool {
+	if !cfg.Messaging.Feishu.Enabled {
+		return false
+	}
+	if len(cfg.Messaging.Feishu.Bots) == 0 {
+		return cfg.ResolveWorkerType("feishu", "") == config.DefaultWorkerType
+	}
+	for _, bot := range cfg.Messaging.Feishu.Bots {
+		if cfg.ResolveWorkerType("feishu", bot.Name) == config.DefaultWorkerType {
+			return true
+		}
+	}
+	return false
+}
+
 // probeClaudeHelp runs `claude --help` with a bounded timeout and returns its
 // combined stdout/stderr. The help text lists supported --permission-mode values.
 func probeClaudeHelp(ctx context.Context, claude string) (string, error) {
@@ -86,4 +201,5 @@ func claudeHelpSupportsAuto(helpText string) bool {
 
 func init() {
 	cli.DefaultRegistry.Register(claudeAutoModeChecker{})
+	cli.DefaultRegistry.Register(claudeBypassModeChecker{})
 }

--- a/internal/cli/checkers/permission_mode_test.go
+++ b/internal/cli/checkers/permission_mode_test.go
@@ -1,9 +1,14 @@
 package checkers
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cli"
 )
 
 func TestClaudeHelpSupportsAuto(t *testing.T) {
@@ -52,4 +57,171 @@ func TestClaudeAutoModeCheckerMetadata(t *testing.T) {
 	c := claudeAutoModeChecker{}
 	require.Equal(t, "worker.claude_auto_mode", c.Name())
 	require.Equal(t, "worker", c.Category())
+}
+
+func TestClaudeBypassModeChecker(t *testing.T) {
+	// This test changes package-global configPath and process environment, so it
+	// must remain serial (see withConfigPath in config_test.go).
+	checker := registeredChecker("worker.claude_bypass_mode")
+	require.NotNil(t, checker, "doctor must register the Claude bypass risk checker")
+
+	tests := []struct {
+		name       string
+		yaml       string
+		configPath string
+		noConfig   bool
+		env        map[string]string
+		wantStatus cli.Status
+		wantHint   bool
+	}{
+		{
+			name:       "no configuration skips the risk check",
+			noConfig:   true,
+			wantStatus: cli.StatusPass,
+		},
+		{
+			name: "YAML workspace defaults pass",
+			yaml: `worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: workspace
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			wantStatus: cli.StatusPass,
+		},
+		{
+			name: "YAML workspace default bypass is clamped by the operator ceiling",
+			yaml: `worker:
+  default_permission_mode: bypass
+  claude_code:
+    permission_mode: workspace
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			wantStatus: cli.StatusPass,
+		},
+		{
+			name: "YAML bypass defaults warn when the operator does not tighten them",
+			yaml: `worker:
+  default_permission_mode: bypass
+  claude_code:
+    permission_mode: bypass
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			wantStatus: cli.StatusWarn,
+			wantHint:   true,
+		},
+		{
+			name: "YAML Claude Code platform default bypass warns",
+			yaml: `worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: bypass
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			wantStatus: cli.StatusWarn,
+			wantHint:   true,
+		},
+		{
+			name: "default permission environment variable is not a runtime override",
+			yaml: `worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: workspace
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			env: map[string]string{
+				"HOTPLEX_WORKER_DEFAULT_PERMISSION_MODE": "bypass",
+			},
+			wantStatus: cli.StatusPass,
+		},
+		{
+			name: "Claude Code permission environment override warns",
+			yaml: `worker:
+  default_permission_mode: workspace
+  claude_code:
+    permission_mode: workspace
+messaging:
+  feishu:
+    enabled: true
+    worker_type: claude_code
+`,
+			env: map[string]string{
+				"HOTPLEX_WORKER_CLAUDE_CODE_PERMISSION_MODE": "bypass",
+			},
+			wantStatus: cli.StatusWarn,
+			wantHint:   true,
+		},
+		{
+			name: "non Claude Code Feishu platform does not warn",
+			yaml: `worker:
+  default_permission_mode: bypass
+  claude_code:
+    permission_mode: bypass
+messaging:
+  feishu:
+    enabled: true
+    worker_type: codex_cli
+    bots:
+      - name: operations
+        app_id: cli_test
+        app_secret: secret
+        worker_type: acp
+`,
+			wantStatus: cli.StatusPass,
+		},
+		{
+			name:       "unreadable configuration warns with remediation",
+			configPath: filepath.Join(t.TempDir(), "missing.yaml"),
+			wantStatus: cli.StatusWarn,
+			wantHint:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOTPLEX_WORKER_DEFAULT_PERMISSION_MODE", "")
+			t.Setenv("HOTPLEX_WORKER_CLAUDE_CODE_PERMISSION_MODE", "")
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			path := tt.configPath
+			if path == "" && !tt.noConfig {
+				path = filepath.Join(t.TempDir(), "config.yaml")
+				require.NoError(t, os.WriteFile(path, []byte(tt.yaml), 0o600))
+			}
+			withConfigPath(t, path)
+
+			diagnostic := checker.Check(context.Background())
+			require.Equal(t, tt.wantStatus, diagnostic.Status, diagnostic.Detail)
+			require.Equal(t, "worker.claude_bypass_mode", diagnostic.Name)
+			require.Equal(t, "worker", diagnostic.Category)
+			require.Equal(t, tt.wantHint, diagnostic.FixHint != "")
+			require.Nil(t, diagnostic.FixFunc, "this checker must never modify production configuration")
+		})
+	}
+}
+
+func registeredChecker(name string) cli.Checker {
+	for _, checker := range cli.DefaultRegistry.All() {
+		if checker.Name() == name {
+			return checker
+		}
+	}
+	return nil
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -194,7 +194,7 @@ func Default() *Config {
 		Audit: AuditConfig{
 			Enabled:              true,
 			Retention:            26280 * time.Hour, // 3 years
-			FullContentRetention: 2160 * time.Hour,  // 90 days (spec §5.3)
+			FullContentRetention: 2160 * time.Hour,  // 90 days; compatibility field, not used by events/turns GC
 			Collector: AuditCollectorConfig{
 				ChannelCap:    4096,
 				BatchInterval: 1 * time.Second,

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -710,18 +710,15 @@ type EventsConfig struct {
 type AuditConfig struct {
 	Enabled              bool                 `mapstructure:"enabled"`
 	Retention            time.Duration        `mapstructure:"retention"`
-	FullContentRetention time.Duration        `mapstructure:"full_content_retention"` // spec §5.3: extends events/turns TTL so audit event_ref drill-down stays valid (default 90d)
+	FullContentRetention time.Duration        `mapstructure:"full_content_retention"` // Compatibility field (default 90d); does not extend events/turns retention.
 	Collector            AuditCollectorConfig `mapstructure:"collector"`
 	Sinks                []AuditSinkConfig    `mapstructure:"sinks"`
 }
 
 // EffectiveEventsRetention computes the events/turns TTL to use at startup.
-// Per spec §5.3: when audit is enabled, the effective retention is
-// max(events.retention, audit.full_content_retention) so that audit event_ref
-// drill-down stays valid for the full-content window. When audit is disabled,
-// events.retention is returned unchanged (audit must not silently shorten the
-// events TTL when the operator turns audit off). A zero events.retention falls
-// back to the package default (720h) before the max is taken.
+// Audit keeps its plaintext independently, so full_content_retention never
+// extends this short-lived operational copy. A zero events.retention falls back
+// to the package default (720h).
 func EffectiveEventsRetention(cfg *Config) time.Duration {
 	if cfg == nil {
 		return 720 * time.Hour
@@ -729,9 +726,6 @@ func EffectiveEventsRetention(cfg *Config) time.Duration {
 	ev := cfg.Events.Retention
 	if ev <= 0 {
 		ev = 720 * time.Hour // 30 days, matches Default()
-	}
-	if cfg.Audit.Enabled && cfg.Audit.FullContentRetention > ev {
-		return cfg.Audit.FullContentRetention
 	}
 	return ev
 }

--- a/internal/config/effective_events_retention_test.go
+++ b/internal/config/effective_events_retention_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEffectiveEventsRetention_Defaults verifies the default config yields the
-// audit full-content retention (90d > 30d events default).
+// TestEffectiveEventsRetention_Defaults verifies that event and audit retention
+// are independent, even when the audit full-content window is longer.
 func TestEffectiveEventsRetention_Defaults(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
@@ -16,14 +16,13 @@ func TestEffectiveEventsRetention_Defaults(t *testing.T) {
 	require.Equal(t, 720*time.Hour, cfg.Events.Retention)
 	require.True(t, cfg.Audit.Enabled)
 	require.Equal(t, 2160*time.Hour, cfg.Audit.FullContentRetention)
-	// Effective = max(720h, 2160h) = 2160h.
-	require.Equal(t, 2160*time.Hour, EffectiveEventsRetention(cfg))
+	// Event storage retains its own 30-day window; audit retains plaintext
+	// independently for its configured 90-day window.
+	require.Equal(t, 720*time.Hour, EffectiveEventsRetention(cfg))
 }
 
-// TestEffectiveEventsRetention_AuditDisabledNoOverride verifies that when audit
-// is disabled, the events retention is returned UNCHANGED even if
-// full_content_retention is longer (audit must not silently lengthen TTL when
-// the operator turned audit off).
+// TestEffectiveEventsRetention_AuditDisabledNoOverride verifies that disabling
+// audit leaves the independent event retention unchanged.
 func TestEffectiveEventsRetention_AuditDisabledNoOverride(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
@@ -34,19 +33,19 @@ func TestEffectiveEventsRetention_AuditDisabledNoOverride(t *testing.T) {
 	require.Equal(t, 720*time.Hour, EffectiveEventsRetention(cfg))
 }
 
-// TestEffectiveEventsRetention_EventsLongerThanFull verifies the max picks
-// events.retention when it exceeds full_content_retention.
+// TestEffectiveEventsRetention_EventsLongerThanFull verifies that audit
+// full-content retention never changes events.retention.
 func TestEffectiveEventsRetention_EventsLongerThanFull(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
 	cfg.Audit.Enabled = true
 	cfg.Events.Retention = 5000 * time.Hour
 	cfg.Audit.FullContentRetention = 2160 * time.Hour
-	// max(5000h, 2160h) = 5000h.
+	// Event retention remains operator-configured at 5000h.
 	require.Equal(t, 5000*time.Hour, EffectiveEventsRetention(cfg))
 }
 
-// TestEffectiveEventsRetention_EqualValues is the boundary case.
+// TestEffectiveEventsRetention_EqualValues is the equal-window boundary case.
 func TestEffectiveEventsRetention_EqualValues(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
@@ -57,14 +56,14 @@ func TestEffectiveEventsRetention_EqualValues(t *testing.T) {
 }
 
 // TestEffectiveEventsRetention_ZeroEventsFallback verifies a zero/empty events
-// retention falls back to the 720h default before the max is taken.
+// retention falls back to the independent 720h default.
 func TestEffectiveEventsRetention_ZeroEventsFallback(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
 	cfg.Audit.Enabled = true
 	cfg.Events.Retention = 0 // unset
 	cfg.Audit.FullContentRetention = 100 * time.Hour
-	// max(720h fallback, 100h) = 720h.
+	// The 720h event fallback is not affected by audit retention.
 	require.Equal(t, 720*time.Hour, EffectiveEventsRetention(cfg))
 }
 
@@ -75,14 +74,14 @@ func TestEffectiveEventsRetention_NilConfig(t *testing.T) {
 }
 
 // TestEffectiveEventsRetention_ZeroFullContent verifies a zero
-// full_content_retention does not shrink events retention (only extends).
+// full_content_retention does not affect events retention.
 func TestEffectiveEventsRetention_ZeroFullContent(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
 	cfg.Audit.Enabled = true
 	cfg.Events.Retention = 720 * time.Hour
 	cfg.Audit.FullContentRetention = 0 // unset
-	// max(720h, 0h) = 720h — no change.
+	// Event retention remains 720h.
 	require.Equal(t, 720*time.Hour, EffectiveEventsRetention(cfg))
 }
 

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -311,7 +313,14 @@ func (h *Handler) Handle(ctx context.Context, env *events.Envelope) (err error) 
 		}
 	}()
 	if env.Event.Type != events.Ping {
-		h.log.Info("gateway: Handle received event", "type", env.Event.Type, "session_id", env.SessionID, "seq", env.Seq, "data", env.Event.Data)
+		dataSize, dataSHA256 := eventDataLogSummary(env.Event.Data)
+		h.log.Info("gateway: Handle received event",
+			"type", env.Event.Type,
+			"session_id", env.SessionID,
+			"seq", env.Seq,
+			"data_size", dataSize,
+			"data_sha256", dataSHA256,
+		)
 	}
 	switch env.Event.Type {
 	case events.Input:
@@ -333,6 +342,18 @@ func (h *Handler) Handle(ctx context.Context, env *events.Envelope) (err error) 
 	default:
 		return h.sendErrorf(ctx, env, events.ErrCodeProtocolViolation, "unknown event type: %s", env.Event.Type)
 	}
+}
+
+// eventDataLogSummary returns an operationally useful, non-plaintext summary
+// of event data. JSON encoding gives maps a stable key order; unsupported
+// values use their type name, which is likewise stable and reveals no body.
+func eventDataLogSummary(data any) (int, string) {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		encoded = []byte(fmt.Sprintf("unsupported:%T", data))
+	}
+	sum := sha256.Sum256(encoded)
+	return len(encoded), hex.EncodeToString(sum[:])[:16]
 }
 
 func (h *Handler) handleInput(ctx context.Context, env *events.Envelope) error {

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1,12 +1,17 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hrygo/hotplex/internal/audit"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/dbutil"
 	"github.com/hrygo/hotplex/internal/eventstore"
@@ -25,6 +31,154 @@ import (
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+type captureAuditStore struct {
+	mu         sync.Mutex
+	activities []audit.UserActivity
+}
+
+func (s *captureAuditStore) BeginTx(context.Context) (audit.Tx, error) {
+	return &captureAuditTx{store: s}, nil
+}
+
+func (s *captureAuditStore) Query(_ context.Context, _ audit.Query) ([]audit.UserActivity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	activities := make([]audit.UserActivity, len(s.activities))
+	copy(activities, s.activities)
+	return activities, nil
+}
+
+func (s *captureAuditStore) Stats(context.Context, audit.Query) (audit.ActivityStats, error) {
+	return audit.ActivityStats{}, nil
+}
+
+func (s *captureAuditStore) QueryAsc(context.Context, int64, int) ([]audit.UserActivity, error) {
+	return nil, nil
+}
+
+func (s *captureAuditStore) DeleteBefore(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (s *captureAuditStore) SaveCheckpoint(context.Context, audit.Checkpoint) error {
+	return nil
+}
+
+func (s *captureAuditStore) LatestCheckpoint(context.Context) (*audit.Checkpoint, error) {
+	return nil, nil
+}
+
+func (s *captureAuditStore) ListIdentityLinks(context.Context, string) ([]audit.IdentityLink, error) {
+	return nil, nil
+}
+
+func (s *captureAuditStore) UpsertIdentityLink(context.Context, audit.IdentityLink) error {
+	return nil
+}
+
+func (s *captureAuditStore) DeleteIdentityLink(context.Context, string) error {
+	return nil
+}
+
+func (s *captureAuditStore) Close() error {
+	return nil
+}
+
+func (s *captureAuditStore) Dialect() dbutil.Dialect {
+	return dbutil.DialectSQLite
+}
+
+type captureAuditTx struct {
+	store *captureAuditStore
+}
+
+func (tx *captureAuditTx) Append(ctx context.Context, activity *audit.UserActivity) error {
+	return tx.AppendBatch(ctx, []*audit.UserActivity{activity})
+}
+
+func (tx *captureAuditTx) AppendBatch(_ context.Context, activities []*audit.UserActivity) error {
+	tx.store.mu.Lock()
+	defer tx.store.mu.Unlock()
+	for _, activity := range activities {
+		tx.store.activities = append(tx.store.activities, *activity)
+	}
+	return nil
+}
+
+func (tx *captureAuditTx) SaveCheckpoint(context.Context, audit.Checkpoint) error {
+	return nil
+}
+
+func (tx *captureAuditTx) TailHash(context.Context) (string, error) {
+	return "", nil
+}
+
+func (tx *captureAuditTx) LastRowBefore(context.Context, time.Time) (int64, string, error) {
+	return 0, "", nil
+}
+
+func (tx *captureAuditTx) DeleteByIDLEQ(context.Context, int64) (int64, error) {
+	return 0, nil
+}
+
+func (tx *captureAuditTx) RowCount(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (tx *captureAuditTx) Commit() error {
+	return nil
+}
+
+func (tx *captureAuditTx) Rollback() error {
+	return nil
+}
+
+// TestHandler_ReceivedEventLogExcludesBodyAndAuditRetainsContent catches a
+// regression that creates an unmanaged plaintext log copy while preserving
+// the governed audit copy.
+func TestHandler_ReceivedEventLogExcludesBodyAndAuditRetainsContent(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	store := &captureAuditStore{}
+	collector := audit.NewCollector(store, nil, nil, logger, audit.CollectorConfig{
+		ChannelCap:    1,
+		BatchSize:     1,
+		BatchInterval: time.Hour,
+	})
+	collector.Start(context.Background())
+	t.Cleanup(func() { require.NoError(t, collector.Close(context.Background())) })
+
+	handler := NewHandler(HandlerDeps{Log: logger, Hub: newTestHub(t)})
+	handler.SetAuditCollector(collector)
+	secret := "customer-secret-message"
+	data := map[string]any{"content": secret}
+	env := events.NewEnvelope(aep.NewID(), "session-1", 7, events.Kind("unknown"), data)
+
+	require.Error(t, handler.Handle(context.Background(), env))
+
+	encoded, err := json.Marshal(data)
+	require.NoError(t, err)
+	sum := sha256.Sum256(encoded)
+	logOutput := logs.String()
+	require.NotContains(t, logOutput, secret)
+	require.Contains(t, logOutput, `"data_size":`+strconv.Itoa(len(encoded)))
+	require.Contains(t, logOutput, `"data_sha256":"`+hex.EncodeToString(sum[:])[:16]+`"`)
+
+	handler.emitAudit(audit.OutcomeSuccess, "user-1", "feishu", "session-1", secret)
+	require.Eventually(t, func() bool {
+		activities, queryErr := store.Query(context.Background(), audit.Query{})
+		return queryErr == nil && len(activities) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	activities, err := store.Query(context.Background(), audit.Query{})
+	require.NoError(t, err)
+	var detail map[string]string
+	require.NoError(t, json.Unmarshal([]byte(activities[0].DetailJSON), &detail))
+	require.Equal(t, secret, detail["content"])
+}
 
 // mockHandlerSM is a mock session manager for handler tests.
 type mockHandlerSM struct {

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -709,12 +709,31 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 		}
 		routeErrs = append(routeErrs, err)
 		h.log.Warn("gateway: write failed", "session_id", msg.Env.SessionID, "err", err)
-		_ = conn.Close()
-		h.mu.Lock()
-		h.removeSession(msg.Env.SessionID, conn)
-		h.mu.Unlock()
+		h.detachAndCloseSessionWriter(msg.Env.SessionID, conn)
 	}
 	return errors.Join(routeErrs...)
+}
+
+// detachAndCloseSessionWriter removes a failed writer from routing before
+// starting cleanup. Close may wait on a platform write that outlives its
+// caller's terminal deadline, so it must never block the Hub's single router.
+func (h *Hub) detachAndCloseSessionWriter(sessionID string, conn SessionWriter) {
+	h.mu.Lock()
+	h.removeSession(sessionID, conn)
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				h.log.Error("gateway: panic closing failed session writer",
+					"session_id", sessionID, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
+		if err := conn.Close(); err != nil {
+			h.log.Warn("gateway: failed session writer cleanup",
+				"session_id", sessionID, "err", err)
+		}
+	}()
 }
 
 // drainBroadcast processes remaining messages in the broadcast channel.

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -148,9 +148,23 @@ type Hub struct {
 type EnvelopeWithConn struct {
 	Env  *events.Envelope
 	Conn *Conn
+	// routeCtx is retained only for terminal platform writes, which need to
+	// surface their actual delivery result to the original caller.
+	routeCtx context.Context
+	result   chan<- error
 	// afterDrain is called (blocking) by Run after routeMessage finishes processing this item.
 	// Tests use it to synchronize against the drain goroutine.
 	afterDrain func()
+}
+
+func (m *EnvelopeWithConn) complete(err error) {
+	if m.result == nil {
+		return
+	}
+	select {
+	case m.result <- err:
+	default:
+	}
 }
 
 // NewHub creates a new Hub.
@@ -464,12 +478,30 @@ func (h *Hub) SendToSession(ctx context.Context, env *events.Envelope, afterDrai
 	// No Clone needed here: Bridge.forwardEvents already clones the envelope
 	// before calling SendToSession, so this is a bridge-owned copy. The Hub.Run
 	// goroutine reads it from the channel for routing without mutation.
+	msg := &EnvelopeWithConn{Env: env, afterDrain: afterDrainCallback}
+	if isTerminalPlatformEvent(env.Event.Type) {
+		result := make(chan error, 1)
+		msg.routeCtx = ctx
+		msg.result = result
+		if !h.sendBroadcast(msg) {
+			return errors.New("gateway: broadcast channel closed")
+		}
+		select {
+		case err := <-result:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-h.ctx.Done():
+			return errors.New("gateway: broadcast channel closed")
+		}
+	}
+
 	if isDroppable(env.Event.Type) {
 		// Non-blocking send — droppable events must never stall Hub.Run.
 		// A full broadcast channel means a slow consumer is already being
 		// protected at the per-conn writeCh layer; dropping here is the
 		// intended backpressure semantics. The UI self-heals on done.
-		if h.trySendBroadcast(&EnvelopeWithConn{Env: env, afterDrain: afterDrainCallback}) {
+		if h.trySendBroadcast(msg) {
 			return nil
 		}
 		observability.GatewayDeltasDropped().Add(context.Background(), 1)
@@ -477,7 +509,7 @@ func (h *Hub) SendToSession(ctx context.Context, env *events.Envelope, afterDrai
 	}
 
 	// Guaranteed delivery path.
-	if h.sendBroadcast(&EnvelopeWithConn{Env: env, afterDrain: afterDrainCallback}) {
+	if h.sendBroadcast(msg) {
 		return nil
 	}
 	return errors.New("gateway: broadcast channel closed")
@@ -608,8 +640,9 @@ func (h *Hub) Run() {
 					attribute.String("event_type", string(msg.Env.Event.Type)),
 					attribute.String("seq", fmt.Sprintf("%d", msg.Env.Seq)),
 				)
-				h.routeMessage(msg)
+				err := h.routeMessage(msg)
 				span.End()
+				msg.complete(err)
 				if msg.afterDrain != nil {
 					msg.afterDrain()
 				}
@@ -618,7 +651,7 @@ func (h *Hub) Run() {
 	}
 }
 
-func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
+func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 	conns := h.snapshotConns(msg.Env.SessionID)
 
 	if len(conns) == 0 {
@@ -633,7 +666,7 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
 			h.log.Debug("gateway: event dropped, no connections",
 				"session_id", msg.Env.SessionID, "event_type", msg.Env.Event.Type)
 		}
-		return
+		return nil
 	}
 
 	if h.LogHandler != nil {
@@ -652,9 +685,10 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
 	data, err := aep.EncodeJSON(msg.Env)
 	if err != nil {
 		h.log.Error("gateway: encode message failed", "session_id", msg.Env.SessionID, "err", err)
-		return
+		return err
 	}
 
+	var routeErrs []error
 	for _, conn := range conns {
 		var err error
 		if conn.PreferEnvelope() {
@@ -662,19 +696,25 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
 			// json:"-" fields (e.g. OwnerID) that EncodeJSON omits.
 			// Use WithoutCancel so cancelled h.ctx doesn't block during
 			// shutdown drain, while preserving tracing propagation.
-			err = conn.RouteWrite(context.WithoutCancel(h.ctx), msg.Env)
+			routeCtx := context.WithoutCancel(h.ctx)
+			if msg.routeCtx != nil {
+				routeCtx = msg.routeCtx
+			}
+			err = conn.RouteWrite(routeCtx, msg.Env)
 		} else {
 			err = conn.RouteWriteData(data, msg.Env.Event.Type)
 		}
 		if err == nil {
 			continue
 		}
+		routeErrs = append(routeErrs, err)
 		h.log.Warn("gateway: write failed", "session_id", msg.Env.SessionID, "err", err)
 		_ = conn.Close()
 		h.mu.Lock()
 		h.removeSession(msg.Env.SessionID, conn)
 		h.mu.Unlock()
 	}
+	return errors.Join(routeErrs...)
 }
 
 // drainBroadcast processes remaining messages in the broadcast channel.
@@ -685,7 +725,8 @@ func (h *Hub) drainBroadcast() {
 		select {
 		case msg := <-h.broadcast:
 			if msg != nil && msg.Env != nil {
-				h.routeMessage(msg)
+				err := h.routeMessage(msg)
+				msg.complete(err)
 				if msg.afterDrain != nil {
 					msg.afterDrain()
 				}

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -702,6 +703,21 @@ func (m *mockPlatformConn) envelopes() []*events.Envelope {
 	return out
 }
 
+type blockingPlatformConn struct {
+	entered chan struct{}
+}
+
+func (m *blockingPlatformConn) WriteCtx(ctx context.Context, _ *events.Envelope) error {
+	select {
+	case m.entered <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (m *blockingPlatformConn) Close() error { return nil }
+
 func testPCEntryConfig() pcEntryConfig {
 	return pcEntryConfig{
 		WriteBuffer:   8,
@@ -711,13 +727,13 @@ func testPCEntryConfig() pcEntryConfig {
 	}
 }
 
-func TestPCEntry_WriteCtx_Async(t *testing.T) {
+func TestPCEntry_WriteCtx_OrdinaryEventAsync(t *testing.T) {
 	t.Parallel()
 	pc := &mockPlatformConn{}
 	e := newPCEntry(context.Background(), pc, testPCEntryConfig(), slog.Default())
 	defer e.Close()
 
-	env := events.NewEnvelope(aep.NewID(), "s1", 1, events.Done, events.DoneData{Success: true})
+	env := events.NewEnvelope(aep.NewID(), "s1", 1, events.State, events.StateData{State: events.StateRunning})
 	err := e.WriteCtx(context.Background(), env)
 	require.NoError(t, err)
 
@@ -727,7 +743,66 @@ func TestPCEntry_WriteCtx_Async(t *testing.T) {
 
 	got := pc.envelopes()
 	require.Len(t, got, 1)
-	require.Equal(t, events.Done, got[0].Event.Type)
+	require.Equal(t, events.State, got[0].Event.Type)
+}
+
+func TestHub_SendToSession_TerminalPlatformWriteErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind events.Kind
+		data any
+	}{
+		{name: "done", kind: events.Done, data: events.DoneData{Success: true}},
+		{name: "error", kind: events.Error, data: events.ErrorData{Code: events.ErrCodeInternalError, Message: "failed"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHub(t)
+			terminalErr := errors.New("terminal delivery failed")
+			pc := &mockPlatformConn{err: terminalErr}
+			h.JoinPlatformSession("s-terminal", pc)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			err := h.SendToSession(ctx, events.NewEnvelope(aep.NewID(), "s-terminal", 0, tt.kind, tt.data))
+			require.ErrorIs(t, err, terminalErr)
+		})
+	}
+}
+
+func TestPCEntry_TerminalWriteHonorsContextAndCloseDoesNotWaitForAck(t *testing.T) {
+	t.Parallel()
+
+	pc := &blockingPlatformConn{entered: make(chan struct{}, 1)}
+	e := newPCEntry(context.Background(), pc, testPCEntryConfig(), slog.Default())
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := e.WriteCtx(ctx, events.NewEnvelope(aep.NewID(), "s1", 1, events.Done, events.DoneData{Success: true}))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, e.Close())
+}
+
+func TestPCEntry_OrdinaryWriteRemainsAsynchronous(t *testing.T) {
+	t.Parallel()
+
+	pc := &blockingPlatformConn{entered: make(chan struct{}, 1)}
+	e := newPCEntry(context.Background(), pc, testPCEntryConfig(), slog.Default())
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, e.WriteCtx(ctx, events.NewEnvelope(aep.NewID(), "s1", 1, events.State, events.StateData{State: events.StateRunning})))
+	require.Eventually(t, func() bool {
+		select {
+		case <-pc.entered:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, e.Close())
 }
 
 func TestPCEntry_WriteCtx_DroppableDroppedAtThreshold(t *testing.T) {
@@ -743,7 +818,7 @@ func TestPCEntry_WriteCtx_DroppableDroppedAtThreshold(t *testing.T) {
 
 	// Fill channel directly (bypassing WriteCtx to avoid writeLoop drain race).
 	for i := 0; i < cfg.WriteBuffer; i++ {
-		e.ch <- events.NewEnvelope(aep.NewID(), "s1", int64(i+1), events.MessageDelta, map[string]any{"content": "x"})
+		e.ch <- platformWrite{env: events.NewEnvelope(aep.NewID(), "s1", int64(i+1), events.MessageDelta, map[string]any{"content": "x"})}
 	}
 
 	// Channel is now full (len=4 >= DropThreshold=2). Droppable should be silently dropped.
@@ -778,7 +853,7 @@ func TestPCEntry_WriteCtx_DroppableDroppedDefault(t *testing.T) {
 
 	// Fill channel to capacity.
 	for i := 0; i < cfg.WriteBuffer; i++ {
-		e.ch <- events.NewEnvelope(aep.NewID(), "s1", int64(i+1), events.MessageDelta, map[string]any{"content": "x"})
+		e.ch <- platformWrite{env: events.NewEnvelope(aep.NewID(), "s1", int64(i+1), events.MessageDelta, map[string]any{"content": "x"})}
 	}
 
 	// Now len(ch) >= DropThreshold, so the fast-path check should drop.

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -805,6 +805,54 @@ func TestPCEntry_OrdinaryWriteRemainsAsynchronous(t *testing.T) {
 	require.NoError(t, e.Close())
 }
 
+func TestHub_TerminalWriteBudgetCancelsBackgroundWriteAndUnblocksOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(t)
+	slowPC := &blockingPlatformConn{entered: make(chan struct{}, 1)}
+	slowEntry := newPCEntry(context.Background(), slowPC, pcEntryConfig{
+		WriteBuffer:     1,
+		DropThreshold:   1,
+		CoalesceIntvl:   time.Hour,
+		CoalesceSize:    1,
+		TerminalTimeout: 50 * time.Millisecond,
+	}, slog.Default())
+	h.mu.Lock()
+	h.sessions["slow"] = map[SessionWriter]bool{slowEntry: true}
+	h.everHadConn["slow"] = true
+	h.mu.Unlock()
+
+	fastPC := &mockPlatformConn{}
+	h.JoinPlatformSession("fast", fastPC)
+
+	terminalResult := make(chan error, 1)
+	go func() {
+		terminalResult <- h.SendToSession(context.Background(), events.NewEnvelope(aep.NewID(), "slow", 0, events.Done, events.DoneData{Success: true}))
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-slowPC.entered:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, h.SendToSession(context.Background(), events.NewEnvelope(aep.NewID(), "fast", 0, events.State, events.StateData{State: events.StateRunning})))
+	require.NoError(t, h.SendToSession(context.Background(), events.NewEnvelope(aep.NewID(), "fast", 0, events.MessageDelta, events.MessageDeltaData{Content: "still routes"})))
+	require.Eventually(t, func() bool {
+		return len(fastPC.envelopes()) == 2
+	}, time.Second, 10*time.Millisecond, "another session's ordinary and delta events must route after the terminal budget expires")
+
+	select {
+	case err := <-terminalResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("terminal write did not finish within its configured budget")
+	}
+}
+
 func TestPCEntry_WriteCtx_DroppableDroppedAtThreshold(t *testing.T) {
 	t.Parallel()
 	cfg := testPCEntryConfig()

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -718,6 +718,36 @@ func (m *blockingPlatformConn) WriteCtx(ctx context.Context, _ *events.Envelope)
 
 func (m *blockingPlatformConn) Close() error { return nil }
 
+type postCancelBlockingPlatformConn struct {
+	entered       chan struct{}
+	parentExpired chan struct{}
+	release       chan struct{}
+	closed        chan struct{}
+	writes        atomic.Int64
+	closeOnce     sync.Once
+}
+
+func (m *postCancelBlockingPlatformConn) WriteCtx(ctx context.Context, _ *events.Envelope) error {
+	m.writes.Add(1)
+	select {
+	case m.entered <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	select {
+	case <-m.parentExpired:
+	default:
+		close(m.parentExpired)
+	}
+	<-m.release
+	return ctx.Err()
+}
+
+func (m *postCancelBlockingPlatformConn) Close() error {
+	m.closeOnce.Do(func() { close(m.closed) })
+	return nil
+}
+
 func testPCEntryConfig() pcEntryConfig {
 	return pcEntryConfig{
 		WriteBuffer:   8,
@@ -850,6 +880,83 @@ func TestHub_TerminalWriteBudgetCancelsBackgroundWriteAndUnblocksOtherSessions(t
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	case <-time.After(time.Second):
 		t.Fatal("terminal write did not finish within its configured budget")
+	}
+}
+
+func TestHub_TerminalFailureDoesNotWaitForPostDeadlineCloseBeforeRoutingOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(t)
+	slowPC := &postCancelBlockingPlatformConn{
+		entered:       make(chan struct{}, 1),
+		parentExpired: make(chan struct{}),
+		release:       make(chan struct{}),
+		closed:        make(chan struct{}),
+	}
+	var releaseOnce sync.Once
+	releaseSlowWrite := func() { releaseOnce.Do(func() { close(slowPC.release) }) }
+	t.Cleanup(releaseSlowWrite)
+	slowEntry := newPCEntry(context.Background(), slowPC, pcEntryConfig{
+		WriteBuffer:     1,
+		DropThreshold:   1,
+		CoalesceIntvl:   time.Hour,
+		CoalesceSize:    1,
+		TerminalTimeout: 50 * time.Millisecond,
+	}, slog.Default())
+	h.mu.Lock()
+	h.sessions["slow-post-cancel"] = map[SessionWriter]bool{slowEntry: true}
+	h.everHadConn["slow-post-cancel"] = true
+	h.mu.Unlock()
+
+	fastPC := &mockPlatformConn{}
+	h.JoinPlatformSession("fast-post-cancel", fastPC)
+
+	terminalResult := make(chan error, 1)
+	go func() {
+		terminalResult <- h.SendToSession(context.Background(), events.NewEnvelope(
+			aep.NewID(), "slow-post-cancel", 0, events.Done, events.DoneData{Success: true},
+		))
+	}()
+
+	select {
+	case <-slowPC.entered:
+	case <-time.After(time.Second):
+		t.Fatal("terminal platform write did not start")
+	}
+	select {
+	case <-slowPC.parentExpired:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("terminal parent context did not expire within its configured budget")
+	}
+
+	require.NoError(t, h.SendToSession(context.Background(), events.NewEnvelope(
+		aep.NewID(), "fast-post-cancel", 0, events.State, events.StateData{State: events.StateRunning},
+	)))
+	require.NoError(t, h.SendToSession(context.Background(), events.NewEnvelope(
+		aep.NewID(), "fast-post-cancel", 0, events.MessageDelta, events.MessageDeltaData{Content: "still routes"},
+	)))
+
+	select {
+	case err := <-terminalResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("terminal caller waited for post-deadline connection cleanup")
+	}
+	require.Eventually(t, func() bool {
+		return len(fastPC.envelopes()) == 2
+	}, 200*time.Millisecond, 5*time.Millisecond,
+		"another session's ordinary and delta events must route while cleanup continues")
+
+	require.NoError(t, h.SendToSession(context.Background(), events.NewEnvelope(
+		aep.NewID(), "slow-post-cancel", 0, events.State, events.StateData{State: events.StateRunning},
+	)))
+	require.Equal(t, int64(1), slowPC.writes.Load(), "failed writer must be removed before asynchronous cleanup")
+
+	releaseSlowWrite()
+	select {
+	case <-slowPC.closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("asynchronous failed-writer cleanup did not complete")
 	}
 }
 

--- a/internal/gateway/platform_writer.go
+++ b/internal/gateway/platform_writer.go
@@ -33,13 +33,22 @@ import (
 type pcEntry struct {
 	pc      messaging.PlatformConn
 	cfg     pcEntryConfig
-	ch      chan *events.Envelope
+	ch      chan platformWrite
 	closeCh chan struct{} // signals Close() was called
 	done    chan struct{}
 	closed  atomic.Bool // fast-path check to avoid send-on-closed-channel
 	closeMu sync.Once
 	log     *slog.Logger
 	ctx     context.Context
+}
+
+// platformWrite carries a queued platform envelope and, for terminal events,
+// a one-shot completion channel. The channel is buffered so a caller that
+// times out cannot strand the write loop while it reports its eventual result.
+type platformWrite struct {
+	env    *events.Envelope
+	ctx    context.Context
+	result chan<- error
 }
 
 type pcEntryConfig struct {
@@ -74,7 +83,7 @@ func defaultPCEntryConfig(cfg *config.Config) pcEntryConfig {
 func newPCEntry(ctx context.Context, pc messaging.PlatformConn, cfg pcEntryConfig, log *slog.Logger) *pcEntry {
 	e := &pcEntry{
 		pc:      pc,
-		ch:      make(chan *events.Envelope, cfg.WriteBuffer),
+		ch:      make(chan platformWrite, cfg.WriteBuffer),
 		closeCh: make(chan struct{}),
 		done:    make(chan struct{}),
 		cfg:     cfg,
@@ -123,13 +132,20 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 		return errors.New("platform conn closed")
 	}
 
+	write := platformWrite{env: env, ctx: ctx}
+	var result <-chan error
+	if isTerminalPlatformEvent(env.Event.Type) {
+		ack := make(chan error, 1)
+		write.result = ack
+		result = ack
+	}
 	if isDroppable(env.Event.Type) {
 		if len(e.ch) >= e.cfg.DropThreshold {
 			observability.GatewayPlatformDropped().Add(ctx, 1, metric.WithAttributes(attribute.String("event_type", string(env.Event.Type))))
 			return nil
 		}
 		select {
-		case e.ch <- env:
+		case e.ch <- write:
 			return nil
 		default:
 			observability.GatewayPlatformDropped().Add(ctx, 1, metric.WithAttributes(attribute.String("event_type", string(env.Event.Type))))
@@ -137,13 +153,27 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	select {
-	case e.ch <- env:
-		return nil
-	case <-ctx.Done():
+	case e.ch <- write:
+	case <-writeCtx.Done():
 		return fmt.Errorf("platform conn write timeout: buffer full")
+	case <-e.closeCh:
+		return errors.New("platform conn closed")
+	case <-e.done:
+		return errors.New("platform conn closed")
+	}
+
+	if result == nil {
+		return nil
+	}
+
+	select {
+	case err := <-result:
+		return err
+	case <-writeCtx.Done():
+		return fmt.Errorf("platform conn terminal write timeout: %w", writeCtx.Err())
 	case <-e.closeCh:
 		return errors.New("platform conn closed")
 	case <-e.done:
@@ -203,16 +233,17 @@ func (e *pcEntry) writeLoop() {
 			timer.Stop()
 			timerCh = nil
 		}
-		e.writeOne(merged)
+		e.writeOne(platformWrite{env: merged, ctx: e.ctx})
 	}
 
 	for {
 		select {
-		case env, ok := <-e.ch:
+		case write, ok := <-e.ch:
 			if !ok {
 				flush(pendingSID)
 				return
 			}
+			env := write.env
 
 			if isDroppable(env.Event.Type) {
 				content := extractDeltaContent(env)
@@ -239,7 +270,7 @@ func (e *pcEntry) writeLoop() {
 				}
 			} else {
 				flush(pendingSID)
-				e.writeOne(env)
+				e.writeOne(write)
 			}
 
 		case <-timerCh:
@@ -248,15 +279,30 @@ func (e *pcEntry) writeLoop() {
 	}
 }
 
-func (e *pcEntry) writeOne(env *events.Envelope) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func (e *pcEntry) writeOne(write platformWrite) {
+	ctx := write.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if err := e.pc.WriteCtx(ctx, env); err != nil {
+	err := e.pc.WriteCtx(ctx, write.env)
+	if write.result != nil {
+		select {
+		case write.result <- err:
+		default:
+		}
+	}
+	if err != nil {
 		e.log.Warn("platform async write failed",
-			"event_type", env.Event.Type,
-			"session_id", env.SessionID,
+			"event_type", write.env.Event.Type,
+			"session_id", write.env.SessionID,
 			"err", err)
 	}
+}
+
+func isTerminalPlatformEvent(kind events.Kind) bool {
+	return kind == events.Done || kind == events.Error
 }
 
 func extractDeltaContent(env *events.Envelope) string {

--- a/internal/gateway/platform_writer.go
+++ b/internal/gateway/platform_writer.go
@@ -52,18 +52,22 @@ type platformWrite struct {
 }
 
 type pcEntryConfig struct {
-	WriteBuffer   int
-	DropThreshold int
-	CoalesceIntvl time.Duration
-	CoalesceSize  int
+	WriteBuffer     int
+	DropThreshold   int
+	CoalesceIntvl   time.Duration
+	CoalesceSize    int
+	TerminalTimeout time.Duration
 }
+
+const defaultPlatformTerminalTimeout = 5 * time.Second
 
 func defaultPCEntryConfig(cfg *config.Config) pcEntryConfig {
 	c := pcEntryConfig{
-		WriteBuffer:   cfg.Gateway.PlatformWriteBuffer,
-		DropThreshold: cfg.Gateway.PlatformDropThreshold,
-		CoalesceIntvl: cfg.Gateway.DeltaCoalesceInterval,
-		CoalesceSize:  cfg.Gateway.DeltaCoalesceSize,
+		WriteBuffer:     cfg.Gateway.PlatformWriteBuffer,
+		DropThreshold:   cfg.Gateway.PlatformDropThreshold,
+		CoalesceIntvl:   cfg.Gateway.DeltaCoalesceInterval,
+		CoalesceSize:    cfg.Gateway.DeltaCoalesceSize,
+		TerminalTimeout: defaultPlatformTerminalTimeout,
 	}
 	if c.WriteBuffer <= 0 {
 		c.WriteBuffer = 64
@@ -77,10 +81,16 @@ func defaultPCEntryConfig(cfg *config.Config) pcEntryConfig {
 	if c.CoalesceSize <= 0 {
 		c.CoalesceSize = 200
 	}
+	if c.TerminalTimeout <= 0 {
+		c.TerminalTimeout = defaultPlatformTerminalTimeout
+	}
 	return c
 }
 
 func newPCEntry(ctx context.Context, pc messaging.PlatformConn, cfg pcEntryConfig, log *slog.Logger) *pcEntry {
+	if cfg.TerminalTimeout <= 0 {
+		cfg.TerminalTimeout = defaultPlatformTerminalTimeout
+	}
 	e := &pcEntry{
 		pc:      pc,
 		ch:      make(chan platformWrite, cfg.WriteBuffer),
@@ -135,6 +145,9 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 	write := platformWrite{env: env, ctx: ctx}
 	var result <-chan error
 	if isTerminalPlatformEvent(env.Event.Type) {
+		terminalCtx, cancel := context.WithTimeout(ctx, e.cfg.TerminalTimeout)
+		defer cancel()
+		write.ctx = terminalCtx
 		ack := make(chan error, 1)
 		write.result = ack
 		result = ack
@@ -153,7 +166,11 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 		}
 	}
 
-	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	writeCtx := write.ctx
+	cancel := func() {}
+	if result == nil {
+		writeCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	}
 	defer cancel()
 	select {
 	case e.ch <- write:
@@ -284,8 +301,11 @@ func (e *pcEntry) writeOne(write platformWrite) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	if !isTerminalPlatformEvent(write.env.Event.Type) {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
 	err := e.pc.WriteCtx(ctx, write.env)
 	if write.result != nil {
 		select {

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -84,8 +84,10 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 		b.hub.JoinPlatformSession(env.SessionID, pc)
 	}
 
-	// Auto-create session if starter is available.
-	if b.starter != nil {
+	// Auto-create sessions for input and existing control flows. A stop must
+	// target an already-derived session: starting one here could spawn a worker
+	// solely to stop it.
+	if b.starter != nil && shouldStartPlatformSession(env) {
 		// Extract platform key from envelope metadata for persistence.
 		platform, platformKey := b.extractPlatformKey(env)
 		if b.acpCommand != "" {
@@ -131,6 +133,14 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 	}
 
 	return b.handler.Handle(ctx, env)
+}
+
+func shouldStartPlatformSession(env *events.Envelope) bool {
+	if env.Event.Type != events.Control {
+		return true
+	}
+	data, ok := env.Event.Data.(events.ControlData)
+	return !ok || data.Action != events.ControlActionStop
 }
 
 // JoinSession subscribes a PlatformConn to a gateway session.

--- a/internal/messaging/bridge_test.go
+++ b/internal/messaging/bridge_test.go
@@ -143,6 +143,15 @@ type mockHandler struct{}
 
 func (m *mockHandler) Handle(_ context.Context, _ *events.Envelope) error { return nil }
 
+type recordingHandler struct {
+	envelope *events.Envelope
+}
+
+func (h *recordingHandler) Handle(_ context.Context, env *events.Envelope) error {
+	h.envelope = env
+	return nil
+}
+
 // mockStarter captures botID passed to StartPlatformSession.
 type mockStarter struct {
 	startFn func(params worker.SessionStartParams) error
@@ -153,6 +162,75 @@ func (s *mockStarter) StartPlatformSession(_ context.Context, params worker.Sess
 		return s.startFn(params)
 	}
 	return nil
+}
+
+func TestBridge_Handle_ControlStopDoesNotStartSession(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBridge()
+	handler := &recordingHandler{}
+	b.handler = handler
+	var startCalls atomic.Int32
+	b.starter = &mockStarter{
+		startFn: func(worker.SessionStartParams) error {
+			startCalls.Add(1)
+			return nil
+		},
+	}
+	env := &events.Envelope{
+		SessionID: "existing-session",
+		OwnerID:   "owner1",
+		Event: events.Event{
+			Type: events.Control,
+			Data: events.ControlData{Action: events.ControlActionStop},
+		},
+	}
+
+	require.NoError(t, b.Handle(context.Background(), env, nil))
+	require.Zero(t, startCalls.Load(), "stop must not create or start a platform session")
+	require.Same(t, env, handler.envelope, "stop must still reach Gateway's control handler")
+}
+
+func TestBridge_Handle_NonStopEventsStillStartSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event events.Event
+	}{
+		{
+			name:  "input",
+			event: events.Event{Type: events.Input, Data: map[string]any{"content": "hello"}},
+		},
+		{
+			name:  "gc control",
+			event: events.Event{Type: events.Control, Data: events.ControlData{Action: events.ControlActionGC}},
+		},
+		{
+			name:  "reset control",
+			event: events.Event{Type: events.Control, Data: events.ControlData{Action: events.ControlActionReset}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTestBridge()
+			handler := &recordingHandler{}
+			b.handler = handler
+			var startCalls atomic.Int32
+			b.starter = &mockStarter{
+				startFn: func(worker.SessionStartParams) error {
+					startCalls.Add(1)
+					return nil
+				},
+			}
+			env := &events.Envelope{SessionID: "sid1", OwnerID: "owner1", Event: tt.event}
+
+			require.NoError(t, b.Handle(context.Background(), env, nil))
+			require.Equal(t, int32(1), startCalls.Load())
+			require.Same(t, env, handler.envelope)
+		})
+	}
 }
 
 // I5: nil adapter passes empty botID to StartPlatformSession.

--- a/internal/messaging/control_command.go
+++ b/internal/messaging/control_command.go
@@ -53,6 +53,7 @@ var controlCommands = NewCommandMap(
 		"/park":  {Action: events.ControlActionGC, Label: "gc"},
 		"/reset": {Action: events.ControlActionReset, Label: "reset"},
 		"/new":   {Action: events.ControlActionReset, Label: "reset"},
+		"/stop":  {Action: events.ControlActionStop, Label: "stop"},
 		"/cd":    {Action: events.ControlActionCD, Label: "cd"},
 	},
 	map[string]ControlCommandResult{

--- a/internal/messaging/control_command_test.go
+++ b/internal/messaging/control_command_test.go
@@ -62,6 +62,20 @@ func TestParseControlCommand_NaturalLanguage(t *testing.T) {
 	}
 }
 
+func TestDetectCommand_AbortTriggersRouteToControlStop(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"stop", "停止", "/stop"} {
+		t.Run(input, func(t *testing.T) {
+			result := DetectCommand(input)
+			require.Equal(t, CmdControl, result.Action)
+			require.NotNil(t, result.Control)
+			require.Equal(t, events.ControlActionStop, result.Control.Action)
+			require.Equal(t, "stop", result.Control.Label)
+		})
+	}
+}
+
 func TestParseWorkerCommand_SlashCommands(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/messaging/dedup.go
+++ b/internal/messaging/dedup.go
@@ -10,12 +10,30 @@ import (
 // Supports both self-cleanup (via StartCleanup/Close) and manual Sweep.
 type Dedup struct {
 	mu         sync.Mutex
-	entries    map[string]time.Time
-	order      []string // FIFO eviction order
+	entries    map[string]dedupEntry
+	order      []dedupOrderEntry // FIFO eviction order
+	nextHandle uint64
 	maxEntries int
 	ttl        time.Duration
 	done       chan struct{}
 	closeOnce  sync.Once
+}
+
+type dedupEntry struct {
+	recordedAt time.Time
+	handle     uint64
+}
+
+type dedupOrderEntry struct {
+	id     string
+	handle uint64
+}
+
+// DedupHandle identifies one successful TryRecordWithHandle call. It can be
+// used to roll back an admission failure without removing a later retry.
+type DedupHandle struct {
+	id     string
+	handle uint64
 }
 
 // NewDedup creates a new bounded dedup map.
@@ -28,8 +46,8 @@ func NewDedup(maxEntries int, ttl time.Duration) *Dedup {
 		ttl = 12 * time.Hour
 	}
 	return &Dedup{
-		entries:    make(map[string]time.Time),
-		order:      make([]string, 0, maxEntries),
+		entries:    make(map[string]dedupEntry),
+		order:      make([]dedupOrderEntry, 0, maxEntries),
 		maxEntries: maxEntries,
 		ttl:        ttl,
 	}
@@ -45,32 +63,63 @@ func (d *Dedup) StartCleanup() {
 // TryRecord records an id and returns true if it was not previously seen.
 // Returns false if the id is a duplicate.
 func (d *Dedup) TryRecord(id string) bool {
+	_, accepted := d.TryRecordWithHandle(id)
+	return accepted
+}
+
+// TryRecordWithHandle records an id and returns a handle for conditionally
+// rolling back that exact registration if downstream admission fails.
+func (d *Dedup) TryRecordWithHandle(id string) (*DedupHandle, bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if _, seen := d.entries[id]; seen {
-		return false
+		return nil, false
 	}
 
 	for len(d.entries) >= d.maxEntries && len(d.order) > 0 {
-		// Use writeIdx compaction to release backing array references.
-		writeIdx := 0
-		target := len(d.entries) - d.maxEntries + 1
-		for _, id := range d.order {
-			if target > 0 {
-				delete(d.entries, id)
-				target--
-			} else {
-				d.order[writeIdx] = id
-				writeIdx++
-			}
+		oldest := d.order[0]
+		d.order = d.order[1:]
+		if entry, ok := d.entries[oldest.id]; ok && entry.handle == oldest.handle {
+			delete(d.entries, oldest.id)
 		}
-		d.order = d.order[:writeIdx]
 	}
 
-	d.entries[id] = time.Now()
-	d.order = append(d.order, id)
-	return true
+	d.nextHandle++
+	handle := d.nextHandle
+	d.entries[id] = dedupEntry{recordedAt: time.Now(), handle: handle}
+	d.order = append(d.order, dedupOrderEntry{id: id, handle: handle})
+	return &DedupHandle{id: id, handle: handle}, true
+}
+
+// Rollback removes an entry only when it still matches the supplied handle.
+// A delayed failure therefore cannot erase a later platform retry record.
+func (d *Dedup) Rollback(handle *DedupHandle) {
+	if handle == nil {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	entry, ok := d.entries[handle.id]
+	if !ok || entry.handle != handle.handle {
+		return
+	}
+	delete(d.entries, handle.id)
+	d.removeOrderEntryLocked(handle.id, handle.handle)
+}
+
+func (d *Dedup) removeOrderEntryLocked(id string, handle uint64) {
+	writeIdx := 0
+	for _, entry := range d.order {
+		if entry.id == id && entry.handle == handle {
+			continue
+		}
+		d.order[writeIdx] = entry
+		writeIdx++
+	}
+	d.order = d.order[:writeIdx]
 }
 
 // Sweep removes expired entries. Can be called manually or from a background goroutine.
@@ -80,12 +129,13 @@ func (d *Dedup) Sweep() {
 
 	cutoff := time.Now().Add(-d.ttl)
 	writeIdx := 0
-	for _, id := range d.order {
-		if t, ok := d.entries[id]; ok && t.After(cutoff) {
-			d.order[writeIdx] = id
+	for _, ordered := range d.order {
+		entry, ok := d.entries[ordered.id]
+		if ok && entry.handle == ordered.handle && entry.recordedAt.After(cutoff) {
+			d.order[writeIdx] = ordered
 			writeIdx++
-		} else {
-			delete(d.entries, id)
+		} else if ok && entry.handle == ordered.handle {
+			delete(d.entries, ordered.id)
 		}
 	}
 	d.order = d.order[:writeIdx]

--- a/internal/messaging/dedup_test.go
+++ b/internal/messaging/dedup_test.go
@@ -81,3 +81,20 @@ func TestDedup_TryRecord_FIFOEvict(t *testing.T) {
 	require.False(t, d.TryRecord("a"))
 	require.Equal(t, 3, len(d.order))
 }
+
+func TestDedup_RollbackDoesNotRemoveRetryRecord(t *testing.T) {
+	t.Parallel()
+
+	d := NewDedup(10, time.Hour)
+	first, accepted := d.TryRecordWithHandle("message-1")
+	require.True(t, accepted)
+	d.Rollback(first)
+
+	retry, accepted := d.TryRecordWithHandle("message-1")
+	require.True(t, accepted)
+	d.Rollback(first)
+
+	require.False(t, d.TryRecord("message-1"), "the later retry record must remain deduplicated")
+	d.Rollback(retry)
+	require.True(t, d.TryRecord("message-1"), "rolling back the matching record permits another retry")
+}

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -132,6 +133,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 
 	a.larkClient = lark.NewClient(a.appID, a.appSecret,
 		lark.WithLogger(SlogLogger{Logger: a.Log}),
+		lark.WithHttpClient(newMediaBoundedHTTPClient(http.DefaultClient)),
 	)
 
 	if err := a.fetchBotInfo(ctx); err != nil {

--- a/internal/messaging/feishu/adapter_flow_test.go
+++ b/internal/messaging/feishu/adapter_flow_test.go
@@ -3,6 +3,7 @@ package feishu
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -19,6 +21,15 @@ type controlEnvelopeHandler struct {
 
 func (h *controlEnvelopeHandler) Handle(_ context.Context, env *events.Envelope) error {
 	h.envelopes <- env
+	return nil
+}
+
+type controlSessionStarter struct {
+	calls atomic.Int32
+}
+
+func (s *controlSessionStarter) StartPlatformSession(_ context.Context, _ worker.SessionStartParams) error {
+	s.calls.Add(1)
 	return nil
 }
 
@@ -32,8 +43,9 @@ func TestAdapterFlow_AbortTextRoutesControlStop(t *testing.T) {
 			t.Cleanup(a.chatQueue.Close)
 
 			handler := &controlEnvelopeHandler{envelopes: make(chan *events.Envelope, 1)}
+			starter := &controlSessionStarter{}
 			bridge := messaging.NewBridge(
-				slog.Default(), messaging.PlatformFeishu, nil, handler, nil,
+				slog.Default(), messaging.PlatformFeishu, nil, handler, starter,
 				"test_worker", "", "/tmp", "",
 			)
 			require.NoError(t, a.ConfigureWith(messaging.AdapterConfig{Bridge: bridge}))
@@ -64,6 +76,7 @@ func TestAdapterFlow_AbortTextRoutesControlStop(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("abort text did not reach the control handler")
 			}
+			require.Zero(t, starter.calls.Load(), "stop must not create a platform session")
 		})
 	}
 }

--- a/internal/messaging/feishu/adapter_flow_test.go
+++ b/internal/messaging/feishu/adapter_flow_test.go
@@ -2,14 +2,71 @@ package feishu
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+type controlEnvelopeHandler struct {
+	envelopes chan *events.Envelope
+}
+
+func (h *controlEnvelopeHandler) Handle(_ context.Context, env *events.Envelope) error {
+	h.envelopes <- env
+	return nil
+}
+
+func TestAdapterFlow_AbortTextRoutesControlStop(t *testing.T) {
+	t.Parallel()
+
+	for _, text := range []string{"stop", "停止", "/stop"} {
+		t.Run(text, func(t *testing.T) {
+			a := newTestAdapter(t)
+			a.chatQueue = NewChatQueue(discardLogger)
+			t.Cleanup(a.chatQueue.Close)
+
+			handler := &controlEnvelopeHandler{envelopes: make(chan *events.Envelope, 1)}
+			bridge := messaging.NewBridge(
+				slog.Default(), messaging.PlatformFeishu, nil, handler, nil,
+				"test_worker", "", "/tmp", "",
+			)
+			require.NoError(t, a.ConfigureWith(messaging.AdapterConfig{Bridge: bridge}))
+
+			sender := larkim.NewEventSenderBuilder().
+				SenderId(larkim.NewUserIdBuilder().OpenId("user-stop").Build()).
+				SenderType("user").
+				Build()
+			message := larkim.NewEventMessageBuilder().
+				MessageId("message-stop-" + text).
+				MessageType("text").
+				Content(`{"text":"` + text + `"}`).
+				ChatId("chat-stop").
+				ChatType("p2p").
+				Build()
+
+			require.NoError(t, a.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+				Event: &larkim.P2MessageReceiveV1Data{Sender: sender, Message: message},
+			}))
+
+			select {
+			case envelope := <-handler.envelopes:
+				require.NotEmpty(t, envelope.SessionID)
+				require.Equal(t, events.Control, envelope.Event.Type)
+				control, ok := envelope.Event.Data.(events.ControlData)
+				require.True(t, ok)
+				require.Equal(t, events.ControlActionStop, control.Action)
+			case <-time.After(time.Second):
+				t.Fatal("abort text did not reach the control handler")
+			}
+		})
+	}
+}
 
 func TestAdapterFlow_HandleTextMessage_NilBridge(t *testing.T) {
 	t.Parallel()

--- a/internal/messaging/feishu/adapter_flow_test.go
+++ b/internal/messaging/feishu/adapter_flow_test.go
@@ -81,6 +81,105 @@ func TestAdapterFlow_AbortTextRoutesControlStop(t *testing.T) {
 	}
 }
 
+func TestAdapterFlow_ConversionFailureRollsBackDedup(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter(t)
+	message := larkim.NewEventMessageBuilder().
+		MessageId("conversion-retry").
+		MessageType("unsupported").
+		Content(`{"text":"hello"}`).
+		ChatId("chat-conversion").
+		ChatType("p2p").
+		Build()
+
+	require.NoError(t, a.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{Message: message},
+	}))
+	require.True(t, a.Dedup.TryRecord("conversion-retry"), "a rejected conversion must be retriable")
+}
+
+func TestAdapterFlow_GateRejectionRollsBackDedup(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter(t)
+	a.Gate = messaging.NewGate("allowlist", "open", false, []string{"allowed-user"}, nil, nil)
+	sender := larkim.NewEventSenderBuilder().
+		SenderId(larkim.NewUserIdBuilder().OpenId("blocked-user").Build()).
+		SenderType("user").
+		Build()
+	message := larkim.NewEventMessageBuilder().
+		MessageId("gate-retry").
+		MessageType("text").
+		Content(`{"text":"hello"}`).
+		ChatId("chat-gate").
+		ChatType("p2p").
+		Build()
+
+	require.NoError(t, a.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{Sender: sender, Message: message},
+	}))
+	require.True(t, a.Dedup.TryRecord("gate-retry"), "a gate rejection must be retriable")
+}
+
+func TestAdapterFlow_QueueFullRollsBackDedup(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter(t)
+	q := NewChatQueue(discardLogger)
+	w := &chatWorker{tasks: make(chan func(context.Context) error, 1)}
+	w.tasks <- func(context.Context) error { return nil }
+	q.mu.Lock()
+	q.workers["chat-full"] = w
+	q.mu.Unlock()
+	a.chatQueue = q
+	t.Cleanup(q.Close)
+
+	message := larkim.NewEventMessageBuilder().
+		MessageId("queue-full-retry").
+		MessageType("text").
+		Content(`{"text":"hello"}`).
+		ChatId("chat-full").
+		ChatType("p2p").
+		Build()
+
+	err := a.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{Message: message},
+	})
+	require.Error(t, err)
+	<-w.tasks
+	require.NoError(t, a.handleMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{Message: message},
+	}))
+	require.Len(t, w.tasks, 1, "a full queue must allow the platform retry to enter")
+}
+
+func TestAdapterFlow_SuccessfulQueueAdmissionKeepsDedup(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAdapter(t)
+	q := NewChatQueue(discardLogger)
+	w := &chatWorker{tasks: make(chan func(context.Context) error, 2)}
+	q.mu.Lock()
+	q.workers["chat-admitted"] = w
+	q.mu.Unlock()
+	a.chatQueue = q
+	t.Cleanup(q.Close)
+
+	message := larkim.NewEventMessageBuilder().
+		MessageId("queue-admitted").
+		MessageType("text").
+		Content(`{"text":"hello"}`).
+		ChatId("chat-admitted").
+		ChatType("p2p").
+		Build()
+	event := &larkim.P2MessageReceiveV1{Event: &larkim.P2MessageReceiveV1Data{Message: message}}
+
+	require.NoError(t, a.handleMessage(context.Background(), event))
+	require.NoError(t, a.handleMessage(context.Background(), event))
+	require.Len(t, w.tasks, 1, "a successfully admitted message must remain deduplicated")
+}
+
 func TestAdapterFlow_HandleTextMessage_NilBridge(t *testing.T) {
 	t.Parallel()
 	a := newTestAdapter(t)

--- a/internal/messaging/feishu/chat_queue.go
+++ b/internal/messaging/feishu/chat_queue.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -17,6 +18,9 @@ const chatTaskTimeout = 10 * time.Minute
 // self-cleaning. Prevents goroutine leaks from one-off chats.
 const chatIdleTimeout = 5 * time.Minute
 
+// ErrChatQueueClosed is returned when a task is submitted after shutdown begins.
+var ErrChatQueueClosed = errors.New("feishu: chat queue closed")
+
 // ChatQueue serializes message sends per chatID to prevent reordering.
 // Each chatID gets a dedicated goroutine that processes tasks sequentially
 // through a buffered channel, eliminating race conditions that existed in the
@@ -25,6 +29,7 @@ type ChatQueue struct {
 	log     *slog.Logger
 	mu      sync.Mutex
 	workers map[string]*chatWorker
+	closed  bool
 	wg      sync.WaitGroup // track worker goroutines for graceful shutdown
 }
 
@@ -46,24 +51,27 @@ func NewChatQueue(log *slog.Logger) *ChatQueue {
 // Returns an error if the per-chatID task channel is full.
 func (q *ChatQueue) Enqueue(chatID string, task func(ctx context.Context) error) error {
 	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return ErrChatQueueClosed
+	}
+
 	w, exists := q.workers[chatID]
 	if !exists {
 		w = &chatWorker{
 			tasks: make(chan func(ctx context.Context) error, 64),
 		}
 		q.workers[chatID] = w
-		q.wg.Add(1) // move inside lock — prevents Close() from seeing worker without wg count
-	}
-	q.mu.Unlock()
-
-	if !exists {
+		q.wg.Add(1)
 		go q.runWorker(chatID, w)
 	}
 
 	select {
 	case w.tasks <- task:
+		q.mu.Unlock()
 		return nil
 	default:
+		q.mu.Unlock()
 		return fmt.Errorf("feishu: chat queue full for %s", chatID)
 	}
 }
@@ -73,11 +81,9 @@ func (q *ChatQueue) Enqueue(chatID string, task func(ctx context.Context) error)
 // elapses with no new tasks. On exit, it removes itself from the workers map.
 func (q *ChatQueue) runWorker(chatID string, w *chatWorker) {
 	defer q.wg.Done()
+	defer q.removeWorkerIfCurrent(chatID, w)
 	defer func() {
 		if r := recover(); r != nil {
-			q.mu.Lock()
-			delete(q.workers, chatID)
-			q.mu.Unlock()
 			if q.log != nil {
 				q.log.Error("feishu: panic in chat queue worker", "chat_id", chatID, "panic", r, "stack", string(debug.Stack()))
 			}
@@ -91,13 +97,13 @@ func (q *ChatQueue) runWorker(chatID string, w *chatWorker) {
 		select {
 		case task, ok := <-w.tasks:
 			if !ok {
-				q.mu.Lock()
-				delete(q.workers, chatID)
-				q.mu.Unlock()
 				return
 			}
 			if !idleTimer.Stop() {
-				<-idleTimer.C
+				select {
+				case <-idleTimer.C:
+				default:
+				}
 			}
 			idleTimer.Reset(chatIdleTimeout)
 
@@ -116,11 +122,34 @@ func (q *ChatQueue) runWorker(chatID string, w *chatWorker) {
 			cancel()
 
 		case <-idleTimer.C:
-			q.mu.Lock()
-			delete(q.workers, chatID)
-			q.mu.Unlock()
-			return
+			if q.tryRemoveIdleWorker(chatID, w) {
+				return
+			}
+			idleTimer.Reset(chatIdleTimeout)
 		}
+	}
+}
+
+// tryRemoveIdleWorker retires w only when it is still current and no accepted
+// task is waiting. Enqueue holds q.mu through its non-blocking channel send,
+// so an accepted task cannot be stranded by the idle boundary.
+func (q *ChatQueue) tryRemoveIdleWorker(chatID string, w *chatWorker) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.workers[chatID] != w || len(w.tasks) != 0 {
+		return false
+	}
+	delete(q.workers, chatID)
+	return true
+}
+
+func (q *ChatQueue) removeWorkerIfCurrent(chatID string, w *chatWorker) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.workers[chatID] == w {
+		delete(q.workers, chatID)
 	}
 }
 
@@ -149,14 +178,13 @@ func (q *ChatQueue) Abort(chatID string) {
 // It waits for all in-flight tasks to complete.
 func (q *ChatQueue) Close() {
 	q.mu.Lock()
-	workers := make(map[string]*chatWorker, len(q.workers))
-	for k, v := range q.workers {
-		workers[k] = v
+	if !q.closed {
+		q.closed = true
+		for _, w := range q.workers {
+			close(w.tasks)
+		}
 	}
 	q.mu.Unlock()
 
-	for _, w := range workers {
-		close(w.tasks)
-	}
 	q.wg.Wait() // wait for all workers to finish
 }

--- a/internal/messaging/feishu/chat_queue_test.go
+++ b/internal/messaging/feishu/chat_queue_test.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -183,4 +184,103 @@ func TestChatQueue_TaskTimeout(t *testing.T) {
 	t.Parallel()
 	// Verify that the timeout constant is set to 10 minutes.
 	require.Equal(t, 10*time.Minute, chatTaskTimeout)
+}
+
+func TestChatQueue_CloseRejectsNewTasks(t *testing.T) {
+	t.Parallel()
+
+	q := NewChatQueue(nil)
+	q.Close()
+
+	err := q.Enqueue("closed-chat", func(context.Context) error { return nil })
+	require.ErrorIs(t, err, ErrChatQueueClosed)
+}
+
+func TestChatQueue_CloseAndEnqueueConcurrent(t *testing.T) {
+	t.Parallel()
+
+	q := NewChatQueue(nil)
+	start := make(chan struct{})
+	errs := make(chan error, 32)
+	var completed atomic.Int32
+	for range 32 {
+		go func() {
+			defer completed.Add(1)
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					errs <- errors.New("enqueue panicked while close raced")
+				}
+			}()
+			<-start
+			errs <- q.Enqueue("shared-chat", func(context.Context) error { return nil })
+		}()
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		<-start
+		q.Close()
+		close(closeDone)
+	}()
+	close(start)
+
+	require.Eventually(t, func() bool {
+		return completed.Load() == 32
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-closeDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	close(errs)
+	for err := range errs {
+		require.True(t, err == nil || errors.Is(err, ErrChatQueueClosed), "unexpected enqueue result: %v", err)
+	}
+}
+
+func TestChatQueue_IdleCleanupDoesNotOrphanAcceptedTask(t *testing.T) {
+	t.Parallel()
+
+	q := NewChatQueue(nil)
+	w := &chatWorker{tasks: make(chan func(context.Context) error, 1)}
+	taskRan := make(chan struct{})
+	w.tasks <- func(context.Context) error {
+		close(taskRan)
+		return nil
+	}
+	q.mu.Lock()
+	q.workers["idle-boundary"] = w
+	q.wg.Add(1)
+	q.mu.Unlock()
+
+	require.False(t, q.tryRemoveIdleWorker("idle-boundary", w))
+
+	go q.runWorker("idle-boundary", w)
+	select {
+	case <-taskRan:
+	case <-time.After(time.Second):
+		t.Fatal("accepted task was orphaned at idle cleanup boundary")
+	}
+	q.Close()
+}
+
+func TestChatQueue_WorkerExitDoesNotRemoveReplacement(t *testing.T) {
+	t.Parallel()
+
+	q := NewChatQueue(nil)
+	exiting := &chatWorker{tasks: make(chan func(context.Context) error)}
+	replacement := &chatWorker{tasks: make(chan func(context.Context) error)}
+	q.mu.Lock()
+	q.workers["replacement"] = replacement
+	q.mu.Unlock()
+
+	q.removeWorkerIfCurrent("replacement", exiting)
+
+	q.mu.Lock()
+	current := q.workers["replacement"]
+	q.mu.Unlock()
+	require.Same(t, replacement, current)
 }

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -45,6 +46,8 @@ type FeishuConn struct {
 	// triggers never double-rotate. See #839.
 	rotateMu sync.Mutex
 }
+
+const terminalDeliveryFallbackText = "⚠️ 回复投递异常，请稍后重试。"
 
 func NewFeishuConn(adapter *Adapter, chatID, threadKey, workDir string) *FeishuConn {
 	return &FeishuConn{adapter: adapter, chatID: chatID, threadKey: threadKey, workDir: workDir}
@@ -329,6 +332,9 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		closeErr = streamCtrl.Close(closeCtx)
 		closeCancel()
+		if closeErr != nil {
+			closeErr = c.handleTerminalDeliveryError(ctx, closeErr)
+		}
 	}
 
 	ttsOK := c.adapter.ttsPipeline != nil
@@ -379,6 +385,7 @@ func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) erro
 		closeCancel()
 		if err != nil {
 			c.adapter.Log.Warn("feishu: failed to close streaming card on error", "err", err)
+			return c.handleTerminalDeliveryError(ctx, err)
 		} else if errMsg != "" {
 			return nil
 		}
@@ -392,6 +399,38 @@ func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) erro
 		}
 	}
 	return nil
+}
+
+// handleTerminalDeliveryError preserves the finalization error for upstream
+// visibility. It sends one short, independent terminal message only when the
+// streaming card did not present the body; decoration-only failures must never
+// duplicate the full response.
+func (c *FeishuConn) handleTerminalDeliveryError(ctx context.Context, closeErr error) error {
+	var terminalErr *TerminalDeliveryError
+	if !errors.As(closeErr, &terminalErr) {
+		return closeErr
+	}
+
+	if terminalErr.ContentPresented {
+		c.adapter.Log.Warn("feishu: terminal decoration failed after body was presented", "err", closeErr)
+		observability.StreamingTerminalFailures().Add(ctx, 1,
+			metric.WithAttributes(attribute.String("fallback_result", "skipped_body_presented")))
+		return closeErr
+	}
+
+	fallbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := c.sendOrReply(fallbackCtx, terminalDeliveryFallbackText); err != nil {
+		c.adapter.Log.Warn("feishu: terminal fallback delivery failed", "err", err)
+		observability.StreamingTerminalFailures().Add(ctx, 1,
+			metric.WithAttributes(attribute.String("fallback_result", "failed")))
+		return errors.Join(closeErr, fmt.Errorf("feishu: terminal fallback delivery: %w", err))
+	}
+
+	c.adapter.Log.Warn("feishu: terminal fallback delivered after streaming close failure", "err", closeErr)
+	observability.StreamingTerminalFailures().Add(ctx, 1,
+		metric.WithAttributes(attribute.String("fallback_result", "sent")))
+	return closeErr
 }
 
 func (c *FeishuConn) handleToolCall(_ context.Context, env *events.Envelope) error {

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -40,6 +40,7 @@ type FeishuConn struct {
 	lastSummarySentMs atomic.Int64
 	voiceTriggered    atomic.Bool
 	paraBreaker       textutil.ParagraphBreaker
+	terminalFailures  metric.Int64Counter // test injection; nil uses observability accessor
 
 	// rotateMu serializes proactive TTL rotation between the controller's
 	// timer callback and the lazy check inside writeContent, so concurrent
@@ -48,6 +49,14 @@ type FeishuConn struct {
 }
 
 const terminalDeliveryFallbackText = "⚠️ 回复投递异常，请稍后重试。"
+
+func (c *FeishuConn) recordTerminalFailure(ctx context.Context, result string) {
+	counter := c.terminalFailures
+	if counter == nil {
+		counter = observability.StreamingTerminalFailures()
+	}
+	counter.Add(ctx, 1, metric.WithAttributes(attribute.String("fallback_result", result)))
+}
 
 func NewFeishuConn(adapter *Adapter, chatID, threadKey, workDir string) *FeishuConn {
 	return &FeishuConn{adapter: adapter, chatID: chatID, threadKey: threadKey, workDir: workDir}
@@ -413,8 +422,7 @@ func (c *FeishuConn) handleTerminalDeliveryError(ctx context.Context, closeErr e
 
 	if terminalErr.ContentPresented {
 		c.adapter.Log.Warn("feishu: terminal decoration failed after body was presented", "err", closeErr)
-		observability.StreamingTerminalFailures().Add(ctx, 1,
-			metric.WithAttributes(attribute.String("fallback_result", "skipped_body_presented")))
+		c.recordTerminalFailure(ctx, "skipped_body_presented")
 		return closeErr
 	}
 
@@ -422,14 +430,12 @@ func (c *FeishuConn) handleTerminalDeliveryError(ctx context.Context, closeErr e
 	defer cancel()
 	if err := c.sendOrReply(fallbackCtx, terminalDeliveryFallbackText); err != nil {
 		c.adapter.Log.Warn("feishu: terminal fallback delivery failed", "err", err)
-		observability.StreamingTerminalFailures().Add(ctx, 1,
-			metric.WithAttributes(attribute.String("fallback_result", "failed")))
+		c.recordTerminalFailure(ctx, "failed")
 		return errors.Join(closeErr, fmt.Errorf("feishu: terminal fallback delivery: %w", err))
 	}
 
 	c.adapter.Log.Warn("feishu: terminal fallback delivered after streaming close failure", "err", closeErr)
-	observability.StreamingTerminalFailures().Add(ctx, 1,
-		metric.WithAttributes(attribute.String("fallback_result", "sent")))
+	c.recordTerminalFailure(ctx, "sent")
 	return closeErr
 }
 

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -48,7 +48,17 @@ type FeishuConn struct {
 	rotateMu sync.Mutex
 }
 
-const terminalDeliveryFallbackText = "⚠️ 回复投递异常，请稍后重试。"
+const (
+	terminalDeliveryFallbackText   = "⚠️ 回复投递异常，请稍后重试。"
+	defaultTerminalDeliveryTimeout = 5 * time.Second
+)
+
+func terminalDeliveryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, defaultTerminalDeliveryTimeout)
+}
 
 func (c *FeishuConn) recordTerminalFailure(ctx context.Context, result string) {
 	counter := c.terminalFailures
@@ -302,7 +312,10 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 }
 
 func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error {
-	streamCtrl := c.clearActiveIndicators(ctx)
+	terminalCtx, terminalCancel := terminalDeliveryContext(ctx)
+	defer terminalCancel()
+
+	streamCtrl := c.clearActiveIndicators(terminalCtx)
 	c.adapter.Interactions.CancelAll(env.SessionID)
 
 	d := messaging.ExtractTurnSummary(env)
@@ -338,11 +351,9 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 	var closeErr error
 	if streamCtrl != nil && streamCtrl.IsCreated() {
 		streamCtrl.SetCloseMeta(d)
-		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		closeErr = streamCtrl.Close(closeCtx)
-		closeCancel()
+		closeErr = streamCtrl.Close(terminalCtx)
 		if closeErr != nil {
-			closeErr = c.handleTerminalDeliveryError(ctx, closeErr)
+			closeErr = c.handleTerminalDeliveryError(terminalCtx, closeErr)
 		}
 	}
 
@@ -376,7 +387,10 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 }
 
 func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) error {
-	streamCtrl := c.clearActiveIndicators(ctx)
+	terminalCtx, terminalCancel := terminalDeliveryContext(ctx)
+	defer terminalCancel()
+
+	streamCtrl := c.clearActiveIndicators(terminalCtx)
 	c.adapter.Interactions.CancelAll(env.SessionID)
 	errMsg := messaging.ExtractErrorMessage(env)
 	// Reset paragraph counter on error.
@@ -389,12 +403,10 @@ func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) erro
 		if errMsg != "" {
 			streamCtrl.SetTerminalContent(errMsg)
 		}
-		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		err := streamCtrl.Close(closeCtx)
-		closeCancel()
+		err := streamCtrl.Close(terminalCtx)
 		if err != nil {
 			c.adapter.Log.Warn("feishu: failed to close streaming card on error", "err", err)
-			return c.handleTerminalDeliveryError(ctx, err)
+			return c.handleTerminalDeliveryError(terminalCtx, err)
 		} else if errMsg != "" {
 			return nil
 		}
@@ -404,7 +416,7 @@ func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) erro
 		platformMsgID := c.platformMsgID
 		c.mu.RUnlock()
 		if platformMsgID != "" {
-			_ = c.adapter.replyMessage(ctx, platformMsgID, errMsg, false)
+			_ = c.adapter.replyMessage(terminalCtx, platformMsgID, errMsg, false)
 		}
 	}
 	return nil
@@ -426,9 +438,7 @@ func (c *FeishuConn) handleTerminalDeliveryError(ctx context.Context, closeErr e
 		return closeErr
 	}
 
-	fallbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-	if err := c.sendOrReply(fallbackCtx, terminalDeliveryFallbackText); err != nil {
+	if err := c.sendOrReply(ctx, terminalDeliveryFallbackText); err != nil {
 		c.adapter.Log.Warn("feishu: terminal fallback delivery failed", "err", err)
 		c.recordTerminalFailure(ctx, "failed")
 		return errors.Join(closeErr, fmt.Errorf("feishu: terminal fallback delivery: %w", err))

--- a/internal/messaging/feishu/conn_test.go
+++ b/internal/messaging/feishu/conn_test.go
@@ -11,14 +11,52 @@ import (
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
+func newTerminalFailureMetric(t *testing.T) (*sdkmetric.ManualReader, metric.Int64Counter) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	counter, err := provider.Meter("feishu-test").Int64Counter("hotplex.streaming.terminal_failures")
+	require.NoError(t, err)
+	return reader, counter
+}
+
+func terminalFailureResults(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &metrics))
+	for _, scope := range metrics.ScopeMetrics {
+		for _, instrument := range scope.Metrics {
+			if instrument.Name != "hotplex.streaming.terminal_failures" {
+				continue
+			}
+			sum, ok := instrument.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			results := make(map[string]int64, len(sum.DataPoints))
+			for _, point := range sum.DataPoints {
+				value, ok := point.Attributes.Value("fallback_result")
+				require.True(t, ok)
+				results[value.AsString()] = point.Value
+			}
+			return results
+		}
+	}
+	t.Fatal("terminal failures metric was not collected")
+	return nil
+}
+
 func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t *testing.T) {
 	t.Parallel()
 
+	reader, terminalFailures := newTerminalFailureMetric(t)
 	var mu sync.Mutex
 	var sentBodies []string
 	adapter := newTestAdapter(t)
@@ -46,6 +84,7 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 		return nil, apiErr
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -54,6 +93,7 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 	ctrl.mu.Unlock()
 
 	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.terminalFailures = terminalFailures
 	conn.EnableStreaming(ctrl)
 	err := conn.WriteCtx(context.Background(), &events.Envelope{
 		Version:   events.Version,
@@ -67,11 +107,13 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 	require.Len(t, sentBodies, 1)
 	require.Contains(t, sentBodies[0], terminalDeliveryFallbackText)
 	require.NotContains(t, sentBodies[0], "full worker response must not be sent again")
+	require.Equal(t, map[string]int64{"pending": 1, "sent": 1}, terminalFailureResults(t, reader))
 }
 
 func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *testing.T) {
 	t.Parallel()
 
+	reader, terminalFailures := newTerminalFailureMetric(t)
 	apiErr := errors.New("terminal API unavailable")
 	limiter := NewFeishuRateLimiter()
 	t.Cleanup(limiter.Stop)
@@ -79,6 +121,7 @@ func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *
 		return nil, apiErr
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -89,6 +132,7 @@ func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *
 	adapter := newTestAdapter(t) // nil lark client makes the static fallback fail.
 	adapter.Interactions = messaging.NewInteractionManager(discardLogger)
 	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.terminalFailures = terminalFailures
 	conn.EnableStreaming(ctrl)
 	err := conn.WriteCtx(context.Background(), &events.Envelope{
 		Version:   events.Version,
@@ -100,11 +144,13 @@ func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "terminal fallback delivery")
 	require.ErrorContains(t, err, "lark client not initialized")
+	require.Equal(t, map[string]int64{"pending": 1, "failed": 1}, terminalFailureResults(t, reader))
 }
 
 func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *testing.T) {
 	t.Parallel()
 
+	reader, terminalFailures := newTerminalFailureMetric(t)
 	var mu sync.Mutex
 	var sentBodies []string
 	adapter := newTestAdapter(t)
@@ -140,6 +186,7 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 		}, nil
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -148,6 +195,7 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 	ctrl.mu.Unlock()
 
 	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.terminalFailures = terminalFailures
 	conn.EnableStreaming(ctrl)
 	err := conn.WriteCtx(context.Background(), &events.Envelope{
 		Version:   events.Version,
@@ -159,4 +207,5 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 	mu.Lock()
 	defer mu.Unlock()
 	require.Empty(t, sentBodies)
+	require.Equal(t, map[string]int64{"pending": 1, "skipped_body_presented": 1}, terminalFailureResults(t, reader))
 }

--- a/internal/messaging/feishu/conn_test.go
+++ b/internal/messaging/feishu/conn_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/stretchr/testify/require"
@@ -208,4 +209,135 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 	defer mu.Unlock()
 	require.Empty(t, sentBodies)
 	require.Equal(t, map[string]int64{"pending": 1, "skipped_body_presented": 1}, terminalFailureResults(t, reader))
+}
+
+func TestFeishuConn_TerminalHandlersShareCallerDeadlineAcrossCloseAndFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind events.Kind
+		data any
+	}{
+		{name: "done", kind: events.Done, data: events.DoneData{Success: true}},
+		{name: "error", kind: events.Error, data: events.ErrorData{Code: "MODEL_ERROR", Message: "model failed"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				mu                sync.Mutex
+				closeDeadlines    []time.Time
+				fallbackDeadlines []time.Time
+			)
+			captureDeadline := func(dst *[]time.Time) mediaHTTPClientFunc {
+				return func(req *http.Request) (*http.Response, error) {
+					deadline, ok := req.Context().Deadline()
+					require.True(t, ok, "terminal HTTP request must carry a deadline")
+					mu.Lock()
+					*dst = append(*dst, deadline)
+					mu.Unlock()
+					return nil, errors.New("terminal HTTP unavailable")
+				}
+			}
+
+			limiter := NewFeishuRateLimiter()
+			t.Cleanup(limiter.Stop)
+			ctrlClient := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(captureDeadline(&closeDeadlines)))
+			ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+			ctrl.phase.Store(int32(PhaseStreaming))
+			ctrl.mu.Lock()
+			ctrl.cardID = "card-1"
+			ctrl.msgID = "msg-1"
+			ctrl.buf.WriteString("terminal body")
+			ctrl.mu.Unlock()
+
+			adapter := newTestAdapter(t)
+			adapter.Interactions = messaging.NewInteractionManager(discardLogger)
+			adapter.larkClient = lark.NewClient("test-app", "test-secret", lark.WithHttpClient(captureDeadline(&fallbackDeadlines)))
+			conn := NewFeishuConn(adapter, "chat-1", "", "")
+			conn.EnableStreaming(ctrl)
+
+			callerTimeout := 250 * time.Millisecond
+			if tt.kind == events.Error {
+				callerTimeout = 6 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), callerTimeout)
+			defer cancel()
+			callerDeadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			err := conn.WriteCtx(ctx, &events.Envelope{
+				Version:   events.Version,
+				SessionID: "session-1",
+				Event:     events.Event{Type: tt.kind, Data: tt.data},
+			})
+
+			require.ErrorIs(t, err, ErrTerminalDelivery)
+			mu.Lock()
+			defer mu.Unlock()
+			require.NotEmpty(t, closeDeadlines)
+			require.NotEmpty(t, fallbackDeadlines)
+			for _, deadline := range append(closeDeadlines, fallbackDeadlines...) {
+				require.WithinDuration(t, callerDeadline, deadline, 10*time.Millisecond,
+					"close and fallback must share the caller's terminal budget")
+			}
+		})
+	}
+}
+
+func TestFeishuConn_HandleDone_DefaultTerminalDeadlineIsSharedWithFallback(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu                sync.Mutex
+		closeDeadlines    []time.Time
+		fallbackDeadlines []time.Time
+	)
+	captureDeadline := func(dst *[]time.Time) mediaHTTPClientFunc {
+		return func(req *http.Request) (*http.Response, error) {
+			deadline, ok := req.Context().Deadline()
+			require.True(t, ok, "terminal HTTP request must carry the default deadline")
+			mu.Lock()
+			*dst = append(*dst, deadline)
+			mu.Unlock()
+			return nil, errors.New("terminal HTTP unavailable")
+		}
+	}
+
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	ctrlClient := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(captureDeadline(&closeDeadlines)))
+	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.phase.Store(int32(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.cardID = "card-1"
+	ctrl.msgID = "msg-1"
+	ctrl.buf.WriteString("terminal body")
+	ctrl.mu.Unlock()
+
+	adapter := newTestAdapter(t)
+	adapter.Interactions = messaging.NewInteractionManager(discardLogger)
+	adapter.larkClient = lark.NewClient("test-app", "test-secret", lark.WithHttpClient(captureDeadline(&fallbackDeadlines)))
+	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.EnableStreaming(ctrl)
+
+	started := time.Now()
+	err := conn.WriteCtx(context.Background(), &events.Envelope{
+		Version:   events.Version,
+		SessionID: "session-1",
+		Event:     events.Event{Type: events.Done, Data: events.DoneData{Success: true}},
+	})
+
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, closeDeadlines)
+	require.NotEmpty(t, fallbackDeadlines)
+	sharedDeadline := closeDeadlines[0]
+	require.WithinDuration(t, started.Add(defaultTerminalDeliveryTimeout), sharedDeadline, 50*time.Millisecond)
+	for _, deadline := range append(closeDeadlines, fallbackDeadlines...) {
+		require.Equal(t, sharedDeadline, deadline, "close and fallback must use one default end-to-end deadline")
+	}
 }

--- a/internal/messaging/feishu/conn_test.go
+++ b/internal/messaging/feishu/conn_test.go
@@ -68,3 +68,95 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 	require.Contains(t, sentBodies[0], terminalDeliveryFallbackText)
 	require.NotContains(t, sentBodies[0], "full worker response must not be sent again")
 }
+
+func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("terminal API unavailable")
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	ctrlClient := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+		return nil, apiErr
+	})))
+	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.phase.Store(int32(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.cardID = "card-1"
+	ctrl.msgID = "msg-1"
+	ctrl.buf.WriteString("full worker response")
+	ctrl.mu.Unlock()
+
+	adapter := newTestAdapter(t) // nil lark client makes the static fallback fail.
+	adapter.Interactions = messaging.NewInteractionManager(discardLogger)
+	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.EnableStreaming(ctrl)
+	err := conn.WriteCtx(context.Background(), &events.Envelope{
+		Version:   events.Version,
+		SessionID: "session-1",
+		Event:     events.Event{Type: events.Done, Data: events.DoneData{Success: true}},
+	})
+
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	require.ErrorIs(t, err, apiErr)
+	require.ErrorContains(t, err, "terminal fallback delivery")
+	require.ErrorContains(t, err, "lark client not initialized")
+}
+
+func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var sentBodies []string
+	adapter := newTestAdapter(t)
+	adapter.Interactions = messaging.NewInteractionManager(discardLogger)
+	adapter.larkClient = lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == "/open-apis/im/v1/messages" {
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			mu.Lock()
+			sentBodies = append(sentBodies, string(body))
+			mu.Unlock()
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"msg":"ok"}`)),
+			Request:    req,
+		}, nil
+	})))
+
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	ctrlClient := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok"}`
+		if req.Method == http.MethodPut && strings.HasSuffix(req.URL.Path, "/cards/card-1") {
+			body = `{"code":999,"msg":"header update failed"}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})))
+	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.phase.Store(int32(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.cardID = "card-1"
+	ctrl.msgID = "msg-1"
+	ctrl.buf.WriteString("full worker response")
+	ctrl.mu.Unlock()
+
+	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.EnableStreaming(ctrl)
+	err := conn.WriteCtx(context.Background(), &events.Envelope{
+		Version:   events.Version,
+		SessionID: "session-1",
+		Event:     events.Event{Type: events.Done, Data: events.DoneData{Success: true}},
+	})
+
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, sentBodies)
+}

--- a/internal/messaging/feishu/conn_test.go
+++ b/internal/messaging/feishu/conn_test.go
@@ -1,0 +1,70 @@
+package feishu
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var sentBodies []string
+	adapter := newTestAdapter(t)
+	adapter.Interactions = messaging.NewInteractionManager(discardLogger)
+	adapter.larkClient = lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == "/open-apis/im/v1/messages" {
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			mu.Lock()
+			sentBodies = append(sentBodies, string(body))
+			mu.Unlock()
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"msg":"ok"}`)),
+			Request:    req,
+		}, nil
+	})))
+
+	apiErr := errors.New("terminal API unavailable")
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	ctrlClient := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+		return nil, apiErr
+	})))
+	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	ctrl.phase.Store(int32(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.cardID = "card-1"
+	ctrl.msgID = "msg-1"
+	ctrl.buf.WriteString("full worker response must not be sent again")
+	ctrl.mu.Unlock()
+
+	conn := NewFeishuConn(adapter, "chat-1", "", "")
+	conn.EnableStreaming(ctrl)
+	err := conn.WriteCtx(context.Background(), &events.Envelope{
+		Version:   events.Version,
+		SessionID: "session-1",
+		Event:     events.Event{Type: events.Done, Data: events.DoneData{Success: true}},
+	})
+
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, sentBodies, 1)
+	require.Contains(t, sentBodies[0], terminalDeliveryFallbackText)
+	require.NotContains(t, sentBodies[0], "full worker response must not be sent again")
+}

--- a/internal/messaging/feishu/handler.go
+++ b/internal/messaging/feishu/handler.go
@@ -62,7 +62,8 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 	if dedup == nil {
 		return nil // adapter is closing
 	}
-	if !dedup.TryRecord(messageID) {
+	dedupHandle, recorded := dedup.TryRecordWithHandle(messageID)
+	if !recorded {
 		return nil
 	}
 
@@ -70,6 +71,7 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 	msgType := ptrStr(msg.MessageType)
 	text, ok, medias := ConvertMessage(msgType, ptrStr(msg.Content), msg.Mentions, a.botOpenID, messageID)
 	if !ok || text == "" {
+		dedup.Rollback(dedupHandle)
 		return nil
 	}
 	text = messaging.SanitizeText(text)
@@ -104,6 +106,7 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 	if a.Gate != nil {
 		if allowed, reason := a.Gate.Check(chatType == "p2p", userID, botMentioned); !allowed {
 			a.Log.Debug("feishu: gate rejected", "reason", reason, "chat", chatID, "user", userID)
+			dedup.Rollback(dedupHandle)
 			return nil
 		}
 	}
@@ -116,7 +119,7 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 		replyToMsgID = rootID
 	}
 
-	return a.chatQueue.Enqueue(chatID, func(qtx context.Context) error {
+	err := a.chatQueue.Enqueue(chatID, func(qtx context.Context) error {
 		cmd := messaging.DetectCommand(text)
 		switch cmd.Action {
 		case messaging.CmdHelp:
@@ -140,6 +143,10 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 
 		return a.handleTextMessage(qtx, messageID, chatID, chatType, userID, text, threadKey, replyToMsgID, hasVoice)
 	})
+	if err != nil {
+		dedup.Rollback(dedupHandle)
+	}
+	return err
 }
 
 func isBotMentioned(mentions []*larkim.MentionEvent, botOpenID string) bool {

--- a/internal/messaging/feishu/handler.go
+++ b/internal/messaging/feishu/handler.go
@@ -108,13 +108,7 @@ func (a *Adapter) handleMessage(ctx context.Context, event *larkim.P2MessageRece
 		}
 	}
 
-	// Step 8: Abort fast-path.
-	if messaging.IsAbortCommand(text) {
-		a.chatQueue.Abort(chatID)
-		return nil
-	}
-
-	// Step 9: All message processing (including control commands) goes through
+	// Step 8: All message processing (including stop and other control commands) goes through
 	// chatQueue to serialize execution per chatID, preventing races between
 	// reset's Terminate→Start and the next message's Input() call.
 	replyToMsgID := parentID
@@ -257,6 +251,11 @@ func (a *Adapter) GetOrCreateConn(chatID, threadKey string) *FeishuConn {
 }
 
 func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, threadKey, platformMsgID string, result *messaging.ControlCommandResult) {
+	if a.Bridge() == nil {
+		a.Log.Warn("feishu: text control command dropped without bridge", "action", result.Label)
+		return
+	}
+
 	conn := a.GetOrCreateConn(chatID, threadKey)
 	envelope := a.makeEnvelope(chatID, threadKey, userID, "", conn.WorkDir())
 	if envelope == nil {
@@ -313,8 +312,10 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, chatID, userID, 
 		conn.mu.Unlock()
 	}
 
-	// Completion feedback for non-CD actions (CD feedback was sent before execution).
-	if result.Action != events.ControlActionCD {
+	// Stop is confirmed by Gateway's done.reason=stopped_by_user event. Avoid a
+	// duplicate local completion message while its terminal delivery settles.
+	// CD feedback was sent before execution; other controls complete locally.
+	if result.Action != events.ControlActionCD && result.Action != events.ControlActionStop {
 		_ = a.replyOrSend(ctx, platformMsgID, chatID, controlFeedbackMessageCN(result.Action))
 	}
 }

--- a/internal/messaging/feishu/media.go
+++ b/internal/messaging/feishu/media.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -60,6 +61,8 @@ func (a *Adapter) processMediaAttachments(ctx context.Context, medias []*MediaIn
 
 const mediaMaxSize = 10 * 1024 * 1024 // 10 MB
 
+var ErrMediaTooLarge = errors.New("feishu: file too large")
+
 const silenceTimeout = 30 * time.Second
 
 // mediaTypeToResourceType maps our internal media types to Feishu resource types.
@@ -111,24 +114,31 @@ func (a *Adapter) fetchMediaBytes(ctx context.Context, media *MediaInfo) ([]byte
 		ext = mimeExt(ct)
 	}
 
-	data, err := io.ReadAll(resp.File)
+	data, err := readMediaBytes(resp.File)
 	if err != nil {
-		return nil, "", fmt.Errorf("feishu: read file content: %w", err)
-	}
-	if len(data) > mediaMaxSize {
-		return nil, "", fmt.Errorf("feishu: file too large: %d > %d bytes", len(data), mediaMaxSize)
+		return nil, "", err
 	}
 
 	a.Log.Debug("feishu: media fetched", "type", media.Type, "key", media.Key, "size", len(data))
 	return data, ext, nil
 }
 
+// readMediaBytes reads one extra byte so oversized media is rejected without
+// allowing an untrusted reader to consume unbounded memory or input.
+func readMediaBytes(r io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, mediaMaxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("feishu: read file content: %w", err)
+	}
+	if len(data) > mediaMaxSize {
+		return nil, fmt.Errorf("%w: %d > %d bytes", ErrMediaTooLarge, len(data), mediaMaxSize)
+	}
+	return data, nil
+}
+
 // saveMediaBytes writes media data to disk and returns the file path.
 func (a *Adapter) saveMediaBytes(data []byte, media *MediaInfo, ext string) (string, error) {
 	mediaDir := filepath.Join(config.TempBaseDir(), "media", media.Type+"s")
-	if err := os.MkdirAll(mediaDir, 0o755); err != nil {
-		return "", fmt.Errorf("feishu: create media dir: %w", err)
-	}
 
 	filename := media.Key + ext
 	if media.Name != "" {
@@ -136,13 +146,54 @@ func (a *Adapter) saveMediaBytes(data []byte, media *MediaInfo, ext string) (str
 			filename = media.Key + "_" + base
 		}
 	}
-	filePath := filepath.Join(mediaDir, filename)
-
-	if err := os.WriteFile(filePath, data, 0o644); err != nil {
-		return "", fmt.Errorf("feishu: write file: %w", err)
+	filePath, err := saveMediaFile(mediaDir, data, filename)
+	if err != nil {
+		return "", err
 	}
 
 	a.Log.Debug("feishu: media saved", "type", media.Type, "key", media.Key, "path", filePath)
+	return filePath, nil
+}
+
+// saveMediaFile writes a media file atomically with owner-only permissions.
+func saveMediaFile(mediaDir string, data []byte, filename string) (string, error) {
+	if filepath.Base(filename) != filename || filename == "." || filename == ".." {
+		return "", fmt.Errorf("feishu: unsafe media filename %q", filename)
+	}
+	if err := os.MkdirAll(mediaDir, 0o700); err != nil {
+		return "", fmt.Errorf("feishu: create media dir: %w", err)
+	}
+	if err := os.Chmod(mediaDir, 0o700); err != nil {
+		return "", fmt.Errorf("feishu: restrict media dir: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(mediaDir, ".media-*")
+	if err != nil {
+		return "", fmt.Errorf("feishu: create media file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tempFile.Close()
+		}
+		_ = os.Remove(tempPath)
+	}()
+	if err := tempFile.Chmod(0o600); err != nil {
+		return "", fmt.Errorf("feishu: restrict media file: %w", err)
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		return "", fmt.Errorf("feishu: write file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return "", fmt.Errorf("feishu: close media file: %w", err)
+	}
+	closed = true
+
+	filePath := filepath.Join(mediaDir, filename)
+	if err := os.Rename(tempPath, filePath); err != nil {
+		return "", fmt.Errorf("feishu: finalize media file: %w", err)
+	}
 	return filePath, nil
 }
 

--- a/internal/messaging/feishu/media.go
+++ b/internal/messaging/feishu/media.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
@@ -64,6 +66,48 @@ const mediaMaxSize = 10 * 1024 * 1024 // 10 MB
 var ErrMediaTooLarge = errors.New("feishu: file too large")
 
 const silenceTimeout = 30 * time.Second
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type mediaBoundedHTTPClient struct {
+	client httpDoer
+}
+
+func newMediaBoundedHTTPClient(client httpDoer) *mediaBoundedHTTPClient {
+	return &mediaBoundedHTTPClient{client: client}
+}
+
+func (c *mediaBoundedHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil || resp == nil || resp.Body == nil || !isMessageResourceDownload(req) {
+		return resp, err
+	}
+	resp.Body = &mediaLimitReadCloser{
+		Reader: io.LimitReader(resp.Body, mediaMaxSize+1),
+		Closer: resp.Body,
+	}
+	return resp, nil
+}
+
+func isMessageResourceDownload(req *http.Request) bool {
+	if req == nil || req.Method != http.MethodGet {
+		return false
+	}
+	parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	return len(parts) == 7 &&
+		parts[0] == "open-apis" &&
+		parts[1] == "im" &&
+		parts[2] == "v1" &&
+		parts[3] == "messages" &&
+		parts[5] == "resources"
+}
+
+type mediaLimitReadCloser struct {
+	io.Reader
+	io.Closer
+}
 
 // mediaTypeToResourceType maps our internal media types to Feishu resource types.
 var mediaTypeToResourceType = map[string]string{

--- a/internal/messaging/feishu/media_test.go
+++ b/internal/messaging/feishu/media_test.go
@@ -2,11 +2,17 @@ package feishu
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +46,47 @@ func TestReadMediaBytes_StopsAtLimitForInfiniteReader(t *testing.T) {
 	require.Equal(t, mediaMaxSize+1, reader.bytesRead)
 }
 
+func TestFetchMediaBytes_BoundsSDKResponseBeforeSDKBuffering(t *testing.T) {
+	t.Parallel()
+
+	resourceBody := &infiniteMediaReadCloser{}
+	client := lark.NewClient("media-test-app", "media-test-secret",
+		lark.WithHttpClient(newMediaBoundedHTTPClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/open-apis/auth/v3/tenant_access_token/internal":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"code":0,"tenant_access_token":"test-token","expire":7200}`)),
+					Request:    req,
+				}, nil
+			case "/open-apis/im/v1/messages/message-id/resources/resource-key":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+					Body:       resourceBody,
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected SDK request path %q", req.URL.Path)
+			}
+		}))),
+	)
+	adapter := newTestAdapter(t)
+	adapter.larkClient = client
+
+	data, _, err := adapter.fetchMediaBytes(context.Background(), &MediaInfo{
+		Type:      "file",
+		Key:       "resource-key",
+		MessageID: "message-id",
+	})
+
+	require.ErrorIs(t, err, ErrMediaTooLarge)
+	require.Nil(t, data)
+	require.Equal(t, mediaMaxSize+1, resourceBody.bytesRead)
+	require.True(t, resourceBody.closed)
+}
+
 func TestSaveMediaFile_UsesPrivatePermissions(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -71,6 +118,22 @@ func TestSaveMediaFile_RejectsUnsafeFilename(t *testing.T) {
 
 type infiniteMediaReader struct {
 	bytesRead int
+}
+
+type infiniteMediaReadCloser struct {
+	infiniteMediaReader
+	closed bool
+}
+
+func (r *infiniteMediaReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type mediaHTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (f mediaHTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func (r *infiniteMediaReader) Read(p []byte) (int, error) {

--- a/internal/messaging/feishu/media_test.go
+++ b/internal/messaging/feishu/media_test.go
@@ -1,0 +1,82 @@
+package feishu
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMediaBytes_AllowsExactlyMediaMaxSize(t *testing.T) {
+	t.Parallel()
+
+	want := bytes.Repeat([]byte{'a'}, mediaMaxSize)
+	data, err := readMediaBytes(bytes.NewReader(want))
+
+	require.NoError(t, err)
+	require.Equal(t, want, data)
+}
+
+func TestReadMediaBytes_RejectsMediaMaxSizePlusOne(t *testing.T) {
+	t.Parallel()
+
+	data, err := readMediaBytes(bytes.NewReader(bytes.Repeat([]byte{'a'}, mediaMaxSize+1)))
+
+	require.ErrorIs(t, err, ErrMediaTooLarge)
+	require.Nil(t, data)
+}
+
+func TestReadMediaBytes_StopsAtLimitForInfiniteReader(t *testing.T) {
+	t.Parallel()
+
+	reader := &infiniteMediaReader{}
+	data, err := readMediaBytes(reader)
+
+	require.ErrorIs(t, err, ErrMediaTooLarge)
+	require.Nil(t, data)
+	require.Equal(t, mediaMaxSize+1, reader.bytesRead)
+}
+
+func TestSaveMediaFile_UsesPrivatePermissions(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+
+	mediaDir := filepath.Join(t.TempDir(), "media", "images")
+	path, err := saveMediaFile(mediaDir, []byte("media content"), "payload.bin")
+
+	require.NoError(t, err)
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	dirInfo, err := os.Stat(mediaDir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+	require.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+}
+
+func TestSaveMediaFile_RejectsUnsafeFilename(t *testing.T) {
+	t.Parallel()
+
+	mediaDir := filepath.Join(t.TempDir(), "media", "files")
+	path, err := saveMediaFile(mediaDir, []byte("media content"), "../escaped.bin")
+
+	require.Error(t, err)
+	require.Empty(t, path)
+	require.NoFileExists(t, filepath.Join(filepath.Dir(mediaDir), "escaped.bin"))
+}
+
+type infiniteMediaReader struct {
+	bytesRead int
+}
+
+func (r *infiniteMediaReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	r.bytesRead += len(p)
+	return len(p), nil
+}

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -61,6 +61,13 @@ func newTerminalDeliveryError(contentPresented bool, errs ...error) error {
 	}
 }
 
+func (c *StreamingCardController) terminalFailureCounter() metric.Int64Counter {
+	if c.terminalFailures != nil {
+		return c.terminalFailures
+	}
+	return observability.StreamingTerminalFailures()
+}
+
 const (
 	PhaseIdle CardPhase = iota
 	PhaseCreating
@@ -130,9 +137,10 @@ type StreamingCardController struct {
 	failedFlushes   int
 
 	// Reliability — metrics and health tracking.
-	streamStartTime time.Time
-	ttlWarnOnce     sync.Once
-	bytesWritten    int64
+	streamStartTime  time.Time
+	ttlWarnOnce      sync.Once
+	bytesWritten     int64
+	terminalFailures metric.Int64Counter // test injection; nil uses observability accessor
 
 	// Tool state — tool call/result display strip.
 	toolEntries       []toolEntry // ring buffer, max 2 entries
@@ -879,7 +887,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 
 	err := newTerminalDeliveryError(bodyPresented, terminalErrs...)
 	if err != nil {
-		observability.StreamingTerminalFailures().Add(ctx, 1,
+		c.terminalFailureCounter().Add(ctx, 1,
 			metric.WithAttributes(attribute.String("fallback_result", "pending")))
 	}
 	return err

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -3,6 +3,7 @@ package feishu
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -15,6 +16,8 @@ import (
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcardkit "github.com/larksuite/oapi-sdk-go/v3/service/cardkit/v1"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/phrases"
@@ -22,6 +25,41 @@ import (
 )
 
 type CardPhase int32
+
+// ErrTerminalDelivery identifies a streaming-card finalization that could not
+// complete cleanly. Callers can use TerminalDeliveryError to decide whether a
+// static fallback is still necessary.
+var ErrTerminalDelivery = errors.New("feishu: terminal delivery failed")
+
+// TerminalDeliveryError reports a finalization failure while preserving whether
+// the terminal body is already visible. A decoration failure (for example, the
+// header update) must remain observable without causing the connection to send
+// the response body a second time.
+type TerminalDeliveryError struct {
+	ContentPresented bool
+	err              error
+}
+
+func (e *TerminalDeliveryError) Error() string {
+	if e.ContentPresented {
+		return fmt.Sprintf("feishu: terminal delivery failed after body was presented: %v", e.err)
+	}
+	return fmt.Sprintf("feishu: terminal delivery failed before body was presented: %v", e.err)
+}
+
+func (e *TerminalDeliveryError) Unwrap() error {
+	return e.err
+}
+
+func newTerminalDeliveryError(contentPresented bool, errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return &TerminalDeliveryError{
+		ContentPresented: contentPresented,
+		err:              errors.Join(append([]error{ErrTerminalDelivery}, errs...)...),
+	}
+}
 
 const (
 	PhaseIdle CardPhase = iota
@@ -756,6 +794,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		"last_flushed_len", len(c.lastFlushed))
 
 	finalFlushOK := false
+	var terminalErrs []error
 	// Skip final flush when content is empty — CardKit rejects empty content
 	// with code 99992402. If lastFlushed has content, the streaming card already
 	// displays it from the periodic flush loop.
@@ -768,9 +807,13 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		if err := c.flushCardKitElement(ctx, c.elementID, content, seq); err != nil {
 			c.log.Warn("feishu: final cardkit flush failed, attempting IM patch fallback",
 				"err", err)
+			terminalErrs = append(terminalErrs, err)
 			if c.msgID != "" {
 				if err := c.flushIMPatchWithConfig(ctx, content); err == nil {
 					finalFlushOK = true
+					terminalErrs = nil
+				} else {
+					terminalErrs = append(terminalErrs, err)
 				}
 			}
 		} else {
@@ -780,6 +823,8 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		c.log.Debug("feishu: cardkit degraded, using IM patch with final config")
 		if err := c.flushIMPatchWithConfig(ctx, content); err == nil {
 			finalFlushOK = true
+		} else {
+			terminalErrs = append(terminalErrs, err)
 		}
 	}
 
@@ -787,6 +832,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	if finalFlushOK {
 		c.lastFlushed = content
 	}
+	bodyPresented := finalFlushOK || c.lastFlushed == content
 	integrityFailed := !finalFlushOK || len(c.lastFlushed) < len(content)*9/10
 	if integrityFailed && c.bytesWritten > 0 {
 		c.log.Warn("feishu: streaming integrity check failed",
@@ -808,6 +854,7 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		if cardID != "" {
 			if err := c.disableStreaming(ctx); err != nil {
 				c.log.Warn("feishu: disable streaming failed", "err", err)
+				terminalErrs = append(terminalErrs, err)
 			} else {
 				c.log.Info("feishu: streaming stopped",
 					"card_id", cardID,
@@ -822,13 +869,20 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 		c.mu.Unlock()
 	}
 
-	c.updateHeader(ctx, cardID, cardHeader{
+	if err := c.updateHeader(ctx, cardID, cardHeader{
 		Title:    c.agentName,
 		Template: headerBlue,
 		Tags:     c.closeTags(),
-	}, content, true)
+	}, content, true); err != nil {
+		terminalErrs = append(terminalErrs, err)
+	}
 
-	return nil
+	err := newTerminalDeliveryError(bodyPresented, terminalErrs...)
+	if err != nil {
+		observability.StreamingTerminalFailures().Add(ctx, 1,
+			metric.WithAttributes(attribute.String("fallback_result", "pending")))
+	}
+	return err
 }
 
 func (c *StreamingCardController) Abort(ctx context.Context) error {
@@ -854,11 +908,13 @@ func (c *StreamingCardController) Abort(ctx context.Context) error {
 		c.sendAbortMessage(ctx, msgID)
 	}
 
-	c.updateHeader(ctx, cardID, cardHeader{
+	if err := c.updateHeader(ctx, cardID, cardHeader{
 		Title:    c.agentName,
 		Template: headerGrey,
 		Tags:     turnTags(c.turnNum, c.model, c.branch, c.workDir),
-	}, "", false)
+	}, "", false); err != nil {
+		c.log.Warn("feishu: abort header update failed", "err", err)
+	}
 
 	return nil
 }
@@ -881,9 +937,9 @@ func (c *StreamingCardController) buildFinalElements(body string, showClosing bo
 	return elements
 }
 
-func (c *StreamingCardController) updateHeader(ctx context.Context, cardID string, header cardHeader, body string, showClosing bool) {
+func (c *StreamingCardController) updateHeader(ctx context.Context, cardID string, header cardHeader, body string, showClosing bool) error {
 	if cardID == "" {
-		return
+		return nil
 	}
 
 	cardJSON := buildCard(header,
@@ -910,7 +966,12 @@ func (c *StreamingCardController) updateHeader(ctx context.Context, cardID strin
 	resp, err := c.client.Cardkit.V1.Card.Update(ctx, req)
 	if err != nil || !resp.Success() {
 		c.log.Warn("feishu: header update failed (non-fatal)", "err", err)
+		if err != nil {
+			return fmt.Errorf("cardkit header update: %w", err)
+		}
+		return fmt.Errorf("cardkit header update failed: code=%d msg=%s", resp.Code, resp.Msg)
 	}
+	return nil
 }
 
 func (c *StreamingCardController) idConvert(ctx context.Context, messageID string) (string, error) {

--- a/internal/messaging/feishu/streaming_test.go
+++ b/internal/messaging/feishu/streaming_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,6 +119,92 @@ func TestStreamingCardController_ConcurrentTransitions(t *testing.T) {
 	// Exactly one should succeed; the rest fail because phase already changed
 	require.Equal(t, 1, successCount)
 	require.Equal(t, PhaseCreating, c.getPhase())
+}
+
+func TestStreamingCardController_Close_ReturnsTerminalDeliveryErrorWhenCardKitAndIMPatchFail(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("terminal API unavailable")
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	client := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+		return nil, apiErr
+	})))
+	c := NewStreamingCardController(client, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	c.phase.Store(int32(PhaseStreaming))
+	c.mu.Lock()
+	c.cardID = "card-1"
+	c.msgID = "msg-1"
+	c.buf.WriteString("final response")
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	require.ErrorIs(t, err, apiErr)
+
+	var terminalErr *TerminalDeliveryError
+	require.ErrorAs(t, err, &terminalErr)
+	require.False(t, terminalErr.ContentPresented)
+}
+
+func TestStreamingCardController_Close_MarksBodyPresentedWhenPriorStreamingFlushSucceeded(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errors.New("terminal API unavailable")
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	client := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(*http.Request) (*http.Response, error) {
+		return nil, apiErr
+	})))
+	c := NewStreamingCardController(client, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	c.phase.Store(int32(PhaseStreaming))
+	c.mu.Lock()
+	c.cardID = "card-1"
+	c.msgID = "msg-1"
+	c.buf.WriteString("final response")
+	c.lastFlushed = "final response"
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+
+	var terminalErr *TerminalDeliveryError
+	require.ErrorAs(t, err, &terminalErr)
+	require.True(t, terminalErr.ContentPresented)
+}
+
+func TestStreamingCardController_Close_ReturnsVisibleHeaderErrorAfterBodyPresented(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	client := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok"}`
+		if req.Method == http.MethodPut && strings.HasSuffix(req.URL.Path, "/cards/card-1") {
+			body = `{"code":999,"msg":"header update failed"}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})))
+	c := NewStreamingCardController(client, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	c.phase.Store(int32(PhaseStreaming))
+	c.mu.Lock()
+	c.cardID = "card-1"
+	c.msgID = "msg-1"
+	c.buf.WriteString("final response")
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+
+	var terminalErr *TerminalDeliveryError
+	require.ErrorAs(t, err, &terminalErr)
+	require.True(t, terminalErr.ContentPresented)
+	require.Contains(t, err.Error(), "header")
 }
 
 // ─── truncateForSummary ──────────────────────────────────────────────────────

--- a/internal/messaging/feishu/streaming_test.go
+++ b/internal/messaging/feishu/streaming_test.go
@@ -207,6 +207,69 @@ func TestStreamingCardController_Close_ReturnsVisibleHeaderErrorAfterBodyPresent
 	require.Contains(t, err.Error(), "header")
 }
 
+func TestStreamingCardController_Close_CardKitFailureWithIMPatchSuccessDegradesSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	client := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok"}`
+		if strings.HasSuffix(req.URL.Path, "/elements/streaming_content/content") {
+			body = `{"code":999,"msg":"cardkit final flush failed"}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})))
+	c := NewStreamingCardController(client, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	c.phase.Store(int32(PhaseStreaming))
+	c.mu.Lock()
+	c.cardID = "card-1"
+	c.msgID = "msg-1"
+	c.buf.WriteString("final response")
+	c.mu.Unlock()
+
+	require.NoError(t, c.Close(context.Background()))
+}
+
+func TestStreamingCardController_Close_AggregatesDisableStreamingFailureAfterBodyPresented(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewFeishuRateLimiter()
+	t.Cleanup(limiter.Stop)
+	client := lark.NewClient("test-app", "test-secret", lark.WithHttpClient(mediaHTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"code":0,"msg":"ok"}`
+		if strings.HasSuffix(req.URL.Path, "/settings") {
+			body = `{"code":999,"msg":"disable streaming failed"}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})))
+	c := NewStreamingCardController(client, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
+	c.phase.Store(int32(PhaseStreaming))
+	c.mu.Lock()
+	c.cardID = "card-1"
+	c.msgID = "msg-1"
+	c.streamingActive = true
+	c.buf.WriteString("final response")
+	c.mu.Unlock()
+
+	err := c.Close(context.Background())
+	require.ErrorIs(t, err, ErrTerminalDelivery)
+	require.Contains(t, err.Error(), "disable streaming")
+
+	var terminalErr *TerminalDeliveryError
+	require.ErrorAs(t, err, &terminalErr)
+	require.True(t, terminalErr.ContentPresented)
+}
+
 // ─── truncateForSummary ──────────────────────────────────────────────────────
 
 func TestTruncateForSummary(t *testing.T) {

--- a/internal/messaging/pipeline.go
+++ b/internal/messaging/pipeline.go
@@ -3,6 +3,8 @@ package messaging
 import (
 	"strings"
 	"sync"
+
+	"github.com/hrygo/hotplex/pkg/events"
 )
 
 // Source: OpenClaw abort-detect.ts (core triggers, covering English/Chinese/Japanese/Russian).
@@ -38,7 +40,6 @@ type CommandAction int
 
 const (
 	CmdNone CommandAction = iota
-	CmdAbort
 	CmdHelp
 	CmdControl
 	CmdWorker
@@ -53,7 +54,13 @@ type CommandResult struct {
 
 func DetectCommand(text string) CommandResult {
 	if IsAbortCommand(text) {
-		return CommandResult{Action: CmdAbort}
+		return CommandResult{
+			Action: CmdControl,
+			Control: &ControlCommandResult{
+				Action: events.ControlActionStop,
+				Label:  "stop",
+			},
+		}
 	}
 	if IsHelpCommand(text) {
 		return CommandResult{Action: CmdHelp}

--- a/internal/messaging/pipeline_test.go
+++ b/internal/messaging/pipeline_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
 )
 
 func TestIsAbortCommand(t *testing.T) {
@@ -59,7 +61,7 @@ func TestDetectCommand(t *testing.T) {
 		input  string
 		action CommandAction
 	}{
-		{"abort", "stop", CmdAbort},
+		{"abort becomes control stop", "stop", CmdControl},
 		{"help", "/help", CmdHelp},
 		{"control /gc", "/gc", CmdControl},
 		{"control /reset", "/reset", CmdControl},
@@ -83,6 +85,15 @@ func TestDetectCommand_ControlResult(t *testing.T) {
 	result := DetectCommand("/gc")
 	require.NotNil(t, result.Control)
 	require.Equal(t, "gc", result.Control.Label)
+}
+
+func TestDetectCommand_AbortControlResult(t *testing.T) {
+	t.Parallel()
+
+	result := DetectCommand("stop")
+	require.Equal(t, CmdControl, result.Action)
+	require.NotNil(t, result.Control)
+	require.Equal(t, events.ControlActionStop, result.Control.Action)
 }
 
 func TestDetectCommand_WorkerResult(t *testing.T) {

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -508,9 +508,6 @@ func (a *Adapter) handleMessageEvent(ctx context.Context, msgEvent *slackevents.
 
 	cmd := messaging.DetectCommand(text)
 	switch cmd.Action {
-	case messaging.CmdAbort:
-		a.Log.Info("slack: abort command received", "channel", channelID)
-		return
 	case messaging.CmdHelp:
 		_ = a.SetStatus(ctx, channelID, threadTS, StatusThinking, "Loading help...")
 		opts := []slack.MsgOption{
@@ -736,6 +733,11 @@ func (a *Adapter) handleAudioMessage(ctx context.Context, m *MediaInfo) (string,
 // handleTextControlCommand sends a control event derived from a text message
 // through the bridge, then sends ephemeral feedback to the user.
 func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelID, threadTS, userID string, result *messaging.ControlCommandResult) {
+	if a.Bridge() == nil {
+		a.Log.Warn("slack: text control command dropped without bridge", "action", result.Label)
+		return
+	}
+
 	conn := a.GetOrCreateConn(channelID, threadTS)
 	if conn == nil {
 		a.Log.Warn("slack: adapter closed, dropping control command", "action", result.Label)
@@ -790,8 +792,10 @@ func (a *Adapter) handleTextControlCommand(ctx context.Context, teamID, channelI
 		}
 	}
 
-	// Completion feedback for non-CD actions (CD feedback was sent before execution).
-	if result.Action != events.ControlActionCD {
+	// Stop is confirmed by Gateway's done.reason=stopped_by_user event. Avoid a
+	// duplicate local completion message while its terminal delivery settles.
+	// CD feedback was sent before execution; other controls complete locally.
+	if result.Action != events.ControlActionCD && result.Action != events.ControlActionStop {
 		a.sendEphemeralOrPost(ctx, channelID, threadTS, userID, controlFeedbackMessage(result.Action))
 	}
 }

--- a/internal/messaging/slack/e2e_test.go
+++ b/internal/messaging/slack/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -92,16 +94,26 @@ func (h *controlCaptureHandler) Handle(_ context.Context, env *events.Envelope) 
 	return nil
 }
 
-func newAdapterWithControlCapture(t *testing.T) (*Adapter, <-chan *events.Envelope) {
+type controlSessionStarter struct {
+	calls atomic.Int32
+}
+
+func (s *controlSessionStarter) StartPlatformSession(_ context.Context, _ worker.SessionStartParams) error {
+	s.calls.Add(1)
+	return nil
+}
+
+func newAdapterWithControlCapture(t *testing.T) (*Adapter, <-chan *events.Envelope, *controlSessionStarter) {
 	t.Helper()
 	a := newTestAdapter(t)
 	handler := &controlCaptureHandler{envelopes: make(chan *events.Envelope, 1)}
+	starter := &controlSessionStarter{}
 	bridge := messaging.NewBridge(
-		slog.Default(), messaging.PlatformSlack, nil, handler, nil,
+		slog.Default(), messaging.PlatformSlack, nil, handler, starter,
 		"test_worker", "", "/tmp", "",
 	)
 	require.NoError(t, a.ConfigureWith(messaging.AdapterConfig{Bridge: bridge}))
-	return a, handler.envelopes
+	return a, handler.envelopes, starter
 }
 
 // newAdapterWithCapture creates an adapter whose bridge captures Handle calls.
@@ -319,7 +331,7 @@ func TestE2E_AbortCommandRoutesControlStop(t *testing.T) {
 
 	for _, text := range []string{"stop", "停止", "/stop"} {
 		t.Run(text, func(t *testing.T) {
-			a, envelopes := newAdapterWithControlCapture(t)
+			a, envelopes, starter := newAdapterWithControlCapture(t)
 			a.handleEventsAPI(context.Background(), makeDMEvent("U_ALICE", text))
 
 			select {
@@ -332,6 +344,7 @@ func TestE2E_AbortCommandRoutesControlStop(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("abort text did not reach the control handler")
 			}
+			require.Zero(t, starter.calls.Load(), "stop must not create a platform session")
 		})
 	}
 }

--- a/internal/messaging/slack/e2e_test.go
+++ b/internal/messaging/slack/e2e_test.go
@@ -83,6 +83,27 @@ func (h *captureHandler) Handle(_ context.Context, env *events.Envelope) error {
 	return nil
 }
 
+type controlCaptureHandler struct {
+	envelopes chan *events.Envelope
+}
+
+func (h *controlCaptureHandler) Handle(_ context.Context, env *events.Envelope) error {
+	h.envelopes <- env
+	return nil
+}
+
+func newAdapterWithControlCapture(t *testing.T) (*Adapter, <-chan *events.Envelope) {
+	t.Helper()
+	a := newTestAdapter(t)
+	handler := &controlCaptureHandler{envelopes: make(chan *events.Envelope, 1)}
+	bridge := messaging.NewBridge(
+		slog.Default(), messaging.PlatformSlack, nil, handler, nil,
+		"test_worker", "", "/tmp", "",
+	)
+	require.NoError(t, a.ConfigureWith(messaging.AdapterConfig{Bridge: bridge}))
+	return a, handler.envelopes
+}
+
 // newAdapterWithCapture creates an adapter whose bridge captures Handle calls.
 // The capture handler records every envelope that reaches Bridge.Handle.
 func newAdapterWithCapture(t *testing.T) (*Adapter, *[]capturedCall) {
@@ -293,16 +314,26 @@ func TestE2E_SelfMentionBlocked(t *testing.T) {
 	require.Len(t, *calls, 1)
 }
 
-func TestE2E_AbortCommandBlocked(t *testing.T) {
+func TestE2E_AbortCommandRoutesControlStop(t *testing.T) {
 	t.Parallel()
-	a, calls := newAdapterWithCapture(t)
 
-	// Abort commands pass dedup but are caught by IsAbortCommand before HandleTextMessage
-	a.handleEventsAPI(context.Background(), makeDMEvent("U_ALICE", "stop"))
-	require.Empty(t, *calls, "'stop' should not reach HandleTextMessage")
+	for _, text := range []string{"stop", "停止", "/stop"} {
+		t.Run(text, func(t *testing.T) {
+			a, envelopes := newAdapterWithControlCapture(t)
+			a.handleEventsAPI(context.Background(), makeDMEvent("U_ALICE", text))
 
-	a.handleEventsAPI(context.Background(), makeDMEvent("U_ALICE", "停止"))
-	require.Empty(t, *calls, "'停止' should not reach HandleTextMessage")
+			select {
+			case envelope := <-envelopes:
+				require.NotEmpty(t, envelope.SessionID)
+				require.Equal(t, events.Control, envelope.Event.Type)
+				control, ok := envelope.Event.Data.(events.ControlData)
+				require.True(t, ok)
+				require.Equal(t, events.ControlActionStop, control.Action)
+			case <-time.After(time.Second):
+				t.Fatal("abort text did not reach the control handler")
+			}
+		})
+	}
 }
 
 func TestE2E_RichTextPasses(t *testing.T) {

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -794,15 +794,19 @@ func StreamingCardFlushFallbacks() metric.Int64Counter {
 func StreamingTerminalFailures() metric.Int64Counter {
 	streamingTerminalFailuresInit.Do(func() {
 		var err error
-		streamingTerminalFailures, err = Meter().Int64Counter(
-			"hotplex.streaming.terminal_failures",
-			metric.WithDescription("Streaming card terminal delivery failures by fallback result"),
-		)
+		streamingTerminalFailures, err = newStreamingTerminalFailures(Meter())
 		if err != nil {
 			warnInstrument("hotplex.streaming.terminal_failures", err)
 		}
 	})
 	return streamingTerminalFailures
+}
+
+func newStreamingTerminalFailures(meter metric.Meter) (metric.Int64Counter, error) {
+	return meter.Int64Counter(
+		"hotplex.streaming.terminal_failures",
+		metric.WithDescription("Streaming card terminal delivery failures by fallback result"),
+	)
 }
 
 // ─── ACP Instruments ────────────────────────────────────────────────

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -740,6 +740,9 @@ var (
 
 	streamingCardFlushFallbacks     metric.Int64Counter
 	streamingCardFlushFallbacksInit sync.Once
+
+	streamingTerminalFailures     metric.Int64Counter
+	streamingTerminalFailuresInit sync.Once
 )
 
 func StreamingCardRotations() metric.Int64Counter {
@@ -782,6 +785,24 @@ func StreamingCardFlushFallbacks() metric.Int64Counter {
 		}
 	})
 	return streamingCardFlushFallbacks
+}
+
+// StreamingTerminalFailures counts terminal-card finalization failures. The
+// fallback_result attribute records whether the connection later sent the short
+// static terminal fallback, could not send it, or skipped it because the body
+// was already visible.
+func StreamingTerminalFailures() metric.Int64Counter {
+	streamingTerminalFailuresInit.Do(func() {
+		var err error
+		streamingTerminalFailures, err = Meter().Int64Counter(
+			"hotplex.streaming.terminal_failures",
+			metric.WithDescription("Streaming card terminal delivery failures by fallback result"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.streaming.terminal_failures", err)
+		}
+	})
+	return streamingTerminalFailures
 }
 
 // ─── ACP Instruments ────────────────────────────────────────────────

--- a/internal/observability/instruments_test.go
+++ b/internal/observability/instruments_test.go
@@ -1,0 +1,15 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingTerminalFailuresInstrument(t *testing.T) {
+	t.Parallel()
+
+	// The accessor must be safe before Init: Meter() supplies a noop meter and
+	// sync.Once caches the lazily-created instrument for production callers.
+	require.NotNil(t, StreamingTerminalFailures())
+}

--- a/internal/observability/instruments_test.go
+++ b/internal/observability/instruments_test.go
@@ -1,9 +1,14 @@
 package observability
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestStreamingTerminalFailuresInstrument(t *testing.T) {
@@ -12,4 +17,37 @@ func TestStreamingTerminalFailuresInstrument(t *testing.T) {
 	// The accessor must be safe before Init: Meter() supplies a noop meter and
 	// sync.Once caches the lazily-created instrument for production callers.
 	require.NotNil(t, StreamingTerminalFailures())
+}
+
+func TestStreamingTerminalFailuresInstrument_RecordsFallbackResult(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	counter, err := newStreamingTerminalFailures(provider.Meter("test"))
+	require.NoError(t, err)
+	counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("fallback_result", "failed")))
+	counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("fallback_result", "skipped_body_presented")))
+
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &metrics))
+	for _, scope := range metrics.ScopeMetrics {
+		for _, instrument := range scope.Metrics {
+			if instrument.Name != "hotplex.streaming.terminal_failures" {
+				continue
+			}
+			sum, ok := instrument.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 2)
+			results := make(map[string]int64, len(sum.DataPoints))
+			for _, point := range sum.DataPoints {
+				value, ok := point.Attributes.Value("fallback_result")
+				require.True(t, ok)
+				results[value.AsString()] = point.Value
+			}
+			require.Equal(t, map[string]int64{"failed": 1, "skipped_body_presented": 1}, results)
+			return
+		}
+	}
+	t.Fatal("terminal failures metric was not collected")
 }

--- a/internal/observability/instruments_test.go
+++ b/internal/observability/instruments_test.go
@@ -1,14 +1,9 @@
 package observability
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestStreamingTerminalFailuresInstrument(t *testing.T) {
@@ -17,37 +12,4 @@ func TestStreamingTerminalFailuresInstrument(t *testing.T) {
 	// The accessor must be safe before Init: Meter() supplies a noop meter and
 	// sync.Once caches the lazily-created instrument for production callers.
 	require.NotNil(t, StreamingTerminalFailures())
-}
-
-func TestStreamingTerminalFailuresInstrument_RecordsFallbackResult(t *testing.T) {
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
-
-	counter, err := newStreamingTerminalFailures(provider.Meter("test"))
-	require.NoError(t, err)
-	counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("fallback_result", "failed")))
-	counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("fallback_result", "skipped_body_presented")))
-
-	var metrics metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &metrics))
-	for _, scope := range metrics.ScopeMetrics {
-		for _, instrument := range scope.Metrics {
-			if instrument.Name != "hotplex.streaming.terminal_failures" {
-				continue
-			}
-			sum, ok := instrument.Data.(metricdata.Sum[int64])
-			require.True(t, ok)
-			require.Len(t, sum.DataPoints, 2)
-			results := make(map[string]int64, len(sum.DataPoints))
-			for _, point := range sum.DataPoints {
-				value, ok := point.Attributes.Value("fallback_result")
-				require.True(t, ok)
-				results[value.AsString()] = point.Value
-			}
-			require.Equal(t, map[string]int64{"failed": 1, "skipped_body_presented": 1}, results)
-			return
-		}
-	}
-	t.Fatal("terminal failures metric was not collected")
 }


### PR DESCRIPTION
## 概要

完成 Epic #941 的飞书 × Claude Code 端到端消息链加固：

- 保留 `message.inbound` 审计原文明文，移除 INFO 日志中的正文副本，并让 event store 只按自身短期 TTL 回收。
- 将 `stop`、`停止`、`/stop` 等停止词统一路由到 AEP `control.stop`，不存在会话时不启动 Worker。
- 修复 ChatQueue 的 Close/Enqueue/idle 生命周期竞态，以及 queue-full 后去重登记无法回滚的问题。
- 在 Lark SDK 首次读取前限制媒体响应为 10 MiB + 1，并将临时目录/文件收紧为 `0700/0600`。
- 让 CardKit / IM Patch / header / fallback 终态失败可返回、可计量；Hub 对 Done/Error 使用结果回执和统一 deadline，失败连接异步清理不阻塞其他 session。
- 新增只读 `worker.claude_bypass_mode` doctor 告警，与真实 Feishu/Claude Code 配置优先级保持一致，不自动修改生产权限。

## 数据治理决策

- Audit user activity 是长期原文真相源，继续保存完整消息正文。
- Event store 是短期运行副本，只按 `events.retention` 留存。
- INFO 日志只保留事件类型、session、seq、大小和 SHA-256 短指纹。
- 不删除、不迁移、不脱敏历史审计原文。

## 验证

- 最终整分支独立审查：APPROVED，Critical / Important / Minor 均为 0。
- 关键 terminal 并发回归：`-race -count=20`，100/100 通过。
- 受影响范围：`rtk go test ./internal/messaging/... ./internal/gateway ./internal/config ./internal/cli/checkers ./internal/observability -count=1 -race`，3222 tests / 14 packages 通过。
- `rtk make check`：format、lint（0 issues）、全仓测试、Swagger、Docs、Webchat、Go binary 全部通过。
- pre-push hooks：format、vet、mod verify、lint、build、tests，6/6 通过。

## 现场证据边界

- 未调用 live Feishu API 做破坏性或生产态故障注入；SDK 首轮限流、CardKit/IM/fallback 失败和跨 session terminal deadline 均由真实 SDK 路径或故障注入测试覆盖。
- `bypass` 仅告警，不自动调整现网权限模式。
- 若底层无 context 的 `Close` 永久不返回，detached cleanup goroutine 可能保留，但不会再阻塞 Hub 或 terminal ack。

Closes #941
