### PR TITLE
docs(patrol): 2026-08-04 文档维护

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -189,7 +189,7 @@ hotplex version --format json
 
 ### `hotplex doctor`
 
-运行环境诊断检查，验证 HotPlex 配置是否正确。检查按类别组织：environment、config、dependencies、security、runtime、messaging、stt。
+运行环境诊断检查，验证 HotPlex 配置是否正确。检查按类别组织：environment、config、dependencies、security、runtime、messaging、stt、tts、agent_config、worker。
 
 **示例**：
 
@@ -207,7 +207,7 @@ hotplex doctor --json              # JSON 输出（用于脚本集成）
 | `--fix` | | `bool` | `false` | 自动修复可修复的问题 |
 | `--verbose` | `-v` | `bool` | `false` | 显示详细信息 |
 | `--json` | | `bool` | `false` | JSON 格式输出 |
-| `--category` | `-C` | `string` | | 仅检查指定类别：`environment`、`config`、`dependencies`、`security`、`runtime`、`messaging`、`stt` |
+| `--category` | `-C` | `string` | | 仅检查指定类别：`environment`、`config`、`dependencies`、`security`、`runtime`、`messaging`、`stt`、`tts`、`agent_config`、`worker` |
 
 **退出码**：
 


### PR DESCRIPTION
## Summary
- `docs/reference/cli.md`: doctor 检查类别列表与 `-C` 标志说明补全 `tts`、`agent_config`、`worker` 三类（`worker` 类别检查器 `worker.claude_bypass_mode` 由 #943 引入，cli.md 未同步）

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)