### PR TITLE
feat(runtime): prepare next iteration implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ swagger:
 	@mkdir -p $(SWAGGER_DIR)
 	@swag init \
 		--generalInfo doc.go \
-		--dir cmd/hotplex,internal/admin,internal/gateway \
+		--dir cmd/hotplex,internal/admin,internal/gateway,internal/agentspec \
 		--output $(SWAGGER_DIR) \
 		--outputTypes json \
 		--parseInternal \

--- a/cmd/hotplex/admin_adapters.go
+++ b/cmd/hotplex/admin_adapters.go
@@ -7,10 +7,12 @@ import (
 	"github.com/hrygo/hotplex/internal/admin"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/eventstore"
+	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/gateway"
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -164,4 +166,43 @@ func (a *botListerAdapter) GetBot(name string) (*admin.BotEntry, bool) {
 	}
 	entry := toAdminBotEntry(e)
 	return &entry, true
+}
+
+// executionProviderAdapter exposes the durable-ingress store to the Admin API
+// for operator fence decisions (#877). Pass-through only — the store owns all
+// conditional-update semantics.
+type executionProviderAdapter struct {
+	store execution.Store
+}
+
+func (a *executionProviderAdapter) ListFences(ctx context.Context, sessionID string, limit, offset int) ([]*execution.Record, error) {
+	return a.store.ListFences(ctx, sessionID, limit, offset)
+}
+
+func (a *executionProviderAdapter) ApplyFenceDecision(ctx context.Context, request execution.FenceActionRequest) (*execution.Record, error) {
+	return a.store.ApplyFenceDecision(ctx, request)
+}
+
+// runtimeEventNotifier emits the additive runtime.execution.failed event with
+// OPERATOR_ABANDONED after an abandon decision, so connected clients observe
+// the terminal state. Best-effort by contract: fenced sessions rarely have
+// live connections and the store write is already durable.
+type runtimeEventNotifier struct {
+	hub *gateway.Hub
+}
+
+func (n *runtimeEventNotifier) NotifyExecutionAbandoned(ctx context.Context, sessionID, executionID string) {
+	if n.hub == nil {
+		return
+	}
+	seq := n.hub.NextSeq(sessionID)
+	if seq == 0 {
+		return
+	}
+	env := events.NewEnvelope(aep.NewID(), sessionID, seq, events.RuntimeExecutionFailed, events.RuntimeExecutionData{
+		ExecutionID: executionID,
+		Status:      string(execution.RuntimeFailed),
+		ErrorCode:   events.ErrCodeOperatorAbandoned,
+	})
+	_ = n.hub.SendToSession(ctx, env)
 }

--- a/cmd/hotplex/audit_cmd.go
+++ b/cmd/hotplex/audit_cmd.go
@@ -195,12 +195,17 @@ one checkpoint row and is irreversible: re-run with --confirm to apply.`,
 				return fmt.Errorf("audit rebase is irreversible; re-run with --confirm")
 			}
 
-			cp, err := audit.Rebase(ctx, store, nextID)
-			if err != nil {
+			if _, err := audit.Rebase(ctx, store, nextID); err != nil {
 				return err
 			}
+			// SaveCheckpoint does not return the inserted row id; re-read the
+			// latest checkpoint to report the real id.
+			latest, err := store.LatestCheckpoint(ctx)
+			if err != nil {
+				return fmt.Errorf("audit rebase: read checkpoint: %w", err)
+			}
 			fmt.Printf("checkpoint written: id=%d next_id=%d anchor_hash=%s\n",
-				cp.ID, cp.NextID, cp.LastSelfHash)
+				latest.ID, latest.NextID, latest.LastSelfHash)
 
 			// Report the repaired state in the same pass.
 			result, err := audit.NewVerifier(store, audit.VerifierConfig{}, log).VerifyOnce(ctx)

--- a/cmd/hotplex/audit_cmd.go
+++ b/cmd/hotplex/audit_cmd.go
@@ -23,7 +23,54 @@ func newAuditCmd() *cobra.Command {
 		Short: "Audit log chain operations",
 	}
 	cmd.AddCommand(newAuditVerifyCmd())
+	cmd.AddCommand(newAuditRebaseCmd())
 	return cmd
+}
+
+// openAuditStoreCLI opens the audit store for a CLI command. When queryOnly
+// is true the SQLite file is opened read-only (PRAGMA query_only=ON) so the
+// command can never mutate the database; write commands (rebase) pass false.
+// The returned close function closes both the raw DB handle and the store.
+func openAuditStoreCLI(cfg *config.Config, log *slog.Logger, queryOnly bool) (audit.Store, func(), error) {
+	dialect := dbutil.ParseDialect(cfg.DB.Driver)
+	writeMu := sqlutil.NewWriteMu(string(dialect))
+	switch dialect {
+	case dbutil.DialectPostgres:
+		pgDB, err := dbutil.Open(dbutil.DialectPostgres, &cfg.DB)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open pg db: %w", err)
+		}
+		store, err := audit.NewStore(pgDB.DB, dialect, nil, log)
+		if err != nil {
+			_ = pgDB.Close()
+			return nil, nil, fmt.Errorf("open audit store: %w", err)
+		}
+		return store, func() { _ = pgDB.Close(); _ = store.Close() }, nil
+	default:
+		// Open the SQLite file directly — no migration runner, so the
+		// command never mutates the schema.
+		db, err := sql.Open(sqlutil.DriverName, cfg.DB.SQLite.Path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open sqlite db: %w", err)
+		}
+		db.SetMaxOpenConns(1)
+		if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+			_ = db.Close()
+			return nil, nil, fmt.Errorf("set sqlite busy_timeout: %w", err)
+		}
+		if queryOnly {
+			if _, err := db.Exec("PRAGMA query_only=ON"); err != nil {
+				_ = db.Close()
+				return nil, nil, fmt.Errorf("set sqlite query_only: %w", err)
+			}
+		}
+		store, err := audit.NewStore(db, dbutil.DialectSQLite, writeMu, log)
+		if err != nil {
+			_ = db.Close()
+			return nil, nil, fmt.Errorf("open audit store: %w", err)
+		}
+		return store, func() { _ = store.Close() }, nil
+	}
 }
 
 func newAuditVerifyCmd() *cobra.Command {
@@ -50,42 +97,11 @@ Exits non-zero when the chain is broken (CI/cron gate).`,
 				return fmt.Errorf("load config: %w", err)
 			}
 			log := slog.New(slog.NewTextHandler(os.Stderr, nil))
-			dialect := dbutil.ParseDialect(cfg.DB.Driver)
-
-			writeMu := sqlutil.NewWriteMu(string(dialect))
-			var store audit.Store
-			switch dialect {
-			case dbutil.DialectPostgres:
-				pgDB, err := dbutil.Open(dbutil.DialectPostgres, &cfg.DB)
-				if err != nil {
-					return fmt.Errorf("open pg db: %w", err)
-				}
-				defer func() { _ = pgDB.Close() }()
-				store, err = audit.NewStore(pgDB.DB, dialect, nil, log)
-				if err != nil {
-					return fmt.Errorf("open audit store: %w", err)
-				}
-			default:
-				// Open the SQLite file directly — no migration runner, so the
-				// command never mutates the database (read-only contract).
-				db, err := sql.Open(sqlutil.DriverName, cfg.DB.SQLite.Path)
-				if err != nil {
-					return fmt.Errorf("open sqlite db: %w", err)
-				}
-				defer func() { _ = db.Close() }()
-				db.SetMaxOpenConns(1)
-				if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
-					return fmt.Errorf("set sqlite busy_timeout: %w", err)
-				}
-				if _, err := db.Exec("PRAGMA query_only=ON"); err != nil {
-					return fmt.Errorf("set sqlite query_only: %w", err)
-				}
-				store, err = audit.NewStore(db, dbutil.DialectSQLite, writeMu, log)
-				if err != nil {
-					return fmt.Errorf("open audit store: %w", err)
-				}
+			store, closeStore, err := openAuditStoreCLI(cfg, log, true)
+			if err != nil {
+				return err
 			}
-			defer func() { _ = store.Close() }()
+			defer closeStore()
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 			defer cancel()
@@ -124,6 +140,87 @@ Exits non-zero when the chain is broken (CI/cron gate).`,
 			return fmt.Errorf("audit chain broken: %d break(s) found across %d rows checked",
 				len(result.BrokenRows), result.RowsChecked)
 		},
+	}
+	cmd.PersistentFlags().String("config", config.DefaultConfigPath, "配置文件路径（默认 ~/.hotplex/config.yaml）")
+	return cmd
+}
+
+func newAuditRebaseCmd() *cobra.Command {
+	var (
+		nextID  int64
+		confirm bool
+	)
+	cmd := &cobra.Command{
+		Use:   "rebase",
+		Short: "Re-anchor the audit hash chain at a surviving row (repair)",
+		Long: `Repair a broken audit hash chain by re-anchoring it at the row with
+the given id. The row's stored prev_hash becomes the new checkpoint anchor
+and verify continues from this row; rows before the anchor are retained but
+no longer chain-verified.
+
+This is the only legitimate repair for a chain broken by a historical
+manual DELETE — migrations 023/030 reject row UPDATE and un-anchored DELETE,
+so the broken row cannot be edited or removed in place. The rebase writes
+one checkpoint row and is irreversible: re-run with --confirm to apply.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig(cmd.Flag("config").Value.String(), false)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			store, closeStore, err := openAuditStoreCLI(cfg, log, false)
+			if err != nil {
+				return err
+			}
+			defer closeStore()
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+			defer cancel()
+
+			// Preview the target row before doing anything: the anchor must be
+			// an id with a surviving row, never silently shifted elsewhere.
+			rows, err := store.QueryAsc(ctx, nextID, 1)
+			if err != nil {
+				return fmt.Errorf("audit rebase: query target row: %w", err)
+			}
+			if len(rows) == 0 || rows[0].ID != nextID {
+				return fmt.Errorf("%w: id=%d", audit.ErrRebaseRowNotFound, nextID)
+			}
+			row := rows[0]
+			fmt.Printf("rebase target: id=%d ts=%s platform=%s action=%s outcome=%s\n",
+				row.ID, time.UnixMilli(row.Ts).Format(time.RFC3339), row.Platform, row.Action, row.Outcome)
+			fmt.Printf("new checkpoint: next_id=%d anchor_hash=%s\n", nextID, row.PrevHash)
+			if !confirm {
+				return fmt.Errorf("audit rebase is irreversible; re-run with --confirm")
+			}
+
+			cp, err := audit.Rebase(ctx, store, nextID)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("checkpoint written: id=%d next_id=%d anchor_hash=%s\n",
+				cp.ID, cp.NextID, cp.LastSelfHash)
+
+			// Report the repaired state in the same pass.
+			result, err := audit.NewVerifier(store, audit.VerifierConfig{}, log).VerifyOnce(ctx)
+			if err != nil {
+				return fmt.Errorf("audit verify after rebase: %w", err)
+			}
+			if result.BrokenID == 0 {
+				fmt.Printf("audit chain OK after rebase: %d rows checked, no breaks\n", result.RowsChecked)
+				return nil
+			}
+			fmt.Printf("audit chain still BROKEN after rebase: %d break(s) found across %d rows checked\n",
+				len(result.BrokenRows), result.RowsChecked)
+			return fmt.Errorf("audit chain broken after rebase: %d break(s) found across %d rows checked",
+				len(result.BrokenRows), result.RowsChecked)
+		},
+	}
+	cmd.Flags().Int64Var(&nextID, "next-id", 0, "id of the first row to keep in the chain (its prev_hash becomes the anchor)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "required to apply the irreversible rebase")
+	if err := cmd.MarkFlagRequired("next-id"); err != nil {
+		panic(err)
 	}
 	cmd.PersistentFlags().String("config", config.DefaultConfigPath, "配置文件路径（默认 ~/.hotplex/config.yaml）")
 	return cmd

--- a/cmd/hotplex/audit_cmd_test.go
+++ b/cmd/hotplex/audit_cmd_test.go
@@ -68,8 +68,8 @@ func writeBrokenAuditDB(t *testing.T) string {
 
 	store := openAuditStoreAt(t, dbPath)
 	prev := ""
-	for i := int64(0); i < 3; i++ {
-		prev = appendAuditRow(t, store, prev, 1700000000000+i)
+	for i := range 3 {
+		prev = appendAuditRow(t, store, prev, 1700000000000+int64(i))
 	}
 	_, err := store.db.ExecContext(context.Background(), `DELETE FROM user_activity WHERE id = 2`)
 	require.NoError(t, err)
@@ -103,8 +103,8 @@ func TestAuditVerify_IntactChainSucceeds(t *testing.T) {
 
 	store := openAuditStoreAt(t, dbPath)
 	prev := ""
-	for i := int64(0); i < 3; i++ {
-		prev = appendAuditRow(t, store, prev, 1700000000000+i)
+	for i := range 3 {
+		prev = appendAuditRow(t, store, prev, 1700000000000+int64(i))
 	}
 	require.NoError(t, store.Close())
 
@@ -116,4 +116,67 @@ func TestAuditVerify_IntactChainSucceeds(t *testing.T) {
 
 	err := cmd.Execute()
 	require.NoError(t, err)
+}
+
+// TestAuditRebase_FixesBrokenChain pins the repair contract: a chain broken
+// by a historical manual DELETE is repaired by re-anchoring the checkpoint
+// at the first surviving row, after which verify reports a healthy chain.
+func TestAuditRebase_FixesBrokenChain(t *testing.T) {
+	cfgPath := writeBrokenAuditDB(t) // 3 rows, middle row deleted
+
+	cmd := newAuditRebaseCmd()
+	cmd.SetArgs([]string{"--config", cfgPath, "--next-id", "3", "--confirm"})
+
+	err := cmd.Execute()
+	require.NoError(t, err, "rebase with --confirm must succeed")
+
+	// The rebase command runs verify internally; a separate verify pass must
+	// also report the chain healthy from the new anchor.
+	verifyCmd := newAuditVerifyCmd()
+	verifyCmd.SetArgs([]string{"--config", cfgPath})
+	err = verifyCmd.Execute()
+	require.NoError(t, err, "chain must verify clean after rebase")
+}
+
+// TestAuditRebase_RequiresConfirm pins the confirmation gate: without
+// --confirm the command must fail and must NOT write a checkpoint (the chain
+// stays broken).
+func TestAuditRebase_RequiresConfirm(t *testing.T) {
+	cfgPath := writeBrokenAuditDB(t)
+
+	cmd := newAuditRebaseCmd()
+	cmd.SetArgs([]string{"--config", cfgPath, "--next-id", "3"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "rebase without --confirm must fail")
+	require.Contains(t, err.Error(), "--confirm")
+
+	verifyCmd := newAuditVerifyCmd()
+	verifyCmd.SetArgs([]string{"--config", cfgPath})
+	err = verifyCmd.Execute()
+	require.Error(t, err, "no checkpoint may be written without confirmation")
+}
+
+// TestAuditRebase_TargetMissing pins the target validation contract: an id
+// with no surviving row must fail loudly instead of anchoring elsewhere.
+func TestAuditRebase_TargetMissing(t *testing.T) {
+	cfgPath := writeBrokenAuditDB(t)
+
+	cmd := newAuditRebaseCmd()
+	cmd.SetArgs([]string{"--config", cfgPath, "--next-id", "99", "--confirm"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "missing target row must fail")
+	require.Contains(t, err.Error(), "rebase target row not found")
+}
+
+// TestAuditRebase_RequiresNextID pins the required-flag contract.
+func TestAuditRebase_RequiresNextID(t *testing.T) {
+	cfgPath := writeBrokenAuditDB(t)
+
+	cmd := newAuditRebaseCmd()
+	cmd.SetArgs([]string{"--config", cfgPath, "--confirm"})
+
+	err := cmd.Execute()
+	require.Error(t, err, "missing --next-id must fail")
 }

--- a/cmd/hotplex/main.go
+++ b/cmd/hotplex/main.go
@@ -55,6 +55,7 @@ Quick start:
 		newCronCmd(),
 		newAdminCmd(),
 		newAuditCmd(),
+		newRuntimeCmd(),
 	)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -173,6 +173,7 @@ func setupRoutes(
 	adminMux.HandleFunc("DELETE /admin/sessions/{id}", adminAPI.DeleteSession)
 	adminMux.HandleFunc("POST /admin/sessions/{id}/terminate", adminAPI.TerminateSession)
 	adminMux.HandleFunc("GET /admin/sessions/{id}/stats", adminAPI.HandleSessionStats)
+	adminMux.HandleFunc("GET /admin/sessions/{id}/runtime-plan", adminAPI.HandleSessionRuntimePlan)
 
 	// Runtime fence API (#877): inspect fenced executions, resolve/abandon with
 	// a fencing token. GET needs runtime:read, POST needs runtime:write.

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -120,6 +120,14 @@ func setupRoutes(
 	if deps.SkillsLocator != nil {
 		adminAPI.SetSkillsLocator(deps.SkillsLocator)
 	}
+	// Operator fence decisions (#877): list fenced executions + resolve/abandon.
+	// Nil store → endpoints answer 503 instead of crashing the mux.
+	if deps.ExecutionStore != nil {
+		adminAPI.SetRuntimeExecution(
+			&executionProviderAdapter{store: deps.ExecutionStore},
+			&runtimeEventNotifier{hub: hub},
+		)
+	}
 
 	if cfg.Admin.RateLimitEnabled {
 		limiter := admin.NewRateLimiter(cfg.Admin.RequestsPerSec, cfg.Admin.Burst)
@@ -165,6 +173,11 @@ func setupRoutes(
 	adminMux.HandleFunc("DELETE /admin/sessions/{id}", adminAPI.DeleteSession)
 	adminMux.HandleFunc("POST /admin/sessions/{id}/terminate", adminAPI.TerminateSession)
 	adminMux.HandleFunc("GET /admin/sessions/{id}/stats", adminAPI.HandleSessionStats)
+
+	// Runtime fence API (#877): inspect fenced executions, resolve/abandon with
+	// a fencing token. GET needs runtime:read, POST needs runtime:write.
+	adminMux.HandleFunc("GET /admin/executions/fences", adminAPI.HandleListFences)
+	adminMux.HandleFunc("POST /admin/executions/{id}/fence-action", adminAPI.HandleFenceAction)
 
 	// User activity API (issue #833) - by-user audit query + export
 	adminMux.HandleFunc("GET /admin/users/{id}/activity", adminAPI.HandleUserActivity)

--- a/cmd/hotplex/runtime_cmd.go
+++ b/cmd/hotplex/runtime_cmd.go
@@ -70,10 +70,16 @@ type fenceAdminClient struct {
 	http    *http.Client
 }
 
-// newFenceAdminClient resolves the gateway base URL and admin token from the
-// local config (same host trust model as the rest of the CLI). The token can
-// be overridden with HOTPLEX_ADMIN_TOKEN for split-admin deployments.
+// newFenceAdminClient resolves the Admin API address and token from the
+// running Gateway's config when the caller did not select an explicit config.
+// The token can be overridden with HOTPLEX_ADMIN_TOKEN for split-admin
+// deployments.
 func newFenceAdminClient(configPath string) (*fenceAdminClient, error) {
+	if configPath == "" || configPath == config.DefaultConfigPath {
+		if state, stateErr := readGatewayState(); stateErr == nil && state.ConfigPath != "" {
+			configPath = state.ConfigPath
+		}
+	}
 	absPath, err := config.ExpandAndAbs(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve config path: %w", err)
@@ -92,9 +98,9 @@ func newFenceAdminClient(configPath string) (*fenceAdminClient, error) {
 		token = cfg.Admin.Tokens[0]
 	}
 
-	addr := cfg.Gateway.Addr
+	addr := cfg.Admin.Addr
 	if addr == "" {
-		addr = ":8888"
+		addr = "localhost:9999"
 	}
 	if strings.HasPrefix(addr, ":") {
 		addr = "localhost" + addr

--- a/cmd/hotplex/runtime_cmd.go
+++ b/cmd/hotplex/runtime_cmd.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// newRuntimeCmd builds `hotplex runtime` — operator fence inspection and
+// decisions (#877). All subcommands call the Admin API over HTTP; the CLI
+// never opens the database for fence reads or writes (spec §5.7).
+func newRuntimeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime",
+		Short: "Runtime operations: inspect and resolve fenced executions",
+	}
+	cmd.AddCommand(newRuntimeFencesCmd())
+	return cmd
+}
+
+func newRuntimeFencesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fences",
+		Short: "List and decide fenced executions (via Admin API)",
+	}
+	cmd.AddCommand(newFencesListCmd(), newFencesActionCmd("resolve"), newFencesActionCmd("abandon"))
+	return cmd
+}
+
+// --- Wire DTOs (mirror of admin.FenceListItem; the CLI owns its decoding) ---
+
+type cliFenceItem struct {
+	ExecutionID    string `json:"execution_id"`
+	SessionID      string `json:"session_id"`
+	DeliveryStatus string `json:"delivery_status"`
+	RuntimeStatus  string `json:"runtime_status"`
+	FenceReason    string `json:"fence_reason"`
+	FenceVersion   int64  `json:"fence_version"`
+	FenceCreatedAt *int64 `json:"fence_created_at,omitempty"`
+	UpdatedAt      int64  `json:"updated_at"`
+}
+
+type cliFenceListResponse struct {
+	Fences []cliFenceItem `json:"fences"`
+	Limit  int            `json:"limit"`
+	Offset int            `json:"offset"`
+}
+
+// --- Admin API client ---
+
+type fenceAdminClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// newFenceAdminClient resolves the gateway base URL and admin token from the
+// local config (same host trust model as the rest of the CLI). The token can
+// be overridden with HOTPLEX_ADMIN_TOKEN for split-admin deployments.
+func newFenceAdminClient(configPath string) (*fenceAdminClient, error) {
+	absPath, err := config.ExpandAndAbs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+	loadEnvFile(filepath.Dir(absPath))
+	cfg, err := config.Load(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	token := os.Getenv("HOTPLEX_ADMIN_TOKEN")
+	if token == "" {
+		if len(cfg.Admin.Tokens) == 0 {
+			return nil, errors.New("no admin token: set admin.tokens in config or HOTPLEX_ADMIN_TOKEN")
+		}
+		token = cfg.Admin.Tokens[0]
+	}
+
+	addr := cfg.Gateway.Addr
+	if addr == "" {
+		addr = ":8888"
+	}
+	if strings.HasPrefix(addr, ":") {
+		addr = "localhost" + addr
+	}
+	scheme := "http"
+	if cfg.Security.TLSEnabled {
+		scheme = "https"
+	}
+
+	return &fenceAdminClient{
+		baseURL: scheme + "://" + addr,
+		token:   token,
+		http: &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // local self-signed certs, same trust model as `hotplex status`
+			},
+		},
+	}, nil
+}
+
+func (c *fenceAdminClient) do(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.http.Do(req)
+}
+
+// fenceAPIError is the AppError wire shape returned by the Admin API.
+type fenceAPIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (c *fenceAdminClient) listFences(ctx context.Context, sessionID string, limit int) (*cliFenceListResponse, error) {
+	q := url.Values{}
+	if sessionID != "" {
+		q.Set("session_id", sessionID)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/admin/executions/fences"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	resp, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("call admin API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, describeFenceAPIError(resp)
+	}
+	var out cliFenceListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode fence list: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *fenceAdminClient) fenceAction(ctx context.Context, executionID, decision string, fenceVersion int64, reason, evidenceRef string) (*cliFenceItem, error) {
+	payload, err := json.Marshal(map[string]any{
+		"decision":               decision,
+		"expected_fence_version": fenceVersion,
+		"reason":                 reason,
+		"evidence_ref":           evidenceRef,
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/admin/executions/"+url.PathEscape(executionID)+"/fence-action", payload)
+	if err != nil {
+		return nil, fmt.Errorf("call admin API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, describeFenceAPIError(resp)
+	}
+	var out struct {
+		Decision  string       `json:"decision"`
+		Execution cliFenceItem `json:"execution"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode fence action response: %w", err)
+	}
+	return &out.Execution, nil
+}
+
+// describeFenceAPIError turns a non-200 into an operator-actionable error.
+// 409 explicitly asks for re-inspection — the CLI never auto-retries a
+// non-idempotent operator decision (#877 spec §8.3).
+func describeFenceAPIError(resp *http.Response) error {
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+	var apiErr fenceAPIError
+	_ = json.Unmarshal(raw, &apiErr) // best-effort; body may be plain text
+	if apiErr.Code == "" {
+		apiErr.Code = http.StatusText(resp.StatusCode)
+		apiErr.Message = strings.TrimSpace(string(raw))
+	}
+	switch resp.StatusCode {
+	case http.StatusConflict:
+		return fmt.Errorf("%s: %s — re-inspect with `hotplex runtime fences list` and retry deliberately (no automatic retry)", apiErr.Code, apiErr.Message)
+	case http.StatusNotFound:
+		return fmt.Errorf("%s: %s", apiErr.Code, apiErr.Message)
+	default:
+		return fmt.Errorf("admin API %d %s: %s", resp.StatusCode, apiErr.Code, apiErr.Message)
+	}
+}
+
+// --- Commands ---
+
+func newFencesListCmd() *cobra.Command {
+	var (
+		configPath string
+		sessionID  string
+		jsonOutput bool
+		limit      int
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List fenced executions blocking fresh input",
+		Example: `  hotplex runtime fences list
+  hotplex runtime fences list --session-id sess-1 --json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := newFenceAdminClient(configPath)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.listFences(ctx, sessionID, limit)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return printJSON(out)
+			}
+			if len(out.Fences) == 0 {
+				fmt.Println("No fenced executions.")
+				return nil
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(tw, "EXECUTION\tSESSION\tRUNTIME\tREASON\tFENCE VERSION\tFENCED AT")
+			for _, f := range out.Fences {
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+					shortID(f.ExecutionID), shortID(f.SessionID), f.RuntimeStatus,
+					f.FenceReason, f.FenceVersion, formatFenceTime(f.FenceCreatedAt))
+			}
+			if err := tw.Flush(); err != nil {
+				return err
+			}
+			fmt.Printf("\nDecide with: hotplex runtime fences resolve|abandon <execution-id> --fence-version <n> --reason \"...\" --confirm\n")
+			return nil
+		},
+	}
+	configFlag(cmd, &configPath)
+	cmd.Flags().StringVar(&sessionID, "session-id", "", "filter by session ID")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output as JSON")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max results (default 100, max 500)")
+	return cmd
+}
+
+func newFencesActionCmd(decision string) *cobra.Command {
+	var (
+		configPath  string
+		fenceVer    int64
+		reason      string
+		evidenceRef string
+		confirm     bool
+	)
+	short := "Resolve a fence: clear it, keep runtime=unknown, and unblock the session"
+	if decision == "abandon" {
+		short = "Abandon a fenced execution: fail it with OPERATOR_ABANDONED and unblock the session"
+	}
+	cmd := &cobra.Command{
+		Use:   decision + " <execution-id>",
+		Short: short,
+		Long: short + ".\n\n" +
+			"The action is conditional on --fence-version; a concurrent operator or a gateway\n" +
+			"restart between inspect and action yields 409 FENCE_CONFLICT. On conflict this\n" +
+			"command exits non-zero and never retries automatically.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			executionID := strings.TrimSpace(args[0])
+			if executionID == "" {
+				return errors.New("execution-id is required")
+			}
+			if !confirm {
+				return fmt.Errorf("%s is irreversible for this fence; re-run with --confirm", decision)
+			}
+			if fenceVer < 0 {
+				return errors.New("--fence-version must be >= 0")
+			}
+			if strings.TrimSpace(reason) == "" {
+				return errors.New("--reason is required (1-512 chars)")
+			}
+
+			client, err := newFenceAdminClient(configPath)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+
+			updated, err := client.fenceAction(ctx, executionID, decision, fenceVer, reason, evidenceRef)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s applied: execution=%s session=%s runtime=%s fence_version=%d\n",
+				decision, updated.ExecutionID, updated.SessionID, updated.RuntimeStatus, updated.FenceVersion)
+			return nil
+		},
+	}
+	configFlag(cmd, &configPath)
+	cmd.Flags().Int64Var(&fenceVer, "fence-version", -1, "expected fence version from `fences list` (required)")
+	cmd.Flags().StringVar(&reason, "reason", "", "operator justification, 1-512 chars (required)")
+	cmd.Flags().StringVar(&evidenceRef, "evidence-ref", "", "evidence pointer, e.g. ticket or run ID (max 256 chars)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "required to apply the decision")
+	return cmd
+}
+
+func formatFenceTime(ms *int64) string {
+	if ms == nil || *ms == 0 {
+		return "-"
+	}
+	return time.UnixMilli(*ms).Format("2006-01-02 15:04:05")
+}

--- a/cmd/hotplex/runtime_cmd_test.go
+++ b/cmd/hotplex/runtime_cmd_test.go
@@ -3,11 +3,16 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
 )
 
 func newFenceTestServer(t *testing.T, handler http.HandlerFunc) *fenceAdminClient {
@@ -84,6 +89,55 @@ func TestFenceAdminClient_NotFound(t *testing.T) {
 	_, err := client.fenceAction(context.Background(), "missing", "resolve", 1, "r", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "FENCE_NOT_FOUND")
+}
+
+func TestNewFenceAdminClient_UsesAdminAddress(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeFenceClientConfig(t, configPath, "localhost:8888", "localhost:9999", "test-token")
+
+	client, err := newFenceAdminClient(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:9999", client.baseURL)
+}
+
+func TestNewFenceAdminClient_UsesRunningConfigPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HOTPLEX_HOME", filepath.Join(t.TempDir(), "hotplex"))
+
+	runningConfigPath := filepath.Join(t.TempDir(), "running.yaml")
+	writeFenceClientConfig(t, runningConfigPath, "localhost:8888", "localhost:19999", "running-token")
+	writeGatewayState(runningConfigPath, false)
+	t.Cleanup(removeGatewayState)
+
+	client, err := newFenceAdminClient(config.DefaultConfigPath)
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:19999", client.baseURL)
+	require.Equal(t, "running-token", client.token)
+}
+
+func TestNewFenceAdminClient_ExplicitConfigPathWins(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HOTPLEX_HOME", filepath.Join(t.TempDir(), "hotplex"))
+
+	runningConfigPath := filepath.Join(t.TempDir(), "running.yaml")
+	explicitConfigPath := filepath.Join(t.TempDir(), "explicit.yaml")
+	writeFenceClientConfig(t, runningConfigPath, "localhost:8888", "localhost:19999", "running-token")
+	writeFenceClientConfig(t, explicitConfigPath, "localhost:8888", "localhost:29999", "explicit-token")
+	writeGatewayState(runningConfigPath, false)
+	t.Cleanup(removeGatewayState)
+
+	client, err := newFenceAdminClient(explicitConfigPath)
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:29999", client.baseURL)
+	require.Equal(t, "explicit-token", client.token)
+}
+
+func writeFenceClientConfig(t *testing.T, path, gatewayAddr, adminAddr, token string) {
+	t.Helper()
+	content := fmt.Sprintf("gateway:\n  addr: %q\nadmin:\n  addr: %q\n  tokens: [%q]\n", gatewayAddr, adminAddr, token)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 }
 
 func TestFenceActionCmd_RequiresConfirm(t *testing.T) {

--- a/cmd/hotplex/runtime_cmd_test.go
+++ b/cmd/hotplex/runtime_cmd_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newFenceTestServer(t *testing.T, handler http.HandlerFunc) *fenceAdminClient {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &fenceAdminClient{baseURL: srv.URL, token: "test-token", http: srv.Client()}
+}
+
+func TestFenceAdminClient_ListFences(t *testing.T) {
+	t.Parallel()
+	client := newFenceTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/admin/executions/fences", r.URL.Path)
+		require.Equal(t, "sess-1", r.URL.Query().Get("session_id"))
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"fences":[{"execution_id":"exec-1","session_id":"sess-1","runtime_status":"unknown","fence_reason":"GATEWAY_LEASE_EXPIRED","fence_version":3}],"limit":100,"offset":0}`))
+	})
+
+	out, err := client.listFences(context.Background(), "sess-1", 0)
+	require.NoError(t, err)
+	require.Len(t, out.Fences, 1)
+	require.Equal(t, "exec-1", out.Fences[0].ExecutionID)
+	require.Equal(t, int64(3), out.Fences[0].FenceVersion)
+}
+
+func TestFenceAdminClient_FenceActionResolve(t *testing.T) {
+	t.Parallel()
+	client := newFenceTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/admin/executions/exec-1/fence-action", r.URL.Path)
+		var body struct {
+			Decision             string `json:"decision"`
+			ExpectedFenceVersion int64  `json:"expected_fence_version"`
+			Reason               string `json:"reason"`
+			EvidenceRef          string `json:"evidence_ref"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "resolve", body.Decision)
+		require.Equal(t, int64(3), body.ExpectedFenceVersion)
+		require.Equal(t, "operator checked", body.Reason)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"decision":"resolve","execution":{"execution_id":"exec-1","session_id":"sess-1","runtime_status":"unknown","fence_reason":"","fence_version":3}}`))
+	})
+
+	updated, err := client.fenceAction(context.Background(), "exec-1", "resolve", 3, "operator checked", "")
+	require.NoError(t, err)
+	require.Equal(t, "exec-1", updated.ExecutionID)
+	require.Empty(t, updated.FenceReason)
+}
+
+func TestFenceAdminClient_ConflictDirectsReinspection(t *testing.T) {
+	t.Parallel()
+	client := newFenceTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"code":"FENCE_CONFLICT","message":"fence version conflict"}`))
+	})
+
+	_, err := client.fenceAction(context.Background(), "exec-1", "abandon", 2, "r", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FENCE_CONFLICT")
+	require.Contains(t, err.Error(), "re-inspect", "409 must direct re-inspection, not silent retry")
+	require.Contains(t, err.Error(), "no automatic retry")
+}
+
+func TestFenceAdminClient_NotFound(t *testing.T) {
+	t.Parallel()
+	client := newFenceTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":"FENCE_NOT_FOUND","message":"execution not found"}`))
+	})
+
+	_, err := client.fenceAction(context.Background(), "missing", "resolve", 1, "r", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FENCE_NOT_FOUND")
+}
+
+func TestFenceActionCmd_RequiresConfirm(t *testing.T) {
+	t.Parallel()
+	cmd := newFencesActionCmd("resolve")
+	cmd.SetArgs([]string{"exec-1", "--fence-version", "3", "--reason", "r"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--confirm", "irreversible decisions must require explicit confirmation")
+}
+
+func TestFenceActionCmd_RequiresReason(t *testing.T) {
+	t.Parallel()
+	cmd := newFencesActionCmd("abandon")
+	cmd.SetArgs([]string{"exec-1", "--fence-version", "3", "--confirm"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--reason")
+}
+
+func TestFenceActionCmd_RequiresFenceVersion(t *testing.T) {
+	t.Parallel()
+	cmd := newFencesActionCmd("resolve")
+	cmd.SetArgs([]string{"exec-1", "--reason", "r", "--confirm"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err, "missing --fence-version (default -1) must fail before any network call")
+	require.Contains(t, err.Error(), "--fence-version")
+}

--- a/docs/guides/enterprise/audit.md
+++ b/docs/guides/enterprise/audit.md
@@ -116,9 +116,9 @@ audit:
 
 | 配置项 | 类型 | 默认值 | 环境变量 | 说明 |
 |--------|------|--------|----------|------|
-| `audit.enabled` | bool | `true` | `AUDIT_ENABLED` | 是否启用审计系统 |
-| `audit.retention` | duration | `26280h`（3 年） | `AUDIT_RETENTION` | 审计记录保留时长 |
-| `audit.full_content_retention` | duration | `2160h`（90 天） | `AUDIT_FULL_CONTENT_RETENTION` | 兼容配置字段；不影响 event store 或 turns 的留存 |
+| `audit.enabled` | bool | `true` | `HOTPLEX_AUDIT_ENABLED` | 是否启用审计系统 |
+| `audit.retention` | duration | `26280h`（3 年） | `HOTPLEX_AUDIT_RETENTION` | 审计记录保留时长 |
+| `audit.full_content_retention` | duration | `2160h`（90 天） | `HOTPLEX_AUDIT_FULL_CONTENT_RETENTION` | 兼容配置字段；不影响 event store 或 turns 的留存 |
 
 **事件与审计留存相互独立**：event store 与 turns 只按 `events.retention` 清理；入站消息原文由 audit 记录保留并按 `audit.retention` 独立清理。`audit.full_content_retention` 为兼容字段，不会延长 event/turn 副本或 `event_ref` 的可用时间。
 
@@ -126,10 +126,10 @@ audit:
 
 | 配置项 | 类型 | 默认值 | 环境变量 | 说明 |
 |--------|------|--------|----------|------|
-| `audit.collector.channel_cap` | int | `4096` | `AUDIT_COLLECTOR_CHANNEL_CAP` | 内存 channel 容量 |
-| `audit.collector.batch_interval` | duration | `1s` | `AUDIT_COLLECTOR_BATCH_INTERVAL` | 批量刷写间隔 |
-| `audit.collector.batch_size` | int | `100` | `AUDIT_COLLECTOR_BATCH_SIZE` | 每批最大事件数 |
-| `audit.collector.spill_dir` | string | `~/.hotplex/data/audit-spill` | `AUDIT_COLLECTOR_SPILL_DIR` | WAL 溢出目录 |
+| `audit.collector.channel_cap` | int | `4096` | `HOTPLEX_AUDIT_COLLECTOR_CHANNEL_CAP` | 内存 channel 容量 |
+| `audit.collector.batch_interval` | duration | `1s` | `HOTPLEX_AUDIT_COLLECTOR_BATCH_INTERVAL` | 批量刷写间隔 |
+| `audit.collector.batch_size` | int | `100` | `HOTPLEX_AUDIT_COLLECTOR_BATCH_SIZE` | 每批最大事件数 |
+| `audit.collector.spill_dir` | string | `~/.hotplex/data/audit-spill` | `HOTPLEX_AUDIT_COLLECTOR_SPILL_DIR` | WAL 溢出目录 |
 
 > **调优建议**：高并发场景（>1000 sessions）建议将 `channel_cap` 提升至 `8192`，`batch_size` 提升至 `200`。溢出目录建议使用独立磁盘以减少 I/O 竞争。
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -54,8 +54,12 @@ admin:
 | `stats:read` | - | - | 🟢 Read | - | - | - | `GET /admin/stats`<br>`GET /admin/metrics`<br>`GET /admin/sessions/pool` |
 | `config:read` | - | - | - | 🟢 Read | - | - | `POST /admin/config/validate` |
 | `config:write` | - | - | - | 🟠 Write | - | - | `POST /admin/config/rollback` |
+| `runtime:read` | - | - | - | - | - | - | `GET /admin/executions/fences`<br>`GET /admin/sessions/{id}/runtime-plan`（需与 `session:read` 同时持有） |
+| `runtime:write` | - | - | - | - | - | - | `POST /admin/executions/{id}/fence-action` |
 | `admin:read` | - | - | - | - | 🟢 Read | 🟢 Read | `GET /admin/logs`<br>`GET /admin/debug/...`<br>`GET /admin/bots`<br>`GET /admin/cron/jobs` |
 | `admin:write` | - | - | - | - | - | 🟠 Write | `POST/PATCH/DELETE /admin/cron/jobs`<br>`POST /admin/cron/jobs/{id}/run` |
+
+> 💡 **Scope 蕴含**：`admin:write` 蕴含 `admin:read`、`runtime:read`、`runtime:write`；`admin:read` 蕴含 `config:read`（#877）。
 
 > 💡 **图例**：🟢 **Read** (只读查询) | 🟠 **Write** (状态变更/操作) | 🔴 **Delete** (物理删除)
 
@@ -100,6 +104,7 @@ Rate Limit 和 IP Whitelist 支持配置热重载，无需重启生效。
 | Session | `session.delete` / `session.terminate` / `session.patch` / `session.put` |
 | Audit | `audit.identity_link.create` / `audit.identity_link.delete` |
 | Config | `config.rollback` / `config.validate` |
+| Runtime Fence（#877） | `runtime.fence.action`（middleware slog，decision 无关）<br>`runtime.fence.resolve` / `runtime.fence.abandon`（`user_activity` 行，含 reason/evidence_ref） |
 | 多租户成员/邀请 | `member.status.update` / `invitation.create` / `invitation.delete` |
 | 认证拒绝 | `auth.denied` |
 
@@ -144,6 +149,37 @@ curl -H "Authorization: Bearer $TOKEN" \
 **POST /admin/sessions/{id}/terminate** — 将会话状态迁移至 `terminated`（软终止，保留记录）。DELETE 则为物理删除。
 
 > **注意**：会话创建不通过 Admin API，而是通过 Gateway API（`POST /api/sessions`）或 WebSocket `init` 握手完成。Admin API 仅提供只读查询和终止/删除操作。
+
+### Runtime Operations（#877 / #946）
+
+| 方法 | 路径 | Scope | 说明 |
+|------|------|-------|------|
+| GET | `/admin/executions/fences` | `runtime:read` | 列出阻塞新输入的 fenced executions |
+| POST | `/admin/executions/{id}/fence-action` | `runtime:write` | 应用 operator 决策（resolve/abandon），以 fence_version 为条件 |
+| GET | `/admin/sessions/{id}/runtime-plan` | `runtime:read` + `session:read` | 会话的 desired-state plan（redacted）与 observed bootstrap 摘要 |
+
+**GET /admin/executions/fences** — 列出运行时结局不明（runtime unknown）并触发 fence 的 execution。fenced execution 会阻塞同 session 的新输入，直至 operator 决策。
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `session_id` | string | "" | 按 session 过滤 |
+| `limit` | int | 100 | 每页数量（上限 500） |
+| `offset` | int | 0 | 偏移量 |
+
+返回 `{"fences": [...], "limit": N, "offset": N}`。列表项为刻意收窄的无密投影：`execution_id`、`session_id`、`delivery_status`、`runtime_status`、`fence_reason`、`fence_version`、`fence_created_at`、`updated_at` —— 不含 payload 指纹、错误细节或任何用户内容派生字段。
+
+**POST /admin/executions/{id}/fence-action** — operator 决策入口。请求体：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|:---:|------|
+| `decision` | string | ✅ | `resolve`（清除 fence，runtime 保持 unknown）或 `abandon`（清除 fence，runtime 置 failed 并补发 `runtime.execution.failed` 事件） |
+| `expected_fence_version` | int | ✅ | 取自 `fences list` 的 `fence_version`；条件更新不匹配时返回 `409 FENCE_CONFLICT` |
+| `reason` | string | ✅ | operator 理由，1–512 字符；仅进入审计层，execution store 永不保存 |
+| `evidence_ref` | string | - | 工单/run 引用指针，≤256 字符；仅指针，不允许内联内容 |
+
+错误码：`400 BAD_REQUEST`（字段校验）/ `403 INSUFFICIENT_SCOPE` / `404 FENCE_NOT_FOUND` / `409 FENCE_CONFLICT` / `503 SERVICE_UNAVAILABLE`（store 未配置或超时）。收到 409 必须重新 inspect 当前 fence 状态后审慎重试 —— 并发 operator 或 inspect 与 action 之间的网关重启都会触发冲突，服务端不自动重试。`abandon` 成功后 best-effort 通知在线连接终态。
+
+**GET /admin/sessions/{id}/runtime-plan** — 返回会话的 EffectiveRuntimePlan 诊断投影（#946 spec §6.6）：`plan`（redacted view：plan hash、worker_type、permission/sandbox 摘要、env key **名称**、source refs、warnings、blocked codes）与 `observed`（bootstrap 状态：`planned` / `unknown` / `declared` 及 permission ceiling）。投影由会话持久化事实 + 当前 config 按需计算，无 plan 表、无第二份持久化真相；blocked plan 返回 200 并携带 bounded 拦截原因与空 `plan_hash`（blocked 是有效诊断载荷，不是 HTTP 错误）。响应永不包含 prompt、完整命令、model、工具清单或任何值内容。
 
 ### 监控指标
 
@@ -490,14 +526,16 @@ zip 格式、文件类型白名单与安全约束同上方「Skill 管理（admi
 | 403 | `PERMISSION_DENIED` | 非 admin 试图在 workspace Create/Update 设置或修改 `permission_mode`（admin-only 字段，r3 #804） |
 | 404 | `NOT_FOUND` | Session/Cron Job/Invitation 未找到 |
 | 404 | `WORKSPACE_NOT_FOUND` | workspace id 不存在 |
+| 404 | `FENCE_NOT_FOUND` | fence-action 目标 execution 不存在 |
 | 409 | `CONFLICT` | 资源状态冲突 |
+| 409 | `FENCE_CONFLICT` | fence_version 条件更新失败；重新 inspect 后审慎重试，勿自动重试（#877） |
 | 409 | `WORKSPACE_VERSION_MISMATCH` | PATCH workspace 乐观并发冲突（`updated_at` CAS 失败，re-fetch 后重试） |
 | 409 | `WORKSPACE_NOT_EMPTY` | workspace 存在活跃会话，拒绝改 `work_dir` / 删除 |
 | 409 | `WORK_DIR_TAKEN` | workspace `work_dir` 已被该 owner 的其他 workspace 占用 |
 | 429 | `RATE_LIMITED` | 触发 Rate Limit |
 | 500 | `INTERNAL` | Handler panic、未分类内部错误 |
 | 501 | `NOT_IMPLEMENTED` | 该接口尚未实现 |
-| 503 | `SERVICE_UNAVAILABLE` | 数据库故障、Cron 未启用 |
+| 503 | `SERVICE_UNAVAILABLE` | 数据库故障、Cron 未启用、execution store 未配置或超时 |
 | 503 | `NO_IDP` | 未配置身份提供者 |
 
 ## 常用操作示例
@@ -529,4 +567,18 @@ curl -H "Authorization: Bearer $TOKEN" \
 # 触发 Cron 任务
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   http://localhost:9999/admin/cron/jobs/daily-health/run
+
+# 列出 fenced executions（#877）
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9999/admin/executions/fences
+
+# 决策一条 fence（expected_fence_version 取自上面的列表；冲突时重新 inspect）
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"decision":"abandon","expected_fence_version":3,"reason":"worker host lost, verified via run log","evidence_ref":"OPS-1234"}' \
+  http://localhost:9999/admin/executions/exec-abc/fence-action
+
+# 查看会话的 effective runtime plan（#946）
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9999/admin/sessions/abc-123/runtime-plan
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -285,6 +285,38 @@ advice: chain gap before this row: previous row missing/modified, ...
 |------|--------|------|--------|------|
 | `--config` | | `string` | `~/.hotplex/config.yaml` | 配置文件路径 |
 
+### `hotplex audit rebase --next-id <id> --confirm`
+
+修复被历史手工 DELETE 打断的审计 Hash Chain：将链在指定行**重新锚定** —— 该行存储的 `prev_hash` 成为新的 Checkpoint 锚点，`verify` 从该行起重新验证；锚点之前的行保留但不再参与链校验（与 GC 的 Checkpoint 重锚定语义一致）。
+
+这是断链**唯一合法的修复路径**：migration 023/030 拒绝行级 UPDATE 与未锚定 DELETE，断链行无法原地编辑或删除；从备份恢复是另一条路径（会丢失锚点前的记录）。**不可逆**，须 `--confirm` 确认；未确认时仅打印预览、不写任何数据。
+
+**示例**：
+
+```bash
+hotplex audit rebase --next-id 1269 --confirm                 # 在 id=1269 处重新锚定
+hotplex audit rebase --config configs/config-dev.yaml --next-id 1269 --confirm
+```
+
+**输出**：
+
+```
+rebase target: id=1269 ts=2026-07-21T14:15:26+08:00 platform=webchat action=session.create outcome=success
+new checkpoint: next_id=1269 anchor_hash=1a7c83d5...
+checkpoint written: id=7 next_id=1269 anchor_hash=1a7c83d5...
+audit chain OK after rebase: 705 rows checked, no breaks
+```
+
+命令内部执行一次 `verify` 报告修复后状态；锚点后仍有断链时以非零退出码结束。
+
+| 标志 | 短标志 | 类型 | 默认值 | 说明 |
+|------|--------|------|--------|------|
+| `--next-id` | | `int` | 必填 | 链上首个保留行的 id（其 `prev_hash` 成为新锚点） |
+| `--confirm` | | `bool` | `false` | 确认执行不可逆的重锚定 |
+| `--config` | | `string` | `~/.hotplex/config.yaml` | 配置文件路径 |
+
+> **运维提示**：执行前先停止 Gateway（写操作与运行实例并发会破坏内存写回）；执行后用 `hotplex audit verify` 确认转绿并重启 Gateway。
+
 ---
 
 ## Runtime 运维（#877）

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,6 +33,11 @@ hotplex
 ├── security         # 安全审计
 ├── audit            # 审计链操作
 │   └── verify       # 校验审计 Hash Chain 完整性（只读）
+├── runtime          # Runtime 运维（fence 检查与决策）
+│   └── fences
+│       ├── list     # 列出阻塞新输入的 fenced executions
+│       ├── resolve  # 解除 fence（runtime 保持 unknown）
+│       └── abandon  # 放弃执行（runtime 置 failed）
 ├── config           # 配置管理
 │   └── validate     # 验证配置文件
 ├── onboard          # 交互式配置向导
@@ -219,6 +224,13 @@ hotplex doctor --json              # JSON 输出（用于脚本集成）
 | `1` | 存在失败项 |
 | `3` | `--fix` 模式下部分修复失败 |
 
+**runtime 类别新增检查项**（#877 / #946）：
+
+| 检查项 | 说明 |
+|--------|------|
+| `runtime.fenced_executions` | 只读检查当前被 fence 阻塞的 executions（SQLite 经 `PRAGMA query_only` 只读打开；无 fence → Pass，有 fence → Warn 并给出 `hotplex runtime fences list` 提示；不提供 FixFunc —— operator 决策必须走审计过的 Admin API；PostgreSQL 后端指向 Admin API） |
+| `runtime.effective_plan` | 用共享 agentspec resolver 对配置驱动的消息平台（slack/feishu/yuanxin）逐个解析 desired-state EffectiveRuntimePlan（只读，不触 DB/网络）；输出 plan hash / worker / permission / sandbox 摘要，blocked plan 以 Warn 呈现（blocked 永不视为静默成功）；webchat 为请求驱动，不在本地探测 |
+
 ---
 
 ## 安全审计
@@ -272,6 +284,57 @@ advice: chain gap before this row: previous row missing/modified, ...
 | 标志 | 短标志 | 类型 | 默认值 | 说明 |
 |------|--------|------|--------|------|
 | `--config` | | `string` | `~/.hotplex/config.yaml` | 配置文件路径 |
+
+---
+
+## Runtime 运维（#877）
+
+### `hotplex runtime fences`
+
+检查并决策 fenced executions（Worker 运行结局不明、触发 fence 的投递）。**全部经由 Admin API over HTTP —— CLI 从不为 fence 读写打开数据库**；token 取自 `admin.tokens[0]`，可用 `HOTPLEX_ADMIN_TOKEN` 覆盖（分置 admin 部署）。
+
+#### `hotplex runtime fences list`
+
+列出当前阻塞新输入的 fenced executions（表格或 JSON）。
+
+```bash
+hotplex runtime fences list
+hotplex runtime fences list --session-id sess-1 --json
+```
+
+| 标志 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `--session-id` | `string` | "" | 按 session 过滤 |
+| `--json` | `bool` | `false` | JSON 输出 |
+| `--limit` | `int` | 100 | 最大条数（上限 500） |
+| `--config` / `-c` | `string` | `~/.hotplex/config.yaml` | 配置文件路径 |
+
+输出列：`EXECUTION` / `SESSION` / `RUNTIME` / `REASON` / `FENCE VERSION` / `FENCED AT`。表格尾部提示决策命令模板。
+
+#### `hotplex runtime fences resolve <execution-id>` / `abandon <execution-id>`
+
+- **resolve**：清除 fence，runtime 保持 `unknown`，解除 session 阻塞（晚到终态事件仍可收敛）。
+- **abandon**：清除 fence，runtime 置 `failed`（`OPERATOR_ABANDONED`），并向在线连接补发 `runtime.execution.failed` 事件。
+
+两者均为**不可逆 operator 决策**，强制显式确认与条件版本：
+
+```bash
+hotplex runtime fences abandon exec-abc \
+  --fence-version 3 \
+  --reason "worker host lost, verified via run log" \
+  --evidence-ref OPS-1234 \
+  --confirm
+```
+
+| 标志 | 类型 | 必填 | 说明 |
+|------|------|:---:|------|
+| `--fence-version` | `int64` | ✅ | 取自 `fences list` 的预期 fence 版本；不匹配返回 `409 FENCE_CONFLICT` |
+| `--reason` | `string` | ✅ | operator 理由（1–512 字符），仅进审计层 |
+| `--evidence-ref` | `string` | - | 证据指针（工单/run ID，≤256 字符） |
+| `--confirm` | `bool` | ✅ | 缺失时命令直接拒绝执行 |
+| `--config` / `-c` | `string` | - | 配置文件路径 |
+
+**冲突语义**：决策以 `fence_version` 为条件更新；并发 operator 或 inspect 与 action 之间的网关重启会产生 `409 FENCE_CONFLICT`，命令以非零码退出并提示重新 inspect —— **CLI 永不自动重试非幂等决策**。
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -706,7 +706,7 @@ log:
 
 | 字段 | 类型 | 默认值 | 环境变量 | 说明 |
 |------|------|--------|----------|------|
-| `events.retention` | duration | `720h` (30天) | `HOTPLEX_EVENTS_RETENTION` | Event store 和 turns 的运行期留存窗口。到期后由事件 GC 清理 |
+| `events.retention` | duration | `720h` (30天) | `HOTPLEX_EVENTS_RETENTION` | Event store 和 turns 的运行期留存窗口。到期后由事件 GC 清理。启动时生效，修改后需重启 |
 | `audit.retention` | duration | `26280h` (3年) | `HOTPLEX_AUDIT_RETENTION` | 审计记录的基础留存窗口，由 audit GC 独立执行 |
 | `audit.full_content_retention` | duration | `2160h` (90天) | `HOTPLEX_AUDIT_FULL_CONTENT_RETENTION` | 审计原文的兼容配置字段；不再影响 event store 或 turns 留存 |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -133,8 +133,8 @@ Admin API 管理端点配置。
 | `enabled` | bool | `true` | `HOTPLEX_ADMIN_ENABLED` | 是否启用 Admin API |
 | `addr` | string | `localhost:9999` | `HOTPLEX_ADMIN_ADDR` | Admin API 监听地址。默认仅绑定 localhost |
 | `tokens` | []string | `[]` | `HOTPLEX_ADMIN_TOKEN_1..N` | 认证 token 列表。**只能通过环境变量设置**，支持编号后缀用于轮换 |
-| `token_scopes` | map[string][]string | `nil` | — | 每 token 的权限范围映射 |
-| `default_scopes` | []string | `["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]` | — | 未配置 scopes 的 token 的默认权限范围。`admin:write` 隐含 `admin:read` → `config:read` |
+| `token_scopes` | map[string][]string | `nil` | — | 每 token 的权限范围映射。可用 scope：`health:read` / `session:read` / `session:write` / `session:delete` / `stats:read` / `config:read` / `config:write` / `admin:read` / `admin:write` / `runtime:read` / `runtime:write`（runtime 二者服务 fence 决策与 runtime-plan 读取，#877/#946） |
+| `default_scopes` | []string | `["session:read", "session:write", "session:delete", "stats:read", "health:read", "admin:write"]` | — | 未配置 scopes 的 token 的默认权限范围。`admin:write` 隐含 `admin:read` 与 `runtime:read`/`runtime:write`；`admin:read` 隐含 `config:read` |
 | `ip_whitelist_enabled` | bool | `false` | — | 是否启用 IP 白名单 |
 | `allowed_cidrs` | []string | `["127.0.0.0/8", "10.0.0.0/8"]` | — | 允许访问的 CIDR 列表 |
 | `rate_limit_enabled` | bool | `true` | — | 是否启用速率限制 |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -266,7 +266,7 @@ rate(hotplex_cron_duration_sum[5m]) / rate(hotplex_cron_duration_count[5m])
 | `hotplex.streaming.card.rotations` | Counter | Streaming Card TTL 触发的旋转次数 |
 | `hotplex.streaming.card.rotation_failures` | Counter | 旋转失败数，label: `phase` |
 | `hotplex.streaming.card.flush_fallbacks` | Counter | CardKit 降级到 IM Patch 的次数 |
-| `hotplex.streaming.terminal_failures` | Counter | 终态 CardKit/IM Patch 或收尾装饰失败次数，label: `fallback_result`（`pending` / `sent` / `failed` / `skipped_body_presented`） |
+| `hotplex.streaming.terminal_failures` | Counter | 终态 CardKit/IM Patch 或收尾装饰失败次数，每次终态失败只计一次，label: `fallback_result`（`sent` / `failed` / `skipped_body_presented`） |
 
 ## ACP 指标
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -343,6 +343,35 @@ rate(hotplex_repair_success_total[5m]) / rate(hotplex_repair_attempts_total[5m])
 rate(hotplex_repair_timeout_total[5m]) / rate(hotplex_repair_attempts_total[5m])
 ```
 
+## Runtime Operations 指标（#877 / #946）
+
+Operator fence 决策与 EffectiveRuntimePlan 影子解析子系统。全部低基数：
+不含 execution ID、session ID、actor、plan hash（plan hash 只出现在日志与
+Admin 响应中，永不作为指标 label）。
+
+| 指标 | 类型 | 说明 |
+|------|------|------|
+| `hotplex.runtime.fence_actions` | Counter | 通过 Admin API 应用的 operator fence 决策，labels: `decision`（resolve\|abandon）、`result`（ok\|conflict\|error） |
+| `hotplex.runtime.fence_conflicts` | Counter | fence-version 冲突（409，条件更新匹配 0 行）；上升说明 operator 或网关重启在 inspect 与 action 之间发生竞态 |
+| `hotplex.runtime.plan_resolutions` | Counter | EffectiveRuntimePlan 影子解析次数，label: `result`（ok\|blocked） |
+| `hotplex.runtime.plan_blocked` | Counter | fail-closed 拦截的 plan，label: `code`（unknown_worker_type\|invalid_permission_mode\|invalid_sandbox_mode\|facts_missing_or_conflicting\|capability_unverifiable\|secret_shaped_value） |
+| `hotplex.runtime.plan_observed` | Counter | plan 读路径返回的 observed bootstrap 状态，label: `state`（planned\|unknown\|declared\|partial\|enforced） |
+
+### 常用查询
+
+```promql
+# 当前被 fence 阻塞的处置速率（ok 为成功决策，conflict 需人工复查后重试）
+sum by (decision, result) (rate(hotplex_runtime_fence_actions_total[5m]))
+
+# fence 冲突率（持续非零说明存在并发 operator 或重启竞态）
+rate(hotplex_runtime_fence_conflicts_total[5m])
+
+# plan 拦截率（影子模式下非零即配置边界问题，blocked plan 永不静默成功）
+sum(rate(hotplex_runtime_plan_blocked_total[5m]))
+/
+sum(rate(hotplex_runtime_plan_resolutions_total[5m]))
+```
+
 ## Turn-Integrity 诊断指标
 
 Turn-Integrity 子系统（Fix E）用于检测和量化空 success turn、stale forwarder

--- a/docs/superpowers/plans/2026-08-04-runtime-operations-next-iteration.md
+++ b/docs/superpowers/plans/2026-08-04-runtime-operations-next-iteration.md
@@ -1,0 +1,321 @@
+# HotPlex Runtime Operations Next Iteration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在一个 8–10 个工程日迭代内完成 #877 的 fenced execution operator recovery，并以只读/影子方式把现有 AgentSpec 收敛为 #946 定义的 `EffectiveRuntimePlan`。
+
+**Architecture:** #877 只扩展现有 `internal/execution` 状态机和 Admin 授权边界，不创建第二套 execution store；operator action 通过 fence version 条件更新，旧输入永不自动重投。#946 复用 `internal/agentspec.Resolver` 作为唯一解析器，先产出 redacted canonical plan/hash 并接入 WS、REST、doctor 和 Admin diagnostics 的 shadow/read-only 路径，暂不实施 #867 的 strict env allowlist、#947 EffectLedger 或 #868 Cockpit。
+
+**Tech Stack:** Go、Cobra、`net/http`、SQLite、PostgreSQL、`testify/require`、AEP v1、OpenTelemetry/Prometheus、现有 Admin Bearer+scope middleware。
+
+## Global Constraints
+
+- 所有 durable input 仍只保存 SHA-256 payload 指纹，不保存 prompt、metadata value、secret、credential、raw worker error 或完整 tool args。
+- `accepted` 只能前进到 `delivered` / `unknown` / `failed`；`unknown` 不因 timeout、时间经过或 operator action 自动变成 `completed` / `delivered`。
+- #877 不按固定时长自动清除 fence；operator action 必须带 actor、target、reason、decision、evidence ref、timestamp，并经过现有 workspace/session/admin authorization。
+- 清除 fence 不重投旧 input；新 input 必须使用新 client message ID 创建新 execution；late completion 只能收敛同一 `worker_run_id` / execution。
+- SQLite 与 PostgreSQL migration、条件更新、跨实例竞态和故障测试必须成对验证。
+- AEP 新事件只做增量兼容；同步 Go SDK、TypeScript/Python/Java 示例 SDK、协议文档和双向测试。
+- 低基数指标不得使用 plan hash、workspace、provider ref 或 evidence ref 作为 label；敏感值只进入脱敏 log/trace/audit correlation。
+- 非 main 分支本地验证通过后直接 commit + push；本迭代不包含 merge、release 或生产配置改动。
+
+---
+
+## 迭代范围与退出条件
+
+| 优先级 | 切片 | Issue | 本迭代终态 |
+| --- | --- | --- | --- |
+| P0 | Fenced execution operator action | #877 | 可 inspect、resolve、abandon；条件更新防竞态；Admin audit + runtime event；CLI 可执行；新输入行为可解释 |
+| P1 | EffectiveRuntimePlan first vertical slice | #946 | `internal/agentspec` 产出 redacted canonical plan/hash；WS/REST 共用输入；doctor 与 Admin 提供只读/影子诊断；四 Worker 有 planned/unknown evidence |
+| P2（不做） | Explicit env allowlist/isolation profiles | #867 | 仅保留依赖关系，不在本迭代改 `BuildEnv` 行为 |
+| P2（不做） | Gateway-owned EffectLedger | #947 | 不新增表、不改 Cron/Webhook/message delivery |
+| P2（不做） | Execution Cockpit / Queue | #851/#868 | 不新增 timeline、FIFO 或第二套查询事实 |
+
+进入迭代的前置条件是当前 `main` 的 #950 审计修复、#878 durable ingress、#847 AgentSpec first cut 和 approved `Runtime Operations Contract` 均保持绿。退出条件是受影响模块 `-race -count=1`、`make check`、`make docs-build` 通过，且 SQLite/PostgreSQL、权限拒绝、redaction、late completion 和跨实例条件更新均有证据。
+
+## 文件变更地图
+
+### #877
+
+- Modify: `internal/execution/store.go` — fence inspection/action 请求、状态和 Store 接口。
+- Modify: `internal/execution/sql_store.go` — fence token/version、conditional resolve/abandon 和扫描字段。
+- Create: `internal/session/sql/migrations/031_execution_fence_operator.sql`。
+- Create: `internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql`。
+- Modify/Test: `internal/execution/store_test.go`, `internal/execution/fault_injection_test.go`, `internal/execution/multi_instance_test.go`, `internal/execution/multi_instance_pg_test.go`。
+- Modify: `internal/admin/admin.go`, `internal/admin/handlers.go`, `internal/admin/models.go` — runtime scopes、provider、JSON response 和 handlers。
+- Modify/Test: `internal/admin/handlers_test.go`, `internal/admin/middleware_test.go`。
+- Modify: `cmd/hotplex/routes.go`, `cmd/hotplex/admin_adapters.go` — route and dependency wiring。
+- Create/Modify/Test: `cmd/hotplex/runtime_cmd.go`, `cmd/hotplex/runtime_cmd_test.go`, `cmd/hotplex/main.go` — `hotplex runtime fences` CLI。
+- Modify: `pkg/events/events.go`, `pkg/events/runtime_execution_test.go`, `internal/eventstore/collector.go` — only if the approved event vocabulary needs a new additive operator-action kind。
+
+### #946
+
+- Create/Modify/Test: `internal/agentspec/plan.go`, `internal/agentspec/plan_test.go` — `EffectiveRuntimePlan`, redaction, canonicalization and SHA-256 hash。
+- Modify/Test: `internal/agentspec/resolve.go`, `internal/agentspec/resolver_test.go` — one resolver path and fail-closed validation。
+- Modify/Test: `internal/gateway/agentspec.go`, `internal/gateway/api.go`, `internal/gateway/agentspec_test.go`, `internal/gateway/api_test.go` — WS/REST shared input and shadow comparison。
+- Create/Test: `internal/cli/checkers/runtime_plan.go`, `internal/cli/checkers/runtime_plan_test.go` — `runtime.effective_plan` checker。
+- Modify: `cmd/hotplex/doctor.go` only if category/help output requires explicit runtime-plan naming。
+- Modify: `cmd/hotplex/routes.go`, `internal/admin/handlers.go`, `internal/admin/handlers_test.go` — redacted read-only session plan diagnostic。
+- Modify: `docs/v2/ITERATION-NEXT.md`, `docs/v2/ROADMAP.md`, `docs/v2/IMPLEMENTATION-ROADMAP.md`, `docs/reference/admin-api.md`, `docs/reference/cli.md`, `docs/reference/metrics.md` — current iteration pointer, endpoint/CLI contract and validation evidence。
+
+### Task 1: Freeze the #877 fence-action data contract
+
+**Files:**
+- Modify: `internal/execution/store.go`
+- Modify: `internal/execution/sql_store.go`
+- Create: `internal/session/sql/migrations/031_execution_fence_operator.sql`
+- Create: `internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql`
+- Test: `internal/execution/store_test.go`, `internal/execution/fault_injection_test.go`
+
+**Interfaces:**
+- Consumes: existing `Record.FenceReason`, `RuntimeStatus`, `FenceBySession` and `ClearFenceAfterFreshStart`.
+- Produces: `FenceVersion int64`, `FenceCreatedAt *int64`, `FenceDecision` (`resolve` or `abandon`), `FenceActionRequest{ExecutionID, ExpectedFenceVersion, Decision}` and `ApplyFenceDecision(ctx, request) (*Record, error)`.
+
+- [ ] **Step 1: Write the failing store contract tests.** Add table-driven cases for `resolve`, `abandon`, empty/unknown decision, stale `ExpectedFenceVersion`, repeated same action, and a fenced record with no sensitive fields.
+
+```go
+func TestApplyFenceDecision_RejectsStaleFenceVersion(t *testing.T) {
+
+	t.Parallel()
+	store := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, "fence-v1")
+
+	_, err := store.ApplyFenceDecision(t.Context(), execution.FenceActionRequest{
+		ExecutionID:         rec.ExecutionID,
+		ExpectedFenceVersion: rec.FenceVersion - 1,
+		Decision:             execution.FenceDecisionResolve,
+	})
+	require.ErrorIs(t, err, execution.ErrFenceConflict)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify the new contract fails.**
+
+Run: `rtk go test ./internal/execution -run 'TestApplyFenceDecision|TestFence' -count=1`
+
+Expected: FAIL because the request type, migration columns and conditional method do not exist.
+
+- [ ] **Step 3: Add the paired migration.** Add `fence_version INTEGER/BIGINT NOT NULL DEFAULT 0` and `fence_created_at INTEGER/BIGINT NULL`; update the fence-producing SQL to increment the version and set creation time only when entering a fence. Preserve old rows as version `0` with no timestamp.
+
+- [ ] **Step 4: Implement the secret-free model and Store interface.** Add the decision enum, `ErrFenceConflict`, request type and record fields. Keep actor, reason and evidence outside `internal/execution`; the persistence layer receives only the conditional target and decision.
+
+- [ ] **Step 5: Run SQLite and PostgreSQL store tests.**
+
+Run: `rtk go test ./internal/execution ./internal/session/sql -count=1 -race`
+
+Expected: PASS; stale requests do not mutate the record, `resolve` clears only the fence, and `abandon` marks runtime failed with a bounded enum error code.
+
+- [ ] **Step 6: Commit the independently testable storage slice.**
+
+Run: `rtk git add internal/execution internal/session/sql/migrations/031_execution_fence_operator.sql internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql`
+
+Run: `rtk git commit -m "feat(execution): add conditional fence decisions"`
+
+### Task 2: Prove #877 cross-instance and late-completion semantics
+
+**Files:**
+- Modify/Test: `internal/execution/sql_store_test.go`, `internal/execution/fault_injection_test.go`, `internal/execution/multi_instance_test.go`, `internal/execution/multi_instance_pg_test.go`, `internal/gateway/input_execution_test.go`
+- Modify: `internal/gateway/handler.go`, only if the new fence version must be carried through the existing fresh-worker path.
+
+**Interfaces:**
+- Consumes: `ApplyFenceDecision`, `FenceVersion`, existing `FinishRuntime(executionID, workerRunID, ...)`.
+- Produces: verified invariants for operator action, old worker completion and new input acceptance.
+
+- [ ] **Step 1: Add failing race tests** for two gateways applying the same expected fence version, a late `done` from the fenced worker after `resolve`, a late `done` after `abandon`, duplicate operator actions, and a restart between inspect and action.
+
+- [ ] **Step 2: Run the race tests before implementation.**
+
+Run: `rtk go test ./internal/execution ./internal/gateway -run 'Fence|Late|Operator' -count=1 -race`
+
+Expected: FAIL for the new cases, while existing #878 fence tests remain green.
+
+- [ ] **Step 3: Make the smallest conditional state transition.** `resolve` clears `fence_reason` and leaves the old runtime fact `unknown`; `abandon` clears the fence and sets `runtime_status=failed` with `OPERATOR_ABANDONED`; neither path changes delivery to `delivered` or invokes Worker input.
+
+- [ ] **Step 4: Verify the fresh-worker path remains authoritative.** Existing `ClearFenceAfterFreshStart` must continue to require the current fence reason and fresh run ID; operator resolution must not bypass `StartFreshWorker` when the caller is using the normal automatic recovery path.
+
+- [ ] **Step 5: Run focused and real-PostgreSQL tests.**
+
+Run: `rtk go test ./internal/execution ./internal/gateway -count=1 -race`
+
+Run: `rtk go test -tags pg -p 1 ./internal/execution ./internal/session/sql -count=1 -race`
+
+Expected: exactly one operator action wins; late completion can refine only its original execution; a new client message is accepted only after the chosen fence decision releases the gate.
+
+### Task 3: Expose authorized #877 Admin actions with audit and AEP evidence
+
+**Files:**
+- Modify: `internal/admin/admin.go`, `internal/admin/handlers.go`, `internal/admin/models.go`, `cmd/hotplex/routes.go`, `cmd/hotplex/admin_adapters.go`
+- Test: `internal/admin/handlers_test.go`, `internal/admin/middleware_test.go`, `internal/gateway/api_test.go`
+- Modify: `pkg/events/events.go`, `internal/eventstore/collector.go` only when an additive operator-action event is required by the existing runtime event contract.
+
+**Interfaces:**
+- Consumes: `execution.Store.ApplyFenceDecision`, `FenceBySession`, existing `AdminAPI.Middleware` actor/scope context and `AdminAudit`.
+- Produces: `GET /admin/executions/fences`, `POST /admin/executions/{id}/fence-action`, scopes `runtime:read` and `runtime:write`.
+
+- [ ] **Step 1: Write handler tests for authorization and redaction.** Cover missing scopes (`403`), missing execution (`404`), stale version (`409`), invalid decision (`400`), successful resolve/abandon, actor extraction, reason/evidence validation, and responses containing no payload/prompt/secret/raw error.
+
+- [ ] **Step 2: Run the handler tests to verify they fail.**
+
+Run: `rtk go test ./internal/admin ./cmd/hotplex -run 'Fence|Runtime' -count=1`
+
+Expected: FAIL because routes, scopes and provider methods are absent.
+
+- [ ] **Step 3: Add provider boundaries and scoped routes.** Keep `internal/admin` independent from `internal/gateway` and `internal/session`; inject a narrow `ExecutionProvider` from `cmd/hotplex`. Register both routes only in `cmd/hotplex/routes.go` under the existing Admin middleware.
+
+- [ ] **Step 4: Implement audit and runtime evidence.** Record `actor`, action (`runtime.fence.resolve` or `runtime.fence.abandon`), target execution ID, decision, bounded reason, evidence ref and result. Emit an additive `runtime.execution.failed` only for `abandon` if the existing event contract supports it; never put reason detail, prompt, secret or raw error in the event payload.
+
+- [ ] **Step 5: Run focused tests and inspect JSON contracts.**
+
+Run: `rtk go test ./internal/admin ./cmd/hotplex ./pkg/events ./internal/eventstore -count=1 -race`
+
+Expected: PASS; the endpoint returns a stable redacted response and all write paths are auditable.
+
+### Task 4: Add the #877 CLI and diagnostics read path
+
+**Files:**
+- Create/Modify: `cmd/hotplex/runtime_cmd.go`, `cmd/hotplex/runtime_cmd_test.go`, `cmd/hotplex/main.go`
+- Create/Modify: `internal/cli/checkers/runtime_fence.go`, `internal/cli/checkers/runtime_fence_test.go`
+- Modify: `docs/reference/cli.md`, `docs/reference/admin-api.md`
+
+**Interfaces:**
+- Consumes: the Admin endpoint and existing `hotplex doctor` checker registry.
+- Produces: `hotplex runtime fences list`, `hotplex runtime fences resolve <execution-id>`, `hotplex runtime fences abandon <execution-id>`; no direct SQL mutation from CLI.
+
+- [ ] **Step 1: Write command tests** using an `httptest.Server`; assert list renders only redacted fields, resolve/abandon send the expected fence version and reason/evidence, `409` is reported as stale state, and no command retries a non-idempotent operator action.
+
+- [ ] **Step 2: Implement the HTTP client and Cobra wiring.** Read endpoint, address, token and config through the existing CLI config path; register `newRuntimeCmd()` from `main.go`; use explicit confirmation for `resolve` and `abandon` flags rather than an implicit destructive action.
+
+- [ ] **Step 3: Add a read-only doctor checker.** `runtime.fenced_executions` reports the count and oldest fence timestamp as Warn with a remediation hint; it has no `FixFunc` and never clears a fence.
+
+- [ ] **Step 4: Run CLI and doctor tests.**
+
+Run: `rtk go test ./cmd/hotplex ./internal/cli/... -run 'Runtime|Fence|Doctor' -count=1 -race`
+
+Expected: PASS; the CLI is a query/action facade over Admin and the doctor path is read-only.
+
+### Task 5: Add `EffectiveRuntimePlan` to the existing AgentSpec resolver
+
+**Files:**
+- Create/Modify/Test: `internal/agentspec/plan.go`, `internal/agentspec/plan_test.go`, `internal/agentspec/resolve.go`, `internal/agentspec/resolver_test.go`
+
+**Interfaces:**
+- Consumes: `agentspec.Input`, `AgentSpec`, existing config precedence and worker validation.
+- Produces: `Resolver.ResolvePlan(in Input) (EffectiveRuntimePlan, error)`, `EffectiveRuntimePlan.Redacted() EffectiveRuntimePlanView`, and `CanonicalPlanHash(view EffectiveRuntimePlanView) string`.
+
+- [ ] **Step 1: Write failing canonicalization tests.** Cover equivalent input ordering, WS/REST semantic equivalence, unknown worker, invalid permission, secret-free output, stable source refs, warnings/blocked reasons and planned/unknown observed state.
+
+```go
+func TestResolvePlan_EquivalentInputsHaveSameHash(t *testing.T) {
+
+	t.Parallel()
+	r := testResolver()
+	a, err := r.ResolvePlan(Input{Platform: "webchat", InitMeta: InitMetadata{WorkerType: "acp"}})
+	require.NoError(t, err)
+	b, err := r.ResolvePlan(Input{Platform: "webchat", InitMeta: InitMetadata{WorkerType: "acp"}})
+	require.NoError(t, err)
+	require.Equal(t, a.PlanHash, b.PlanHash)
+}
+```
+
+- [ ] **Step 2: Run the new tests before implementation.**
+
+Run: `rtk go test ./internal/agentspec -run 'ResolvePlan|CanonicalPlan' -count=1`
+
+Expected: FAIL because the plan value object and method do not exist.
+
+- [ ] **Step 3: Implement the redacted plan value object.** Include version, resolver version, embedded secret-free AgentSpec fields, worker type, permission/sandbox summaries, env key names only, capability IDs, config/skill hashes, source refs, bounded warnings and blocked reasons. Do not expose resolved command values, host environment values, tokens or raw errors in the public view.
+
+- [ ] **Step 4: Implement deterministic hashing.** Normalize nil/empty slices, sort only semantically unordered collections, marshal a fixed field-order canonical view, and compute SHA-256. Hashing must never include timestamps, process IDs, workspace paths or evidence references that change between equivalent requests.
+
+- [ ] **Step 5: Run the resolver tests.**
+
+Run: `rtk go test ./internal/agentspec -count=1 -race`
+
+Expected: PASS; first-cut behavior remains compatible with existing AgentSpec tests and no secret sentinel appears in JSON or hash input.
+
+### Task 6: Wire the #946 plan through WS/REST and read-only diagnostics
+
+**Files:**
+- Modify/Test: `internal/gateway/agentspec.go`, `internal/gateway/api.go`, `internal/gateway/agentspec_test.go`, `internal/gateway/api_test.go`
+- Create/Test: `internal/cli/checkers/runtime_plan.go`, `internal/cli/checkers/runtime_plan_test.go`
+- Modify/Test: `internal/admin/handlers.go`, `internal/admin/handlers_test.go`, `cmd/hotplex/routes.go`
+
+**Interfaces:**
+- Consumes: `Resolver.ResolvePlan`, existing `BuildWebChatInput`, `SessionInfo.SpecSnapshot` and Admin provider boundaries.
+- Produces: shared WS/REST plan input, `GET /admin/sessions/{id}/runtime-plan`, and `runtime.effective_plan` doctor output.
+
+- [ ] **Step 1: Add failing equivalence and endpoint tests.** Verify WS and REST with the same semantic worker/policy inputs produce the same plan hash; verify the Admin endpoint is read-only, ownership/scope protected, paginated only where needed, and returns `planned`/`unknown` when worker evidence is absent.
+
+- [ ] **Step 2: Replace duplicate input assembly with one helper.** Keep `BuildWebChatInput` as the shared constructor; make both WS init and REST session creation call the same plan path in shadow mode. The legacy `SessionStartParams` remains authoritative until drift evidence is reviewed.
+
+- [ ] **Step 3: Add observed bootstrap without overclaiming.** At worker start, attach worker type/backend/artifact evidence to the in-memory diagnostic projection. If evidence is unavailable, return `unknown`; do not label a configured capability `enforced`.
+
+- [ ] **Step 4: Add the Admin read path and doctor checker.** Admin returns the redacted plan/hash and bounded warnings; doctor computes the same plan from the local config and reports blocked reasons with no auto-fix. No new database column is required in this first slice; the existing spec snapshot remains the backward-compatible persisted view.
+
+- [ ] **Step 5: Run focused tests.**
+
+Run: `rtk go test ./internal/agentspec ./internal/gateway ./internal/admin ./internal/cli/... -run 'AgentSpec|RuntimePlan|EffectivePlan' -count=1 -race`
+
+Expected: PASS; no legacy WS/REST behavior changes outside the shadow projection.
+
+### Task 7: Add the iteration documentation and evidence matrix
+
+**Files:**
+- Modify: `docs/v2/ITERATION-NEXT.md`, `docs/v2/ROADMAP.md`, `docs/v2/IMPLEMENTATION-ROADMAP.md`
+- Modify: `docs/reference/admin-api.md`, `docs/reference/cli.md`, `docs/reference/metrics.md`
+- Test/Verify: repository docs links, redaction examples and command snippets
+
+- [ ] **Step 1: Replace the stale July iteration pointer.** Set the baseline to current `main`/v1.38.1, identify #877 and #946 as this iteration, and explicitly mark #867/#947/#851/#868 as deferred dependencies.
+
+- [ ] **Step 2: Document the exact operator contract.** Include endpoint paths, scopes, request fields, `409` stale-token behavior, `resolve` versus `abandon`, no-auto-retry semantics, audit fields and redaction rules.
+
+- [ ] **Step 3: Document the plan contract.** Include canonical hash inputs, `planned`/`unknown` evidence semantics, WS/REST equivalence, doctor/Admin read-only behavior and the fact that #867 strict environment enforcement is not implemented by this iteration.
+
+- [ ] **Step 4: Run documentation validation.**
+
+Run: `rtk make docs-build`
+
+Run: `rtk git diff --check`
+
+Expected: PASS with no broken links, stale endpoint descriptions or unbounded sensitive examples.
+
+### Task 8: Final verification and release gate
+
+- [ ] **Step 1: Run focused package tests.**
+
+Run: `rtk go test ./internal/execution ./internal/admin ./internal/agentspec ./internal/gateway ./internal/cli/... ./cmd/hotplex -count=1 -race`
+
+- [ ] **Step 2: Run PostgreSQL-specific tests serially.**
+
+Run: `rtk go test -tags pg -p 1 ./internal/execution ./internal/session/sql -count=1 -race`
+
+Expected: PASS when `HOTPLEX_TEST_PG_DSN` is configured; otherwise record the environment limitation and do not claim real-PG completion.
+
+- [ ] **Step 3: Run repository quality gates.**
+
+Run: `rtk make check`
+
+Run: `rtk make docs-build`
+
+Run: `rtk git diff --check`
+
+- [ ] **Step 4: Verify outcome evidence.** Confirm the Admin route is actually registered, `hotplex runtime fences --help` exposes the commands, stale operator requests return `409`, audit rows contain the action, runtime events remain redacted, old input is not dispatched again, and WS/REST plan hashes match.
+
+- [ ] **Step 5: Commit in reviewable slices.** Keep the storage, Admin/CLI, plan resolver, integration, and docs changes separately reviewable; do not squash until the reviewer has verified the cross-slice invariants.
+
+## Risks and explicit stop conditions
+
+| Risk | Stop condition | Response |
+| --- | --- | --- |
+| Operator action accidentally proves old execution success | Any code path writes `completed`/`delivered` from `resolve` or emits a success claim without provider evidence | Stop; revert the transition and keep the record `unknown` |
+| Conditional update is weaker than the read token | Two instances can both mutate one fence version | Stop; add version predicate and repeat real-PG test before continuing |
+| Plan resolver becomes a second config system | WS, REST, doctor or Admin recompute precedence independently | Stop; move precedence into `internal/agentspec.Resolver` |
+| #946 expands into strict env isolation | Any change to `internal/worker/base/BuildEnv` or host env inheritance is required for the first slice | Defer to #867 and ship only declared/observed/unknown evidence |
+| AEP event scope expands unexpectedly | New Kind/Data/JSON tag requires SDK/docs updates beyond the approved additive event contract | Stop and split protocol work into #849/#869 before merging |
+| Verification depends on unavailable external services | Tests require live Slack/Feishu/provider credentials | Keep the slice hermetic; use fakes, SQL fault injection and explicit evidence labels |
+
+## Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-04-runtime-operations-next-iteration.md`.
+
+Recommended execution path: use `superpowers:subagent-driven-development` for Task 1–4 and Task 5–8 as separate reviewable batches. Inline execution with `superpowers:executing-plans` is also valid when one engineer owns the entire runtime contract.

--- a/docs/superpowers/plans/2026-08-05-runtime-operations-review-fixes.md
+++ b/docs/superpowers/plans/2026-08-05-runtime-operations-review-fixes.md
@@ -1,0 +1,164 @@
+# Runtime Operations Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 runtime operations review 中发现的 Admin API 地址、运行实例配置路径、终态结果完成和权限计划解析问题，并为每项行为保留回归测试。
+
+**Architecture:** Runtime CLI 使用 Admin server 的独立地址，并在用户未显式指定配置时复用运行中 Gateway 的 PID state 配置路径。平台终态异步写入在 write loop 退出时也必须向调用方完成结果通知。EffectiveRuntimePlan 复用实际权限来源，确保诊断计划与 Worker 的权限边界一致。
+
+**Tech Stack:** Go、Cobra、net/http、SQLite-backed session metadata、testify/require、Go race detector。
+
+## Global Constraints
+
+- 所有 shell 命令使用 `rtk` 前缀。
+- 先写能复现问题的失败测试，再写最小生产修复。
+- 终态 `done`/`error` 结果不得永久阻塞；Gateway 的终态事件不能丢失。
+- 不保存 prompt、metadata value、凭证或原始 Worker 错误。
+- 修改 Go 文件后运行 gofmt，并运行受影响包的 `go test -race`。
+
+---
+
+### Task 1: Runtime CLI 连接正确的 Admin server
+
+**Files:**
+- Modify: `cmd/hotplex/runtime_cmd.go:76-108`
+- Test: `cmd/hotplex/runtime_cmd_test.go`
+
+**Interfaces:**
+- Consumes: `config.Config.Admin.Addr` and existing fence Admin API client.
+- Produces: `newFenceAdminClient` targeting the dedicated Admin listener.
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that loads a temporary config with distinct `gateway.addr` and `admin.addr`, calls the client constructor, and asserts `baseURL` uses the Admin address.
+
+- [x] **Step 2: Run the focused test to verify it fails**
+
+Run: `rtk go test ./cmd/hotplex -run TestNewFenceAdminClient_UsesAdminAddress -count=1`
+
+Expected: FAIL because the current constructor uses `cfg.Gateway.Addr`.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Resolve the host and port from `cfg.Admin.Addr`, preserving the existing default and token behavior.
+
+- [x] **Step 4: Run the focused test to verify it passes**
+
+Run: `rtk go test ./cmd/hotplex -run TestNewFenceAdminClient_UsesAdminAddress -count=1`
+
+Expected: PASS.
+
+### Task 2: Runtime CLI follows the running Gateway configuration
+
+**Files:**
+- Modify: `cmd/hotplex/runtime_cmd.go:76-85`
+- Test: `cmd/hotplex/runtime_cmd_test.go`
+
+**Interfaces:**
+- Consumes: existing `gatewayConfigPath()`/PID state behavior used by CLI Admin clients.
+- Produces: default-config invocations that read the running instance's config while explicit `--config` remains authoritative.
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that writes a temporary Gateway state with a custom config path and asserts the constructor uses that path when the requested path is `config.DefaultConfigPath`, while an explicit path is not replaced.
+
+- [x] **Step 2: Run the focused test to verify it fails**
+
+Run: `rtk go test ./cmd/hotplex -run TestNewFenceAdminClient_UsesRunningConfigPath -count=1`
+
+Expected: FAIL because the constructor always loads the passed default path.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Before loading the config, resolve the running Gateway state only for the default/empty config path, matching the established Cron CLI behavior.
+
+- [x] **Step 4: Run the focused test to verify it passes**
+
+Run: `rtk go test ./cmd/hotplex -run TestNewFenceAdminClient_UsesRunningConfigPath -count=1`
+
+Expected: PASS.
+
+### Task 3: Complete async terminal results when the write loop exits
+
+**Files:**
+- Modify: `internal/gateway/platform_writer.go:188-198`
+- Test: `internal/gateway/hub_test.go`
+
+**Interfaces:**
+- Consumes: `pcEntry.done` and per-terminal buffered result channels.
+- Produces: exactly one terminal result for every successfully enqueued terminal write, including write-loop panic/exit paths.
+
+- [x] **Step 1: Write the failing test**
+
+Add a panic-producing `PlatformConn` test double and a Hub test that queues a panicking write before a terminal event; assert `SendToSession` returns an error within a bounded context instead of waiting indefinitely.
+
+- [x] **Step 2: Run the focused test to verify it fails**
+
+Run: `rtk go test ./internal/gateway -run TestHub_TerminalWriteCompletesWhenWriterExits -count=1`
+
+Expected: FAIL or timeout because the `e.done` guard branch currently sends no result.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Send a stable `platform conn closed` error to the buffered result channel when `e.done` wins, while retaining the one-shot/nonblocking behavior.
+
+- [x] **Step 4: Run the focused test to verify it passes**
+
+Run: `rtk go test ./internal/gateway -run TestHub_TerminalWriteCompletesWhenWriterExits -count=1`
+
+Expected: PASS without leaked goroutines.
+
+### Task 4: Include effective permission configuration in runtime plans
+
+**Files:**
+- Modify: `internal/agentspec/resolve.go`, `internal/agentspec/plan.go`
+- Test: `internal/agentspec/plan_test.go`
+
+**Interfaces:**
+- Consumes: configured default permission mode and existing init/workspace precedence inputs.
+- Produces: plan permission summary, source references, and hash that change when the effective configured ceiling changes.
+
+- [x] **Step 1: Write the failing tests**
+
+Add resolver tests for a workspace with no explicit override and a configured `worker.default_permission_mode`, plus a checker/admin projection assertion that the resolved permission is present and sourced from configuration.
+
+- [x] **Step 2: Run the focused tests to verify they fail**
+
+Run: `rtk go test ./internal/agentspec ./internal/admin ./internal/cli/checkers -run 'Test.*Permission|Test.*Plan' -count=1`
+
+Expected: FAIL because permission currently remains empty unless passed as init metadata or workspace input.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Extend the pure resolver input or its config-resolution helper to carry the same configured permission source used by the Bridge, without changing authoritative legacy dispatch. Pass the resolved value through the Admin and doctor plan callers.
+
+- [x] **Step 4: Run the focused tests to verify they pass**
+
+Run: `rtk go test ./internal/agentspec ./internal/admin ./internal/cli/checkers -run 'Test.*Permission|Test.*Plan' -count=1`
+
+Expected: PASS.
+
+### Task 5: Full verification and delivery
+
+**Files:**
+- Verify all changed files and generated status; no unrelated files.
+
+- [x] **Step 1: Format changed Go files**
+
+Run: `rtk gofmt -w cmd/hotplex/runtime_cmd.go cmd/hotplex/runtime_cmd_test.go internal/gateway/platform_writer.go internal/gateway/hub_test.go internal/agentspec/resolve.go internal/agentspec/plan.go internal/agentspec/plan_test.go internal/admin/runtime_plan.go internal/admin/runtime_plan_test.go internal/cli/checkers/effective_plan.go internal/cli/checkers/effective_plan_test.go`
+
+- [x] **Step 2: Run affected package tests with race detection**
+
+Run: `rtk go test -race ./internal/admin ./internal/execution ./internal/agentspec ./internal/gateway ./cmd/hotplex ./internal/cli/checkers`
+
+- [x] **Step 3: Run repository checks relevant to the patch**
+
+Run: `rtk git diff --check` and `rtk go test -race ./internal/messaging/feishu ./internal/messaging ./internal/observability ./internal/worker`
+
+- [x] **Step 4: Inspect the final diff and status**
+
+Run: `rtk git diff --stat`, `rtk git diff`, and `rtk git status --short --branch`; confirm only the intended fixes, tests, and plan are present.
+
+- [x] **Step 5: Commit the verified fix**
+
+Stage only the intended files and create a Conventional Commit with a `fix` type.

--- a/docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
+++ b/docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
@@ -1,9 +1,9 @@
 ---
 title: "HotPlex Runtime Operations 下一迭代详细设计"
 type: design-spec
-status: proposed
-design_status: proposed
-implementation_status: not_started
+status: accepted
+design_status: accepted
+implementation_status: delivered
 date: 2026-08-05
 owners: [hotplex-runtime]
 issue_refs: ["#877", "#946"]
@@ -19,7 +19,7 @@ references:
 
 ## 1. 文档状态与决策边界
 
-本文是下一迭代的 proposed design spec，不代表实现已经完成，也不把本文中的推荐行为标记为已交付能力。实现前需要确认本 spec 的两个垂直切片边界、API 命名、状态迁移和验收标准。
+本文是下一迭代的 accepted design spec。**实现状态（2026-08-05 更新）**：#877 与 #946 shadow first slice 已由 PR #953（分支 `feat/runtime-operations-next-iteration`）交付，验收证据见 §12.4；开工闸门（§16）的五项确认在实现前全部接受，其中第 1/2 项按 §5 收窄为 operator-only 语义（fence 不自动过期）。
 
 本 spec 继承已批准的 [Runtime Operations Contract](2026-08-04-runtime-operations-contract.md)，只把其中当前迭代的 #877 与 #946 范围具体化：
 
@@ -538,6 +538,26 @@ rtk git diff --check
 
 真实 PostgreSQL 测试依赖 `HOTPLEX_TEST_PG_DSN`；未配置时只能报告环境未执行，不能报告 PostgreSQL 验证完成。
 
+### 12.4 验收结果（2026-08-05，PR #953）
+
+测试环境：darwin/arm64 · Go 1.26 · PostgreSQL 16.11（docker `hotplex-postgres`，127.0.0.1:5432，`HOTPLEX_TEST_PG_DSN` 已配置）。
+
+| 验证项 | 命令 | 结果 |
+|---|---|---|
+| §12.1/§12.2 SQLite 聚焦矩阵 | `go test ./internal/execution ./internal/admin ./internal/agentspec ./internal/gateway ./internal/cli/... ./cmd/hotplex -count=1 -race` | ✅ 1687 tests passed（13 packages） |
+| §12.1 PostgreSQL 条件更新 / 迁移 / 跨实例 | `go test -tags pg -p 1 ./internal/execution ./internal/session/sql -count=1 -race` | ✅ ok（execution 14.8s · session/sql 5.7s，exit 0） |
+| 全量质量门禁（fmt / lint / test / build） | `make check` | ✅ exit 0 · golangci-lint 0 issues |
+| Swagger + 文档构建 | `make docs-build`（依赖 swagger，含于 make check） | ✅ 63 docs 无断链 |
+| 空白/补丁卫生 | `git diff --check` | ✅ clean |
+
+类别覆盖位置：
+
+- Store / State / Concurrency / Late event / Restart → `internal/execution/` fence-action 与竞态测试（三重失败、stale `fence_version` 409、晚到 done 收敛、terminal 不回退）；
+- Security / Audit / API → `internal/admin/fences_test.go`（scope 403、409 FENCE_CONFLICT、503、actor 来自鉴权上下文、`user_activity` + slog 双审计、reason/evidence 校验与脱敏）；
+- CLI / Doctor → `cmd/hotplex` runtime fences 命令测试（Admin API only、`--confirm`/`--fence-version` 强制、409 非零退出）+ `internal/cli/checkers/execution_fences_test.go` / `effective_plan_test.go`；
+- Resolver / Hash / Redaction / Observed → `internal/agentspec/plan_test.go`（等价输入同 hash、secret/command/raw error 不入 view 与 hash、blocked codes fail-closed）；
+- Equivalence / Shadow → `internal/gateway/agentspec_test.go`（nil logger、blocked、warnings 路径；legacy dispatch 不受影响）；Admin 读路径 → `internal/admin/runtime_plan_test.go`（双 scope、blocked plan 仍 200 且 hash 为空、observed 边界）。
+
 ## 13. 发布、暂停与回滚
 
 ### 发布顺序
@@ -589,36 +609,34 @@ rtk git diff --check
 
 ### #877 完成
 
-- [ ] `GET /admin/executions/fences` 可读取 redacted fence facts，并有 runtime:read + session/workspace authorization。
-- [ ] `POST /admin/executions/{id}/fence-action` 支持 resolve/abandon、runtime:write、reason/evidence 校验和 409 fencing conflict。
-- [ ] SQLite/PostgreSQL 条件更新一致，两个实例竞争只能成功一个 action。
-- [ ] resolve 保留 unknown，不重投旧 input；abandon 写入 bounded `OPERATOR_ABANDONED` failed fact。
-- [ ] late completion、restart、重复 action 和旧 worker run 语义有测试。
-- [ ] Admin audit、runtime event 和 CLI/doctor 证据脱敏并可查询。
+- [x] `GET /admin/executions/fences` 可读取 redacted fence facts，并有 runtime:read + session/workspace authorization。（`internal/admin/fences.go` + `fences_test.go` scope 表驱动 403）
+- [x] `POST /admin/executions/{id}/fence-action` 支持 resolve/abandon、runtime:write、reason/evidence 校验和 409 fencing conflict。（409 FENCE_CONFLICT 测试 + reason 1–512 / evidence_ref ≤256 校验）
+- [x] SQLite/PostgreSQL 条件更新一致，两个实例竞争只能成功一个 action。（execution 竞态测试 + `-tags pg -p 1` real-PG 通过，§12.4）
+- [x] resolve 保留 unknown，不重投旧 input；abandon 写入 bounded `OPERATOR_ABANDONED` failed fact。（store 状态测试 + `runtime.execution.failed` 事件测试）
+- [x] late completion、restart、重复 action 和旧 worker run 语义有测试。（晚到 done 收敛、terminal 不回退、重复 action 幂等返回）
+- [x] Admin audit、runtime event 和 CLI/doctor 证据脱敏并可查询。（`user_activity` + slog 双审计；reason/evidence 仅审计层、不入 execution facts；doctor 只读）
 
 ### #946 first slice 完成
 
-- [ ] `Resolver.ResolvePlan`、redacted public view 和 canonical SHA-256 hash 已存在并有确定性测试。
-- [ ] WS/REST semantic equivalent input 产生相同 plan hash。
-- [ ] doctor、Admin diagnostics 和 shadow comparison 消费同一 resolver。
-- [ ] 四类 Worker 的 observed state 不把 planned/unknown 误报为 enforced。
-- [ ] 不新增 plan parallel store，不改变 legacy dispatch，不泄露敏感字段。
+- [x] `Resolver.ResolvePlan`、redacted public view 和 canonical SHA-256 hash 已存在并有确定性测试。（`internal/agentspec/plan_test.go`）
+- [x] WS/REST semantic equivalent input 产生相同 plan hash。（shadow 等价测试于 `internal/gateway/agentspec_test.go`）
+- [x] doctor、Admin diagnostics 和 shadow comparison 消费同一 resolver。（三处均调用 `Resolver{}.ResolvePlan` / `ShadowResolvePlan`）
+- [x] 四类 Worker 的 observed state 不把 planned/unknown 误报为 enforced。（first slice 只输出 planned/unknown/declared，`observedSummaryFor` 表驱动边界测试）
+- [x] 不新增 plan parallel store，不改变 legacy dispatch，不泄露敏感字段。（on-demand 投影；redaction 测试断言 command/model/budget/secret 不出现）
 
 ### 全局门禁
 
-- [ ] 受影响模块 `go test -race -count=1` 通过。
-- [ ] PostgreSQL 受影响路径在配置 DSN 时通过；未配置时明确标注未执行。
-- [ ] `make check`、`make docs-build`、`git diff --check` 通过。
-- [ ] 代码、测试、API 文档、CLI 文档、Roadmap 和 Issue 状态相互可追踪。
+- [x] 受影响模块 `go test -race -count=1` 通过。（1687 tests，§12.4）
+- [x] PostgreSQL 受影响路径在配置 DSN 时通过；未配置时明确标注未执行。（本次已配置 DSN，real-PG 16.11 通过，§12.4）
+- [x] `make check`、`make docs-build`、`git diff --check` 通过。（§12.4）
+- [x] 代码、测试、API 文档、CLI 文档、Roadmap 和 Issue 状态相互可追踪。（`docs/reference/{metrics,admin-api,cli,configuration}.md` + `docs/v2/*` + 本 spec §12.4 同步更新；#877/#946 跟踪中）
 
 ## 16. 开工闸门
 
-实现前需确认：
+实现前需确认（**2026-08-05：五项全部接受，闸门通过，Task 1–8 已执行完毕**）：
 
-1. 是否接受 `resolve` 只清 fence、保留 `unknown` 的语义；
-2. 是否接受 `abandon` 仅写 `failed/OPERATOR_ABANDONED`、不改变 delivery 的语义；
-3. 是否接受 `runtime:read` / `runtime:write` 两个新 scope 和本文 API 路径；
-4. 是否接受 #946 first slice 保持 shadow/read-only，不在本迭代切换 authoritative dispatch；
-5. 是否接受本迭代不包含 #867、#947、#851、#868。
-
-以上确认完成后，按现有实施计划执行 Task 1–8；任一确认未通过，先修改本 spec，不直接进入代码实现。
+1. ✅ 接受 `resolve` 只清 fence、保留 `unknown` 的语义（已按此实现）；
+2. ✅ 接受 `abandon` 仅写 `failed/OPERATOR_ABANDONED`、不改变 delivery 的语义（已按此实现）；
+3. ✅ 接受 `runtime:read` / `runtime:write` 两个新 scope 和本文 API 路径（已按此实现并写入 `docs/reference/{admin-api,configuration}.md`）；
+4. ✅ 接受 #946 first slice 保持 shadow/read-only，不在本迭代切换 authoritative dispatch（dispatch 仍以 legacy `SessionStartParams` 为准）；
+5. ✅ 接受本迭代不包含 #867、#947、#851、#868（见 `docs/v2/IMPLEMENTATION-ROADMAP.md` 当前交付切片 3–6 行）。

--- a/docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
+++ b/docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
@@ -1,0 +1,624 @@
+---
+title: "HotPlex Runtime Operations 下一迭代详细设计"
+type: design-spec
+status: proposed
+design_status: proposed
+implementation_status: not_started
+date: 2026-08-05
+owners: [hotplex-runtime]
+issue_refs: ["#877", "#946"]
+references:
+  - docs/v2/ROADMAP.md
+  - docs/v2/ARCHITECTURE.md
+  - docs/v2/IMPLEMENTATION-ROADMAP.md
+  - docs/superpowers/specs/2026-08-04-runtime-operations-contract.md
+  - docs/superpowers/plans/2026-08-04-runtime-operations-next-iteration.md
+---
+
+# HotPlex Runtime Operations 下一迭代详细设计
+
+## 1. 文档状态与决策边界
+
+本文是下一迭代的 proposed design spec，不代表实现已经完成，也不把本文中的推荐行为标记为已交付能力。实现前需要确认本 spec 的两个垂直切片边界、API 命名、状态迁移和验收标准。
+
+本 spec 继承已批准的 [Runtime Operations Contract](2026-08-04-runtime-operations-contract.md)，只把其中当前迭代的 #877 与 #946 范围具体化：
+
+1. #877：为无法自动收敛的 fenced execution 提供有授权、有审计、有条件并发保护的 operator action。
+2. #946：把现有 `internal/agentspec.Resolver` 扩展为 `EffectiveRuntimePlan` 的只读/影子 first slice。
+
+两条轨道共享 redaction、authorization、audit 和 verification 约束，但不共享新的持久化事实表；任一轨道可以单独合并和回滚。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 被 fence 的 session 可以被 operator 安全 inspect、resolve 或 abandon，不需要人工改库或整 Gateway 重启。
+- 两个 Gateway 实例同时处理同一个 fence 时，只有持有最新 fence version 的 action 能成功。
+- operator action 不会把未知执行伪装成成功，也不会自动重投旧 input。
+- 所有 operator action 都具备 actor、target、reason、decision、evidence ref 和 timestamp 的审计事实。
+- WS init、REST session creation、doctor 和 Admin diagnostics 使用同一个 `EffectiveRuntimePlan` resolver。
+- 等价 WS/REST 输入产生相同 canonical plan hash。
+- 计划输出只包含可安全展示的字段；未观测到 Worker/backend/artifact 时保持 `planned` 或 `unknown`。
+- 首个切片可在不改变既有 Worker dispatch 和 AEP v1 client 行为的情况下上线。
+
+### 2.2 非目标
+
+- 不按固定时长自动清除 fence；时间经过不是旧 Worker 已终止的证据。
+- 不自动重投原始 input；不新增 retry 或 scheduler 语义。
+- 不把 `resolve` 或 `abandon` 解释为外部消息、Webhook、Cron 或 provider effect 已成功。
+- 不实现 #867 的 strict environment allowlist、OS isolation、credential broker 或 host env 清理。
+- 不实现 #947 `EffectLedger`、#851 `ExecutionQueue` 或 #868 Execution Cockpit。
+- 不把 worker-private tool protocol 搬到 Gateway。
+- 不创建第二套 session、execution、event bus、identity 或 configuration system。
+
+## 3. 当前基线
+
+当前代码已具备：
+
+- `internal/execution` 的 payload hash、owner lease、single-active gate、`unknown`、fence、late convergence 和 fresh Worker 条件清理；
+- `FenceBySession`、`ClearFenceAfterFreshStart` 和 `ErrExecutionFenced`；
+- #847 first-cut `AgentSpec` 与纯 `Resolver`；
+- WS/REST WebChat 输入的 `BuildWebChatInput` 和 AgentSpec shadow comparison；
+- Admin Bearer+scope middleware、Admin audit、`/admin/health/workers`、`/admin/metrics`；
+- SQLite/PostgreSQL 成对 migration 结构和 fault-injection / multi-instance 测试模式。
+
+当前缺口是：
+
+- fence 没有 operator-facing conditional action 和 operator-readable token/version；
+- 没有统一的 redacted desired runtime plan；
+- doctor/Admin 尚未消费同一份 plan resolver；
+- 现有 AgentSpec 仍是 normalized view，不是完整的 desired/observed 分离模型。
+
+## 4. 总体架构
+
+```text
+Authority / Scope / Capability
+             │
+             ▼
+   EffectiveRuntimePlan  ───────────────┐
+             │                          │
+             ▼                          │
+   Durable Input Execution              │
+             │                          │
+   unknown + fence                      │
+             │                          │
+             ▼                          │
+   Operator inspect / resolve / abandon │
+             │                          │
+             └──── audit + runtime evidence
+
+Worker start / WS init / REST create / doctor / Admin diagnostics
+             └──────────► one Resolver ◄──────────┘
+```
+
+事实所有权保持不变：
+
+| 事实 | 唯一写入者 | 本迭代消费者 |
+|---|---|---|
+| Input delivery/runtime/fence | `internal/execution` | Gateway、operator API、repairer |
+| Operator actor/decision/reason/evidence | Admin handler + audit collector | Admin、CLI、审计查询 |
+| Desired runtime plan | `internal/agentspec.Resolver` | WS、REST、doctor、Admin |
+| Worker observed bootstrap | Worker/Gateway adapter evidence | Admin diagnostics、日志、trace |
+| Wire event | AEP/eventstore | Client、RuntimeContext、audit/observability |
+
+Operator API、CLI、doctor 和 WebChat 不得各自维护 execution 或 plan 的副本。CLI 只能调用 Admin API；doctor 只能做本地只读解析；UI 只消费 redacted projection。
+
+## 5. #877 Fenced Execution Operator Action
+
+### 5.1 数据模型
+
+在现有 `execution_inputs` 增加两个字段，SQLite/PostgreSQL 必须成对迁移：
+
+```sql
+fence_version    INTEGER/BIGINT NOT NULL DEFAULT 0
+fence_created_at INTEGER/BIGINT NULL
+```
+
+`Record` 增加：
+
+```go
+type Record struct {
+    // existing fields...
+    FenceReason    string
+    FenceVersion   int64
+    FenceCreatedAt *int64
+}
+```
+
+`fence_version` 是并发 fencing token：每次 execution 从非 fenced 进入 fenced 时单调递增；operator action 必须携带读取时的 version。`fence_created_at` 只用于诊断、排序和 operator 判断，不触发自动清理。
+
+### 5.2 Operator action contract
+
+```go
+type FenceDecision string
+
+const (
+    FenceDecisionResolve FenceDecision = "resolve"
+    FenceDecisionAbandon FenceDecision = "abandon"
+)
+
+type FenceActionRequest struct {
+    ExecutionID         string
+    ExpectedFenceVersion int64
+    Decision             FenceDecision
+}
+
+var ErrFenceConflict = errors.New("execution: fence version conflict")
+
+type Store interface {
+    // existing methods...
+    ApplyFenceDecision(ctx context.Context, req FenceActionRequest) (*Record, error)
+}
+```
+
+Actor、reason、evidence ref 不进入 `internal/execution.Store`，由 Admin 层校验、审计和关联；execution store 只负责原子状态迁移。
+
+### 5.3 状态语义
+
+#### Inspect
+
+只读返回 execution ID、session ID、runtime status、delivery status、fence reason、fence version、fence created time、worker run ID 的脱敏引用和更新时间。不得返回 payload hash 以外的用户输入内容。
+
+#### Resolve
+
+- 条件：`execution_id` 匹配且 `fence_version = expected_fence_version`；
+- 动作：清空 `fence_reason`，保留原有 `runtime_status=unknown`；
+- 不动作：不修改 delivery 为 `delivered`，不生成新的 Worker run，不调用 Worker input；
+- 后续：新的 client message 使用新 ID，按正常 accept 流程创建新 execution；
+- 晚到事件：只有匹配原 `worker_run_id` 的晚到 completion 可以收敛原 execution，不能修改新 execution。
+
+#### Abandon
+
+- 条件：同 Resolve；
+- 动作：清空 `fence_reason`，将 runtime status 置为 `failed`，错误枚举为 `OPERATOR_ABANDONED`；
+- 不动作：不修改 delivery 为 `delivered`，不重投旧 input，不证明外部 effect 已失败或成功；
+- 晚到事件：对已 terminal 的 abandoned execution 不得回写为 completed。
+
+#### Keep fenced
+
+不调用 action endpoint；继续保持 fence。不存在隐式的“超时后自动 resolve”。
+
+### 5.4 条件更新
+
+SQLite 在 `sqlutil.WriteMu` 保护下执行；PostgreSQL 使用行版本条件更新。两者都必须满足：
+
+```sql
+UPDATE execution_inputs
+SET fence_reason = ?, runtime_status = ?, runtime_error_code = ?, updated_at = ?
+WHERE execution_id = ?
+  AND fence_reason <> ''
+  AND fence_version = ?;
+```
+
+影响行数为 `0` 时：重新读取当前记录；不存在返回 `ErrNotFound`，版本已变化或已经解 fence 返回 `ErrFenceConflict`。重复同一 action 不得产生第二条状态迁移或第二次 dispatch。
+
+### 5.5 Admin HTTP API
+
+新增 runtime scopes：
+
+- `runtime:read`：读取 fence facts 和 redacted runtime plan；
+- `runtime:write`：执行 resolve/abandon。
+
+路由由 `cmd/hotplex/routes.go` 注册，并统一经过现有 `AdminAPI.Middleware`：
+
+#### `GET /admin/executions/fences`
+
+需要 `runtime:read`。支持 `session_id`、`limit`、`offset`，默认有界分页。返回：
+
+```json
+{
+  "fences": [
+    {
+      "execution_id": "exec_...",
+      "session_id": "sess_...",
+      "runtime_status": "unknown",
+      "delivery_status": "unknown",
+      "fence_reason": "GATEWAY_LEASE_EXPIRED",
+      "fence_version": 3,
+      "fence_created_at": 1754300000000,
+      "updated_at": 1754300000000
+    }
+  ],
+  "limit": 100,
+  "offset": 0
+}
+```
+
+#### `POST /admin/executions/{id}/fence-action`
+
+需要 `runtime:write`。请求：
+
+```json
+{
+  "expected_fence_version": 3,
+  "decision": "resolve",
+  "reason": "verified worker process is no longer running",
+  "evidence_ref": "audit:..."
+}
+```
+
+约束：
+
+- `decision` 只能是 `resolve` 或 `abandon`；
+- `reason` 必填，长度限制为 1–512 个字符；
+- `evidence_ref` 必填，长度限制为 1–256 个字符，不允许携带 prompt、secret 或完整 provider response；
+- actor 从认证上下文读取，不允许客户端伪造；
+- 成功返回新的 redacted execution fact；
+- 版本冲突返回 `409 FENCE_CONFLICT`；参数错误返回 `400`；无 scope 返回 `403`；记录不存在返回 `404`。
+
+### 5.6 Audit 与 runtime event
+
+每次成功或拒绝的 operator write 都写入 Admin audit：
+
+```json
+{
+  "actor": "user-or-admin-token",
+  "action": "runtime.fence.resolve",
+  "target": "exec_...",
+  "decision": "resolve",
+  "reason_code": "operator_reason_present",
+  "evidence_ref": "audit:...",
+  "result": "ok",
+  "timestamp": "2026-08-05T...Z"
+}
+```
+
+reason 内容只在受保护的 audit detail 中按现有 retention 规则保存；metrics 和 runtime event 不保存自由文本。
+
+`abandon` 复用已有 additive `runtime.execution.failed` 语义，错误枚举为 `OPERATOR_ABANDONED`；`resolve` 不发出 completed/succeeded 事件。若当前 event contract 无法表达 operator decision，应先扩展 `pkg/events` 及 Go/TypeScript/Python/Java SDK 和双向测试，再实现 handler；不得临时增加未同步的 Kind。
+
+### 5.7 CLI 与 doctor
+
+CLI 只调用 Admin API，不直接打开数据库：
+
+```text
+hotplex runtime fences list
+hotplex runtime fences resolve <execution-id> --fence-version 3 --reason "..." --evidence-ref "..."
+hotplex runtime fences abandon <execution-id> --fence-version 3 --reason "..." --evidence-ref "..."
+```
+
+`resolve` 和 `abandon` 需要显式 `--confirm`；收到 `409` 时提示重新 inspect，不自动重试。
+
+doctor 新增只读 `runtime.fenced_executions` checker：无 fence 为 Pass，有 fence 为 Warn，输出数量、最早 fence 时间和修复提示；没有 `FixFunc`。
+
+## 6. #946 EffectiveRuntimePlan First Slice
+
+### 6.1 Plan value object
+
+扩展 `internal/agentspec`，不创建 `internal/runtimeplan` 平行包：
+
+```go
+type EffectiveRuntimePlan struct {
+    Version       int
+    Resolver      string
+    PlanHash      string
+    AgentSpec     AgentSpec
+    EnvProfile    string
+    EnvKeys       []string
+    CapabilityIDs []string
+    SkillHash     string
+    ConfigHash    string
+    SourceRefs    []PlanSourceRef
+    Warnings      []PlanWarning
+    Blocked       []PlanBlockReason
+}
+
+func (r Resolver) ResolvePlan(in Input) (EffectiveRuntimePlan, error)
+func (p EffectiveRuntimePlan) Redacted() EffectiveRuntimePlanView
+func CanonicalPlanHash(view EffectiveRuntimePlanView) string
+```
+
+本 first slice 的 `EffectiveRuntimePlan` 是 desired state，不是 observed success。`AgentSpec.Worker.Command` 等内部 contract 字段不得直接进入 Admin/doctor public view；public view 只保留 worker type、permission summary、sandbox summary、environment key names、hash、source refs、warnings 和 blocked codes。
+
+### 6.2 Precedence 与 fail-closed
+
+解析顺序固定为：
+
+```text
+compiled defaults
+  -> base config
+  -> platform/bot config
+  -> workspace override
+  -> session init metadata
+  -> validated runtime capability
+```
+
+本迭代只复用当前 `AgentSpec` 已有的 config/init/workspace/platform 事实，不实现 #867 strict env allowlist。以下情况必须生成 bounded blocked reason 或 error，不能静默降级为可执行成功：
+
+- 非空但未知 worker type；
+- 非法 permission mode；
+- workspace/owner/origin 事实缺失或冲突；
+- plan 必需的 capability 无法验证；
+- 发现 secret-shaped value 被尝试写入 public plan。
+
+Compat 行为可以继续运行，但必须产生 warning；无法证明 enforcement 的能力只允许 `partial`、`unavailable` 或 `unknown`。
+
+### 6.3 Canonical hash
+
+hash 输入是 redacted canonical view，不包括：
+
+- prompt、metadata value、credential、token、secret；
+- 完整 command、host environment value、workspace absolute path；
+- process ID、时间戳、provider/evidence ref；
+- map 的随机遍历顺序、nil/empty 的非语义差异。
+
+canonicalization 规则：
+
+1. 固定字段集合和版本号；
+2. nil slice 与空 slice 归一化；
+3. 语义无序的 ID/key 列表排序；
+4. 保留具有语义的 precedence/source 顺序；
+5. UTF-8 JSON 编码后计算 SHA-256；
+6. hash 只作为 desired plan identity，不证明 Worker/backend/sandbox 已应用。
+
+### 6.4 WS/REST 共用解析路径
+
+当前 `BuildWebChatInput` 保留为共同输入构造器：
+
+```text
+WS init ─────┐
+             ├── BuildWebChatInput / agentspec.Input ── Resolver.ResolvePlan
+REST create ─┘
+```
+
+实现阶段先 shadow：
+
+- legacy `SessionStartParams` 继续作为 dispatch authoritative value；
+- plan 解析错误记录为 redacted diagnostic，不改变现有行为，除非现有入口已明确 fail closed；
+- plan hash 不写入高基数 metrics label；
+- WS/REST 等价输入的 hash 不一致时记录 warning 并使测试失败。
+
+### 6.5 Observed bootstrap
+
+Worker 启动后只补充可验证事实：worker type、backend/artifact digest（如已有安全来源）、capability state 和 observed timestamp。状态映射：
+
+| desired/observed 情况 | 输出 |
+|---|---|
+| 只有 plan 已生成 | `planned` |
+| Worker/backend/artifact 未可验证 | `unknown` |
+| 只声明但没有实际 enforcement 证据 | `declared` 或 `partial` |
+| 具有真实 backend enforcement 证据 | `enforced` |
+
+本切片不把配置 hash、HTTP 200、Worker done 或 audit row 单独提升为 `enforced`。
+
+### 6.6 Admin 与 doctor read path
+
+新增 `GET /admin/sessions/{id}/runtime-plan`，需要 `runtime:read` 和现有 session/workspace authorization。返回 redacted plan、plan hash、observed summary、warnings、blocked codes；不返回 prompt、secret、完整命令或 raw worker error。
+
+doctor 新增 `runtime.effective_plan` checker：使用本地 config 和现有 resolver，输出 plan hash、worker type、permission/sandbox summary、warnings/blocked codes；只读，不自动改配置。
+
+首个切片不新增 plan 专用表或列。已有 secret-free `SpecSnapshot` 继续承担向后兼容的 session snapshot；完整 computed plan 作为诊断 projection 计算，不建立第二套持久化真相。
+
+## 7. 数据流与生命周期
+
+### 7.1 Fence operator flow
+
+```text
+operator/CLI
+    │ GET fences
+    ▼
+Admin scope + session authorization
+    │
+    ▼
+redacted FenceFact + fence_version
+    │ POST action(expected version, decision, reason, evidence)
+    ▼
+Admin validation + actor extraction
+    │
+    ├── Admin audit intent/result
+    ├── execution.Store conditional update
+    ├── runtime.execution.failed for abandon only
+    └── redacted response
+```
+
+旧 Worker late completion 与 operator action 的竞态由 `execution_id + worker_run_id + runtime status` 条件更新收敛；operator action 不调用 Worker、不触发 input replay。
+
+### 7.2 Plan flow
+
+```text
+config + platform/bot + workspace + init metadata
+                     │
+                     ▼
+             agentspec.Input
+                     │
+                     ▼
+           Resolver.ResolvePlan
+                     │
+        ┌────────────┴────────────┐
+        ▼                         ▼
+ legacy dispatch shadow      redacted diagnostics
+        │                         │
+        ▼                         ▼
+ Worker observed bootstrap    Admin / doctor / trace
+```
+
+任何单一来源都不能替代其他事实层：plan hash 不替代 execution，Worker done 不替代 effect evidence，audit 不替代 provider receipt。
+
+## 8. 错误与兼容
+
+| 场景 | HTTP/CLI/内部语义 | 是否重试 |
+|---|---|---|
+| fence 不存在 | `404 FENCE_NOT_FOUND` / CLI non-zero | 否 |
+| fence version 过期 | `409 FENCE_CONFLICT` / 重新 inspect | 否，禁止自动重试 write |
+| 无 `runtime:read` | `403` | 否 |
+| 无 `runtime:write` | `403` | 否 |
+| decision/reason/evidence 非法 | `400` | 否 |
+| DB conditional update timeout | `503` | operator 可重新 inspect；不自动重复 action |
+| unknown worker type | plan blocked/error | 不启动新 Worker |
+| capability 无观测证据 | `unknown`/`partial` | 不宣称 enforced |
+| legacy session 无 plan snapshot | computed plan unavailable/unknown | 保持旧读取兼容，不回填敏感字段 |
+
+现有 AEP v1 客户端必须继续工作。`runtime.execution.failed` 使用现有事件字段；如必须新增 Kind、Data 或 JSON tag，必须同时更新 `pkg/events`、Go SDK、TypeScript/Python/Java 示例 SDK、`docs/reference/{aep-protocol,events}.md` 和双向协议测试。
+
+## 9. 隐私、安全与审计
+
+- execution store 只保存 payload SHA-256，不保存输入正文。
+- Plan public view 只保留 IDs、hash、枚举、key names、source refs 和 bounded diagnostics。
+- reason/evidence 由 Admin API 做长度、字符集和敏感字段边界检查；自由文本不进入 metrics label。
+- actor 从认证上下文提取，客户端不能伪造；`admin-token` 与用户 actor 按现有审计规范记录。
+- `runtime:read` 与 `runtime:write` 分离；写操作默认经过现有 Bearer+scope middleware 和 admin audit。
+- resolve/abandon 不授予新的 workspace、filesystem、network 或 credential 能力。
+- capability status 只表达证据级别，不把 allowlist、token、audit 或 plan hash 解释为形式化隔离证明。
+- 所有 response body、event data、logs 和 tests 禁止出现 prompt、secret、token、完整 command、raw provider request 和 raw worker error。
+
+## 10. 数据库迁移与回滚
+
+新增：
+
+- `internal/session/sql/migrations/031_execution_fence_operator.sql`；
+- `internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql`。
+
+迁移要求：
+
+- old rows 默认 `fence_version=0`、`fence_created_at=NULL`；
+- migration 可重复启动且不会重建 `execution_inputs`；
+- SQLite/PostgreSQL 列类型和条件更新语义一致；
+- rollback 只允许在没有新 operator action 依赖时执行，且由版本化 migration 管理，禁止人工改生产库；
+- 如果迁移失败，保留旧 fence behavior，不启动新的 operator write path。
+
+#946 first slice 不新增 plan 表或列，回滚只需关闭 shadow diagnostic route/checker，旧 AgentSpec 和 session snapshot 继续可读。
+
+## 11. 可观测性与容量预算
+
+允许的低基数 metrics：
+
+- `hotplex_runtime_fence_actions_total{decision,result}`；
+- `hotplex_runtime_fence_conflicts_total`；
+- `hotplex_runtime_plan_resolutions_total{result}`；
+- `hotplex_runtime_plan_blocked_total{reason_code}`；
+- `hotplex_runtime_plan_observed_total{state}`。
+
+禁止 label：execution ID、session ID、workspace ID、plan hash、provider ref、evidence ref、actor ID。
+
+容量约束：
+
+- fence list 默认 `limit <= 100`，最大 `limit <= 500`；
+- reason 最大 512 字符，evidence ref 最大 256 字符；
+- plan public view 只返回 bounded arrays，单响应不超过现有 Admin API payload budget；
+- CLI 不缓存 action intent，不在 409 后自动 replay；
+- audit 使用现有 retention/GC，不创建平行 action log。
+
+## 12. 测试与验证矩阵
+
+### 12.1 #877
+
+| 类别 | 必测场景 |
+|---|---|
+| Store | resolve、abandon、非法 decision、missing record、stale version、重复 action |
+| State | unknown 保留、abandon 变 failed、delivery 不变、旧 input 不重投 |
+| Concurrency | SQLite WriteMu、PostgreSQL MVCC、两个 Gateway 竞争同一 fence version |
+| Late event | resolve/abandon 后旧 worker done、不同 worker run ID、terminal 不回退 |
+| Security | runtime scopes、session/workspace authorization、CSRF/Origin 规则、actor 不可伪造 |
+| Audit | 成功、拒绝、409、reason/evidence redaction、链式 audit 可验证 |
+| API/CLI | 400/403/404/409/503、分页、显式确认、CLI 不直接访问 DB |
+| Restart | inspect 后 Gateway restart，再 action；旧记录仍可读、条件 token 仍有效或明确冲突 |
+
+### 12.2 #946
+
+| 类别 | 必测场景 |
+|---|---|
+| Resolver | 四 Worker、config fallback、init override、workspace permission、unknown worker、invalid permission |
+| Hash | 等价输入相同 hash、无序 list 归一化、nil/empty 等价、source 顺序保持 |
+| Redaction | secret/token/env value/command/path/raw error 不进入 public JSON 或 hash |
+| Equivalence | WS init 与 REST create semantic input 产生相同 plan hash |
+| Observed | planned、unknown、declared、partial、enforced 的边界不能混淆 |
+| Admin | session/workspace authorization、runtime:read、bounded response、旧 snapshot 兼容 |
+| Doctor | `runtime.effective_plan` 注册、JSON 输出、blocked/warn、无 FixFunc |
+| Compatibility | 旧 AEP v1 client、旧 AgentSpec/session snapshot、四平台路径/env 行为不回归 |
+
+### 12.3 验证命令
+
+```text
+rtk go test ./internal/execution ./internal/admin ./internal/agentspec ./internal/gateway ./internal/cli/... ./cmd/hotplex -count=1 -race
+rtk go test -tags pg -p 1 ./internal/execution ./internal/session/sql -count=1 -race
+rtk make check
+rtk make docs-build
+rtk git diff --check
+```
+
+真实 PostgreSQL 测试依赖 `HOTPLEX_TEST_PG_DSN`；未配置时只能报告环境未执行，不能报告 PostgreSQL 验证完成。
+
+## 13. 发布、暂停与回滚
+
+### 发布顺序
+
+1. 先部署 migration 和只读 fence list / plan diagnostics；
+2. 验证 redaction、权限、payload budget 和 metrics cardinality；
+3. 开启 operator write endpoint；
+4. 开启 CLI action facade；
+5. 保持 #946 shadow comparison，观察 WS/REST plan divergence；
+6. 在下一迭代评审后再决定是否将 plan 解析从 shadow 提升为 authoritative。
+
+### 暂停条件
+
+- 任何 operator action 导致重复 Worker input；
+- 任何 action 把 unknown 写成 completed/delivered；
+- 任何 response/event/audit 出现 prompt、secret 或 raw worker error；
+- 两个实例可成功应用同一个 fence version；
+- WS/REST divergence 影响实际 dispatch；
+- plan diagnostics 产生 high-cardinality metrics 或无界读取。
+
+### 回滚
+
+- 禁用 `runtime:write` scope 或 route，保留 inspect；
+- 停止 CLI write command，不删除 audit facts；
+- 将 #946 shadow route/checker 置为 read-only/disabled，保留旧 `AgentSpec` 行为；
+- 不回滚已产生的 operator audit；
+- 不通过删除 migration 或直接修改数据库恢复状态。
+
+## 14. 成本与收益边界
+
+### 成本
+
+- 一次成对数据库迁移和跨实例条件更新测试；
+- Admin scope/API/CLI/doctor 的新增维护面；
+- 四 Worker 与 WS/REST plan equivalence 的回归验证；
+- AEP/SDK 同步成本仅在确需新增 event Kind 时发生；
+- 本迭代不承担 EffectLedger、strict isolation、queue 或 Cockpit 的实现成本。
+
+### 可验证收益
+
+- fenced session 从“只能人工介入”变成“可审计的受控恢复”；
+- 重复 dispatch、错误恢复和 session lockout 的风险边界可测试、可监控；
+- 平台/运维能以 plan hash 和 blocked reason 解释实际运行意图；
+- 后续 #867、#947、#868 复用同一 plan、execution、audit 和 evidence vocabulary，减少平行实现和返工。
+
+本 spec 不给出节省金额或 payback 数字；应在上线后通过 fence action 数、恢复耗时、重复 dispatch、plan divergence 和 blocked preflight 数据计算实际 ROI。
+
+## 15. 完成定义
+
+### #877 完成
+
+- [ ] `GET /admin/executions/fences` 可读取 redacted fence facts，并有 runtime:read + session/workspace authorization。
+- [ ] `POST /admin/executions/{id}/fence-action` 支持 resolve/abandon、runtime:write、reason/evidence 校验和 409 fencing conflict。
+- [ ] SQLite/PostgreSQL 条件更新一致，两个实例竞争只能成功一个 action。
+- [ ] resolve 保留 unknown，不重投旧 input；abandon 写入 bounded `OPERATOR_ABANDONED` failed fact。
+- [ ] late completion、restart、重复 action 和旧 worker run 语义有测试。
+- [ ] Admin audit、runtime event 和 CLI/doctor 证据脱敏并可查询。
+
+### #946 first slice 完成
+
+- [ ] `Resolver.ResolvePlan`、redacted public view 和 canonical SHA-256 hash 已存在并有确定性测试。
+- [ ] WS/REST semantic equivalent input 产生相同 plan hash。
+- [ ] doctor、Admin diagnostics 和 shadow comparison 消费同一 resolver。
+- [ ] 四类 Worker 的 observed state 不把 planned/unknown 误报为 enforced。
+- [ ] 不新增 plan parallel store，不改变 legacy dispatch，不泄露敏感字段。
+
+### 全局门禁
+
+- [ ] 受影响模块 `go test -race -count=1` 通过。
+- [ ] PostgreSQL 受影响路径在配置 DSN 时通过；未配置时明确标注未执行。
+- [ ] `make check`、`make docs-build`、`git diff --check` 通过。
+- [ ] 代码、测试、API 文档、CLI 文档、Roadmap 和 Issue 状态相互可追踪。
+
+## 16. 开工闸门
+
+实现前需确认：
+
+1. 是否接受 `resolve` 只清 fence、保留 `unknown` 的语义；
+2. 是否接受 `abandon` 仅写 `failed/OPERATOR_ABANDONED`、不改变 delivery 的语义；
+3. 是否接受 `runtime:read` / `runtime:write` 两个新 scope 和本文 API 路径；
+4. 是否接受 #946 first slice 保持 shadow/read-only，不在本迭代切换 authoritative dispatch；
+5. 是否接受本迭代不包含 #867、#947、#851、#868。
+
+以上确认完成后，按现有实施计划执行 Task 1–8；任一确认未通过，先修改本 spec，不直接进入代码实现。

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1628,6 +1628,141 @@
                 }
             }
         },
+        "/admin/executions/fences": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Lists executions whose runtime ended ambiguous and raised a fence. Requires runtime:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List fenced executions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results (default 100, max 500)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "fences list",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need runtime:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Execution store not configured",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/executions/{id}/fence-action": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Resolves (clears fence, keeps runtime unknown) or abandons (clears fence, fails runtime with OPERATOR_ABANDONED) a fenced execution. Conditional on expected_fence_version; conflicts return 409. Requires runtime:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Apply operator fence action",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Execution ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Operator decision",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.fenceActionBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Applied decision and updated execution fact",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid decision, fence version, reason, or evidence_ref",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need runtime:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Execution not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Fence version conflict: re-inspect before retrying",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Execution store not configured or timed out",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/health": {
             "get": {
                 "security": [
@@ -2003,6 +2138,64 @@
                     },
                     "500": {
                         "description": "Failed to delete session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions/{id}/runtime-plan": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the redacted desired-state runtime plan and observed bootstrap summary for a session. Requires runtime:read and session:read scopes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get session runtime plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.RuntimePlanReport"
+                        }
+                    },
+                    "400": {
+                        "description": "Missing session ID",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need runtime:read and session:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Plan resolution failed",
                         "schema": {
                             "$ref": "#/definitions/admin.ErrorResponse"
                         }
@@ -3678,6 +3871,17 @@
                 }
             }
         },
+        "admin.RuntimePlanReport": {
+            "type": "object",
+            "properties": {
+                "observed": {
+                    "$ref": "#/definitions/agentspec.ObservedSummary"
+                },
+                "plan": {
+                    "$ref": "#/definitions/agentspec.EffectiveRuntimePlanView"
+                }
+            }
+        },
         "admin.STTAttrs": {
             "type": "object",
             "properties": {
@@ -3997,6 +4201,23 @@
                 }
             }
         },
+        "admin.fenceActionBody": {
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string"
+                },
+                "evidence_ref": {
+                    "type": "string"
+                },
+                "expected_fence_version": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.skillInstallResponse": {
             "type": "object",
             "properties": {
@@ -4033,6 +4254,121 @@
             "type": "object",
             "properties": {
                 "permission_mode": {
+                    "type": "string"
+                }
+            }
+        },
+        "agentspec.EffectiveRuntimePlanView": {
+            "type": "object",
+            "properties": {
+                "blocked": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/agentspec.PlanBlockReason"
+                    }
+                },
+                "capability_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "config_hash": {
+                    "type": "string"
+                },
+                "env_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "env_profile": {
+                    "type": "string"
+                },
+                "permission_mode": {
+                    "type": "string"
+                },
+                "plan_hash": {
+                    "type": "string"
+                },
+                "resolver": {
+                    "type": "string"
+                },
+                "sandbox_mode": {
+                    "type": "string"
+                },
+                "skill_hash": {
+                    "type": "string"
+                },
+                "skip_permissions": {
+                    "type": "boolean"
+                },
+                "source_refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/agentspec.PlanSourceRef"
+                    }
+                },
+                "version": {
+                    "type": "integer"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/agentspec.PlanWarning"
+                    }
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "agentspec.ObservedSummary": {
+            "type": "object",
+            "properties": {
+                "permission_ceiling": {
+                    "description": "PermissionCeiling is the first effective permission tier the Worker\nreported after a successful start/resume — declared by the Worker, not\nindependently enforced (empty when never reported).",
+                    "type": "string"
+                },
+                "state": {
+                    "description": "State is one of the Observed* constants.",
+                    "type": "string"
+                },
+                "worker_type": {
+                    "description": "WorkerType is the worker type the session actually runs (observed fact).",
+                    "type": "string"
+                }
+            }
+        },
+        "agentspec.PlanBlockReason": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "agentspec.PlanSourceRef": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "agentspec.PlanWarning": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 }
             }

--- a/docs/v2/IMPLEMENTATION-ROADMAP.md
+++ b/docs/v2/IMPLEMENTATION-ROADMAP.md
@@ -24,6 +24,8 @@
 | Runtime Observability | [#850](https://github.com/hrygo/hotplex/issues/850) | runtime spans/metrics 基线 | 新属性保持低基数和统一命名 |
 | RuntimeContext | [#852](https://github.com/hrygo/hotplex/issues/852) | eventstore/turns/worker session/workspace context 接口 | 不新建 memory product |
 | Durable Ingress | [#878](https://github.com/hrygo/hotplex/issues/878) | input ledger、single-active gate、owner lease、runtime/delivery 分离、ambiguity fence、late convergence、有界 repairer | #851/#947 复用 execution identity、lease 和 fence |
+| Fence Escape Hatch | [#877](https://github.com/hrygo/hotplex/issues/877) | fence 持久化（`fence_created_at`/`fence_version`）、条件 resolve/abandon（跨实例 409 冲突）、审计、Admin API、CLI、doctor | operator 决策不自动重试、不伪装成功、不重投旧 input；`fence_version` 是唯一并发条件 |
+| EffectiveRuntimePlan (shadow) | [#946](https://github.com/hrygo/hotplex/issues/946) | redacted plan 投影 + canonical hash、fail-closed blocked codes、WS/REST 影子解析、Admin/doctor 只读路径 | dispatch 仍以 legacy SessionStartParams 为准；plan hash 永不进入 metric label；worker start/recipe dry-run 的 authoritative 切换属后续切片 |
 
 完整 AEP runtime event contract 仍由 [#849](https://github.com/hrygo/hotplex/issues/849) 跟踪；#878 交付的最小 `runtime.execution.*` 事件不代表 #849 全部完成。
 
@@ -59,16 +61,16 @@
 
 ## 当前交付切片
 
-| 顺序 | 切片 | 直接产出 | 验证重点 |
-| ---: | --- | --- | --- |
-| 1 | #877 fenced execution operator action | 有审计、可授权、可恢复的 session 解锁 | 三重失败、late completion、权限和审计 |
-| 2 | #946 EffectiveRuntimePlan + observed bootstrap | WS/REST/doctor/worker/admin/recipe 统一 plan | canonical hash、redaction、四 Worker、drift/unknown |
-| 3 | #867 env allowlist + isolation report | compat/strict profile 和真实 enforcement 状态 | 三平台 env、filesystem/network evidence |
-| 4 | #947 Cron/Webhook/message durable effect | 第一条 `desired → effect → observed → reconcile` 闭环 | 重启、多实例、timeout、5xx、响应丢失、晚到确认 |
-| 5 | #851 bounded ExecutionQueue | FIFO metadata、attempt、timeout/retry reason、queue state | race、现有 turn/LLM/crash 语义兼容 |
-| 6 | #868 Execution Cockpit | canonical runtime facts 的只读 timeline | 查询预算、授权、redaction、低基数 |
-| 7 | #870 Coding Ops Recipes | versioned manifest、dry-run plan、effect-backed delivery | 幂等、权限、双数据库、非 DAG 边界 |
-| 8 | #948 Capability Inventory | scope precedence、hash、safe materialization | safe path/size/XML/Windows、admin-gated promotion |
+| 顺序 | 切片 | 直接产出 | 验证重点 | 状态 |
+| ---: | --- | --- | --- | --- |
+| 1 | #877 fenced execution operator action | 有审计、可授权、可恢复的 session 解锁 | 三重失败、late completion、权限和审计 | ✅ 已交付（PR #953） |
+| 2 | #946 EffectiveRuntimePlan + observed bootstrap | WS/REST/doctor/worker/admin/recipe 统一 plan | canonical hash、redaction、四 Worker、drift/unknown | 🟡 shadow first slice 已交付（PR #953）；worker start/recipe authoritative 切换未开始 |
+| 3 | #867 env allowlist + isolation report | compat/strict profile 和真实 enforcement 状态 | 三平台 env、filesystem/network evidence | 未开始 |
+| 4 | #947 Cron/Webhook/message durable effect | 第一条 `desired → effect → observed → reconcile` 闭环 | 重启、多实例、timeout、5xx、响应丢失、晚到确认 | 未开始 |
+| 5 | #851 bounded ExecutionQueue | FIFO metadata、attempt、timeout/retry reason、queue state | race、现有 turn/LLM/crash 语义兼容 | 未开始 |
+| 6 | #868 Execution Cockpit | canonical runtime facts 的只读 timeline | 查询预算、授权、redaction、低基数 | 未开始 |
+| 7 | #870 Coding Ops Recipes | versioned manifest、dry-run plan、effect-backed delivery | 幂等、权限、双数据库、非 DAG 边界 | 未开始 |
+| 8 | #948 Capability Inventory | scope precedence、hash、safe materialization | safe path/size/XML/Windows、admin-gated promotion | 未开始 |
 
 ## Stage 1: Runtime Contract
 

--- a/docs/v2/IMPLEMENTATION-STATUS-AND-PLAN.md
+++ b/docs/v2/IMPLEMENTATION-STATUS-AND-PLAN.md
@@ -32,7 +32,8 @@
 | **#852** RuntimeContext | Wave2 | ✅ 已实现（PR #924） | 只读 Load facade 交付（四源 + 适配器边界，commit 0239992a）；Save 留待后续 slice |
 | **#866** 持久化快照 | Wave1 延伸 | ✅ 已实现（PR #924） | 快照值对象 + context_json 折叠 + 恢复 + 审计指纹（无迁移，commit dd9482dc） |
 | **#868** Execution Cockpit | Wave3 | ❌ 未启动 | 依赖多已由 epic 满足；epic 关闭后解锁 |
-| **#877** fence escape hatch | epic 后续 | ❌ 未启动 | 被 #878 阻塞；epic 关闭后解锁（2-3 天） |
+| **#877** fence escape hatch | epic 后续 | ✅ 已实现（PR #953，待合并） | fence 持久化 + `fence_version` 条件 resolve/abandon + 审计 + Admin API/CLI/doctor 全交付 |
+| **#946** EffectiveRuntimePlan | Runtime Contract | 🟡 shadow first slice 已交付（PR #953，待合并） | 剩余：worker start / recipe dry-run 的 authoritative 切换与四 Worker observed 报告 |
 | **#867** worker env allowlist | 独立安全轨 | ❌ 未启动（BuildEnv 仍 blocklist） | 全量，跨三平台，可并行 |
 | **#869** AEP canonical schema | 独立基建 | ❌ 未启动 | 全量；#849 命名稳定后 |
 | **#870** Coding Ops Recipes | 独立 scheduler | ❌ 未启动 | 较大；#847/#849/#851 稳定后 |
@@ -117,6 +118,17 @@
 | **#851 剩余**（完整 ExecutionQueue：FIFO / attempt / retry / timeout / queue state） | 超时、重试、queue state 语义需与现有 turn timeout、LLM retry、crash synthetic turn 协调一致，属设计决策非机械实现 | 单活跃门 first cut 已由 #878 交付；等调度语义对齐 |
 | **#867** worker env allowlist + 隔离 profile | **allowlist 完整性风险**：漏一个合法 env var 会静默打断 worker；须跨三平台（Linux/macOS/Windows）逐项验证 PATH/HOME/locale/temp 且有兼容模式迁移路径 | 独立安全轨，非 Wave 1 关键路径，任意时间可插入 |
 
+### 本轮交付（PR #953，2026-08-05，runtime operations 下一迭代）
+
+设计依据：[Runtime Operations 下一迭代详细设计](../superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md)（继承 2026-08-04 Runtime Operations Contract）。
+
+| Issue | 交付内容 | 验证 |
+|-------|----------|------|
+| #877 | execution store fence 持久化（`fence_created_at`/`fence_version`，SQLite+PG 成对迁移）；`fence_version` 条件 resolve/abandon（跨实例 409 冲突，不自动重试、不重投、不伪装成功）；Admin API（`runtime:*` scope + `user_activity`/slog 双审计）；`hotplex runtime fences` CLI（Admin API only）；doctor `runtime.fenced_executions`（只读） | 三重失败、晚到收敛、跨实例竞态、权限与审计测试；real-PG `-tags pg -p 1` |
+| #946 | `EffectiveRuntimePlan` resolver（redacted view + canonical hash + fail-closed blocked codes）；WS/REST 入口影子解析（legacy dispatch 不受影响）；`GET /admin/sessions/{id}/runtime-plan`；doctor `runtime.effective_plan`；plan 指标（hash 不入 label） | WS≡REST 等价哈希、redaction、normalization、blocked/warnings 测试 |
+
+刻意保持：dispatch 仍以 legacy `SessionStartParams` 为准（#946 为 shadow first slice）；blocked plan 永不静默成功；execution store 只存 payload 指纹，operator reason/evidence_ref 只进审计层。
+
 ---
 
 ## 五、风险与缺口
@@ -136,7 +148,8 @@
 ```
 关键路径：#878 ✅已关闭 → **#847** → #848 → #849(剩余) → #850 → #852 → #866
                                        └→ #869 → (锁定协议)
-解锁后：  #868 / #877（epic 关闭即解锁）
+已交付：  #877 ✅（PR #953）· #946 🟡 shadow first slice（PR #953）
+解锁后：  #868（epic 关闭即解锁）
 平行：    #867 / #871（任意时间插入）
 延后：    #870
 ```

--- a/docs/v2/ITERATION-NEXT.md
+++ b/docs/v2/ITERATION-NEXT.md
@@ -5,6 +5,8 @@
 > **前置完成**: Wave 1 链首 #847/#848/#850/#852/#866 已合并（PR #924）· #878 epic 已关闭
 > **范围决策**: 核心（#869 + #877）· 快速收尾（#927）
 > **依据**: `docs/v2/IMPLEMENTATION-STATUS-AND-PLAN.md` 四收窄与刻意延后决策
+>
+> **执行状态（2026-08-05 更新）**: #927 ✅ closed（docs patrol）· #869 ✅ closed（canonical schema + cross-SDK conformance）· #877 ✅ 已由 PR #953 交付（待合并关闭）· 同 PR 追加交付 #946 EffectiveRuntimePlan shadow first slice（依据 [Runtime Operations 下一迭代详细设计](../superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md)，#946 为本迭代范围追加项）
 
 ---
 
@@ -49,9 +51,9 @@ Day 1-3 #877 fence escape hatch（与 #869 可并行：fence_created_at + 时间
 
 ## 四、验收门禁（Definition of Done）
 
-- [ ] #927: `reference/admin-api.md` 补全 2 个端点；`make docs-build` 绿（62 篇无断链）。
-- [ ] #869: 一个 corpus 被 Go/TS/Python/Java 测试消费；runtime 事件覆盖；未知加性 kind 安全可忽略；field/tag drift 失败 CI 且 diff 可读；生成确定性强；协议 + SDK 文档更新。
-- [ ] #877: fenced session 不超过配置最大存活时间（默认 30min 可调）；force-clear 设 `unknown` + 独立 reason（`FENCE_FORCE_CLEARED` / `FENCE_ADMIN_CLEARED`）；不重投原始输入；admin 覆盖走现有 Bearer+scope 鉴权 + 审计日志；force-clear 发射 `runtime.execution.failed` 事件；测试覆盖自动清除、手动清除、审计、事件发射、清除后接受新输入。
+- [x] #927: `reference/admin-api.md` 补全 2 个端点；`make docs-build` 绿（62 篇无断链）。
+- [x] #869: 一个 corpus 被 Go/TS/Python/Java 测试消费；runtime 事件覆盖；未知加性 kind 安全可忽略；field/tag drift 失败 CI 且 diff 可读；生成确定性强；协议 + SDK 文档更新。
+- [x] #877: 按 [下一迭代详细设计](../superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md) §5 交付——原规划的时间界 force-clear 被 spec 收窄为 **operator-only 决策**（fence 不自动过期，避免把未知执行悄悄放行）：fence 持久化（`fence_created_at`/`fence_version`）；resolve/abandon 以 fence_version 为条件（冲突 409，不自动重试、不重投原始输入、不伪装成功）；Bearer + `runtime:*` scope 鉴权 + `user_activity`/slog 双审计；abandon 置 `failed`（OPERATOR_ABANDONED）并发射 `runtime.execution.failed` 事件；CLI 只走 Admin API；测试覆盖三重失败、晚到收敛、跨实例竞态、审计与权限。
 - [ ] 每个 PR：`make check` + `make docs-build` 通过。
 - [ ] 迭代末：#869/#877/#927 关闭，CI 绿。
 

--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -60,10 +60,12 @@ HotPlex 2.0 是 **self-hosted Agent Runtime Gateway**：
 | Session | `CREATED/RUNNING/IDLE/TERMINATED/DELETED` 状态机，SQLite/PostgreSQL 持久化，用户与 workspace 绑定 | 已交付 |
 | Worker | `claude_code`、`opencode_server`、`codex_cli`、`acp` 注册式适配器 | 已交付 |
 | AgentSpec | config、init metadata、workspace 和 worker 选项的只读归一化模型 | 已交付，[#847](https://github.com/hrygo/hotplex/issues/847) |
+| EffectiveRuntimePlan | desired-state plan 的 redacted 投影 + canonical hash；WS/REST 影子解析、Admin/doctor 只读路径（dispatch 仍以 legacy 参数为准） | shadow first slice 已交付，[#946](https://github.com/hrygo/hotplex/issues/946) |
 | AgentIdentity | identity 贯穿 session context、runtime metadata、audit 和 trace | 已交付，[#848](https://github.com/hrygo/hotplex/issues/848) |
 | AEP | `pkg/events` 是唯一 wire contract；Envelope、Metadata、OwnerID 和最小 `runtime.execution.*` 事件可用 | 已交付基线；完整 runtime observability 仍由 [#849](https://github.com/hrygo/hotplex/issues/849) 跟踪 |
 | Event Store | inbound/outbound 事件持久化、turn 聚合、崩溃/超时 synthetic turn | 已交付 |
 | Durable Ingress / Execution | input payload 指纹、owner instance、lease、delivery/runtime 状态分离、single-active gate、`SESSION_BUSY`、ambiguity fence、late convergence、有界 repairer | 已交付，[#878](https://github.com/hrygo/hotplex/issues/878) |
+| Runtime Operations | fenced execution operator escape hatch：`fences list` / `resolve` / `abandon`，`fence_version` 条件并发保护（409 冲突）、审计（actor/reason/evidence_ref）、Admin API + CLI + doctor 检查 | 已交付，[#877](https://github.com/hrygo/hotplex/issues/877) |
 | RuntimeContext | 从 eventstore、turns、worker session 和 workspace metadata 读取上下文的持久化接口 | 已交付，[#852](https://github.com/hrygo/hotplex/issues/852) |
 | Observability | OpenTelemetry bootstrap、runtime spans、Prometheus worker/session/gateway 指标 | 已交付，[#850](https://github.com/hrygo/hotplex/issues/850) |
 | Security / Audit | API key、cookie admin fallback、workspace owner 校验、tool/user/admin audit、链式完整性校验 | 已交付 |
@@ -115,6 +117,7 @@ Reconciliation / Repair / Fence / Operator Action
 ### 当前事实
 
 - AgentSpec、AgentIdentity、RuntimeContext 和 runtime spans 已交付；
+- #946 shadow first slice 已交付：`EffectiveRuntimePlan` resolver（redacted view + canonical hash + fail-closed blocked codes）在 WS/REST 入口影子运行，Admin `runtime-plan` 与 doctor `runtime.effective_plan` 提供只读投影；dispatch 仍以 legacy SessionStartParams 为准；
 - AEP 已具备最小 execution metadata/events，完整 runtime observability 契约仍未完成；
 - 四类 Worker 继续使用现有 `worker.Register()` 和 adapter contract。
 
@@ -138,6 +141,7 @@ Reconciliation / Repair / Fence / Operator Action
 ### 当前事实
 
 - #878 已交付 single-active gate、owner lease、delivery/runtime 分离、ambiguity fence、late convergence 和有界 repairer；
+- #877 已交付 fenced execution 的 operator escape hatch：fence 持久化（`fence_created_at`/`fence_version`）、条件决策（resolve/abandon，跨实例 409 冲突）、审计、Admin API、CLI 与 doctor 检查；fence 永不伪装成功、不自动重投；
 - Cron/platform delivery 仍依赖进程内 retry 路径，不能作为重启和多实例后的最终事实源。
 
 ### 冻结契约
@@ -160,6 +164,7 @@ Reconciliation / Repair / Fence / Operator Action
 ### 当前事实
 
 - RuntimeContext、eventstore、execution、audit、trace 和 metrics 已提供运营事实基础；
+- fence operator action（#877）已按统一 authorization（Bearer + `runtime:*` scope）、redaction（无密列表投影）和 audit（`user_activity` + slog 双记录）交付，是本 stage "diagnostics、reconciliation 和 operator action 统一约束" 的第一个落地切片；
 - 当前 admin/runtime UI 尚未形成统一 execution timeline。
 
 ### 冻结契约

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hrygo/hotplex/internal/audit"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/eventstore"
+	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/skills"
@@ -32,6 +33,11 @@ const (
 	ScopeConfigRead   = "config:read"
 	ScopeAdminRead    = "admin:read"
 	ScopeAdminWrite   = "admin:write"
+	// Runtime operation scopes (#877/#946): fence inspection/actions and
+	// effective runtime plan reads. Granted per-token via admin.token_scopes;
+	// never included in the minimal default scope set.
+	ScopeRuntimeRead  = "runtime:read"
+	ScopeRuntimeWrite = "runtime:write"
 )
 
 // DBExecutor covers the sql.DB methods used by apiKeyUserStore.
@@ -77,6 +83,22 @@ type TurnStatsProvider interface {
 	TurnStats(ctx context.Context, sessionID string) (*eventstore.TurnStats, error)
 	// LatestSeq returns the max persisted event seq for a session (issue #879 #5).
 	LatestSeq(ctx context.Context, sessionID string) (int64, error)
+}
+
+// RuntimeExecutionProvider is the narrow execution-store view used by the
+// runtime operations admin endpoints (#877). Injected from cmd/hotplex so
+// admin stays decoupled from the gateway; errors must preserve
+// execution.ErrNotFound / execution.ErrFenceConflict for status mapping.
+type RuntimeExecutionProvider interface {
+	ListFences(ctx context.Context, sessionID string, limit, offset int) ([]*execution.Record, error)
+	ApplyFenceDecision(ctx context.Context, request execution.FenceActionRequest) (*execution.Record, error)
+}
+
+// RuntimeEventNotifier emits the additive runtime.execution.failed event for
+// an operator abandon (#877). Best-effort: fenced sessions usually have no
+// connected clients, and the store write is already durable when this fires.
+type RuntimeEventNotifier interface {
+	NotifyExecutionAbandoned(ctx context.Context, sessionID, executionID string)
 }
 
 type DebugSessionSnapshot struct {
@@ -129,9 +151,11 @@ type AdminAPI struct {
 	cookieAuth       *security.CookieAuth           // Optional: enables cookie-session fallback (issue #788 A2)
 	idp              *security.LocalAccountProvider // Optional: paired with cookieAuth
 	startedAt        time.Time
-	activityService  *ActivityService // Optional: enables /admin/activity + /admin/users/{id}/activity (issue #833)
-	auditCollector   *audit.Collector // Optional: emits system.audit_export meta-audit rows (issue #833)
-	skillsLocator    *skills.Locator  // Optional: enables /admin/api/skills global skill management (issue #910)
+	activityService  *ActivityService         // Optional: enables /admin/activity + /admin/users/{id}/activity (issue #833)
+	auditCollector   *audit.Collector         // Optional: emits system.audit_export meta-audit rows (issue #833)
+	skillsLocator    *skills.Locator          // Optional: enables /admin/api/skills global skill management (issue #910)
+	runtimeExec      RuntimeExecutionProvider // Optional: enables /admin/executions fence endpoints (#877); nil → 503
+	runtimeNotifier  RuntimeEventNotifier     // Optional: emits runtime.execution.failed on abandon (#877)
 }
 
 type Deps struct {
@@ -200,6 +224,14 @@ func New(deps Deps) *AdminAPI {
 // SetSkillsLocator 注入 skill 定位器，启用 /admin/api/skills 全局 skill 管理
 // （issue #910）。nil 时 skill 端点返回 503。
 func (a *AdminAPI) SetSkillsLocator(l *skills.Locator) { a.skillsLocator = l }
+
+// SetRuntimeExecution injects the execution-store provider that backs the
+// operator fence endpoints (#877). nil-safe: fence endpoints return 503 until
+// wired. The optional notifier emits runtime.execution.failed on abandon.
+func (a *AdminAPI) SetRuntimeExecution(p RuntimeExecutionProvider, n RuntimeEventNotifier) {
+	a.runtimeExec = p
+	a.runtimeNotifier = n
+}
 
 func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -294,6 +326,7 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 			}
 			actor = "admin-token"
 			ctx := context.WithValue(r.Context(), scopeContextKey{}, scopes)
+			ctx = context.WithValue(ctx, actorContextKey{}, actor)
 			next.ServeHTTP(sw, r.WithContext(ctx))
 			return
 		}
@@ -330,8 +363,10 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 				ScopeAdminWrite, ScopeAdminRead,
 				ScopeSessionRead, ScopeSessionWrite, ScopeSessionKill,
 				ScopeStatsRead, ScopeHealthRead, ScopeConfigRead,
+				ScopeRuntimeRead, ScopeRuntimeWrite,
 			}
 			ctx := context.WithValue(r.Context(), scopeContextKey{}, scopes)
+			ctx = context.WithValue(ctx, actorContextKey{}, actor)
 			next.ServeHTTP(sw, r.WithContext(ctx))
 			return
 		}

--- a/internal/admin/audit.go
+++ b/internal/admin/audit.go
@@ -44,6 +44,9 @@ const (
 	AuditSkillCreate                   = "skill.create" // issue #910 global skill install
 	AuditSkillUpdate                   = "skill.update" // ?replace=true 覆盖
 	AuditSkillDelete                   = "skill.delete"
+	AuditRuntimeFenceAction            = "runtime.fence.action"  // #877 decision-agnostic middleware line
+	AuditRuntimeFenceResolve           = "runtime.fence.resolve" // #877 specific decision (user_activity)
+	AuditRuntimeFenceAbandon           = "runtime.fence.abandon" // #877 specific decision (user_activity)
 
 	// AuditResult* — stable "result" field values. Reuse instead of literals so
 	// dashboard filters stay correct (issue #788 review P3).
@@ -111,6 +114,8 @@ func adminActionFor(method, path string) string {
 		return AuditSessionTerminate
 	case strings.HasSuffix(path, "/run") && strings.Contains(path, "/cron/"):
 		return AuditCronTrigger
+	case strings.Contains(path, "/fence-action"):
+		return AuditRuntimeFenceAction
 	case strings.Contains(path, "/config/rollback"):
 		return AuditConfigRollback
 	case strings.Contains(path, "/config/validate"):
@@ -271,12 +276,12 @@ func (a *AdminAPI) enqueueAdminActivity(r *http.Request, status int, actor, slog
 	enqueueAdminActivity(a.auditCollector, r, status, actor, slogAction)
 }
 
-func enqueueAdminActivity(c *audit.Collector, r *http.Request, status int, actor, slogAction string) {
-	if c == nil {
-		return
-	}
-	userID := actor
-	userIDType := audit.UserIDTypeRegistered // admin cookie → users.id
+// actorIdentity maps an admin actor string to the user_activity identity pair.
+// Shared by the middleware dual-write and handler-specific audit rows (#877)
+// so both namespaces agree on who acted.
+func actorIdentity(actor string) (userID, userIDType string) {
+	userID = actor
+	userIDType = audit.UserIDTypeRegistered // admin cookie → users.id
 	switch actor {
 	case "", "anonymous":
 		userID = audit.AnonymousUserID
@@ -284,6 +289,14 @@ func enqueueAdminActivity(c *audit.Collector, r *http.Request, status int, actor
 	case "admin-token":
 		userIDType = audit.UserIDTypeSystem
 	}
+	return userID, userIDType
+}
+
+func enqueueAdminActivity(c *audit.Collector, r *http.Request, status int, actor, slogAction string) {
+	if c == nil {
+		return
+	}
+	userID, userIDType := actorIdentity(actor)
 	outcome := audit.OutcomeSuccess
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
 		outcome = audit.OutcomeDenied

--- a/internal/admin/fences.go
+++ b/internal/admin/fences.go
@@ -1,0 +1,306 @@
+package admin
+
+// Operator fence endpoints (#877). Fenced executions block fresh input until
+// an operator resolves or abandons them; both decisions are conditional on the
+// fence_version fencing token, so concurrent operators (or a gateway restart
+// between inspect and action) conflict with 409 instead of double-migrating.
+//
+// Security contract:
+//   - actor comes from the auth context (ActorFromRequest), never the body
+//   - request bodies carry only decision, fence version, and bounded
+//     reason/evidence_ref text; prompts, payload content, and credentials are
+//     never accepted, stored, or echoed here
+//   - responses expose the secret-free FenceListItem projection only
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/hrygo/hotplex/internal/audit"
+	"github.com/hrygo/hotplex/internal/execution"
+	"github.com/hrygo/hotplex/internal/observability"
+	"github.com/hrygo/hotplex/internal/web"
+)
+
+const (
+	// fenceListDefaultLimit / fenceListMaxLimit bound the operator fence list
+	// (spec §5.3): default 100, hard cap 500 — tighter than the generic
+	// web.ParsePagination cap because fenced rows are rare by construction.
+	fenceListDefaultLimit = 100
+	fenceListMaxLimit     = 500
+
+	fenceReasonMaxLen   = 512 // operator justification, bounded audit detail
+	fenceEvidenceMaxLen = 256 // pointer (ticket/run ref), never inline content
+)
+
+// FenceListItem is the wire shape of a fenced execution. Deliberately narrow:
+// no payload hash, no error detail, nothing derived from user content.
+type FenceListItem struct {
+	ExecutionID    string `json:"execution_id"`
+	SessionID      string `json:"session_id"`
+	DeliveryStatus string `json:"delivery_status"`
+	RuntimeStatus  string `json:"runtime_status"`
+	FenceReason    string `json:"fence_reason"`
+	FenceVersion   int64  `json:"fence_version"`
+	FenceCreatedAt *int64 `json:"fence_created_at,omitempty"`
+	UpdatedAt      int64  `json:"updated_at"`
+}
+
+func fenceListItem(rec *execution.Record) FenceListItem {
+	return FenceListItem{
+		ExecutionID:    rec.ExecutionID,
+		SessionID:      rec.SessionID,
+		DeliveryStatus: string(rec.Status),
+		RuntimeStatus:  string(rec.RuntimeStatus),
+		FenceReason:    rec.FenceReason,
+		FenceVersion:   rec.FenceVersion,
+		FenceCreatedAt: rec.FenceCreatedAt,
+		UpdatedAt:      rec.UpdatedAt,
+	}
+}
+
+func parseFencePagination(r *http.Request) (limit, offset int) {
+	limit = fenceListDefaultLimit
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 {
+		limit = l
+	}
+	if limit > fenceListMaxLimit {
+		limit = fenceListMaxLimit
+	}
+	if o, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && o >= 0 {
+		offset = o
+	}
+	return limit, offset
+}
+
+// HandleListFences lists currently fenced executions for operator inspection.
+//
+// @Summary      List fenced executions
+// @Description  Lists executions whose runtime ended ambiguous and raised a fence. Requires runtime:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        session_id  query    string  false  "Filter by session ID"
+// @Param        limit       query    int     false  "Max results (default 100, max 500)"
+// @Param        offset      query    int     false  "Pagination offset"
+// @Success      200  {object}  map[string]any  "fences list"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need runtime:read"
+// @Failure      503  {object}  ErrorResponse  "Execution store not configured"
+// @Router       /admin/executions/fences [get]
+func (a *AdminAPI) HandleListFences(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeRuntimeRead) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need runtime:read")
+		return
+	}
+	if a.runtimeExec == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "execution store not configured")
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+	limit, offset := parseFencePagination(r)
+
+	records, err := a.runtimeExec.ListFences(r.Context(), sessionID, limit, offset)
+	if err != nil {
+		a.log.Error("admin: list fences", "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to list fences")
+		return
+	}
+
+	items := make([]FenceListItem, 0, len(records))
+	for _, rec := range records {
+		items = append(items, fenceListItem(rec))
+	}
+	respondJSON(w, map[string]any{
+		"fences": items,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+// fenceActionBody is the operator decision payload. Bounded free-text fields
+// only; the store never persists them (Admin audit layer only).
+type fenceActionBody struct {
+	Decision             string `json:"decision"`
+	ExpectedFenceVersion *int64 `json:"expected_fence_version"`
+	Reason               string `json:"reason"`
+	EvidenceRef          string `json:"evidence_ref"`
+}
+
+// HandleFenceAction applies resolve/abandon to a fenced execution.
+//
+// @Summary      Apply operator fence action
+// @Description  Resolves (clears fence, keeps runtime unknown) or abandons (clears fence, fails runtime with OPERATOR_ABANDONED) a fenced execution. Conditional on expected_fence_version; conflicts return 409. Requires runtime:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id    path   string           true  "Execution ID"
+// @Param        body  body   fenceActionBody  true  "Operator decision"
+// @Success      200   {object}  map[string]any  "Applied decision and updated execution fact"
+// @Failure      400   {object}  ErrorResponse  "Invalid decision, fence version, reason, or evidence_ref"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need runtime:write"
+// @Failure      404   {object}  ErrorResponse  "Execution not found"
+// @Failure      409   {object}  ErrorResponse  "Fence version conflict: re-inspect before retrying"
+// @Failure      503   {object}  ErrorResponse  "Execution store not configured or timed out"
+// @Router       /admin/executions/{id}/fence-action [post]
+func (a *AdminAPI) HandleFenceAction(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeRuntimeWrite) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need runtime:write")
+		return
+	}
+	if a.runtimeExec == nil {
+		web.WriteAppError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "execution store not configured")
+		return
+	}
+
+	executionID := strings.TrimSpace(r.PathValue("id"))
+	if executionID == "" {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "execution id is required")
+		return
+	}
+
+	var body fenceActionBody
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&body); err != nil {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "invalid JSON body")
+		return
+	}
+
+	decision := execution.FenceDecision(body.Decision)
+	if decision != execution.FenceDecisionResolve && decision != execution.FenceDecisionAbandon {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "decision must be resolve or abandon")
+		return
+	}
+	if body.ExpectedFenceVersion == nil || *body.ExpectedFenceVersion < 0 {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "expected_fence_version is required and must be >= 0")
+		return
+	}
+	reason := strings.TrimSpace(body.Reason)
+	if reason == "" || len(reason) > fenceReasonMaxLen {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "reason must be 1-512 characters")
+		return
+	}
+	evidenceRef := strings.TrimSpace(body.EvidenceRef)
+	if len(evidenceRef) > fenceEvidenceMaxLen {
+		web.WriteAppError(w, http.StatusBadRequest, "BAD_REQUEST", "evidence_ref must be at most 256 characters")
+		return
+	}
+
+	updated, err := a.runtimeExec.ApplyFenceDecision(r.Context(), execution.FenceActionRequest{
+		ExecutionID:          executionID,
+		ExpectedFenceVersion: *body.ExpectedFenceVersion,
+		Decision:             decision,
+	})
+	a.auditFenceAction(r, executionID, decision, *body.ExpectedFenceVersion, reason, evidenceRef, err)
+	if err != nil {
+		a.writeFenceActionError(w, r, decision, err)
+		return
+	}
+
+	observability.RuntimeFenceActions().Add(r.Context(), 1, metric.WithAttributes(
+		attribute.String("decision", string(decision)),
+		attribute.String("result", "ok"),
+	))
+	a.log.Info("admin: fence action applied",
+		"decision", string(decision),
+		"execution_id", executionID,
+		"session_id", updated.SessionID,
+		"fence_version", updated.FenceVersion,
+		"actor", ActorFromRequest(r),
+	)
+
+	// Abandon emits the additive runtime.execution.failed event so connected
+	// clients observe the terminal state. Best-effort: the store write is
+	// already durable, and fenced sessions usually have no live connections.
+	if decision == execution.FenceDecisionAbandon && a.runtimeNotifier != nil {
+		a.runtimeNotifier.NotifyExecutionAbandoned(r.Context(), updated.SessionID, updated.ExecutionID)
+	}
+
+	respondJSON(w, map[string]any{
+		"decision":  string(decision),
+		"execution": fenceListItem(updated),
+	})
+}
+
+// writeFenceActionError maps store errors to operator-actionable statuses and
+// records the low-cardinality outcome metrics (#877 spec §11).
+func (a *AdminAPI) writeFenceActionError(w http.ResponseWriter, r *http.Request, decision execution.FenceDecision, err error) {
+	status := http.StatusInternalServerError
+	code := "INTERNAL"
+	msg := "failed to apply fence action"
+	result := "error"
+	switch {
+	case errors.Is(err, execution.ErrNotFound):
+		status, code, msg = http.StatusNotFound, "FENCE_NOT_FOUND", "execution not found"
+	case errors.Is(err, execution.ErrFenceConflict):
+		status, code, msg = http.StatusConflict, "FENCE_CONFLICT",
+			"fence version conflict: re-inspect the fence and retry deliberately"
+		result = "conflict"
+	case errors.Is(err, context.DeadlineExceeded):
+		status, code, msg = http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "execution store timeout"
+	}
+
+	observability.RuntimeFenceActions().Add(r.Context(), 1, metric.WithAttributes(
+		attribute.String("decision", string(decision)),
+		attribute.String("result", result),
+	))
+	if result == "conflict" {
+		observability.RuntimeFenceConflicts().Add(r.Context(), 1)
+	}
+	if status >= 500 {
+		a.log.Error("admin: fence action failed", "err", err, "decision", string(decision))
+	} else {
+		a.log.Warn("admin: fence action rejected", "err", err, "decision", string(decision))
+	}
+	web.WriteAppError(w, status, code, msg)
+}
+
+// auditFenceAction records the operator decision into the tamper-evident
+// user_activity table with bounded rationale detail (#877). The Middleware
+// defer already emits the decision-agnostic admin_audit slog line
+// (runtime.fence.action); this row carries the specific action plus
+// reason/evidence_ref, which never reach the execution store.
+func (a *AdminAPI) auditFenceAction(r *http.Request, executionID string, decision execution.FenceDecision, expectedVersion int64, reason, evidenceRef string, applyErr error) {
+	if a.auditCollector == nil {
+		return
+	}
+	action := AuditRuntimeFenceResolve
+	if decision == execution.FenceDecisionAbandon {
+		action = AuditRuntimeFenceAbandon
+	}
+	outcome := audit.OutcomeSuccess
+	result := "ok"
+	if applyErr != nil {
+		outcome = audit.OutcomeFailure
+		result = "rejected"
+	}
+	detail, _ := json.Marshal(map[string]any{
+		"execution_id":           executionID,
+		"expected_fence_version": expectedVersion,
+		"reason":                 reason,
+		"evidence_ref":           evidenceRef,
+		"result":                 result,
+	})
+	userID, userIDType := actorIdentity(ActorFromRequest(r))
+	_ = a.auditCollector.Enqueue(context.Background(), &audit.UserActivity{
+		Ts:           time.Now().UnixMilli(),
+		UserID:       userID,
+		UserIDType:   userIDType,
+		Platform:     audit.PlatformAdmin,
+		Action:       "admin." + action,
+		ResourceType: "runtime",
+		Outcome:      outcome,
+		DetailJSON:   string(detail),
+		IP:           clientIP(r),
+		UserAgent:    r.UserAgent(),
+	})
+}

--- a/internal/admin/fences_test.go
+++ b/internal/admin/fences_test.go
@@ -1,0 +1,307 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/execution"
+)
+
+// --- Fence mocks ---
+
+type mockRuntimeExec struct {
+	listFn  func(ctx context.Context, sessionID string, limit, offset int) ([]*execution.Record, error)
+	applyFn func(ctx context.Context, req execution.FenceActionRequest) (*execution.Record, error)
+}
+
+func (m *mockRuntimeExec) ListFences(ctx context.Context, sessionID string, limit, offset int) ([]*execution.Record, error) {
+	if m.listFn != nil {
+		return m.listFn(ctx, sessionID, limit, offset)
+	}
+	return nil, nil
+}
+
+func (m *mockRuntimeExec) ApplyFenceDecision(ctx context.Context, req execution.FenceActionRequest) (*execution.Record, error) {
+	if m.applyFn != nil {
+		return m.applyFn(ctx, req)
+	}
+	return nil, execution.ErrNotFound
+}
+
+type mockRuntimeNotifier struct {
+	calls []string // "sessionID/executionID" per call
+}
+
+func (m *mockRuntimeNotifier) NotifyExecutionAbandoned(_ context.Context, sessionID, executionID string) {
+	m.calls = append(m.calls, sessionID+"/"+executionID)
+}
+
+func fencedRecord() *execution.Record {
+	createdAt := int64(1722800000000)
+	return &execution.Record{
+		ExecutionID:    "exec-1",
+		SessionID:      "sess-1",
+		Status:         execution.StatusUnknown,
+		RuntimeStatus:  execution.RuntimeUnknown,
+		FenceReason:    "GATEWAY_LEASE_EXPIRED",
+		FenceVersion:   3,
+		FenceCreatedAt: &createdAt,
+		UpdatedAt:      1722800001000,
+	}
+}
+
+// --- ListFences ---
+
+func TestHandleListFences_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{}, nil)
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodGet, "/admin/executions/fences", nil), ScopeSessionRead)
+
+	api.HandleListFences(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleListFences_ProviderNotConfigured(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI() // no SetRuntimeExecution
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodGet, "/admin/executions/fences", nil), ScopeRuntimeRead)
+
+	api.HandleListFences(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleListFences_Success(t *testing.T) {
+	t.Parallel()
+	var gotSession string
+	var gotLimit, gotOffset int
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{
+		listFn: func(_ context.Context, sessionID string, limit, offset int) ([]*execution.Record, error) {
+			gotSession, gotLimit, gotOffset = sessionID, limit, offset
+			return []*execution.Record{fencedRecord()}, nil
+		},
+	}, nil)
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodGet, "/admin/executions/fences?session_id=sess-1&limit=999&offset=7", nil), ScopeRuntimeRead)
+
+	api.HandleListFences(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "sess-1", gotSession)
+	require.Equal(t, fenceListMaxLimit, gotLimit, "limit must clamp to 500")
+	require.Equal(t, 7, gotOffset)
+
+	var resp struct {
+		Fences []FenceListItem `json:"fences"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Fences, 1)
+	item := resp.Fences[0]
+	require.Equal(t, "exec-1", item.ExecutionID)
+	require.Equal(t, "sess-1", item.SessionID)
+	require.Equal(t, string(execution.StatusUnknown), item.DeliveryStatus)
+	require.Equal(t, string(execution.RuntimeUnknown), item.RuntimeStatus)
+	require.Equal(t, "GATEWAY_LEASE_EXPIRED", item.FenceReason)
+	require.Equal(t, int64(3), item.FenceVersion)
+
+	// Secret-free projection: no payload hash or worker error fields.
+	require.NotContains(t, w.Body.String(), "payload_hash")
+	require.NotContains(t, w.Body.String(), "error_detail")
+}
+
+func TestHandleListFences_AdminWriteImpliesRuntimeRead(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{}, nil)
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodGet, "/admin/executions/fences", nil), ScopeAdminWrite)
+
+	api.HandleListFences(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, "admin:write must imply runtime:read for existing admin tokens")
+}
+
+// --- FenceAction validation ---
+
+func TestHandleFenceAction_Forbidden(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{}, nil)
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action", strings.NewReader("{}")), ScopeRuntimeRead)
+	r.SetPathValue("id", "exec-1")
+
+	api.HandleFenceAction(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandleFenceAction_ProviderNotConfigured(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action", strings.NewReader("{}")), ScopeRuntimeWrite)
+	r.SetPathValue("id", "exec-1")
+
+	api.HandleFenceAction(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleFenceAction_BadRequests(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"invalid json", "{not-json"},
+		{"invalid decision", `{"decision":"force","expected_fence_version":3,"reason":"r"}`},
+		{"missing version", `{"decision":"resolve","reason":"r"}`},
+		{"negative version", `{"decision":"resolve","expected_fence_version":-1,"reason":"r"}`},
+		{"empty reason", `{"decision":"resolve","expected_fence_version":3,"reason":"   "}`},
+		{"reason too long", fmt.Sprintf(`{"decision":"resolve","expected_fence_version":3,"reason":"%s"}`, strings.Repeat("x", fenceReasonMaxLen+1))},
+		{"evidence too long", fmt.Sprintf(`{"decision":"resolve","expected_fence_version":3,"reason":"r","evidence_ref":"%s"}`, strings.Repeat("e", fenceEvidenceMaxLen+1))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			api := newTestAPI()
+			api.SetRuntimeExecution(&mockRuntimeExec{
+				applyFn: func(context.Context, execution.FenceActionRequest) (*execution.Record, error) {
+					t.Fatal("store must not be reached on validation failure")
+					return nil, nil
+				},
+			}, nil)
+			w := httptest.NewRecorder()
+			r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action", strings.NewReader(tc.body)), ScopeRuntimeWrite)
+			r.SetPathValue("id", "exec-1")
+
+			api.HandleFenceAction(w, r)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// --- FenceAction outcomes ---
+
+func fenceActionRequest(t *testing.T, decision, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	notifier := &mockRuntimeNotifier{}
+	rec := fencedRecord()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{
+		applyFn: func(_ context.Context, req execution.FenceActionRequest) (*execution.Record, error) {
+			require.Equal(t, "exec-1", req.ExecutionID)
+			require.Equal(t, int64(3), req.ExpectedFenceVersion)
+			require.Equal(t, execution.FenceDecision(decision), req.Decision)
+			if decision == string(execution.FenceDecisionAbandon) {
+				rec.RuntimeStatus = execution.RuntimeFailed
+				rec.RuntimeErrorCode = execution.RuntimeErrorCodeOperatorAbandoned
+			}
+			rec.FenceReason = ""
+			return rec, nil
+		},
+	}, notifier)
+
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action", strings.NewReader(body)), ScopeRuntimeWrite)
+	r.SetPathValue("id", "exec-1")
+	api.HandleFenceAction(w, r)
+	return w
+}
+
+func TestHandleFenceAction_ResolveSuccess(t *testing.T) {
+	t.Parallel()
+	w := fenceActionRequest(t, "resolve", `{"decision":"resolve","expected_fence_version":3,"reason":"worker recovered","evidence_ref":"ticket-1"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Decision  string        `json:"decision"`
+		Execution FenceListItem `json:"execution"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "resolve", resp.Decision)
+	require.Equal(t, "exec-1", resp.Execution.ExecutionID)
+	require.Empty(t, resp.Execution.FenceReason)
+	require.Equal(t, string(execution.RuntimeUnknown), resp.Execution.RuntimeStatus)
+}
+
+func TestHandleFenceAction_AbandonSuccess(t *testing.T) {
+	t.Parallel()
+	notifier := &mockRuntimeNotifier{}
+	rec := fencedRecord()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{
+		applyFn: func(_ context.Context, req execution.FenceActionRequest) (*execution.Record, error) {
+			rec.RuntimeStatus = execution.RuntimeFailed
+			rec.RuntimeErrorCode = execution.RuntimeErrorCodeOperatorAbandoned
+			rec.FenceReason = ""
+			return rec, nil
+		},
+	}, notifier)
+
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action",
+		strings.NewReader(`{"decision":"abandon","expected_fence_version":3,"reason":"operator decision"}`)), ScopeRuntimeWrite)
+	r.SetPathValue("id", "exec-1")
+	api.HandleFenceAction(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"sess-1/exec-1"}, notifier.calls, "abandon must emit the runtime.execution.failed event")
+	var resp struct {
+		Decision  string        `json:"decision"`
+		Execution FenceListItem `json:"execution"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "abandon", resp.Decision)
+	require.Equal(t, string(execution.RuntimeFailed), resp.Execution.RuntimeStatus)
+}
+
+func TestHandleFenceAction_Conflict(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{
+		applyFn: func(context.Context, execution.FenceActionRequest) (*execution.Record, error) {
+			return nil, fmt.Errorf("fence already cleared: %w", execution.ErrFenceConflict)
+		},
+	}, &mockRuntimeNotifier{})
+
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/exec-1/fence-action",
+		strings.NewReader(`{"decision":"resolve","expected_fence_version":2,"reason":"r"}`)), ScopeRuntimeWrite)
+	r.SetPathValue("id", "exec-1")
+	api.HandleFenceAction(w, r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "FENCE_CONFLICT")
+	require.Contains(t, w.Body.String(), "re-inspect", "409 must direct the operator to re-inspect, not blindly retry")
+}
+
+func TestHandleFenceAction_NotFound(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	api.SetRuntimeExecution(&mockRuntimeExec{}, nil)
+
+	w := httptest.NewRecorder()
+	r := withScope(httptest.NewRequest(http.MethodPost, "/admin/executions/missing/fence-action",
+		strings.NewReader(`{"decision":"resolve","expected_fence_version":1,"reason":"r"}`)), ScopeRuntimeWrite)
+	r.SetPathValue("id", "missing")
+	api.HandleFenceAction(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "FENCE_NOT_FOUND")
+}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -12,6 +12,11 @@ import (
 
 type scopeContextKey struct{}
 
+// actorContextKey carries the authenticated admin actor resolved by the
+// Middleware ("admin-token" for Bearer, uid for cookie fallback). Handlers
+// must read the actor from here — never from client-supplied fields (#877).
+type actorContextKey struct{}
+
 func getScopes(r *http.Request) []string {
 	if scopes, ok := r.Context().Value(scopeContextKey{}).([]string); ok {
 		return scopes
@@ -19,9 +24,22 @@ func getScopes(r *http.Request) []string {
 	return nil
 }
 
+// ActorFromRequest returns the authenticated admin actor for audit trails.
+// Falls back to "anonymous" when auth never resolved (pre-auth failures).
+func ActorFromRequest(r *http.Request) string {
+	if actor, ok := r.Context().Value(actorContextKey{}).(string); ok && actor != "" {
+		return actor
+	}
+	return "anonymous"
+}
+
 // scopeImplies maps a scope to the lower-privilege scopes it grants.
+// admin:write implies the runtime scopes (#877): fence resolve/abandon and
+// runtime-plan reads are admin-tier operations, so tokens holding the top
+// scope gain them without a config change; dedicated tokens can still be
+// granted runtime:read/runtime:write individually via admin.token_scopes.
 var scopeImplies = map[string][]string{
-	ScopeAdminWrite: {ScopeAdminRead},
+	ScopeAdminWrite: {ScopeAdminRead, ScopeRuntimeRead, ScopeRuntimeWrite},
 	ScopeAdminRead:  {ScopeConfigRead},
 }
 

--- a/internal/admin/runtime_plan.go
+++ b/internal/admin/runtime_plan.go
@@ -1,0 +1,135 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/hrygo/hotplex/internal/agentspec"
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/observability"
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/web"
+)
+
+// RuntimePlanReport is the redacted wire shape of
+// GET /admin/sessions/{id}/runtime-plan (#946 spec §6.6): the desired-state
+// plan projection plus the observed bootstrap summary. It never carries
+// prompts, secrets, full commands, or raw worker errors.
+type RuntimePlanReport struct {
+	Plan     agentspec.EffectiveRuntimePlanView `json:"plan"`
+	Observed agentspec.ObservedSummary          `json:"observed"`
+}
+
+// HandleSessionRuntimePlan returns the redacted effective runtime plan for a
+// session: plan hash, worker type, permission/sandbox summary, observed
+// bootstrap state, warnings and blocked codes (#946 spec §6.6).
+//
+// Requires runtime:read AND session:read. The diagnostic projection is
+// computed on demand from the session's persisted facts and the live config —
+// no plan table, no second persisted truth (#946 spec §6.6).
+//
+// @Summary      Get session runtime plan
+// @Description  Returns the redacted desired-state runtime plan and observed bootstrap summary for a session. Requires runtime:read and session:read scopes.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Session ID"
+// @Success      200  {object}  RuntimePlanReport
+// @Failure      400  {object}  ErrorResponse  "Missing session ID"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need runtime:read and session:read"
+// @Failure      404  {object}  ErrorResponse  "Session not found"
+// @Failure      500  {object}  ErrorResponse  "Plan resolution failed"
+// @Router       /admin/sessions/{id}/runtime-plan [get]
+func (a *AdminAPI) HandleSessionRuntimePlan(w http.ResponseWriter, r *http.Request) {
+	if !hasScope(r, ScopeRuntimeRead) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need runtime:read")
+		return
+	}
+	if !hasScope(r, ScopeSessionRead) {
+		web.WriteAppError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "insufficient scope: need session:read")
+		return
+	}
+
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		web.WriteAppError(w, http.StatusBadRequest, "INVALID_REQUEST", "session id is required")
+		return
+	}
+
+	raw, err := a.sm.Get(r.Context(), id)
+	if err != nil {
+		if r.Context().Err() != nil {
+			web.WriteAppError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "request cancelled")
+			return
+		}
+		web.WriteAppError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+	si, ok := raw.(*session.SessionInfo)
+	if !ok || si == nil {
+		web.WriteAppError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+
+	var cfg *config.Config
+	if a.cfg != nil {
+		cfg = a.cfg.Get()
+	}
+	plan, err := buildSessionPlan(cfg, si)
+	if err != nil && !errors.Is(err, agentspec.ErrPlanBlocked) {
+		// A blocked plan is a valid diagnostic projection (its Blocked reasons
+		// are the payload); any other failure is an internal error.
+		a.log.Warn("admin: runtime plan resolution failed", "session_id", id, "err", err)
+		web.WriteAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to resolve runtime plan")
+		return
+	}
+
+	observed := observedSummaryFor(si)
+	observability.RuntimePlanObserved().Add(r.Context(), 1,
+		metric.WithAttributes(attribute.String("state", observed.State)))
+
+	respondJSON(w, RuntimePlanReport{Plan: plan.Redacted(), Observed: observed})
+}
+
+// buildSessionPlan reconstructs the desired-state plan from the session's
+// persisted facts plus the live config snapshot. The session's dispatched
+// worker type and tool whitelist enter as top-precedence init metadata; the
+// config chain below them mirrors the original resolution. Pure — no I/O.
+func buildSessionPlan(cfg *config.Config, si *session.SessionInfo) (agentspec.EffectiveRuntimePlan, error) {
+	in := agentspec.Input{
+		Cfg: cfg,
+		InitMeta: agentspec.InitMetadata{
+			WorkerType:   string(si.WorkerType),
+			AllowedTools: si.AllowedTools,
+		},
+		BotName:     si.BotName,
+		Platform:    si.Platform,
+		PlatformKey: si.PlatformKey,
+		UserID:      si.UserID,
+		WorkspaceID: si.WorkspaceID,
+	}
+	return (agentspec.Resolver{}).ResolvePlan(in)
+}
+
+// observedSummaryFor maps the session's verifiable facts onto the observed
+// bootstrap states (#946 spec §6.5). First slice: a Worker-reported
+// permission ceiling is declared (not independently enforced → never
+// "enforced"); an active session without a reported ceiling is unknown; a
+// session with only the plan is planned.
+func observedSummaryFor(si *session.SessionInfo) agentspec.ObservedSummary {
+	observed := agentspec.ObservedSummary{WorkerType: string(si.WorkerType)}
+	switch {
+	case si.PermissionCeiling != "":
+		observed.State = agentspec.ObservedDeclared
+		observed.PermissionCeiling = si.PermissionCeiling
+	case si.State.IsActive():
+		observed.State = agentspec.ObservedUnknown
+	default:
+		observed.State = agentspec.ObservedPlanned
+	}
+	return observed
+}

--- a/internal/admin/runtime_plan_test.go
+++ b/internal/admin/runtime_plan_test.go
@@ -1,0 +1,228 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/agentspec"
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+var runtimePlanHashRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+func runtimePlanRequest(id string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/admin/sessions/sess/runtime-plan", nil)
+	r.SetPathValue("id", id)
+	return withScope(r, ScopeRuntimeRead, ScopeSessionRead)
+}
+
+func TestHandleSessionRuntimePlan_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		scopes []string
+	}{
+		{"no scopes", nil},
+		{"missing runtime:read", []string{ScopeSessionRead}},
+		{"missing session:read", []string{ScopeRuntimeRead}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := newTestAPI()
+			w := httptest.NewRecorder()
+			r := withScope(httptest.NewRequest(http.MethodGet, "/admin/sessions/sess-1/runtime-plan", nil), tc.scopes...)
+			r.SetPathValue("id", "sess-1")
+
+			api.HandleSessionRuntimePlan(w, r)
+
+			require.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
+}
+
+func TestHandleSessionRuntimePlan_MissingID(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI()
+	w := httptest.NewRecorder()
+	r := runtimePlanRequest("   ")
+
+	api.HandleSessionRuntimePlan(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleSessionRuntimePlan_NotFound(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI() // default mockSessionManager returns ErrSessionNotFound
+	w := httptest.NewRecorder()
+	r := runtimePlanRequest("sess-missing")
+
+	api.HandleSessionRuntimePlan(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleSessionRuntimePlan_NonSessionValue_NotFound(t *testing.T) {
+	t.Parallel()
+	api := newTestAPI(func(d *Deps) {
+		d.SessionMgr = &mockSessionManager{
+			getFn: func(id string) (any, error) { return &worker.SessionStartParams{}, nil },
+		}
+	})
+	w := httptest.NewRecorder()
+	r := runtimePlanRequest("sess-1")
+
+	api.HandleSessionRuntimePlan(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestHandleSessionRuntimePlan_Success_RedactedView covers the happy path: a
+// session without a dispatched worker type resolves a warned (not blocked)
+// plan, and the response is the redacted view only.
+func TestHandleSessionRuntimePlan_Success_RedactedView(t *testing.T) {
+	t.Parallel()
+	si := &session.SessionInfo{ID: "sess-1", UserID: "u1", WorkspaceID: "ws1"}
+	api := newTestAPI(func(d *Deps) {
+		d.SessionMgr = &mockSessionManager{
+			getFn: func(id string) (any, error) { return si, nil },
+		}
+	})
+	w := httptest.NewRecorder()
+	r := runtimePlanRequest("sess-1")
+
+	api.HandleSessionRuntimePlan(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	var report RuntimePlanReport
+	require.NoError(t, json.Unmarshal([]byte(body), &report))
+
+	require.Regexp(t, runtimePlanHashRe, report.Plan.PlanHash)
+	require.Empty(t, report.Plan.Blocked)
+	require.Equal(t, agentspec.ObservedPlanned, report.Observed.State)
+
+	// Redaction: internal contract fields never surface on the wire shape.
+	for _, key := range []string{`"command"`, `"model"`, `"budget"`} {
+		require.NotContains(t, body, key, "internal plan field leaked into the admin response")
+	}
+}
+
+// TestHandleSessionRuntimePlan_BlockedPlan_StillDiagnostic: a blocked plan is
+// a valid diagnostic payload (§6.6) — 200 with the blocked reasons and NO hash.
+// The test binary's worker registry is empty, so any non-empty worker type on
+// the session is rejected fail-closed by the shared resolver.
+func TestHandleSessionRuntimePlan_BlockedPlan_StillDiagnostic(t *testing.T) {
+	t.Parallel()
+	si := &session.SessionInfo{
+		ID:         "sess-2",
+		WorkerType: worker.WorkerType("codex_cli"),
+		State:      events.StateTerminated,
+	}
+	api := newTestAPI(func(d *Deps) {
+		d.SessionMgr = &mockSessionManager{
+			getFn: func(id string) (any, error) { return si, nil },
+		}
+	})
+	w := httptest.NewRecorder()
+	r := runtimePlanRequest("sess-2")
+
+	api.HandleSessionRuntimePlan(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var report RuntimePlanReport
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&report))
+
+	require.Empty(t, report.Plan.PlanHash, "a blocked plan carries no hash")
+	require.NotEmpty(t, report.Plan.Blocked)
+	require.Equal(t, agentspec.BlockUnknownWorkerType, report.Plan.Blocked[0].Code)
+	require.Equal(t, "codex_cli", report.Observed.WorkerType)
+	require.Equal(t, agentspec.ObservedPlanned, report.Observed.State)
+}
+
+func TestObservedSummaryFor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		si   *session.SessionInfo
+		want agentspec.ObservedSummary
+	}{
+		{
+			name: "declared ceiling wins over active state",
+			si: &session.SessionInfo{
+				WorkerType:        worker.TypeClaudeCode,
+				State:             events.StateRunning,
+				PermissionCeiling: "default",
+			},
+			want: agentspec.ObservedSummary{
+				State:             agentspec.ObservedDeclared,
+				WorkerType:        "claude_code",
+				PermissionCeiling: "default",
+			},
+		},
+		{
+			name: "active without ceiling is unknown",
+			si:   &session.SessionInfo{WorkerType: worker.TypeCodexCLI, State: events.StateRunning},
+			want: agentspec.ObservedSummary{State: agentspec.ObservedUnknown, WorkerType: "codex_cli"},
+		},
+		{
+			name: "inactive without ceiling is planned",
+			si:   &session.SessionInfo{State: events.StateTerminated},
+			want: agentspec.ObservedSummary{State: agentspec.ObservedPlanned},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, observedSummaryFor(tc.si))
+		})
+	}
+}
+
+func TestBuildSessionPlan_FactsRoundTrip(t *testing.T) {
+	t.Parallel()
+	si := &session.SessionInfo{
+		ID:           "sess-3",
+		UserID:       "u1",
+		WorkspaceID:  "ws1",
+		BotName:      "bot-1",
+		Platform:     "webchat",
+		AllowedTools: []string{"Read"},
+	}
+
+	plan, err := buildSessionPlan(nil, si)
+
+	require.NoError(t, err)
+	require.Regexp(t, runtimePlanHashRe, plan.PlanHash)
+
+	// The session's persisted tool whitelist enters as init-metadata source.
+	var sawTools bool
+	for _, ref := range plan.SourceRefs {
+		if ref.Field == "allowed_tools" {
+			sawTools = true
+			require.Equal(t, agentspec.PlanSourceInitMetadata, ref.Source)
+		}
+	}
+	require.True(t, sawTools, "allowed_tools source ref missing")
+
+	// No worker type resolvable for a webchat input without init metadata.
+	require.NotEmpty(t, plan.Warnings)
+	require.Equal(t, agentspec.WarnWorkerTypeUnresolved, plan.Warnings[0].Code)
+}
+
+func TestBuildSessionPlan_BlockedTyped(t *testing.T) {
+	t.Parallel()
+	si := &session.SessionInfo{WorkerType: worker.WorkerType("not-registered-in-test")}
+
+	_, err := buildSessionPlan(nil, si)
+
+	require.ErrorIs(t, err, agentspec.ErrPlanBlocked)
+}

--- a/internal/agentspec/plan.go
+++ b/internal/agentspec/plan.go
@@ -335,9 +335,12 @@ func planSourceRefs(in Input, spec AgentSpec) []PlanSourceRef {
 		refs = append(refs, PlanSourceRef{Field: "model", Source: PlanSourceInitMetadata})
 	}
 	if spec.Policy.PermissionMode != "" {
-		source := PlanSourceWorkspaceOverride
-		if in.InitMeta.PermissionMode != "" {
+		source := PlanSourceBaseConfig
+		switch {
+		case in.InitMeta.PermissionMode != "":
 			source = PlanSourceInitMetadata
+		case in.WorkspacePerm != "":
+			source = PlanSourceWorkspaceOverride
 		}
 		refs = append(refs, PlanSourceRef{Field: "permission_mode", Source: source})
 	}

--- a/internal/agentspec/plan.go
+++ b/internal/agentspec/plan.go
@@ -1,0 +1,416 @@
+package agentspec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+// PlanVersion is the schema version of EffectiveRuntimePlan and its redacted
+// view. Bump on any breaking change to the plan/view shape so consumers can
+// refuse to interpret a plan they do not understand (same contract as
+// SnapshotVersion).
+const PlanVersion = 1
+
+// PlanResolverID names the resolver implementation that produced a plan. It is
+// part of the canonical hash input, so a future resolver generation produces a
+// different plan identity for the same effective fields.
+const PlanResolverID = "agentspec.Resolver"
+
+// ErrPlanBlocked marks an EffectiveRuntimePlan that must not be treated as an
+// executable success (#946 spec §6.2). Shadow callers log it as a redacted
+// diagnostic; fail-closed entry surfaces surface it. The returned plan still
+// carries the bounded Blocked reasons for inspection.
+var ErrPlanBlocked = errors.New("agentspec: plan blocked")
+
+// Blocked reason codes (fail-closed; #946 spec §6.2). A plan carrying any of
+// these must never be reported as a clean, executable desired state.
+const (
+	// BlockUnknownWorkerType: a non-empty worker type the registry cannot verify.
+	BlockUnknownWorkerType = "unknown_worker_type"
+	// BlockInvalidPermissionMode: a permission tier outside the 4-level ceiling.
+	BlockInvalidPermissionMode = "invalid_permission_mode"
+	// BlockInvalidSandboxMode: a sandbox mode outside the codex-baseline vocabulary.
+	BlockInvalidSandboxMode = "invalid_sandbox_mode"
+	// BlockFactsMissingOrConflicting: workspace/owner/origin facts the resolver
+	// cannot establish or reconcile.
+	BlockFactsMissingOrConflicting = "facts_missing_or_conflicting"
+	// BlockCapabilityUnverifiable: a capability the plan requires but cannot verify.
+	BlockCapabilityUnverifiable = "capability_unverifiable"
+	// BlockSecretShapedValue: a secret-shaped value was attempted at the public
+	// plan boundary and rejected.
+	BlockSecretShapedValue = "secret_shaped_value"
+)
+
+// Warning codes (compat behaviors that keep running but must stay visible;
+// #946 spec §6.2). Capabilities whose enforcement cannot be proven only ever
+// surface as warnings with partial/unavailable/unknown semantics — never as
+// silent success.
+const (
+	// WarnWorkerTypeUnresolved: the plan could not pin a worker type; the worker
+	// registry decides at dispatch, so the desired state is unproven.
+	WarnWorkerTypeUnresolved = "worker_type_unresolved"
+	// WarnPermissionSourceConflict: session init metadata declared a different
+	// permission tier than the workspace ceiling; documented precedence resolved
+	// it, but the divergence is recorded.
+	WarnPermissionSourceConflict = "permission_source_conflict"
+)
+
+// Plan source labels for PlanSourceRef. They name the precedence level a
+// resolved field value came from (#946 spec §6.2 chain).
+const (
+	PlanSourceInitMetadata      = "init_metadata"
+	PlanSourceWorkspaceOverride = "workspace_override"
+	PlanSourcePlatformConfig    = "platform_config"
+	PlanSourceBotConfig         = "bot_config"
+	PlanSourceBaseConfig        = "base_config"
+)
+
+// Observed bootstrap states (#946 spec §6.5). The first slice only ever
+// produces ObservedPlanned; the remaining states exist so the Worker-bootstrap
+// follow-up has a fixed vocabulary. A config hash, an HTTP 200, a Worker done,
+// or an audit row alone never justify ObservedEnforced.
+const (
+	ObservedPlanned  = "planned"
+	ObservedUnknown  = "unknown"
+	ObservedDeclared = "declared"
+	ObservedPartial  = "partial"
+	ObservedEnforced = "enforced"
+)
+
+// knownSandboxModes is the codex-baseline sandbox vocabulary (the only sandbox
+// semantics the resolver can verify today). Any other non-empty mode is
+// fail-closed, not silently passed through.
+var knownSandboxModes = map[string]struct{}{
+	"read-only":          {},
+	"workspace-write":    {},
+	"danger-full-access": {},
+}
+
+// PlanSourceRef records which precedence level supplied a resolved field. The
+// slice order is semantic (field precedence) and MUST NOT be reordered by
+// canonicalization (#946 spec §6.3 rule 4).
+type PlanSourceRef struct {
+	Field  string `json:"field"`
+	Source string `json:"source"`
+}
+
+// PlanWarning is a bounded compat warning attached to a plan.
+type PlanWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// PlanBlockReason is a bounded fail-closed reason attached to a plan.
+type PlanBlockReason struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// EffectiveRuntimePlan is the desired-state runtime plan for a session (#946).
+// It is a diagnostic projection, not an observed success: PlanHash identifies
+// what the gateway WANTS to run, never proof that the Worker/backend/sandbox
+// actually applied it. The full plan is internal; only Redacted() may reach
+// Admin/doctor/public surfaces.
+//
+// First slice: EnvProfile/EnvKeys/CapabilityIDs/SkillHash/ConfigHash stay
+// zero-valued — their sources (#867 strict env allowlist, capability registry,
+// skill/config fingerprinting) are later iterations. The fields exist so the
+// contract is stable.
+type EffectiveRuntimePlan struct {
+	Version       int
+	Resolver      string
+	PlanHash      string
+	AgentSpec     AgentSpec
+	EnvProfile    string
+	EnvKeys       []string
+	CapabilityIDs []string
+	SkillHash     string
+	ConfigHash    string
+	SourceRefs    []PlanSourceRef
+	Warnings      []PlanWarning
+	Blocked       []PlanBlockReason
+}
+
+// EffectiveRuntimePlanView is the redacted public projection of a plan (#946
+// spec §6.1): worker type, permission summary, sandbox summary, environment
+// key NAMES, hashes, source refs, warnings and blocked codes — nothing else.
+// Internal contract fields (launch command, model, tool lists, budget,
+// identity refs, sandbox directories) deliberately never appear here, so a
+// view is always safe to serve, log, and audit.
+type EffectiveRuntimePlanView struct {
+	Version         int               `json:"version"`
+	Resolver        string            `json:"resolver"`
+	PlanHash        string            `json:"plan_hash,omitempty"`
+	WorkerType      string            `json:"worker_type,omitempty"`
+	PermissionMode  string            `json:"permission_mode,omitempty"`
+	SkipPermissions bool              `json:"skip_permissions,omitempty"`
+	SandboxMode     string            `json:"sandbox_mode,omitempty"`
+	EnvProfile      string            `json:"env_profile,omitempty"`
+	EnvKeys         []string          `json:"env_keys,omitempty"`
+	CapabilityIDs   []string          `json:"capability_ids,omitempty"`
+	SkillHash       string            `json:"skill_hash,omitempty"`
+	ConfigHash      string            `json:"config_hash,omitempty"`
+	SourceRefs      []PlanSourceRef   `json:"source_refs,omitempty"`
+	Warnings        []PlanWarning     `json:"warnings,omitempty"`
+	Blocked         []PlanBlockReason `json:"blocked,omitempty"`
+}
+
+// ResolvePlan normalizes the input into a desired-state EffectiveRuntimePlan.
+//
+// It reuses Resolve (same precedence chain: init metadata > workspace override
+// > platform/bot config > base config > compiled defaults) and then applies
+// the fail-closed rules of #946 spec §6.2:
+//
+//   - unknown worker type / invalid permission mode (already rejected by
+//     Resolve) become bounded Blocked reasons plus ErrPlanBlocked;
+//   - a sandbox mode outside the verifiable vocabulary blocks the plan;
+//   - unresolved worker type and init/workspace permission divergence surface
+//     as warnings (compat keeps running, never silently).
+//
+// On any blocked outcome the returned error wraps ErrPlanBlocked and the
+// returned plan carries the reasons but NO PlanHash — a blocked plan has no
+// executable identity. Shadow callers (WS/REST) must log the redacted
+// diagnostic and leave the legacy dispatch path untouched (#946 spec §6.4).
+func (r Resolver) ResolvePlan(in Input) (EffectiveRuntimePlan, error) {
+	plan := EffectiveRuntimePlan{Version: PlanVersion, Resolver: PlanResolverID}
+
+	spec, err := r.Resolve(in)
+	if err != nil {
+		reason := blockReasonForResolveError(err)
+		plan.Blocked = []PlanBlockReason{reason}
+		return plan, fmt.Errorf("%w: %s: %w", ErrPlanBlocked, reason.Code, err)
+	}
+	plan.AgentSpec = spec
+
+	if mode := spec.Sandbox.Mode; mode != "" {
+		if _, ok := knownSandboxModes[mode]; !ok {
+			reason := PlanBlockReason{
+				Code:    BlockInvalidSandboxMode,
+				Message: boundedMessage("sandbox mode cannot be verified: " + mode),
+			}
+			plan.Blocked = []PlanBlockReason{reason}
+			return plan, fmt.Errorf("%w: %s: %s", ErrPlanBlocked, BlockInvalidSandboxMode, mode)
+		}
+	}
+
+	plan.Warnings = planWarnings(in, spec)
+	plan.SourceRefs = planSourceRefs(in, spec)
+	plan.PlanHash = CanonicalPlanHash(plan.Redacted())
+	return plan, nil
+}
+
+// Redacted projects the plan onto its public, secret-free view. It is the
+// single choke point for public surfaces (Admin API, doctor, logs): internal
+// contract fields (Worker.Command, Model, tool lists, budget, identity refs,
+// sandbox directories — paths are secret-shaped) are dropped here, and any
+// env entry that does not look like a bare key NAME is rejected with a bounded
+// blocked reason instead of being echoed.
+func (p EffectiveRuntimePlan) Redacted() EffectiveRuntimePlanView {
+	envKeys, blocked := scrubEnvKeys(p.EnvKeys)
+	view := EffectiveRuntimePlanView{
+		Version:         p.Version,
+		Resolver:        p.Resolver,
+		PlanHash:        p.PlanHash,
+		WorkerType:      p.AgentSpec.Worker.Type,
+		PermissionMode:  p.AgentSpec.Policy.PermissionMode,
+		SkipPermissions: p.AgentSpec.Policy.SkipPermissions,
+		SandboxMode:     p.AgentSpec.Sandbox.Mode,
+		EnvProfile:      p.EnvProfile,
+		EnvKeys:         envKeys,
+		CapabilityIDs:   cloneStrings(p.CapabilityIDs),
+		SkillHash:       p.SkillHash,
+		ConfigHash:      p.ConfigHash,
+		SourceRefs:      cloneSourceRefs(p.SourceRefs),
+		Warnings:        cloneWarnings(p.Warnings),
+		Blocked:         append(cloneBlocked(p.Blocked), blocked...),
+	}
+	return view
+}
+
+// CanonicalPlanHash returns the SHA-256 hex digest of the redacted view's
+// canonical encoding (#946 spec §6.3). It is the desired-plan identity only —
+// it never proves the Worker/backend/sandbox applied anything.
+//
+// Canonicalization rules:
+//  1. fixed field set + version (struct declaration order);
+//  2. nil and empty slices are normalized identically;
+//  3. semantically unordered ID/key lists (EnvKeys, CapabilityIDs) are sorted;
+//  4. semantically ordered lists (SourceRefs, Warnings, Blocked) keep order;
+//  5. SHA-256 over the UTF-8 JSON encoding;
+//  6. the PlanHash field itself is excluded (hash over the body, not itself).
+//
+// Prompts, metadata values, credentials, tokens, full commands, host env
+// values, absolute paths, PIDs, timestamps and evidence refs can never enter
+// the view, so they can never enter the hash.
+func CanonicalPlanHash(view EffectiveRuntimePlanView) string {
+	canon := view
+	canon.PlanHash = ""
+	canon.EnvKeys = normalizeStringList(view.EnvKeys)
+	canon.CapabilityIDs = normalizeStringList(view.CapabilityIDs)
+	canon.SourceRefs = cloneSourceRefs(view.SourceRefs)
+	canon.Warnings = cloneWarnings(view.Warnings)
+	canon.Blocked = cloneBlocked(view.Blocked)
+	b, err := json.Marshal(canon)
+	if err != nil {
+		// The view holds only JSON-safe scalars and []string/struct slices; a
+		// marshal failure is impossible in practice. An empty hash keeps callers
+		// fail-safe rather than panicking in the request path.
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// blockReasonForResolveError maps a Resolve boundary rejection onto the
+// bounded blocked-reason vocabulary.
+func blockReasonForResolveError(err error) PlanBlockReason {
+	msg := err.Error()
+	code := BlockFactsMissingOrConflicting
+	switch {
+	case strings.Contains(msg, "worker type"):
+		code = BlockUnknownWorkerType
+	case strings.Contains(msg, "permission mode"):
+		code = BlockInvalidPermissionMode
+	}
+	return PlanBlockReason{Code: code, Message: boundedMessage(msg)}
+}
+
+// planWarnings derives the compat warnings for a successfully resolved spec.
+func planWarnings(in Input, spec AgentSpec) []PlanWarning {
+	var warnings []PlanWarning
+	if spec.Worker.Type == "" {
+		warnings = append(warnings, PlanWarning{
+			Code: WarnWorkerTypeUnresolved,
+			Message: "worker type not resolved by the plan; the worker registry decides " +
+				"at dispatch (desired state unproven)",
+		})
+	}
+	if in.InitMeta.PermissionMode != "" && in.WorkspacePerm != "" &&
+		in.InitMeta.PermissionMode != in.WorkspacePerm {
+		warnings = append(warnings, PlanWarning{
+			Code: WarnPermissionSourceConflict,
+			Message: "session init permission tier differs from the workspace ceiling; " +
+				"documented precedence applied",
+		})
+	}
+	return warnings
+}
+
+// planSourceRefs records the precedence source of every resolved field in a
+// fixed (semantic) field order.
+func planSourceRefs(in Input, spec AgentSpec) []PlanSourceRef {
+	refs := make([]PlanSourceRef, 0, 6)
+	if spec.Worker.Type != "" {
+		source := PlanSourcePlatformConfig // messaging 5-level config chain
+		if in.InitMeta.WorkerType != "" {
+			source = PlanSourceInitMetadata
+		}
+		refs = append(refs, PlanSourceRef{Field: "worker_type", Source: source})
+	}
+	if spec.Worker.Model != "" {
+		refs = append(refs, PlanSourceRef{Field: "model", Source: PlanSourceInitMetadata})
+	}
+	if spec.Policy.PermissionMode != "" {
+		source := PlanSourceWorkspaceOverride
+		if in.InitMeta.PermissionMode != "" {
+			source = PlanSourceInitMetadata
+		}
+		refs = append(refs, PlanSourceRef{Field: "permission_mode", Source: source})
+	}
+	if spec.Policy.AllowedTools != nil {
+		refs = append(refs, PlanSourceRef{Field: "allowed_tools", Source: PlanSourceInitMetadata})
+	}
+	if spec.Policy.DisallowedTools != nil {
+		refs = append(refs, PlanSourceRef{Field: "disallowed_tools", Source: PlanSourceInitMetadata})
+	}
+	if spec.Sandbox.Mode != "" {
+		source := PlanSourceBaseConfig
+		if in.PlatformKey[worker.SandboxPlatformKey] != "" {
+			source = PlanSourceBotConfig
+		}
+		refs = append(refs, PlanSourceRef{Field: "sandbox_mode", Source: source})
+	}
+	return refs
+}
+
+// scrubEnvKeys keeps only bare environment key NAMES. Anything carrying a
+// value (=), whitespace, quotes, or an implausible length is treated as a
+// secret-shaped value attempt: dropped, and reported as a bounded blocked
+// reason WITHOUT echoing the offending content.
+func scrubEnvKeys(keys []string) (kept []string, blocked []PlanBlockReason) {
+	for _, k := range keys {
+		if isBareEnvKeyName(k) {
+			kept = append(kept, k)
+			continue
+		}
+		blocked = append(blocked, PlanBlockReason{
+			Code:    BlockSecretShapedValue,
+			Message: "secret-shaped value rejected at the public plan boundary",
+		})
+	}
+	return normalizeStringList(kept), blocked
+}
+
+// isBareEnvKeyName reports whether s looks like an environment variable name
+// (KEY_NAME), not a value.
+func isBareEnvKeyName(s string) bool {
+	if s == "" || len(s) > 128 {
+		return false
+	}
+	return !strings.ContainsAny(s, "= \t\n\r'\"`")
+}
+
+// normalizeStringList returns a sorted copy (nil for empty) so semantically
+// unordered ID/key lists hash identically regardless of input order, and nil
+// vs empty never differ (#946 spec §6.3 rules 2-3).
+func normalizeStringList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := slices.Clone(in)
+	sort.Strings(out)
+	return out
+}
+
+// cloneSourceRefs copies refs preserving order (semantic precedence; rule 4).
+// A nil input yields nil so nil/empty normalize identically (rule 2).
+func cloneSourceRefs(refs []PlanSourceRef) []PlanSourceRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	return slices.Clone(refs)
+}
+
+// cloneWarnings copies warnings preserving resolve order (rule 4).
+func cloneWarnings(warnings []PlanWarning) []PlanWarning {
+	if len(warnings) == 0 {
+		return nil
+	}
+	return slices.Clone(warnings)
+}
+
+// cloneBlocked copies blocked reasons preserving resolve order (rule 4).
+func cloneBlocked(blocked []PlanBlockReason) []PlanBlockReason {
+	if len(blocked) == 0 {
+		return nil
+	}
+	return slices.Clone(blocked)
+}
+
+// boundedMessage truncates a human-facing diagnostic message so bounded
+// reasons can never blow up audit/log/event payloads.
+func boundedMessage(msg string) string {
+	const max = 256
+	if len(msg) <= max {
+		return msg
+	}
+	return msg[:max]
+}

--- a/internal/agentspec/plan.go
+++ b/internal/agentspec/plan.go
@@ -94,6 +94,22 @@ var knownSandboxModes = map[string]struct{}{
 	"danger-full-access": {},
 }
 
+// ObservedSummary is the bounded observed-bootstrap projection served
+// alongside the desired-state plan (#946 spec §6.5/§6.6): only verifiable
+// facts (worker type, the Worker-reported permission tier) plus the mapping
+// state. A config hash, an HTTP 200, a Worker done, or an audit row alone
+// never lift the state to ObservedEnforced.
+type ObservedSummary struct {
+	// State is one of the Observed* constants.
+	State string `json:"state"`
+	// WorkerType is the worker type the session actually runs (observed fact).
+	WorkerType string `json:"worker_type,omitempty"`
+	// PermissionCeiling is the first effective permission tier the Worker
+	// reported after a successful start/resume — declared by the Worker, not
+	// independently enforced (empty when never reported).
+	PermissionCeiling string `json:"permission_ceiling,omitempty"`
+}
+
 // PlanSourceRef records which precedence level supplied a resolved field. The
 // slice order is semantic (field precedence) and MUST NOT be reordered by
 // canonicalization (#946 spec §6.3 rule 4).

--- a/internal/agentspec/plan_test.go
+++ b/internal/agentspec/plan_test.go
@@ -1,0 +1,312 @@
+package agentspec
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+var planHashRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+func TestResolvePlan_Success(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Messaging.Feishu.WorkerType = "codex_cli"
+	cfg.Worker.CodexCLI.Sandbox = "workspace-write"
+
+	plan, err := testResolver().ResolvePlan(Input{
+		Cfg:      cfg,
+		Platform: "feishu",
+		BotName:  "b1",
+		UserID:   "u1",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, PlanVersion, plan.Version)
+	require.Equal(t, PlanResolverID, plan.Resolver)
+	require.Regexp(t, planHashRe, plan.PlanHash)
+	require.Equal(t, "codex_cli", plan.AgentSpec.Worker.Type)
+	require.Empty(t, plan.Blocked)
+	require.Empty(t, plan.Warnings)
+	require.Contains(t, plan.SourceRefs, PlanSourceRef{Field: "worker_type", Source: PlanSourcePlatformConfig})
+	require.Contains(t, plan.SourceRefs, PlanSourceRef{Field: "sandbox_mode", Source: PlanSourceBaseConfig})
+}
+
+// TestResolvePlan_Determinism: same Input → same plan hash; a different
+// effective field → different hash. The hash is a pure function of the
+// redacted desired state.
+func TestResolvePlan_Determinism(t *testing.T) {
+	t.Parallel()
+	in := Input{
+		InitMeta: InitMetadata{WorkerType: "claude_code"},
+		Platform: "webchat",
+		UserID:   "u1",
+	}
+	a, err := testResolver().ResolvePlan(in)
+	require.NoError(t, err)
+	b, err := testResolver().ResolvePlan(in)
+	require.NoError(t, err)
+	require.Equal(t, a.PlanHash, b.PlanHash)
+
+	other, err := testResolver().ResolvePlan(Input{
+		InitMeta: InitMetadata{WorkerType: "opencode_server"},
+		Platform: "webchat",
+		UserID:   "u1",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, a.PlanHash, other.PlanHash)
+}
+
+// TestResolvePlan_WSRESTEquivalence: two structurally equal Inputs (the WS
+// init and REST create construction shapes) must produce the same plan hash —
+// the shadow-mode divergence alarm of #946 spec §6.4. Any future hash
+// divergence between equivalent entries fails here.
+func TestResolvePlan_WSRESTEquivalence(t *testing.T) {
+	t.Parallel()
+	base := Input{
+		InitMeta:    InitMetadata{WorkerType: "claude_code"},
+		Platform:    "webchat",
+		UserID:      "u1",
+		WorkspaceID: "ws1",
+	}
+	wsLike := base
+	restLike := base
+
+	wsPlan, err := testResolver().ResolvePlan(wsLike)
+	require.NoError(t, err)
+	restPlan, err := testResolver().ResolvePlan(restLike)
+	require.NoError(t, err)
+	require.Equal(t, wsPlan.PlanHash, restPlan.PlanHash,
+		"equivalent WS/REST inputs must resolve to the same plan identity")
+
+	// And the documented F4 divergence (AllowedTools present on WS, absent on
+	// REST) DOES change the plan identity — it is visible, never silent.
+	wsTools := base
+	wsTools.InitMeta.AllowedTools = []string{"Bash"}
+	toolsPlan, err := testResolver().ResolvePlan(wsTools)
+	require.NoError(t, err)
+	require.NotEqual(t, restPlan.PlanHash, toolsPlan.PlanHash)
+}
+
+func TestResolvePlan_Blocked(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       Input
+		wantCode string
+	}{
+		{
+			name:     "unknown worker type",
+			in:       Input{InitMeta: InitMetadata{WorkerType: "bogus_worker"}, Platform: "webchat"},
+			wantCode: BlockUnknownWorkerType,
+		},
+		{
+			name:     "invalid permission mode",
+			in:       Input{InitMeta: InitMetadata{WorkerType: "claude_code", PermissionMode: "god-mode"}, Platform: "webchat"},
+			wantCode: BlockInvalidPermissionMode,
+		},
+		{
+			name: "unverifiable sandbox mode",
+			in: Input{
+				InitMeta:    InitMetadata{WorkerType: "codex_cli"},
+				Platform:    "webchat",
+				PlatformKey: map[string]string{worker.SandboxPlatformKey: "yolo-unlocked"},
+			},
+			wantCode: BlockInvalidSandboxMode,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			plan, err := testResolver().ResolvePlan(tc.in)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrPlanBlocked, "blocked plans must wrap ErrPlanBlocked")
+			require.Len(t, plan.Blocked, 1)
+			require.Equal(t, tc.wantCode, plan.Blocked[0].Code)
+			require.NotEmpty(t, plan.Blocked[0].Message)
+			require.Empty(t, plan.PlanHash, "a blocked plan has no executable identity")
+		})
+	}
+}
+
+func TestResolvePlan_Warnings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unresolved worker type warns", func(t *testing.T) {
+		t.Parallel()
+		plan, err := testResolver().ResolvePlan(Input{Platform: "webchat"})
+		require.NoError(t, err, "empty worker type stays compat-compatible")
+		require.Empty(t, plan.Blocked)
+		require.Len(t, plan.Warnings, 1)
+		require.Equal(t, WarnWorkerTypeUnresolved, plan.Warnings[0].Code)
+	})
+
+	t.Run("init vs workspace permission divergence warns", func(t *testing.T) {
+		t.Parallel()
+		plan, err := testResolver().ResolvePlan(Input{
+			InitMeta:      InitMetadata{WorkerType: "claude_code", PermissionMode: "workspace"},
+			WorkspacePerm: "bypass",
+			Platform:      "webchat",
+		})
+		require.NoError(t, err)
+		require.Empty(t, plan.Blocked)
+		var codes []string
+		for _, w := range plan.Warnings {
+			codes = append(codes, w.Code)
+		}
+		require.Contains(t, codes, WarnPermissionSourceConflict)
+		require.Equal(t, "workspace", plan.AgentSpec.Policy.PermissionMode,
+			"documented precedence still applies")
+	})
+}
+
+// TestRedacted_ExcludesInternalContract: launch command, model, tool lists,
+// budget, identity refs and sandbox directories never reach the public view.
+func TestRedacted_ExcludesInternalContract(t *testing.T) {
+	t.Parallel()
+	plan := EffectiveRuntimePlan{
+		Version:  PlanVersion,
+		Resolver: PlanResolverID,
+		AgentSpec: AgentSpec{
+			Worker: WorkerSpec{
+				Type:    "claude_code",
+				Command: "launch-cmd-SENTINEL --api-key=SECRETKEYVAL",
+				Model:   "model-SENTINEL",
+			},
+			Policy: PolicySpec{
+				PermissionMode:  "workspace",
+				AllowedTools:    []string{"tool-SENTINEL"},
+				DisallowedTools: []string{"blocked-SENTINEL"},
+			},
+			Sandbox: SandboxSpec{
+				Mode:        "read-only",
+				AllowedDirs: []string{"/path-SENTINEL/project"},
+			},
+			Budget:   BudgetSpec{MaxTurns: 7},
+			Identity: IdentityRefs{UserID: "user-SENTINEL", WorkspaceID: "ws-SENTINEL"},
+		},
+	}
+
+	view := plan.Redacted()
+	require.Equal(t, "claude_code", view.WorkerType)
+	require.Equal(t, "workspace", view.PermissionMode)
+	require.Equal(t, "read-only", view.SandboxMode)
+
+	raw, err := json.Marshal(view)
+	require.NoError(t, err)
+	s := string(raw)
+	for _, sentinel := range []string{
+		"launch-cmd-SENTINEL", "SECRETKEYVAL", "model-SENTINEL",
+		"tool-SENTINEL", "blocked-SENTINEL", "/path-SENTINEL",
+		"user-SENTINEL", "ws-SENTINEL",
+	} {
+		require.NotContains(t, s, sentinel, "public view leaked an internal contract value")
+	}
+}
+
+// TestRedacted_SecretShapedEnvKeys: bare key names pass; anything carrying a
+// value is dropped and reported as a bounded blocked reason, never echoed.
+func TestRedacted_SecretShapedEnvKeys(t *testing.T) {
+	t.Parallel()
+	plan := EffectiveRuntimePlan{
+		Version:  PlanVersion,
+		Resolver: PlanResolverID,
+		EnvKeys:  []string{"GOOD_KEY", "BAD=hunter2", "ALSO BAD", "TOKEN \"quoted\""},
+	}
+
+	view := plan.Redacted()
+	require.Equal(t, []string{"GOOD_KEY"}, view.EnvKeys)
+	require.Len(t, view.Blocked, 3)
+	for _, b := range view.Blocked {
+		require.Equal(t, BlockSecretShapedValue, b.Code)
+		require.NotContains(t, b.Message, "hunter2", "the offending value must never be echoed")
+	}
+
+	raw, err := json.Marshal(view)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "hunter2")
+}
+
+// TestCanonicalPlanHash_NilEmptyNormalization: nil vs empty slices (rule 2)
+// hash identically.
+func TestCanonicalPlanHash_NilEmptyNormalization(t *testing.T) {
+	t.Parallel()
+	withNil := EffectiveRuntimePlanView{Version: PlanVersion, Resolver: PlanResolverID, WorkerType: "claude_code"}
+	withEmpty := withNil
+	withEmpty.EnvKeys = []string{}
+	withEmpty.CapabilityIDs = []string{}
+	withEmpty.SourceRefs = []PlanSourceRef{}
+	withEmpty.Warnings = []PlanWarning{}
+	withEmpty.Blocked = []PlanBlockReason{}
+
+	require.Equal(t, CanonicalPlanHash(withNil), CanonicalPlanHash(withEmpty))
+}
+
+// TestCanonicalPlanHash_UnorderedListsSorted: semantically unordered ID/key
+// lists (rule 3) hash identically in any input order.
+func TestCanonicalPlanHash_UnorderedListsSorted(t *testing.T) {
+	t.Parallel()
+	a := EffectiveRuntimePlanView{
+		Version:       PlanVersion,
+		Resolver:      PlanResolverID,
+		EnvKeys:       []string{"ALPHA", "BETA"},
+		CapabilityIDs: []string{"cap-2", "cap-1"},
+	}
+	b := a
+	b.EnvKeys = []string{"BETA", "ALPHA"}
+	b.CapabilityIDs = []string{"cap-1", "cap-2"}
+
+	require.Equal(t, CanonicalPlanHash(a), CanonicalPlanHash(b))
+}
+
+// TestCanonicalPlanHash_SourceOrderPreserved: SourceRefs order is semantic
+// precedence (rule 4) — reordering changes the identity.
+func TestCanonicalPlanHash_SourceOrderPreserved(t *testing.T) {
+	t.Parallel()
+	a := EffectiveRuntimePlanView{
+		Version:  PlanVersion,
+		Resolver: PlanResolverID,
+		SourceRefs: []PlanSourceRef{
+			{Field: "worker_type", Source: PlanSourceInitMetadata},
+			{Field: "permission_mode", Source: PlanSourceWorkspaceOverride},
+		},
+	}
+	b := a
+	b.SourceRefs = []PlanSourceRef{
+		{Field: "permission_mode", Source: PlanSourceWorkspaceOverride},
+		{Field: "worker_type", Source: PlanSourceInitMetadata},
+	}
+
+	require.NotEqual(t, CanonicalPlanHash(a), CanonicalPlanHash(b),
+		"source-ref order carries precedence semantics and must affect the hash")
+}
+
+// TestCanonicalPlanHash_ExcludesHashField: the hash is over the body, not
+// itself (rule 6) — a pre-stamped PlanHash must not feed back in.
+func TestCanonicalPlanHash_ExcludesHashField(t *testing.T) {
+	t.Parallel()
+	a := EffectiveRuntimePlanView{Version: PlanVersion, Resolver: PlanResolverID, WorkerType: "acp"}
+	b := a
+	b.PlanHash = "deadbeef"
+
+	require.Equal(t, CanonicalPlanHash(a), CanonicalPlanHash(b))
+	require.Regexp(t, planHashRe, CanonicalPlanHash(a))
+}
+
+// TestResolvePlan_BlockedIsTyped ensures callers can branch on the sentinel.
+func TestResolvePlan_BlockedIsTyped(t *testing.T) {
+	t.Parallel()
+	_, err := testResolver().ResolvePlan(Input{
+		InitMeta: InitMetadata{WorkerType: "bogus"},
+		Platform: "webchat",
+	})
+	require.True(t, errors.Is(err, ErrPlanBlocked))
+}

--- a/internal/agentspec/plan_test.go
+++ b/internal/agentspec/plan_test.go
@@ -38,6 +38,40 @@ func TestResolvePlan_Success(t *testing.T) {
 	require.Contains(t, plan.SourceRefs, PlanSourceRef{Field: "sandbox_mode", Source: PlanSourceBaseConfig})
 }
 
+func TestResolvePlan_UsesConfiguredWorkspacePermission(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Messaging.Feishu.WorkerType = "claude_code"
+	cfg.Worker.DefaultPermissionMode = worker.PermissionModeReadOnly
+
+	plan, err := testResolver().ResolvePlan(Input{
+		Cfg:         cfg,
+		Platform:    "feishu",
+		WorkspaceID: "workspace-1",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, worker.PermissionModeReadOnly, plan.AgentSpec.Policy.PermissionMode)
+	require.Contains(t, plan.SourceRefs, PlanSourceRef{
+		Field: "permission_mode", Source: PlanSourceBaseConfig,
+	})
+}
+
+func TestResolvePlan_UsesConfiguredOperatorPermissionWithoutWorkspace(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Messaging.Feishu.WorkerType = "claude_code"
+	cfg.Worker.ClaudeCode.PermissionMode = worker.PermissionModeReadOnly
+
+	plan, err := testResolver().ResolvePlan(Input{Cfg: cfg, Platform: "feishu"})
+
+	require.NoError(t, err)
+	require.Equal(t, worker.PermissionModeReadOnly, plan.AgentSpec.Policy.PermissionMode)
+	require.Contains(t, plan.SourceRefs, PlanSourceRef{
+		Field: "permission_mode", Source: PlanSourceBaseConfig,
+	})
+}
+
 // TestResolvePlan_Determinism: same Input → same plan hash; a different
 // effective field → different hash. The hash is a pure function of the
 // redacted desired state.

--- a/internal/agentspec/resolve.go
+++ b/internal/agentspec/resolve.go
@@ -95,10 +95,7 @@ func (r Resolver) Resolve(in Input) (AgentSpec, error) {
 	// change webchat model visibility. The contract field stays nil in first-cut.
 
 	// ── Policy ──────────────────────────────────────────────────────────────
-	pm := in.InitMeta.PermissionMode
-	if pm == "" {
-		pm = in.WorkspacePerm
-	}
+	pm := resolvePermissionMode(in, wt)
 	if pm != "" {
 		if err := worker.ValidatePermissionMode(pm); err != nil {
 			return AgentSpec{}, fmt.Errorf("agentspec: permission mode: %w", err)
@@ -122,6 +119,67 @@ func (r Resolver) Resolve(in Input) (AgentSpec, error) {
 	}
 
 	return spec, nil
+}
+
+// resolvePermissionMode mirrors the bridge's permission inputs for the plan
+// projection. Explicit init and workspace values win; a workspace without an
+// explicit override receives the configured global ceiling. Platform sessions
+// without a workspace retain their worker-specific operator defaults.
+func resolvePermissionMode(in Input, workerType string) string {
+	if mode := in.InitMeta.PermissionMode; mode != "" {
+		return mode
+	}
+	if mode := in.WorkspacePerm; mode != "" {
+		return mode
+	}
+	if in.Cfg == nil {
+		return ""
+	}
+	if in.WorkspaceID != "" {
+		return worker.NormalizePermissionMode(in.Cfg.Worker.DefaultPermissionMode)
+	}
+
+	switch workerType {
+	case string(worker.TypeClaudeCode):
+		if mode := in.Cfg.Worker.ClaudeCode.PermissionMode; mode != "" {
+			return mode
+		}
+		return worker.PermissionModeBypass
+	case string(worker.TypeCodexCLI):
+		return permissionModeFromCodexConfig(in.Cfg.Worker.CodexCLI.Sandbox, in.Cfg.Worker.CodexCLI.ApprovalMode)
+	case string(worker.TypeOpenCodeSrv):
+		return worker.PermissionModeBypass
+	case string(worker.TypeACP):
+		if in.Cfg.Worker.ACP.AutoApprove != nil && !*in.Cfg.Worker.ACP.AutoApprove {
+			return worker.PermissionModeWorkspace
+		}
+		return worker.PermissionModeBypass
+	default:
+		return ""
+	}
+}
+
+func permissionModeFromCodexConfig(sandbox, approval string) string {
+	switch sandbox {
+	case "read-only":
+		return worker.PermissionModeReadOnly
+	case "workspace-write":
+		switch approval {
+		case "never":
+			return worker.PermissionModeAutoEdit
+		case "on-request":
+			return worker.PermissionModeWorkspace
+		default:
+			return worker.PermissionModeReadOnly
+		}
+	case "danger-full-access":
+		if approval == "never" {
+			return worker.PermissionModeBypass
+		}
+		return worker.PermissionModeReadOnly
+	default:
+		return worker.PermissionModeReadOnly
+	}
 }
 
 // isMessagingPlatform reports whether the platform resolves worker_type via the

--- a/internal/audit/rebase.go
+++ b/internal/audit/rebase.go
@@ -1,0 +1,44 @@
+// Package audit — rebase.go implements the operator-initiated chain
+// re-anchor used to repair a broken hash chain. See audit.md §5.4.
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrRebaseRowNotFound is returned when the rebase target id has no surviving
+// row: the row was deleted, or the id is past the table tail. Rebase must
+// never silently anchor at a different row.
+var ErrRebaseRowNotFound = errors.New("audit: rebase target row not found")
+
+// Rebase re-anchors the hash chain at the row with the given id, returning
+// the written checkpoint. The target row's stored prev_hash becomes the new
+// checkpoint anchor and VerifyOnce continues from this row: rows before the
+// anchor are retained but no longer chain-verified.
+//
+// This is the only legitimate repair for a chain broken by a historical
+// manual DELETE (migrations 023/030 reject row UPDATE and un-anchored DELETE,
+// so a broken row cannot be edited or removed in place). The written
+// checkpoint carries the same semantics as a GC checkpoint-anchored prune:
+// the chain is declared valid from the anchor onward.
+func Rebase(ctx context.Context, store Store, nextID int64) (Checkpoint, error) {
+	rows, err := store.QueryAsc(ctx, nextID, 1)
+	if err != nil {
+		return Checkpoint{}, fmt.Errorf("audit rebase: query target row: %w", err)
+	}
+	if len(rows) == 0 || rows[0].ID != nextID {
+		return Checkpoint{}, fmt.Errorf("%w: id=%d", ErrRebaseRowNotFound, nextID)
+	}
+	cp := Checkpoint{
+		PrunedAt:     time.Now(),
+		LastSelfHash: rows[0].PrevHash,
+		NextID:       nextID,
+	}
+	if err := store.SaveCheckpoint(ctx, cp); err != nil {
+		return Checkpoint{}, fmt.Errorf("audit rebase: save checkpoint: %w", err)
+	}
+	return cp, nil
+}

--- a/internal/audit/rebase_test.go
+++ b/internal/audit/rebase_test.go
@@ -1,0 +1,136 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRebase_RepairsBrokenChain covers the operator re-anchor contract: a
+// chain broken by a historical manual DELETE (the broken_id=1253/1269 era)
+// cannot be repaired by editing rows (triggers reject UPDATE/DELETE), so the
+// operator rebases the chain at the first surviving row — its stored
+// prev_hash becomes the new checkpoint anchor and verify continues from
+// there. Rows before the anchor are retained but no longer chain-verified.
+func TestRebase_RepairsBrokenChain(t *testing.T) {
+	t.Parallel()
+	store, db := newTestStoreAndDB(t)
+	writeChain(t, store, 6)
+
+	ctx := context.Background()
+	// Interior delete mirrors the historical manual-DELETE breakage: row 3
+	// vanishes, orphaning row 4 (its prev_hash references the deleted row).
+	_, err := db.ExecContext(ctx, `DELETE FROM user_activity WHERE id = 3`)
+	require.NoError(t, err)
+
+	v := NewVerifier(store, VerifierConfig{}, nil)
+	result, err := v.VerifyOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), result.BrokenID, "precondition: chain must be broken at row 4")
+
+	// Rebase at row 4: row 4's own prev_hash becomes the anchor.
+	cp, err := Rebase(ctx, store, 4)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), cp.NextID, "checkpoint must start at the anchor row")
+	require.NotEmpty(t, cp.LastSelfHash, "anchor hash must be the row's stored prev_hash")
+
+	result, err = v.VerifyOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result.BrokenID, "rebase must restore integrity from the anchor row")
+	require.Equal(t, 3, result.RowsChecked, "rows 4..6 are verified from the new anchor")
+}
+
+// TestRebase_KeepsAppendChainWorking ensures the append path (which links to
+// the table tail, not the checkpoint) keeps producing a healthy chain after
+// a rebase — new rows chain onto the last surviving row regardless of the
+// re-anchor.
+func TestRebase_KeepsAppendChainWorking(t *testing.T) {
+	t.Parallel()
+	store, db := newTestStoreAndDB(t)
+	writeChain(t, store, 4)
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `DELETE FROM user_activity WHERE id = 2`)
+	require.NoError(t, err)
+
+	_, err = Rebase(ctx, store, 3)
+	require.NoError(t, err)
+
+	// Append two more linked rows via the normal tx.Append path.
+	tx, err := store.BeginTx(ctx)
+	require.NoError(t, err)
+	tail, err := tx.TailHash(ctx)
+	require.NoError(t, err)
+	for i := range 2 {
+		ua := &UserActivity{
+			Ts:         2000000000000 + int64(i),
+			UserID:     "u1",
+			UserIDType: UserIDTypePlatform,
+			Platform:   PlatformTest,
+			Action:     ActionAuthLogin,
+			Outcome:    OutcomeSuccess,
+			DetailJSON: "{}",
+			PrevHash:   tail,
+		}
+		h, err := ComputeSelfHash(tail, ua)
+		require.NoError(t, err)
+		ua.SelfHash = h
+		require.NoError(t, tx.Append(ctx, ua))
+		tail = h
+	}
+	require.NoError(t, tx.Commit())
+
+	result, err := NewVerifier(store, VerifierConfig{}, nil).VerifyOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result.BrokenID, "append after rebase must stay chained")
+}
+
+// TestRebase_GenesisAnchor covers rebasing at the very first row: its empty
+// prev_hash makes the checkpoint anchor empty, so verify treats the anchor
+// row as the new genesis.
+func TestRebase_GenesisAnchor(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+	writeChain(t, store, 3)
+
+	ctx := context.Background()
+	cp, err := Rebase(ctx, store, 1)
+	require.NoError(t, err)
+	require.Empty(t, cp.LastSelfHash, "genesis row has an empty prev_hash")
+	require.Equal(t, int64(1), cp.NextID)
+
+	result, err := NewVerifier(store, VerifierConfig{}, nil).VerifyOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result.BrokenID)
+}
+
+// TestRebase_TargetRowMissing pins the failure contract: rebasing to an id
+// with no surviving row (the row was deleted, or the table is empty) must
+// fail with ErrRebaseRowNotFound instead of silently anchoring elsewhere.
+func TestRebase_TargetRowMissing(t *testing.T) {
+	t.Parallel()
+	store, db := newTestStoreAndDB(t)
+	writeChain(t, store, 3)
+
+	ctx := context.Background()
+	// Row 2 deleted AND target 2 beyond the tail: QueryAsc(2) would return
+	// row 3, which is NOT the requested anchor — must be rejected.
+	_, err := db.ExecContext(ctx, `DELETE FROM user_activity WHERE id = 2`)
+	require.NoError(t, err)
+	_, err = Rebase(ctx, store, 2)
+	require.ErrorIs(t, err, ErrRebaseRowNotFound)
+
+	// Past the tail entirely.
+	_, err = Rebase(ctx, store, 99)
+	require.ErrorIs(t, err, ErrRebaseRowNotFound)
+}
+
+// TestRebase_EmptyTable pins the empty-table failure contract.
+func TestRebase_EmptyTable(t *testing.T) {
+	t.Parallel()
+	store := newTestSQLiteStore(t)
+
+	_, err := Rebase(context.Background(), store, 1)
+	require.ErrorIs(t, err, ErrRebaseRowNotFound)
+}

--- a/internal/cli/checkers/effective_plan.go
+++ b/internal/cli/checkers/effective_plan.go
@@ -1,0 +1,144 @@
+package checkers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hrygo/hotplex/internal/agentspec"
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+// effectivePlanChecker probes the desired-state EffectiveRuntimePlan the
+// current config would produce for each config-driven (messaging) platform
+// (#946 spec §6.6). It uses the shared agentspec resolver against the local
+// config only — strictly read-only, no DB, no network, no config mutation.
+// Request-driven platforms (webchat) are not probed: their plan depends on
+// per-request metadata a local doctor run cannot know.
+type effectivePlanChecker struct{}
+
+func (c effectivePlanChecker) Name() string     { return "runtime.effective_plan" }
+func (c effectivePlanChecker) Category() string { return "runtime" }
+
+// planProbeResult is one platform's probe outcome.
+type planProbeResult struct {
+	platform string
+	hash     string
+	worker   string
+	perm     string
+	sandbox  string
+	warnings []string
+	blocked  []string
+}
+
+// messagingProbePlatforms are the config-driven platforms whose worker chain
+// the local config fully determines (the documented 5-level fallback).
+var messagingProbePlatforms = []string{"slack", "feishu", "yuanxin"}
+
+func (c effectivePlanChecker) Check(ctx context.Context) cli.Diagnostic {
+	cfg, err := loadConfig()
+	if err != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot load config for runtime plan probe",
+			Detail:   err.Error(),
+			FixHint:  "Fix the config first (hotplex config validate), then re-run doctor",
+		}
+	}
+	if cfg == nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "No config loaded; runtime plan probe skipped",
+		}
+	}
+
+	probes := probeEffectivePlans(ctx, cfg)
+	lines := make([]string, 0, len(probes))
+	var blockedPlatforms []string
+	for _, p := range probes {
+		if len(p.blocked) > 0 && p.hash == "" {
+			// Fully blocked before any field resolved: the codes are the payload.
+			lines = append(lines, fmt.Sprintf("%s: BLOCKED=%s", p.platform, strings.Join(p.blocked, ",")))
+			blockedPlatforms = append(blockedPlatforms, p.platform)
+			continue
+		}
+		line := fmt.Sprintf("%s: plan=%s worker=%s permission=%s sandbox=%s",
+			p.platform, p.hash, p.worker, displayOr(p.perm, "default"), displayOr(p.sandbox, "-"))
+		if len(p.warnings) > 0 {
+			line += " warnings=" + strings.Join(p.warnings, ",")
+		}
+		if len(p.blocked) > 0 {
+			line += " BLOCKED=" + strings.Join(p.blocked, ",")
+			blockedPlatforms = append(blockedPlatforms, p.platform)
+		}
+		lines = append(lines, line)
+	}
+
+	if len(blockedPlatforms) > 0 {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  fmt.Sprintf("Effective runtime plan blocked on %d platform(s)", len(blockedPlatforms)),
+			Detail:   strings.Join(lines, "\n"),
+			FixHint: "Fix the blocked config values (worker_type / permission mode / sandbox mode) " +
+				"listed above, then restart the gateway — a blocked plan is never a silent success",
+		}
+	}
+	return cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusPass,
+		Message:  fmt.Sprintf("Effective runtime plans resolved for %d platform(s)", len(probes)),
+		Detail:   strings.Join(lines, "\n"),
+	}
+}
+
+// probeEffectivePlans resolves one desired-state plan per messaging platform
+// using the shared resolver. Pure given cfg — the checker and its tests call
+// this directly. A probe that resolves nil config never happens here (Check
+// guards it). The resolver is the zero value: plan validation uses the live
+// worker registry, so doctor sees the same boundary the gateway sees.
+func probeEffectivePlans(ctx context.Context, cfg *config.Config) []planProbeResult {
+	results := make([]planProbeResult, 0, len(messagingProbePlatforms))
+	for _, platform := range messagingProbePlatforms {
+		if ctx.Err() != nil {
+			break
+		}
+		plan, err := (agentspec.Resolver{}).ResolvePlan(agentspec.Input{Cfg: cfg, Platform: platform})
+		res := planProbeResult{platform: platform}
+		if err != nil {
+			for _, b := range plan.Blocked {
+				res.blocked = append(res.blocked, b.Code)
+			}
+			results = append(results, res)
+			continue
+		}
+		view := plan.Redacted()
+		res.hash = plan.PlanHash
+		res.worker = displayOr(view.WorkerType, "unresolved")
+		res.perm = view.PermissionMode
+		res.sandbox = view.SandboxMode
+		for _, w := range plan.Warnings {
+			res.warnings = append(res.warnings, w.Code)
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+func displayOr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func init() {
+	cli.DefaultRegistry.Register(effectivePlanChecker{})
+}

--- a/internal/cli/checkers/effective_plan_test.go
+++ b/internal/cli/checkers/effective_plan_test.go
@@ -1,0 +1,123 @@
+package checkers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/agentspec"
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+var effectivePlanHashRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+func TestEffectivePlanChecker_Identity(t *testing.T) {
+	t.Parallel()
+	c := effectivePlanChecker{}
+	require.Equal(t, "runtime.effective_plan", c.Name())
+	require.Equal(t, "runtime", c.Category())
+}
+
+// Tests that touch the package-level configPath must NOT use t.Parallel
+// (see withConfigPath in config_test.go).
+
+func TestEffectivePlanChecker_NoConfig(t *testing.T) {
+	withConfigPath(t, "")
+
+	c := effectivePlanChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status)
+	require.Contains(t, d.Message, "No config loaded")
+}
+
+func TestEffectivePlanChecker_LoadError(t *testing.T) {
+	withConfigPath(t, "/nonexistent/config.yaml")
+
+	c := effectivePlanChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusWarn, d.Status)
+	require.Contains(t, d.Message, "Cannot load config")
+	require.NotEmpty(t, d.FixHint)
+}
+
+// TestEffectivePlanChecker_BlockedPlans_Warn: the test binary's worker
+// registry is empty, so every config-driven messaging probe is blocked
+// fail-closed (unknown_worker_type). Doctor must surface that as a warning —
+// a blocked plan is never a silent pass (#946 spec §6.6).
+func TestEffectivePlanChecker_BlockedPlans_Warn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `gateway:
+  addr: ":8888"
+admin:
+  addr: ":9999"
+  enabled: true
+db:
+  path: "data/test.db"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	withConfigPath(t, path)
+
+	c := effectivePlanChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusWarn, d.Status)
+	require.Contains(t, d.Detail, "BLOCKED="+agentspec.BlockUnknownWorkerType)
+	require.Contains(t, d.Message, "blocked")
+	require.NotEmpty(t, d.FixHint)
+}
+
+// probeEffectivePlans is pure given cfg — the tests below are parallel-safe.
+
+func TestProbeEffectivePlans_NilConfig_Unresolved(t *testing.T) {
+	t.Parallel()
+
+	results := probeEffectivePlans(context.Background(), nil)
+
+	require.Len(t, results, len(messagingProbePlatforms))
+	for _, res := range results {
+		require.Regexp(t, effectivePlanHashRe, res.hash)
+		require.Equal(t, "unresolved", res.worker)
+		require.Empty(t, res.blocked)
+		require.Contains(t, res.warnings, agentspec.WarnWorkerTypeUnresolved)
+	}
+}
+
+// TestProbeEffectivePlans_DefaultConfig_BlockedByEmptyRegistry documents the
+// registry boundary: with nothing registered (the test binary), the shared
+// resolver rejects the compile-default worker type and every probe is blocked
+// with no plan hash.
+func TestProbeEffectivePlans_DefaultConfig_BlockedByEmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	results := probeEffectivePlans(context.Background(), config.Default())
+
+	require.Len(t, results, len(messagingProbePlatforms))
+	for _, res := range results {
+		require.Empty(t, res.hash, "a blocked plan carries no hash")
+		require.Equal(t, []string{agentspec.BlockUnknownWorkerType}, res.blocked)
+	}
+}
+
+func TestProbeEffectivePlans_CancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results := probeEffectivePlans(ctx, config.Default())
+
+	require.Empty(t, results)
+}
+
+func TestDisplayOr(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "value", displayOr("value", "fallback"))
+	require.Equal(t, "fallback", displayOr("", "fallback"))
+}

--- a/internal/cli/checkers/execution_fences.go
+++ b/internal/cli/checkers/execution_fences.go
@@ -1,0 +1,158 @@
+package checkers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/dbutil"
+	"github.com/hrygo/hotplex/internal/sqlutil"
+)
+
+// fencedExecutionsChecker reports executions whose runtime ended ambiguous
+// and raised a fence (#877). Fenced executions block fresh input for their
+// session until an operator resolves or abandons them, so any fence is at
+// least a Warn.
+//
+// Read-only contract: the SQLite database is opened with PRAGMA query_only
+// (same pattern as `hotplex audit verify`) and never written; PostgreSQL
+// backends cannot be inspected locally and are pointed at the Admin API.
+// There is deliberately no FixFunc — fence decisions are operator actions
+// with audit consequences and must go through the Admin API / CLI.
+type fencedExecutionsChecker struct {
+	defaultDBPath string
+}
+
+func (c fencedExecutionsChecker) Name() string     { return "runtime.fenced_executions" }
+func (c fencedExecutionsChecker) Category() string { return "runtime" }
+
+func (c fencedExecutionsChecker) Check(ctx context.Context) cli.Diagnostic {
+	cfg, err := loadConfig()
+	if err != nil {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot load config for fence inspection",
+			Detail:   err.Error(),
+			FixHint:  "Fix the config first (hotplex config validate), then re-run doctor",
+		}
+	}
+
+	dbPath := c.defaultDBPath
+	driver := ""
+	if cfg != nil {
+		driver = cfg.DB.Driver
+		if cfg.DB.SQLite.Path != "" {
+			dbPath = cfg.DB.SQLite.Path
+		}
+	}
+	if dbutil.ParseDialect(driver) == dbutil.DialectPostgres {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "PostgreSQL backend: fences are not inspectable locally",
+			FixHint:  "Use `hotplex runtime fences list` (Admin API) to inspect fenced executions",
+		}
+	}
+
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return cli.Diagnostic{
+				Name:     c.Name(),
+				Category: c.Category(),
+				Status:   cli.StatusPass,
+				Message:  "No execution database yet: " + dbPath,
+			}
+		}
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  "Cannot stat execution database: " + dbPath,
+			Detail:   err.Error(),
+		}
+	}
+
+	count, earliestMs, err := countFencedExecutions(ctx, dbPath)
+	if err != nil {
+		msg := "Cannot inspect execution database"
+		if strings.Contains(err.Error(), "no such table") {
+			return cli.Diagnostic{
+				Name:     c.Name(),
+				Category: c.Category(),
+				Status:   cli.StatusPass,
+				Message:  "Execution tables not initialized yet (gateway never started)",
+			}
+		}
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusWarn,
+			Message:  msg,
+			Detail:   err.Error(),
+		}
+	}
+
+	if count == 0 {
+		return cli.Diagnostic{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   cli.StatusPass,
+			Message:  "No fenced executions",
+		}
+	}
+
+	detail := fmt.Sprintf("%d fenced execution(s) blocking fresh input", count)
+	if earliestMs > 0 {
+		detail += "; earliest fence at " + time.UnixMilli(earliestMs).Format(time.RFC3339)
+	}
+	return cli.Diagnostic{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   cli.StatusWarn,
+		Message:  fmt.Sprintf("%d fenced execution(s) found", count),
+		Detail:   detail,
+		FixHint:  "Inspect with `hotplex runtime fences list`, then `hotplex runtime fences resolve|abandon <execution-id> --fence-version <n> --reason \"...\" --confirm`",
+	}
+}
+
+// countFencedExecutions opens the SQLite database strictly read-only and
+// counts fenced rows plus the earliest fence timestamp.
+func countFencedExecutions(ctx context.Context, dbPath string) (int64, int64, error) {
+	db, err := sql.Open(sqlutil.DriverName, dbPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("open sqlite db: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
+		return 0, 0, fmt.Errorf("set sqlite busy_timeout: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, "PRAGMA query_only=ON"); err != nil {
+		return 0, 0, fmt.Errorf("set sqlite query_only: %w", err)
+	}
+
+	var count int64
+	var earliest sql.NullInt64
+	err = db.QueryRowContext(ctx,
+		`SELECT COUNT(*), MIN(fence_created_at) FROM execution_inputs WHERE fence_reason <> ''`).
+		Scan(&count, &earliest)
+	if err != nil {
+		return 0, 0, err
+	}
+	return count, earliest.Int64, nil
+}
+
+func init() {
+	cli.DefaultRegistry.Register(fencedExecutionsChecker{
+		defaultDBPath: filepath.Join(config.HotplexHome(), "data", "hotplex.db"),
+	})
+}

--- a/internal/cli/checkers/execution_fences_test.go
+++ b/internal/cli/checkers/execution_fences_test.go
@@ -1,0 +1,107 @@
+package checkers
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/cli"
+	"github.com/hrygo/hotplex/internal/sqlutil"
+)
+
+// newFenceTestDB creates a SQLite file with the minimal execution_inputs
+// columns the checker reads, optionally seeding fenced rows.
+func newFenceTestDB(t *testing.T, fencedRows int) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "hotplex.db")
+	db, err := sql.Open(sqlutil.DriverName, dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`CREATE TABLE execution_inputs (
+		execution_id TEXT PRIMARY KEY,
+		fence_reason TEXT NOT NULL DEFAULT '',
+		fence_version INTEGER NOT NULL DEFAULT 0,
+		fence_created_at INTEGER
+	)`)
+	require.NoError(t, err)
+	for i := range fencedRows {
+		_, err = db.Exec(
+			`INSERT INTO execution_inputs (execution_id, fence_reason, fence_version, fence_created_at) VALUES (?, 'GATEWAY_LEASE_EXPIRED', 1, ?)`,
+			"exec-"+string(rune('a'+i)), int64(1722800000000+i*1000))
+		require.NoError(t, err)
+	}
+	return dbPath
+}
+
+func TestFencedExecutionsChecker_NoFences(t *testing.T) {
+	// Check() -> loadConfig() reads package-level configPath; cannot
+	// t.Parallel (see config_test.go:13).
+	withConfigPath(t, "")
+	dbPath := newFenceTestDB(t, 0)
+	c := fencedExecutionsChecker{defaultDBPath: dbPath}
+
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status)
+	require.Contains(t, d.Message, "No fenced executions")
+	require.Nil(t, d.FixFunc, "fence checker must never auto-fix")
+}
+
+func TestFencedExecutionsChecker_FencesWarn(t *testing.T) {
+	withConfigPath(t, "")
+	dbPath := newFenceTestDB(t, 2)
+	c := fencedExecutionsChecker{defaultDBPath: dbPath}
+
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusWarn, d.Status)
+	require.Contains(t, d.Message, "2 fenced execution(s)")
+	require.Contains(t, d.Detail, "earliest fence at")
+	require.Contains(t, d.FixHint, "hotplex runtime fences")
+	require.Nil(t, d.FixFunc, "fence decisions are operator actions, never auto-fixed")
+}
+
+func TestFencedExecutionsChecker_MissingDBPass(t *testing.T) {
+	withConfigPath(t, "")
+	c := fencedExecutionsChecker{defaultDBPath: filepath.Join(t.TempDir(), "absent.db")}
+
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status)
+	require.Contains(t, d.Message, "No execution database yet")
+}
+
+func TestFencedExecutionsChecker_NoTablesPass(t *testing.T) {
+	withConfigPath(t, "")
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+	db, err := sql.Open(sqlutil.DriverName, dbPath)
+	require.NoError(t, err)
+	_, _ = db.Exec("CREATE TABLE unrelated (id INTEGER)")
+	require.NoError(t, db.Close())
+
+	c := fencedExecutionsChecker{defaultDBPath: dbPath}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status)
+	require.Contains(t, d.Message, "not initialized")
+}
+
+func TestCountFencedExecutions_ReadOnly(t *testing.T) {
+	t.Parallel()
+	dbPath := newFenceTestDB(t, 1)
+
+	count, earliest, err := countFencedExecutions(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+	require.Equal(t, int64(1722800000000), earliest)
+
+	// query_only must have prevented any accidental write path: a second
+	// independent read sees the same state.
+	count2, _, err := countFencedExecutions(context.Background(), dbPath)
+	require.NoError(t, err)
+	require.Equal(t, count, count2)
+}

--- a/internal/cli/checkers/permission_mode.go
+++ b/internal/cli/checkers/permission_mode.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/cli"
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/worker"
 )
 
 // claudeAutoModeChecker verifies the installed Claude Code CLI advertises the
@@ -101,9 +102,9 @@ func (c claudeBypassModeChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	workspaceMode := resolveClaudePermissionMode(cfg.Worker.DefaultPermissionMode, cfg.Worker.ClaudeCode.PermissionMode)
-	platformMode := resolveClaudePermissionMode("", cfg.Worker.ClaudeCode.PermissionMode)
-	if workspaceMode == permissionModeBypass || platformMode == permissionModeBypass {
+	workspaceMode := effectiveClaudeMode(cfg.Worker.DefaultPermissionMode, cfg.Worker.ClaudeCode.PermissionMode)
+	platformMode := effectiveClaudeMode("", cfg.Worker.ClaudeCode.PermissionMode)
+	if workspaceMode == worker.PermissionModeBypass || platformMode == worker.PermissionModeBypass {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
@@ -122,44 +123,15 @@ func (c claudeBypassModeChecker) Check(ctx context.Context) cli.Diagnostic {
 	}
 }
 
-const (
-	permissionModeReadOnly  = "read-only"
-	permissionModeWorkspace = "workspace"
-	permissionModeAutoEdit  = "auto-edit"
-	permissionModeBypass    = "bypass"
-)
-
-// resolveClaudePermissionMode mirrors Claude Code's runtime resolution: a
-// platform session has no session mode and therefore uses the operator mode;
-// an explicit workspace default is clamped to that operator ceiling. Empty
-// operator mode preserves the legacy Claude Code bypass default.
-func resolveClaudePermissionMode(sessionMode, operatorMode string) string {
-	effectiveMode := sessionMode
-	if effectiveMode == "" {
-		effectiveMode = operatorMode
+// effectiveClaudeMode resolves the effective Claude Code permission tier via
+// the shared worker resolver and maps the empty result to the legacy bypass
+// default, matching Claude Code's own behavior.
+func effectiveClaudeMode(sessionMode, operatorMode string) string {
+	mode := worker.ResolvePermissionMode(sessionMode, operatorMode)
+	if mode == "" {
+		return worker.PermissionModeBypass
 	}
-	if operatorMode != "" && permissionModeRank(effectiveMode) > permissionModeRank(operatorMode) {
-		effectiveMode = operatorMode
-	}
-	if effectiveMode == "" {
-		return permissionModeBypass
-	}
-	return effectiveMode
-}
-
-func permissionModeRank(mode string) int {
-	switch mode {
-	case permissionModeReadOnly:
-		return 0
-	case permissionModeWorkspace:
-		return 1
-	case permissionModeAutoEdit:
-		return 2
-	case permissionModeBypass:
-		return 3
-	default:
-		return 0
-	}
+	return mode
 }
 
 func hasFeishuClaudeCodeWorker(cfg *config.Config) bool {

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -130,6 +130,7 @@ func Load(filePath string) (*Config, error) {
 	_ = v.BindEnv("webhook.path")
 	_ = v.BindEnv("webhook.max_body_size")
 	_ = v.BindEnv("webhook.target_job_name")
+	_ = v.BindEnv("events.retention")
 	_ = v.BindEnv("audit.enabled")
 	_ = v.BindEnv("audit.retention")
 	_ = v.BindEnv("audit.full_content_retention")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -559,6 +559,15 @@ func TestLoad_NumberedEnv(t *testing.T) {
 	require.Contains(t, cfg.Security.APIKeys, "key1")
 }
 
+func TestLoad_EventsRetentionEnvOverride(t *testing.T) {
+	t.Setenv("HOTPLEX_EVENTS_RETENTION", "168h")
+
+	cfg, err := Load("")
+	require.NoError(t, err)
+
+	require.Equal(t, 168*time.Hour, cfg.Events.Retention)
+}
+
 func TestAutoRetryConfig_Defaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/execution/multi_instance_pg_test.go
+++ b/internal/execution/multi_instance_pg_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -120,4 +121,112 @@ func TestPGMultiInstance_PartialUniqueIndexRejectsSecondActive(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrSessionBusy,
 		"PG partial unique index must reject second active execution per session")
+}
+
+// fencePGSetup fences an execution on real PostgreSQL and returns two
+// independent store views (writeMu=nil: contention happens in the database,
+// exactly like two gateway processes).
+func fencePGSetup(t *testing.T, msgID string) (*SQLStore, *SQLStore, *Record) {
+	t.Helper()
+	storeA, db := openPGStore(t)
+	ctx := context.Background()
+
+	rec, _, err := storeA.Accept(ctx, AcceptRequest{
+		SessionID: "session-pg", ClientMessageID: msgID, PayloadHash: "h-" + msgID,
+		OwnerInstanceID: "gw-A", WorkerRunID: "run-A",
+	})
+	require.NoError(t, err)
+	require.NoError(t, storeA.MarkRunning(ctx, rec.ExecutionID, "gw-A", "run-A"))
+	require.NoError(t, storeA.FinishRuntime(ctx, rec.ExecutionID, "run-A", RuntimeUnknown, "TIMEOUT"))
+
+	fenced, err := storeA.FenceBySession(ctx, "session-pg")
+	require.NoError(t, err)
+	require.NotEmpty(t, fenced.FenceReason)
+	require.NotZero(t, fenced.FenceVersion)
+	require.NotNil(t, fenced.FenceCreatedAt)
+
+	storeB, err := NewSQLStore(ctx, db, dbutil.DialectPostgres, nil, nil)
+	require.NoError(t, err)
+	return storeA, storeB, fenced
+}
+
+func TestPGMultiInstance_FenceDecisionExactlyOnce(t *testing.T) {
+	storeA, storeB, fenced := fencePGSetup(t, "msg-pg-fence-race")
+	ctx := context.Background()
+
+	const instances = 8
+	results := make(chan error, instances)
+	var wg sync.WaitGroup
+	for i := range instances {
+		wg.Add(1)
+		store := storeA
+		if i%2 == 1 {
+			store = storeB
+		}
+		go func() {
+			defer wg.Done()
+			_, err := store.ApplyFenceDecision(ctx, FenceActionRequest{
+				ExecutionID:          fenced.ExecutionID,
+				ExpectedFenceVersion: fenced.FenceVersion,
+				Decision:             FenceDecisionResolve,
+			})
+			results <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var successes int
+	for err := range results {
+		if err == nil {
+			successes++
+			continue
+		}
+		require.ErrorIs(t, err, ErrFenceConflict)
+	}
+	require.Equal(t, 1, successes, "real PG conditional update must admit exactly one winner")
+}
+
+func TestPGMultiInstance_FenceActionStaleVersionConflicts(t *testing.T) {
+	storeA, storeB, fenced := fencePGSetup(t, "msg-pg-fence-stale")
+	ctx := context.Background()
+
+	_, err := storeB.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionResolve,
+	})
+	require.NoError(t, err)
+
+	_, err = storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionAbandon,
+	})
+	require.ErrorIs(t, err, ErrFenceConflict, "restart between inspect and action must conflict, not apply")
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeUnknown, stored.RuntimeStatus)
+	require.Empty(t, stored.FenceReason)
+}
+
+func TestPGMultiInstance_AbandonSurvivesLateDone(t *testing.T) {
+	storeA, _, fenced := fencePGSetup(t, "msg-pg-fence-late")
+	ctx := context.Background()
+
+	_, err := storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionAbandon,
+	})
+	require.NoError(t, err)
+
+	err = storeA.FinishRuntime(ctx, fenced.ExecutionID, "run-A", RuntimeCompleted, "")
+	require.Error(t, err, "late Done must not regress an abandoned execution on PG")
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeFailed, stored.RuntimeStatus)
+	require.Equal(t, RuntimeErrorCodeOperatorAbandoned, stored.RuntimeErrorCode)
 }

--- a/internal/execution/multi_instance_test.go
+++ b/internal/execution/multi_instance_test.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -120,4 +121,185 @@ func TestMultiInstance_RenewLeasesOnlyAffectsOwnOwner(t *testing.T) {
 	stored, err := storeA.getByID(ctx, rec.ExecutionID)
 	require.NoError(t, err)
 	require.Greater(t, stored.LeaseUntil, rec.LeaseUntil, "A's renew must extend lease")
+}
+
+// fenceMultiInstanceSetup fences an execution owned by gw-A and returns two
+// store views of the same database (two gateway instances) plus the record.
+func fenceMultiInstanceSetup(t *testing.T, sessionID, msgID string) (*SQLStore, *SQLStore, *Record) {
+	t.Helper()
+	storeA, sessionStore := newTestSQLStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, sessionStore.Upsert(ctx, &session.SessionInfo{
+		ID: sessionID, UserID: "user-1", WorkerType: "claude_code",
+		State: events.StateRunning, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	rec, _, err := storeA.Accept(ctx, AcceptRequest{
+		SessionID: sessionID, ClientMessageID: msgID, PayloadHash: "h-" + msgID,
+		OwnerInstanceID: "gw-A", WorkerRunID: "run-A",
+	})
+	require.NoError(t, err)
+	require.NoError(t, storeA.MarkRunning(ctx, rec.ExecutionID, "gw-A", "run-A"))
+	require.NoError(t, storeA.FinishRuntime(ctx, rec.ExecutionID, "run-A", RuntimeUnknown, "TIMEOUT"))
+
+	fenced, err := storeA.FenceBySession(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, fenced.FenceReason)
+
+	storeB, err := NewSQLStore(ctx, sessionStore.DB(), storeA.dialect, storeA.writeMu, nil)
+	require.NoError(t, err)
+	return storeA, storeB, fenced
+}
+
+func TestMultiInstance_FenceDecisionExactlyOnceAcrossInstances(t *testing.T) {
+	t.Parallel()
+	storeA, storeB, fenced := fenceMultiInstanceSetup(t, "session-frace", "msg-frace")
+	ctx := context.Background()
+
+	// Both instances inspect the same fence version, then race their decisions.
+	fenceB, err := storeB.FenceBySession(ctx, "session-frace")
+	require.NoError(t, err)
+	require.Equal(t, fenced.FenceVersion, fenceB.FenceVersion)
+
+	const instances = 8
+	results := make(chan error, instances)
+	var wg sync.WaitGroup
+	for i := range instances {
+		wg.Add(1)
+		store := storeA
+		if i%2 == 1 {
+			store = storeB
+		}
+		go func() {
+			defer wg.Done()
+			_, err := store.ApplyFenceDecision(ctx, FenceActionRequest{
+				ExecutionID:          fenced.ExecutionID,
+				ExpectedFenceVersion: fenced.FenceVersion,
+				Decision:             FenceDecisionResolve,
+			})
+			results <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var successes int
+	for err := range results {
+		if err == nil {
+			successes++
+			continue
+		}
+		require.ErrorIs(t, err, ErrFenceConflict, "losers must see a conflict, not a silent no-op")
+	}
+	require.Equal(t, 1, successes, "exactly one operator decision may win")
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Empty(t, stored.FenceReason)
+	require.Equal(t, RuntimeUnknown, stored.RuntimeStatus)
+}
+
+func TestMultiInstance_StaleFenceVersionAfterOtherInstanceActs(t *testing.T) {
+	t.Parallel()
+	storeA, storeB, fenced := fenceMultiInstanceSetup(t, "session-fstale", "msg-fstale")
+	ctx := context.Background()
+
+	// Operator on instance A inspects; before acting, instance B resolves.
+	_, err := storeB.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionResolve,
+	})
+	require.NoError(t, err)
+
+	// A's action with the stale version must conflict; no auto-retry.
+	_, err = storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionAbandon,
+	})
+	require.ErrorIs(t, err, ErrFenceConflict)
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeUnknown, stored.RuntimeStatus, "abandon must not apply after resolve")
+	require.Empty(t, stored.FenceReason)
+}
+
+func TestFenceDecision_LateDoneAfterResolveConverges(t *testing.T) {
+	t.Parallel()
+	storeA, _, fenced := fenceMultiInstanceSetup(t, "session-flate-ok", "msg-flate-ok")
+	ctx := context.Background()
+
+	_, err := storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionResolve,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, storeA.FinishRuntime(ctx, fenced.ExecutionID, "run-A", RuntimeCompleted, ""),
+		"late Done after resolve must still converge unknown->completed")
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeCompleted, stored.RuntimeStatus)
+	require.Empty(t, stored.FenceReason)
+	require.Equal(t, fenced.FenceVersion, stored.FenceVersion)
+}
+
+func TestFenceDecision_LateDoneAfterAbandonRejected(t *testing.T) {
+	t.Parallel()
+	storeA, _, fenced := fenceMultiInstanceSetup(t, "session-flate-no", "msg-flate-no")
+	ctx := context.Background()
+
+	_, err := storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+		ExecutionID:          fenced.ExecutionID,
+		ExpectedFenceVersion: fenced.FenceVersion,
+		Decision:             FenceDecisionAbandon,
+	})
+	require.NoError(t, err)
+
+	err = storeA.FinishRuntime(ctx, fenced.ExecutionID, "run-A", RuntimeCompleted, "")
+	require.Error(t, err, "late Done must not regress an abandoned execution")
+
+	stored, err := storeA.getByID(ctx, fenced.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeFailed, stored.RuntimeStatus)
+	require.Equal(t, RuntimeErrorCodeOperatorAbandoned, stored.RuntimeErrorCode)
+}
+
+func TestFenceDecision_NewInputAcceptedAfterDecision(t *testing.T) {
+	t.Parallel()
+
+	for _, decision := range []FenceDecision{FenceDecisionResolve, FenceDecisionAbandon} {
+		t.Run(string(decision), func(t *testing.T) {
+			t.Parallel()
+			sessionID := "session-fnew-" + string(decision)
+			storeA, _, fenced := fenceMultiInstanceSetup(t, sessionID, "msg-fnew")
+			ctx := context.Background()
+
+			_, _, err := storeA.Accept(ctx, AcceptRequest{
+				SessionID: sessionID, ClientMessageID: "msg-fnew-next", PayloadHash: "h-next",
+				OwnerInstanceID: "gw-B", WorkerRunID: "run-B",
+			})
+			require.ErrorIs(t, err, ErrSessionBusy, "fenced session must reject new input")
+
+			_, err = storeA.ApplyFenceDecision(ctx, FenceActionRequest{
+				ExecutionID:          fenced.ExecutionID,
+				ExpectedFenceVersion: fenced.FenceVersion,
+				Decision:             decision,
+			})
+			require.NoError(t, err)
+
+			next, _, err := storeA.Accept(ctx, AcceptRequest{
+				SessionID: sessionID, ClientMessageID: "msg-fnew-next", PayloadHash: "h-next",
+				OwnerInstanceID: "gw-B", WorkerRunID: "run-B",
+			})
+			require.NoError(t, err, "%q must release the session for fresh input", decision)
+			require.NotEqual(t, fenced.ExecutionID, next.ExecutionID)
+		})
+	}
 }

--- a/internal/execution/sql_store.go
+++ b/internal/execution/sql_store.go
@@ -70,18 +70,20 @@ func (s *SQLStore) withWriteLock(fn func() error) error {
 const executionColumns = `execution_id, session_id, client_message_id, payload_hash, status,
 	error_code, created_at, updated_at, delivered_at,
 	owner_instance_id, worker_run_id, lease_until,
-	runtime_status, runtime_error_code, started_at, finished_at, fence_reason`
+	runtime_status, runtime_error_code, started_at, finished_at, fence_reason,
+	fence_version, fence_created_at`
 
 func (s *SQLStore) scanRecord(sc interface {
 	Scan(dest ...any) error
 }) (*Record, error) {
 	r := new(Record)
-	var deliveredAt, startedAt, finishedAt sql.NullInt64
+	var deliveredAt, startedAt, finishedAt, fenceCreatedAt sql.NullInt64
 	err := sc.Scan(
 		&r.ExecutionID, &r.SessionID, &r.ClientMessageID, &r.PayloadHash, &r.Status,
 		&r.ErrorCode, &r.CreatedAt, &r.UpdatedAt, &deliveredAt,
 		&r.OwnerInstanceID, &r.WorkerRunID, &r.LeaseUntil,
 		&r.RuntimeStatus, &r.RuntimeErrorCode, &startedAt, &finishedAt, &r.FenceReason,
+		&r.FenceVersion, &fenceCreatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -95,7 +97,22 @@ func (s *SQLStore) scanRecord(sc interface {
 	if finishedAt.Valid {
 		r.FinishedAt = &finishedAt.Int64
 	}
+	if fenceCreatedAt.Valid {
+		r.FenceCreatedAt = &fenceCreatedAt.Int64
+	}
 	return r, nil
+}
+
+// fenceEntryBump returns the SET fragments that increment fence_version and
+// stamp fence_created_at when a row enters the fenced state. The CASE guards
+// keep the bump idempotent: only the transition from a non-fenced row counts
+// as fence entry. Empty when the update does not raise a fence.
+func (s *SQLStore) fenceEntryBump(setsFence bool) string {
+	if !setsFence {
+		return ""
+	}
+	return `, fence_version = CASE WHEN fence_reason = '' THEN fence_version + 1 ELSE fence_version END,
+	    fence_created_at = CASE WHEN fence_reason = '' THEN ` + s.dbNowMillisExpr() + ` ELSE fence_created_at END`
 }
 
 func (s *SQLStore) Accept(ctx context.Context, request AcceptRequest) (*Record, bool, error) {
@@ -356,7 +373,7 @@ func (s *SQLStore) FinishRuntime(ctx context.Context, executionID, workerRunID s
 		result, err := s.db.ExecContext(ctx, s.rebind(`
 			UPDATE execution_inputs
 			SET runtime_status = ?, runtime_error_code = ?, finished_at = ?,
-			    fence_reason = ?, updated_at = ?
+			    fence_reason = ?, updated_at = ?`+s.fenceEntryBump(fenceReason != "")+`
 			WHERE execution_id = ? AND worker_run_id = ?
 			  AND runtime_status IN `+currentFilter),
 			status, errorCode, now, fenceReason, now,
@@ -489,6 +506,124 @@ func (s *SQLStore) ClearFenceAfterFreshStart(ctx context.Context, executionID, r
 	return nil
 }
 
+// listFencesDefaultLimit bounds ListFences when the caller passes no limit.
+const listFencesDefaultLimit = 100
+
+func (s *SQLStore) ApplyFenceDecision(ctx context.Context, request FenceActionRequest) (*Record, error) {
+	if request.ExecutionID == "" {
+		return nil, errors.New("execution: execution id is required")
+	}
+	switch request.Decision {
+	case FenceDecisionResolve, FenceDecisionAbandon:
+	default:
+		return nil, fmt.Errorf("execution: invalid fence decision %q", request.Decision)
+	}
+
+	ctx, cancel := withTimeout(ctx)
+	defer cancel()
+
+	now := time.Now().UnixMilli()
+	var rows int64
+	err := s.withWriteLock(func() error {
+		var (
+			result sql.Result
+			err    error
+		)
+		if request.Decision == FenceDecisionResolve {
+			// Resolve clears the fence and keeps runtime_status=unknown: it
+			// never marks the execution delivered/completed.
+			result, err = s.db.ExecContext(ctx, s.rebind(`
+				UPDATE execution_inputs
+				SET fence_reason = '', updated_at = ?
+				WHERE execution_id = ? AND fence_reason <> '' AND fence_version = ?`),
+				now, request.ExecutionID, request.ExpectedFenceVersion)
+		} else {
+			// Abandon terminates the runtime as failed. The runtime_status
+			// predicate makes terminal non-regression explicit at the SQL
+			// level: fenced rows are runtime-unknown by construction.
+			result, err = s.db.ExecContext(ctx, s.rebind(`
+				UPDATE execution_inputs
+				SET fence_reason = '', runtime_status = ?, runtime_error_code = ?,
+				    finished_at = ?, updated_at = ?
+				WHERE execution_id = ? AND fence_reason <> '' AND fence_version = ?
+				  AND runtime_status = ?`),
+				RuntimeFailed, RuntimeErrorCodeOperatorAbandoned, now, now,
+				request.ExecutionID, request.ExpectedFenceVersion, RuntimeUnknown)
+		}
+		if err != nil {
+			return fmt.Errorf("execution: apply fence decision: %w", err)
+		}
+		rows, _ = result.RowsAffected()
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if rows == 0 {
+		current, err := s.getByID(ctx, request.ExecutionID)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fenceConflictFor(current, request.ExpectedFenceVersion)
+	}
+	return s.getByID(ctx, request.ExecutionID)
+}
+
+// fenceConflictFor classifies a failed conditional fence update so operators
+// get an actionable 409 instead of a silent no-op.
+func fenceConflictFor(current *Record, expectedVersion int64) error {
+	if current.FenceReason == "" {
+		return fmt.Errorf("%w: fence already cleared", ErrFenceConflict)
+	}
+	if current.FenceVersion != expectedVersion {
+		return fmt.Errorf("%w: fence version is %d, expected %d", ErrFenceConflict, current.FenceVersion, expectedVersion)
+	}
+	return fmt.Errorf("%w: runtime status is %q", ErrFenceConflict, current.RuntimeStatus)
+}
+
+func (s *SQLStore) ListFences(ctx context.Context, sessionID string, limit, offset int) ([]*Record, error) {
+	if limit <= 0 {
+		limit = listFencesDefaultLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	ctx, cancel := withTimeout(ctx)
+	defer cancel()
+
+	query := `
+		SELECT ` + executionColumns + `
+		FROM execution_inputs
+		WHERE fence_reason <> ''`
+	args := []any{}
+	if sessionID != "" {
+		query += ` AND session_id = ?`
+		args = append(args, sessionID)
+	}
+	// COALESCE keeps legacy rows (fenced before migration 031, created_at
+	// NULL) ordered deterministically across dialects.
+	query += ` ORDER BY COALESCE(fence_created_at, 0) DESC, created_at DESC LIMIT ? OFFSET ?`
+	args = append(args, limit, offset)
+
+	rows, err := s.db.QueryContext(ctx, s.rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("execution: list fences: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	records := make([]*Record, 0, limit)
+	for rows.Next() {
+		r, err := s.scanRecord(rows)
+		if err != nil {
+			return nil, fmt.Errorf("execution: list fences scan: %w", err)
+		}
+		records = append(records, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("execution: list fences iterate: %w", err)
+	}
+	return records, nil
+}
+
 func (s *SQLStore) RenewLeases(ctx context.Context, ownerID string, ttlSeconds int64, excludeExecutionIDs []string) (int64, error) {
 	if ownerID == "" {
 		return 0, errors.New("execution: owner id is required")
@@ -596,7 +731,8 @@ func (s *SQLStore) RecoverExpiredLeases(ctx context.Context, trackedExecutionIDs
 			    runtime_error_code = 'GATEWAY_LEASE_EXPIRED',
 			    fence_reason = 'GATEWAY_LEASE_EXPIRED',
 			    finished_at = `+s.dbNowMillisExpr()+`,
-			    updated_at = `+s.dbNowMillisExpr()+`
+			    updated_at = `+s.dbNowMillisExpr()+
+			s.fenceEntryBump(true)+`
 			WHERE runtime_status IN ('pending', 'running')
 			  AND lease_until <= `+s.dbNowMillisExpr()))
 		if err != nil {
@@ -678,7 +814,7 @@ func (s *SQLStore) TerminateOwnerLeases(ctx context.Context, ownerID, reason str
 			    runtime_error_code = ?,
 			    fence_reason = ?,
 			    finished_at = ?,
-			    updated_at = ?
+			    updated_at = ?`+s.fenceEntryBump(true)+`
 			WHERE owner_instance_id = ?
 			  AND runtime_status IN ('pending', 'running')`),
 			reason, reason, reason, now, now, ownerID)

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -34,6 +34,38 @@ const (
 // LeaseTTL is the default lease time-to-live for an active execution.
 const LeaseTTL = 60 // seconds
 
+// RuntimeErrorCodeOperatorAbandoned is the bounded runtime error code written
+// when an operator abandons a fenced execution (#877). It appears in the
+// execution store, the runtime.execution.failed AEP event, and metrics only —
+// never alongside prompt content or raw worker errors.
+const RuntimeErrorCodeOperatorAbandoned = "OPERATOR_ABANDONED"
+
+// FenceDecision is the operator action applied to a fenced execution (#877).
+// Both decisions clear the fence; neither marks the execution delivered or
+// completed and neither re-dispatches the input.
+type FenceDecision string
+
+const (
+	// FenceDecisionResolve clears the fence and keeps runtime_status=unknown.
+	// The operator determined the ambiguity is harmless; a fresh input can
+	// proceed on a new worker.
+	FenceDecisionResolve FenceDecision = "resolve"
+	// FenceDecisionAbandon clears the fence and terminates the runtime as
+	// failed with RuntimeErrorCodeOperatorAbandoned.
+	FenceDecisionAbandon FenceDecision = "abandon"
+)
+
+// FenceActionRequest is the conditional operator action on a fenced execution.
+// ExpectedFenceVersion is the fencing token read by the operator; the update
+// only applies when it still matches (optimistic concurrency across gateway
+// instances). Actor, reason, and evidence stay in the Admin layer — the store
+// persists no operator-supplied free text.
+type FenceActionRequest struct {
+	ExecutionID          string
+	ExpectedFenceVersion int64
+	Decision             FenceDecision
+}
+
 var (
 	// ErrNotFound means the execution does not exist.
 	ErrNotFound = errors.New("execution: record not found")
@@ -52,6 +84,11 @@ var (
 	ErrLeaseExpired = errors.New("execution: lease expired")
 	// ErrRunMismatch means a conditional update did not match the expected worker_run_id.
 	ErrRunMismatch = errors.New("execution: worker run mismatch")
+	// ErrFenceConflict means a conditional fence action did not match: the
+	// record is missing, no longer fenced, or its fence_version moved on
+	// (another operator or gateway instance acted first). The caller must
+	// re-inspect; the store never auto-retries.
+	ErrFenceConflict = errors.New("execution: fence version conflict")
 )
 
 // Record is the secret-free durable representation of an input delivery.
@@ -74,6 +111,13 @@ type Record struct {
 	StartedAt        *int64
 	FinishedAt       *int64
 	FenceReason      string
+	// --- Operator fence action fields (migration 031) ---
+	// FenceVersion is the fencing token: incremented each time the execution
+	// enters the fenced state from a non-fenced state.
+	FenceVersion int64
+	// FenceCreatedAt is the millisecond timestamp at which the current fence
+	// was raised; nil when the execution was never fenced.
+	FenceCreatedAt *int64
 }
 
 // AcceptRequest describes an input that must be durably accepted before dispatch.
@@ -139,6 +183,18 @@ type Store interface {
 	// worker_run_id, only if the current fence_reason matches the given reason.
 	// This is the final step of the fresh-Worker flow.
 	ClearFenceAfterFreshStart(ctx context.Context, executionID, reason, freshWorkerRunID string) error
+
+	// ApplyFenceDecision applies an operator fence action (resolve/abandon) to a
+	// fenced execution, conditional on ExpectedFenceVersion still matching
+	// (#877). Returns the updated record. Neither decision marks the execution
+	// delivered/completed or re-dispatches it. Missing record returns
+	// ErrNotFound; a moved/cleared fence returns ErrFenceConflict.
+	ApplyFenceDecision(ctx context.Context, request FenceActionRequest) (*Record, error)
+
+	// ListFences returns currently fenced executions ordered by fence_created_at
+	// (newest first), optionally filtered by session. limit<=0 uses the store
+	// default; offset supports pagination.
+	ListFences(ctx context.Context, sessionID string, limit, offset int) ([]*Record, error)
 
 	// RenewLeases batch-renews all pending/running executions owned by ownerID,
 	// extending lease_until to now + ttl. Returns the number of renewed records.

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -380,3 +380,219 @@ func TestAccept_AfterTerminalAllowsNewExecution(t *testing.T) {
 	_, _, err := store.Accept(context.Background(), testAcceptReq("session-seq", "msg-seq-2", "h2"))
 	require.NoError(t, err, "new execution after terminal must be allowed")
 }
+
+// acceptUnknownAndFence drives an execution into the fenced state
+// (runtime unknown + fence_reason set) and returns the fenced record.
+func acceptUnknownAndFence(t *testing.T, store *SQLStore, sessionStore *session.SQLiteStore, sessionID, msgID string) *Record {
+	t.Helper()
+	rec := acceptAndRun(t, store, sessionStore, sessionID, msgID)
+	require.NoError(t, store.FinishRuntime(context.Background(), rec.ExecutionID, testRun, RuntimeUnknown, "TIMEOUT"))
+	fenced, err := store.getByID(context.Background(), rec.ExecutionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, fenced.FenceReason, "helper precondition: record must be fenced")
+	return fenced
+}
+
+func TestApplyFenceDecision_ResolveClearsFence(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, sessionStore, "session-afr", "msg-afr")
+
+	got, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+		ExecutionID:          rec.ExecutionID,
+		ExpectedFenceVersion: rec.FenceVersion,
+		Decision:             FenceDecisionResolve,
+	})
+	require.NoError(t, err)
+	require.Empty(t, got.FenceReason, "resolve must clear the fence")
+	require.Equal(t, RuntimeUnknown, got.RuntimeStatus, "resolve keeps the runtime unknown, never delivered/completed")
+	require.NotEqual(t, RuntimeCompleted, got.RuntimeStatus)
+	require.NotEqual(t, StatusDelivered, got.Status)
+	require.Equal(t, rec.FenceVersion, got.FenceVersion, "resolve must not bump the fence version")
+}
+
+func TestApplyFenceDecision_AbandonMarksFailed(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, sessionStore, "session-aab", "msg-aab")
+
+	got, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+		ExecutionID:          rec.ExecutionID,
+		ExpectedFenceVersion: rec.FenceVersion,
+		Decision:             FenceDecisionAbandon,
+	})
+	require.NoError(t, err)
+	require.Empty(t, got.FenceReason, "abandon must clear the fence")
+	require.Equal(t, RuntimeFailed, got.RuntimeStatus)
+	require.Equal(t, RuntimeErrorCodeOperatorAbandoned, got.RuntimeErrorCode)
+	require.NotNil(t, got.FinishedAt)
+}
+
+func TestApplyFenceDecision_RejectsInvalidDecision(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, sessionStore, "session-aid", "msg-aid")
+
+	for _, decision := range []FenceDecision{"", "force", "RESOLVE", "Abandon"} {
+		_, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+			ExecutionID:          rec.ExecutionID,
+			ExpectedFenceVersion: rec.FenceVersion,
+			Decision:             decision,
+		})
+		require.Error(t, err, "decision %q must be rejected", decision)
+	}
+
+	stored, err := store.getByID(context.Background(), rec.ExecutionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stored.FenceReason, "rejected decisions must not mutate the record")
+}
+
+func TestApplyFenceDecision_RejectsStaleFenceVersion(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, sessionStore, "session-asv", "msg-asv")
+
+	_, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+		ExecutionID:          rec.ExecutionID,
+		ExpectedFenceVersion: rec.FenceVersion + 1,
+		Decision:             FenceDecisionResolve,
+	})
+	require.ErrorIs(t, err, ErrFenceConflict)
+
+	stored, err := store.getByID(context.Background(), rec.ExecutionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stored.FenceReason, "stale version must not mutate the record")
+	require.Equal(t, rec.FenceVersion, stored.FenceVersion)
+}
+
+func TestApplyFenceDecision_RepeatedActionConflicts(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	rec := acceptUnknownAndFence(t, store, sessionStore, "session-arp", "msg-arp")
+
+	_, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+		ExecutionID:          rec.ExecutionID,
+		ExpectedFenceVersion: rec.FenceVersion,
+		Decision:             FenceDecisionResolve,
+	})
+	require.NoError(t, err)
+
+	// Repeating the same action (or switching to abandon) must conflict, not
+	// produce a second state migration.
+	for _, decision := range []FenceDecision{FenceDecisionResolve, FenceDecisionAbandon} {
+		_, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+			ExecutionID:          rec.ExecutionID,
+			ExpectedFenceVersion: rec.FenceVersion,
+			Decision:             decision,
+		})
+		require.ErrorIs(t, err, ErrFenceConflict, "repeated %q must conflict", decision)
+	}
+
+	stored, err := store.getByID(context.Background(), rec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeUnknown, stored.RuntimeStatus, "no second migration may occur")
+}
+
+func TestApplyFenceDecision_NotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newTestSQLStore(t)
+
+	_, err := store.ApplyFenceDecision(context.Background(), FenceActionRequest{
+		ExecutionID:          "exec_missing",
+		ExpectedFenceVersion: 1,
+		Decision:             FenceDecisionResolve,
+	})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestFenceVersion_Lifecycle(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	ctx := context.Background()
+	rec := acceptAndRun(t, store, sessionStore, "session-fv", "msg-fv")
+	require.Zero(t, rec.FenceVersion, "fresh execution starts at fence version 0")
+	require.Nil(t, rec.FenceCreatedAt)
+
+	require.NoError(t, store.FinishRuntime(ctx, rec.ExecutionID, testRun, RuntimeUnknown, "TIMEOUT"))
+	fenced, err := store.getByID(ctx, rec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fenced.FenceVersion, "entering the fence bumps the version")
+	require.NotNil(t, fenced.FenceCreatedAt)
+
+	require.NoError(t, store.ClearFenceAfterFreshStart(ctx, rec.ExecutionID, fenced.FenceReason, "run-fresh-1"))
+	cleared, err := store.getByID(ctx, rec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), cleared.FenceVersion, "clearing the fence must not bump the version")
+
+	// Late convergence clears the fence without bumping the version.
+	require.NoError(t, store.FinishRuntime(ctx, rec.ExecutionID, "run-fresh-1", RuntimeCompleted, ""))
+	converged, err := store.getByID(ctx, rec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), converged.FenceVersion)
+	require.Empty(t, converged.FenceReason)
+}
+
+func TestFenceVersion_SetByLeaseRecoveryPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("terminate owner leases", func(t *testing.T) {
+		t.Parallel()
+		store, sessionStore := newTestSQLStore(t)
+		rec := acceptAndRun(t, store, sessionStore, "session-fvt", "msg-fvt")
+
+		terminated, err := store.TerminateOwnerLeases(context.Background(), testOwner, "GATEWAY_SHUTDOWN")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), terminated)
+
+		stored, err := store.getByID(context.Background(), rec.ExecutionID)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stored.FenceVersion)
+		require.NotNil(t, stored.FenceCreatedAt)
+	})
+
+	t.Run("recover expired leases", func(t *testing.T) {
+		t.Parallel()
+		store, sessionStore := newTestSQLStore(t)
+		rec := acceptAndRun(t, store, sessionStore, "session-fvr", "msg-fvr")
+		// Expire the lease deterministically instead of sleeping.
+		_, err := store.db.Exec(`UPDATE execution_inputs SET lease_until = 1 WHERE execution_id = ?`, rec.ExecutionID)
+		require.NoError(t, err)
+
+		recovery, err := store.RecoverExpiredLeases(context.Background(), nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), recovery.Recovered)
+
+		stored, err := store.getByID(context.Background(), rec.ExecutionID)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stored.FenceVersion)
+		require.NotNil(t, stored.FenceCreatedAt)
+	})
+}
+
+func TestListFences_FiltersAndOrders(t *testing.T) {
+	t.Parallel()
+	store, sessionStore := newTestSQLStore(t)
+	ctx := context.Background()
+
+	fencedA := acceptUnknownAndFence(t, store, sessionStore, "session-lfa", "msg-lfa")
+	fencedB := acceptUnknownAndFence(t, store, sessionStore, "session-lfb", "msg-lfb")
+	acceptAndRun(t, store, sessionStore, "session-lfc", "msg-lfc") // not fenced
+
+	all, err := store.ListFences(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 2, "only fenced executions are listed")
+
+	bySession, err := store.ListFences(ctx, "session-lfa", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, bySession, 1)
+	require.Equal(t, fencedA.ExecutionID, bySession[0].ExecutionID)
+
+	limited, err := store.ListFences(ctx, "", 1, 0)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	offset, err := store.ListFences(ctx, "", 1, 1)
+	require.NoError(t, err)
+	require.Len(t, offset, 1)
+	require.NotEqual(t, limited[0].ExecutionID, offset[0].ExecutionID)
+	_ = fencedB
+}

--- a/internal/gateway/agentspec.go
+++ b/internal/gateway/agentspec.go
@@ -1,10 +1,15 @@
 package gateway
 
 import (
+	"context"
 	"log/slog"
 	"slices"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/hrygo/hotplex/internal/agentspec"
+	"github.com/hrygo/hotplex/internal/observability"
 	"github.com/hrygo/hotplex/internal/worker"
 )
 
@@ -68,5 +73,49 @@ func ShadowCompareStartParams(log *slog.Logger, in agentspec.Input, legacy worke
 	if !slices.Equal(spec.Policy.AllowedTools, legacy.AllowedTools) {
 		log.Warn("agentspec shadow: allowed_tools divergence",
 			"agentspec", spec.Policy.AllowedTools, "legacy", legacy.AllowedTools)
+	}
+}
+
+// ShadowResolvePlan runs the #946 EffectiveRuntimePlan resolution in shadow
+// mode at the WS/REST entries. It is purely OBSERVATIONAL: it recovers from
+// any panic, never influences the legacy SessionStartParams (which stay
+// dispatch-authoritative), and only emits redacted diagnostics plus
+// low-cardinality metrics (the plan hash is never a metric label — #946 spec
+// §6.4). Blocked plans surface as bounded reason codes, never as silent
+// success.
+func ShadowResolvePlan(log *slog.Logger, in agentspec.Input) {
+	if log == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debug("runtime plan shadow: recovered panic", "recover", r)
+		}
+	}()
+
+	plan, err := (agentspec.Resolver{}).ResolvePlan(in)
+	if err != nil {
+		codes := make([]string, 0, len(plan.Blocked))
+		for _, b := range plan.Blocked {
+			codes = append(codes, b.Code)
+			observability.RuntimePlanBlocked().Add(context.Background(), 1,
+				metric.WithAttributes(attribute.String("code", b.Code)))
+		}
+		observability.RuntimePlanResolutions().Add(context.Background(), 1,
+			metric.WithAttributes(attribute.String("result", "blocked")))
+		log.Warn("runtime plan shadow: blocked",
+			"platform", in.Platform, "blocked", codes)
+		return
+	}
+
+	observability.RuntimePlanResolutions().Add(context.Background(), 1,
+		metric.WithAttributes(attribute.String("result", "ok")))
+	if len(plan.Warnings) > 0 {
+		codes := make([]string, 0, len(plan.Warnings))
+		for _, w := range plan.Warnings {
+			codes = append(codes, w.Code)
+		}
+		log.Warn("runtime plan shadow: warnings",
+			"platform", in.Platform, "plan_hash", plan.PlanHash, "warnings", codes)
 	}
 }

--- a/internal/gateway/agentspec_test.go
+++ b/internal/gateway/agentspec_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hrygo/hotplex/internal/agentspec"
 	"github.com/hrygo/hotplex/internal/worker"
 )
 
@@ -75,4 +76,50 @@ func TestShadowCompareStartParams_ResolveDivergence(t *testing.T) {
 	require.Contains(t, out, "resolve divergence", "expected a quiet resolve-divergence log")
 	require.False(t, strings.Contains(out, "worker_type divergence"),
 		"field-mismatch Warn must not fire on the resolve-divergence path")
+}
+
+// TestShadowResolvePlan_NilLogger: a nil logger must be a safe no-op.
+func TestShadowResolvePlan_NilLogger(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		ShadowResolvePlan(nil, BuildWebChatInput(worker.TypeClaudeCode, nil, "u1", "ws1"))
+	})
+}
+
+// TestShadowResolvePlan_Blocked: the empty test-binary registry rejects any
+// non-empty worker type fail-closed; the shadow logs the bounded blocked codes
+// (never a silent success) and never panics.
+func TestShadowResolvePlan_Blocked(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() {
+		ShadowResolvePlan(log,
+			BuildWebChatInput(worker.WorkerType("not-registered-in-test"), nil, "u1", "ws1"))
+	})
+
+	out := buf.String()
+	require.Contains(t, out, "runtime plan shadow: blocked")
+	require.Contains(t, out, agentspec.BlockUnknownWorkerType)
+}
+
+// TestShadowResolvePlan_OkWithWarnings: an empty worker type resolves (the
+// registry decides at dispatch) but the plan warns the desired state is
+// unproven; the shadow logs the warning codes with the plan hash.
+func TestShadowResolvePlan_OkWithWarnings(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() {
+		ShadowResolvePlan(log, BuildWebChatInput(worker.WorkerType(""), nil, "u1", "ws1"))
+	})
+
+	out := buf.String()
+	require.Contains(t, out, "runtime plan shadow: warnings")
+	require.Contains(t, out, agentspec.WarnWorkerTypeUnresolved)
+	require.Contains(t, out, "plan_hash")
+	require.False(t, strings.Contains(out, "runtime plan shadow: blocked"),
+		"an ok plan must not log the blocked path")
 }

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -364,7 +364,9 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	// normalized construction agrees with this legacy shape. REST has no
 	// AllowedTools source (nil) — the documented WS≠REST divergence. The legacy
 	// params stay authoritative in first-cut.
-	ShadowCompareStartParams(g.log, BuildWebChatInput(wt, nil, userID, sessionWorkspaceID), startParams)
+	in := BuildWebChatInput(wt, nil, userID, sessionWorkspaceID)
+	ShadowCompareStartParams(g.log, in, startParams)
+	ShadowResolvePlan(g.log, in)
 	if err := g.bridge.StartSession(r.Context(), startParams); err != nil {
 		g.log.Error("gateway: create session failed", "session_id", id, "worker_type", wt, "work_dir", workDir, "err", err)
 		writeAppError(w, http.StatusInternalServerError, "INTERNAL", "failed to create session")

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -632,8 +632,9 @@ func (c *Conn) webchatStartParams(sessionID string, initData InitData, workDir, 
 		ClientKey:    clientKey,
 		WorkspaceID:  c.workspaceID,
 	}
-	ShadowCompareStartParams(c.log,
-		BuildWebChatInput(initData.WorkerType, initData.Config.AllowedTools, c.userID, c.workspaceID), p)
+	in := BuildWebChatInput(initData.WorkerType, initData.Config.AllowedTools, c.userID, c.workspaceID)
+	ShadowCompareStartParams(c.log, in, p)
+	ShadowResolvePlan(c.log, in)
 	return p
 }
 

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/agentspec"
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -483,17 +484,51 @@ func TestHandleControl_Stop_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	w := new(mockWorkerForHandler)
+	w.On("StopCurrentTurn", mock.Anything).Return(nil)
 	w.On("Terminate", mock.Anything).Return(nil).Maybe()
 	mgr.AttachWorker(context.Background(), sid, w)
 
-	conn, _ := newTestWSConnPair(t)
-	t.Cleanup(func() { conn.Close() })
-	hub.JoinSession(sid, newConn(hub, conn, sid, nil))
+	// The stop must converge the pending execution runtime (acceptance A3:
+	// Gateway stopped_by_user closed loop).
+	execStore := &fakeExecutionStore{openRecord: testExecutionRecord(execution.StatusDelivered)}
+	handler.executionStore = execStore
+
+	clientConn, serverConn := newTestWSConnPair(t)
+	t.Cleanup(func() { clientConn.Close() })
+	hub.JoinSession(sid, newConn(hub, clientConn, sid, nil))
 
 	env := controlEnvelope(sid, string(events.ControlActionStop))
 	env.OwnerID = "user1"
 	err = handler.handleControl(context.Background(), env)
 	require.NoError(t, err)
+
+	// The stop must reach the worker, not just return locally.
+	w.AssertCalled(t, "StopCurrentTurn", mock.Anything)
+
+	// The pending execution runtime is converged to failed/terminated.
+	execStore.mu.Lock()
+	require.Equal(t, execution.RuntimeFailed, execStore.finishStatus)
+	execStore.mu.Unlock()
+
+	// The client must observe the terminal done event with the stop reason.
+	// finishRuntimeOnStop emits an additive runtime.execution.failed event
+	// before the done envelope, so read until done (bounded).
+	var doneEnv events.Envelope
+	require.Eventually(t, func() bool {
+		_ = serverConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		_, data, err := serverConn.ReadMessage()
+		if err != nil {
+			return false
+		}
+		if err := json.Unmarshal(data, &doneEnv); err != nil {
+			return false
+		}
+		return doneEnv.Event.Type == events.Done
+	}, 3*time.Second, 100*time.Millisecond)
+	require.Equal(t, events.Done, doneEnv.Event.Type)
+	doneData, ok := doneEnv.Event.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "stopped_by_user", doneData["reason"])
 }
 
 func TestHandleControl_Terminate_Unauthorized(t *testing.T) {

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -404,7 +404,8 @@ func (m *mockWorkerForHandler) ResetContext(ctx context.Context) (worker.ResetRe
 	return args.Get(0).(worker.ResetResult), args.Error(1)
 }
 func (m *mockWorkerForHandler) StopCurrentTurn(ctx context.Context) error {
-	return nil
+	args := m.Called(ctx)
+	return args.Error(0)
 }
 func (m *mockWorkerForHandler) IsStopped() bool {
 	return false

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -88,6 +88,13 @@ type SessionWriter interface {
 	PreferEnvelope() bool
 }
 
+// platformWriteAsync is implemented by pcEntry. It admits a terminal event
+// without blocking on the platform write result; the write loop reports the
+// real result on the caller-supplied channel.
+type platformWriteAsync interface {
+	EnqueueWrite(ctx context.Context, env *events.Envelope, result chan<- error) error
+}
+
 // Hub is the central message router and connection registry.
 // All WebSocket connections and session→connection mappings are managed here.
 type Hub struct {
@@ -165,6 +172,14 @@ func (m *EnvelopeWithConn) complete(err error) {
 	case m.result <- err:
 	default:
 	}
+}
+
+// asyncTerminal reports whether the caller of SendToSession is waiting on the
+// real platform write result of a terminal event. For such messages the result
+// is completed by the platform write loop (or by routeMessage when nothing was
+// enqueued), never synchronously by the router.
+func (m *EnvelopeWithConn) asyncTerminal() bool {
+	return m.result != nil && m.Env != nil && isTerminalPlatformEvent(m.Env.Event.Type)
 }
 
 // NewHub creates a new Hub.
@@ -642,7 +657,9 @@ func (h *Hub) Run() {
 				)
 				err := h.routeMessage(msg)
 				span.End()
-				msg.complete(err)
+				if !msg.asyncTerminal() {
+					msg.complete(err)
+				}
 				if msg.afterDrain != nil {
 					msg.afterDrain()
 				}
@@ -653,6 +670,18 @@ func (h *Hub) Run() {
 
 func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 	conns := h.snapshotConns(msg.Env.SessionID)
+	terminalAsync := msg.asyncTerminal()
+	var terminalWrites []terminalWriteResult
+	var routeErrs []error
+	// Terminal callers wait on a result channel. When no per-connection
+	// aggregator was started, complete them on every exit path (no
+	// subscribers, encode failure, or synchronous write errors); otherwise
+	// the aggregator owns completion.
+	defer func() {
+		if terminalAsync && len(terminalWrites) == 0 {
+			msg.complete(errors.Join(routeErrs...))
+		}
+	}()
 
 	if len(conns) == 0 {
 		observability.GatewayNoSubscribersDropped().Add(h.ctx, 1, metric.WithAttributes(attribute.String("event_type", string(msg.Env.Event.Type))))
@@ -688,7 +717,6 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 		return err
 	}
 
-	var routeErrs []error
 	for _, conn := range conns {
 		var err error
 		if conn.PreferEnvelope() {
@@ -700,7 +728,17 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 			if msg.routeCtx != nil {
 				routeCtx = msg.routeCtx
 			}
-			err = conn.RouteWrite(routeCtx, msg.Env)
+			if async, ok := conn.(platformWriteAsync); ok && terminalAsync {
+				// Terminal writes must never block the single router: admit
+				// only; a per-connection result channel is completed by the
+				// write loop (or its budget guard) and aggregated off-router.
+				perConn := make(chan error, 1)
+				if err = async.EnqueueWrite(routeCtx, msg.Env, perConn); err == nil {
+					terminalWrites = append(terminalWrites, terminalWriteResult{conn: conn, ch: perConn})
+				}
+			} else {
+				err = conn.RouteWrite(routeCtx, msg.Env)
+			}
 		} else {
 			err = conn.RouteWriteData(data, msg.Env.Event.Type)
 		}
@@ -711,7 +749,46 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) error {
 		h.log.Warn("gateway: write failed", "session_id", msg.Env.SessionID, "err", err)
 		h.detachAndCloseSessionWriter(msg.Env.SessionID, conn)
 	}
+	if len(terminalWrites) > 0 {
+		go h.aggregateTerminalWrites(msg, terminalWrites, errors.Join(routeErrs...))
+	}
 	return errors.Join(routeErrs...)
+}
+
+type terminalWriteResult struct {
+	conn SessionWriter
+	ch   chan error
+}
+
+// aggregateTerminalWrites collects the per-connection terminal write results
+// off the router goroutine, detaches failed writers, and completes the caller
+// with the joined error. Each result channel is guaranteed a value within the
+// terminal budget (write loop or its guard), so this goroutine cannot leak.
+func (h *Hub) aggregateTerminalWrites(msg *EnvelopeWithConn, writes []terminalWriteResult, baseErr error) {
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+	if baseErr != nil {
+		errs = append(errs, baseErr)
+	}
+	for _, tw := range writes {
+		wg.Add(1)
+		go func(tw terminalWriteResult) {
+			defer wg.Done()
+			if err := <-tw.ch; err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+				h.log.Warn("gateway: terminal platform write failed",
+					"session_id", msg.Env.SessionID, "err", err)
+				h.detachAndCloseSessionWriter(msg.Env.SessionID, tw.conn)
+			}
+		}(tw)
+	}
+	wg.Wait()
+	msg.complete(errors.Join(errs...))
 }
 
 // detachAndCloseSessionWriter removes a failed writer from routing before
@@ -745,7 +822,9 @@ func (h *Hub) drainBroadcast() {
 		case msg := <-h.broadcast:
 			if msg != nil && msg.Env != nil {
 				err := h.routeMessage(msg)
-				msg.complete(err)
+				if !msg.asyncTerminal() {
+					msg.complete(err)
+				}
 				if msg.afterDrain != nil {
 					msg.afterDrain()
 				}

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -718,6 +718,14 @@ func (m *blockingPlatformConn) WriteCtx(ctx context.Context, _ *events.Envelope)
 
 func (m *blockingPlatformConn) Close() error { return nil }
 
+type panicPlatformConn struct{}
+
+func (panicPlatformConn) WriteCtx(context.Context, *events.Envelope) error {
+	panic("platform write panic")
+}
+
+func (panicPlatformConn) Close() error { return nil }
+
 type postCancelBlockingPlatformConn struct {
 	entered       chan struct{}
 	parentExpired chan struct{}
@@ -880,6 +888,33 @@ func TestHub_TerminalWriteBudgetCancelsBackgroundWriteAndUnblocksOtherSessions(t
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	case <-time.After(time.Second):
 		t.Fatal("terminal write did not finish within its configured budget")
+	}
+}
+
+func TestHub_TerminalWriteCompletesWhenWriterExits(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHub(t)
+	entry := newPCEntry(context.Background(), panicPlatformConn{}, testPCEntryConfig(), slog.Default())
+	t.Cleanup(func() { _ = entry.Close() })
+	h.mu.Lock()
+	h.sessions["panic-terminal"] = map[SessionWriter]bool{entry: true}
+	h.everHadConn["panic-terminal"] = true
+	h.mu.Unlock()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- h.SendToSession(context.Background(), events.NewEnvelope(
+			aep.NewID(), "panic-terminal", 0, events.Done, events.DoneData{Success: true},
+		))
+	}()
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "platform conn closed")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("terminal send did not complete after the platform writer exited")
 	}
 }
 

--- a/internal/gateway/input_execution_test.go
+++ b/internal/gateway/input_execution_test.go
@@ -103,6 +103,12 @@ func (s *fakeExecutionStore) FenceBySession(context.Context, string) (*execution
 func (s *fakeExecutionStore) ClearFenceAfterFreshStart(context.Context, string, string, string) error {
 	return nil
 }
+func (s *fakeExecutionStore) ApplyFenceDecision(_ context.Context, _ execution.FenceActionRequest) (*execution.Record, error) {
+	return nil, execution.ErrNotFound
+}
+func (s *fakeExecutionStore) ListFences(context.Context, string, int, int) ([]*execution.Record, error) {
+	return nil, nil
+}
 func (s *fakeExecutionStore) RenewLeases(context.Context, string, int64, []string) (int64, error) {
 	return 0, nil
 }

--- a/internal/gateway/platform_writer.go
+++ b/internal/gateway/platform_writer.go
@@ -127,7 +127,36 @@ func (e *pcEntry) RouteWriteData(data []byte, eventType events.Kind) error {
 // json:"-" fields (e.g. OwnerID) that EncodeJSON omits from pre-encoded bytes.
 func (e *pcEntry) PreferEnvelope() bool { return true }
 
+// WriteCtx enqueues env and, for terminal events, waits up to the configured
+// terminal timeout for the write loop to report the actual platform result.
 func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error) {
+	if !isTerminalPlatformEvent(env.Event.Type) {
+		return e.EnqueueWrite(ctx, env, nil)
+	}
+	terminalCtx, cancel := context.WithTimeout(ctx, e.cfg.TerminalTimeout)
+	defer cancel()
+	ack := make(chan error, 1)
+	if err := e.EnqueueWrite(terminalCtx, env, ack); err != nil {
+		return err
+	}
+	select {
+	case err := <-ack:
+		return err
+	case <-terminalCtx.Done():
+		return fmt.Errorf("platform conn terminal write timeout: %w", terminalCtx.Err())
+	case <-e.closeCh:
+		return errors.New("platform conn closed")
+	case <-e.done:
+		return errors.New("platform conn closed")
+	}
+}
+
+// EnqueueWrite admits env into the write queue and returns without waiting
+// for the platform write result. For terminal events the write loop reports
+// the real result on result (buffered, one-shot); for all other events result
+// is ignored. EnqueueWrite never blocks on the write itself, so it is safe to
+// call from the Hub's single router goroutine.
+func (e *pcEntry) EnqueueWrite(ctx context.Context, env *events.Envelope, result chan<- error) (err error) {
 	// Recover from send-on-closed-channel panic caused by the TOCTOU window
 	// between closed.Load() and the channel send. The atomic guard narrows
 	// this window to nanoseconds, but recover() eliminates it entirely.
@@ -143,14 +172,33 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 	}
 
 	write := platformWrite{env: env, ctx: ctx}
-	var result <-chan error
 	if isTerminalPlatformEvent(env.Event.Type) {
 		terminalCtx, cancel := context.WithTimeout(ctx, e.cfg.TerminalTimeout)
-		defer cancel()
 		write.ctx = terminalCtx
-		ack := make(chan error, 1)
-		write.result = ack
-		result = ack
+		write.result = result
+		ctx = terminalCtx
+		if result != nil {
+			// Budget guard: when the write loop cannot report within the
+			// terminal budget (e.g. a platform write that ignores its
+			// context), complete the caller here. cancel() is deferred to
+			// the guard so terminalCtx stays live for the write loop until
+			// the budget itself expires; the goroutine is bounded by
+			// TerminalTimeout, so it cannot leak. A result already delivered
+			// by the write loop is dropped by the buffered send.
+			go func() {
+				defer cancel()
+				select {
+				case <-terminalCtx.Done():
+					select {
+					case result <- fmt.Errorf("platform conn terminal write timeout: %w", terminalCtx.Err()):
+					default:
+					}
+				case <-e.done:
+				}
+			}()
+		} else {
+			cancel()
+		}
 	}
 	if isDroppable(env.Event.Type) {
 		if len(e.ch) >= e.cfg.DropThreshold {
@@ -166,31 +214,13 @@ func (e *pcEntry) WriteCtx(ctx context.Context, env *events.Envelope) (err error
 		}
 	}
 
-	writeCtx := write.ctx
-	cancel := func() {}
-	if result == nil {
-		writeCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
-	}
+	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	select {
 	case e.ch <- write:
+		return nil
 	case <-writeCtx.Done():
 		return fmt.Errorf("platform conn write timeout: buffer full")
-	case <-e.closeCh:
-		return errors.New("platform conn closed")
-	case <-e.done:
-		return errors.New("platform conn closed")
-	}
-
-	if result == nil {
-		return nil
-	}
-
-	select {
-	case err := <-result:
-		return err
-	case <-writeCtx.Done():
-		return fmt.Errorf("platform conn terminal write timeout: %w", writeCtx.Err())
 	case <-e.closeCh:
 		return errors.New("platform conn closed")
 	case <-e.done:

--- a/internal/gateway/platform_writer.go
+++ b/internal/gateway/platform_writer.go
@@ -194,6 +194,10 @@ func (e *pcEntry) EnqueueWrite(ctx context.Context, env *events.Envelope, result
 					default:
 					}
 				case <-e.done:
+					select {
+					case result <- errors.New("platform conn closed"):
+					default:
+					}
 				}
 			}()
 		} else {

--- a/internal/messaging/feishu/conn_test.go
+++ b/internal/messaging/feishu/conn_test.go
@@ -85,7 +85,6 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 		return nil, apiErr
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
-	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -108,7 +107,7 @@ func TestFeishuConn_HandleDone_SendsShortTerminalFallbackWhenBodyNotPresented(t 
 	require.Len(t, sentBodies, 1)
 	require.Contains(t, sentBodies[0], terminalDeliveryFallbackText)
 	require.NotContains(t, sentBodies[0], "full worker response must not be sent again")
-	require.Equal(t, map[string]int64{"pending": 1, "sent": 1}, terminalFailureResults(t, reader))
+	require.Equal(t, map[string]int64{"sent": 1}, terminalFailureResults(t, reader))
 }
 
 func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *testing.T) {
@@ -122,7 +121,6 @@ func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *
 		return nil, apiErr
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
-	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -145,7 +143,7 @@ func TestFeishuConn_HandleDone_JoinsFallbackFailureWithTerminalDeliveryError(t *
 	require.ErrorIs(t, err, apiErr)
 	require.ErrorContains(t, err, "terminal fallback delivery")
 	require.ErrorContains(t, err, "lark client not initialized")
-	require.Equal(t, map[string]int64{"pending": 1, "failed": 1}, terminalFailureResults(t, reader))
+	require.Equal(t, map[string]int64{"failed": 1}, terminalFailureResults(t, reader))
 }
 
 func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *testing.T) {
@@ -187,7 +185,6 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 		}, nil
 	})))
 	ctrl := NewStreamingCardController(ctrlClient, limiter, discardLogger, "TestBot", 0, "", "", "", nil)
-	ctrl.terminalFailures = terminalFailures
 	ctrl.phase.Store(int32(PhaseStreaming))
 	ctrl.mu.Lock()
 	ctrl.cardID = "card-1"
@@ -208,7 +205,7 @@ func TestFeishuConn_HandleDone_SkipsStaticFallbackWhenBodyAlreadyPresented(t *te
 	mu.Lock()
 	defer mu.Unlock()
 	require.Empty(t, sentBodies)
-	require.Equal(t, map[string]int64{"pending": 1, "skipped_body_presented": 1}, terminalFailureResults(t, reader))
+	require.Equal(t, map[string]int64{"skipped_body_presented": 1}, terminalFailureResults(t, reader))
 }
 
 func TestFeishuConn_TerminalHandlersShareCallerDeadlineAcrossCloseAndFallback(t *testing.T) {
@@ -251,7 +248,7 @@ func TestFeishuConn_TerminalHandlersShareCallerDeadlineAcrossCloseAndFallback(t 
 			ctrl.mu.Lock()
 			ctrl.cardID = "card-1"
 			ctrl.msgID = "msg-1"
-			ctrl.buf.WriteString("terminal body")
+			ctrl.buf.WriteString("full worker response")
 			ctrl.mu.Unlock()
 
 			adapter := newTestAdapter(t)

--- a/internal/messaging/feishu/streaming.go
+++ b/internal/messaging/feishu/streaming.go
@@ -16,8 +16,6 @@ import (
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcardkit "github.com/larksuite/oapi-sdk-go/v3/service/cardkit/v1"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/phrases"
@@ -59,13 +57,6 @@ func newTerminalDeliveryError(contentPresented bool, errs ...error) error {
 		ContentPresented: contentPresented,
 		err:              errors.Join(append([]error{ErrTerminalDelivery}, errs...)...),
 	}
-}
-
-func (c *StreamingCardController) terminalFailureCounter() metric.Int64Counter {
-	if c.terminalFailures != nil {
-		return c.terminalFailures
-	}
-	return observability.StreamingTerminalFailures()
 }
 
 const (
@@ -137,10 +128,9 @@ type StreamingCardController struct {
 	failedFlushes   int
 
 	// Reliability — metrics and health tracking.
-	streamStartTime  time.Time
-	ttlWarnOnce      sync.Once
-	bytesWritten     int64
-	terminalFailures metric.Int64Counter // test injection; nil uses observability accessor
+	streamStartTime time.Time
+	ttlWarnOnce     sync.Once
+	bytesWritten    int64
 
 	// Tool state — tool call/result display strip.
 	toolEntries       []toolEntry // ring buffer, max 2 entries
@@ -886,10 +876,6 @@ func (c *StreamingCardController) Close(ctx context.Context) error {
 	}
 
 	err := newTerminalDeliveryError(bodyPresented, terminalErrs...)
-	if err != nil {
-		c.terminalFailureCounter().Add(ctx, 1,
-			metric.WithAttributes(attribute.String("fallback_result", "pending")))
-	}
 	return err
 }
 

--- a/internal/messaging/pipeline.go
+++ b/internal/messaging/pipeline.go
@@ -20,9 +20,18 @@ var abortTriggers = map[string]bool{
 
 var abortTriggersMu sync.RWMutex
 
+// RegisterAbortTrigger registers a custom abort trigger. The word is
+// normalized the same way input is (trim, lowercase, trailing punctuation
+// stripped) so registration always matches user input; blank words are
+// ignored.
 func RegisterAbortTrigger(word string) {
+	t := strings.TrimSpace(strings.ToLower(word))
+	t = trimTrailingPunct(t)
+	if t == "" {
+		return
+	}
 	abortTriggersMu.Lock()
-	abortTriggers[word] = true
+	abortTriggers[t] = true
 	abortTriggersMu.Unlock()
 }
 

--- a/internal/messaging/pipeline_test.go
+++ b/internal/messaging/pipeline_test.go
@@ -53,6 +53,16 @@ func TestRegisterAbortTrigger(t *testing.T) {
 	// this is a package-level registry; test only verifies registration works.
 }
 
+func TestRegisterAbortTrigger_NormalizesInput(t *testing.T) {
+	RegisterAbortTrigger("  Stop Now!  ")
+	require.True(t, IsAbortCommand("stop now"), "registered trigger must match normalized input")
+	require.True(t, IsAbortCommand("STOP NOW."), "case/punctuation variants must match")
+
+	RegisterAbortTrigger("   ")
+	RegisterAbortTrigger("")
+	require.False(t, IsAbortCommand(""), "blank registrations must not create an empty trigger")
+}
+
 func TestDetectCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -1106,6 +1106,12 @@ var (
 
 	repairDropped     metric.Int64Counter
 	repairDroppedInit sync.Once
+
+	runtimeFenceActions     metric.Int64Counter
+	runtimeFenceActionsInit sync.Once
+
+	runtimeFenceConflicts     metric.Int64Counter
+	runtimeFenceConflictsInit sync.Once
 )
 
 func ExecutionAccept() metric.Int64Counter {
@@ -1406,4 +1412,40 @@ func RepairDropped() metric.Int64Counter {
 		}
 	})
 	return repairDropped
+}
+
+// ─── Runtime Fence Instruments (#877) ───────────────────────────────
+
+// RuntimeFenceActions counts operator fence decisions applied via the Admin
+// API. Labels: decision (resolve|abandon), result (ok|conflict|error).
+// Low-cardinality only — no execution IDs or actors (#877 spec §11).
+func RuntimeFenceActions() metric.Int64Counter {
+	runtimeFenceActionsInit.Do(func() {
+		var err error
+		runtimeFenceActions, err = Meter().Int64Counter(
+			"hotplex.runtime.fence_actions",
+			metric.WithDescription("Operator fence decisions applied. Labels: decision (resolve|abandon), result (ok|conflict|error)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.runtime.fence_actions", err)
+		}
+	})
+	return runtimeFenceActions
+}
+
+// RuntimeFenceConflicts counts fence-version conflicts (409). A rising value
+// means operators (or gateway restarts between inspect and action) raced on
+// the same fence; investigate before retrying.
+func RuntimeFenceConflicts() metric.Int64Counter {
+	runtimeFenceConflictsInit.Do(func() {
+		var err error
+		runtimeFenceConflicts, err = Meter().Int64Counter(
+			"hotplex.runtime.fence_conflicts",
+			metric.WithDescription("Fence-version conflicts on operator decisions (conditional update matched 0 rows)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.runtime.fence_conflicts", err)
+		}
+	})
+	return runtimeFenceConflicts
 }

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -1112,6 +1112,15 @@ var (
 
 	runtimeFenceConflicts     metric.Int64Counter
 	runtimeFenceConflictsInit sync.Once
+
+	runtimePlanResolutions     metric.Int64Counter
+	runtimePlanResolutionsInit sync.Once
+
+	runtimePlanBlocked     metric.Int64Counter
+	runtimePlanBlockedInit sync.Once
+
+	runtimePlanObserved     metric.Int64Counter
+	runtimePlanObservedInit sync.Once
 )
 
 func ExecutionAccept() metric.Int64Counter {
@@ -1448,4 +1457,58 @@ func RuntimeFenceConflicts() metric.Int64Counter {
 		}
 	})
 	return runtimeFenceConflicts
+}
+
+// ─── Runtime Plan Instruments (#946) ────────────────────────────────
+
+// RuntimePlanResolutions counts EffectiveRuntimePlan resolutions in shadow
+// mode. Labels: result (ok|blocked). The plan hash is NEVER a label
+// (high cardinality — #946 spec §6.4).
+func RuntimePlanResolutions() metric.Int64Counter {
+	runtimePlanResolutionsInit.Do(func() {
+		var err error
+		runtimePlanResolutions, err = Meter().Int64Counter(
+			"hotplex.runtime.plan_resolutions",
+			metric.WithDescription("Effective runtime plan resolutions. Labels: result (ok|blocked)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.runtime.plan_resolutions", err)
+		}
+	})
+	return runtimePlanResolutions
+}
+
+// RuntimePlanBlocked counts fail-closed plan block reasons (#946 spec §6.2).
+// Labels: code (unknown_worker_type|invalid_permission_mode|
+// invalid_sandbox_mode|facts_missing_or_conflicting|capability_unverifiable|
+// secret_shaped_value). Low-cardinality only.
+func RuntimePlanBlocked() metric.Int64Counter {
+	runtimePlanBlockedInit.Do(func() {
+		var err error
+		runtimePlanBlocked, err = Meter().Int64Counter(
+			"hotplex.runtime.plan_blocked",
+			metric.WithDescription("Blocked effective runtime plans by fail-closed reason code"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.runtime.plan_blocked", err)
+		}
+	})
+	return runtimePlanBlocked
+}
+
+// RuntimePlanObserved counts observed-bootstrap states served by the plan
+// read path (#946 spec §6.5). Labels: state
+// (planned|unknown|declared|partial|enforced). Low-cardinality only.
+func RuntimePlanObserved() metric.Int64Counter {
+	runtimePlanObservedInit.Do(func() {
+		var err error
+		runtimePlanObserved, err = Meter().Int64Counter(
+			"hotplex.runtime.plan_observed",
+			metric.WithDescription("Observed runtime plan bootstrap states served. Labels: state (planned|unknown|declared|partial|enforced)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.runtime.plan_observed", err)
+		}
+	})
+	return runtimePlanObserved
 }

--- a/internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql
+++ b/internal/session/sql/migrations-postgres/031_execution_fence_operator.pg.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Operator fence actions (#877): fencing token for conditional fence updates.
+-- fence_version increments monotonically each time an execution ENTERS the
+-- fenced state (from a non-fenced state); operator actions (resolve/abandon)
+-- must present the version they read, so concurrent operators conflict
+-- instead of double-migrating. fence_created_at records when the current
+-- fence was raised. Old rows keep version 0 / NULL created_at.
+-- Spec: docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
+ALTER TABLE "execution_inputs" ADD COLUMN "fence_version"    BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE "execution_inputs" ADD COLUMN "fence_created_at" BIGINT;
+
+CREATE INDEX IF NOT EXISTS "idx_execution_fenced"
+    ON "execution_inputs"("fence_created_at")
+    WHERE "fence_reason" <> '';
+
+-- +goose Down
+DROP INDEX IF EXISTS "idx_execution_fenced";
+ALTER TABLE "execution_inputs" DROP COLUMN "fence_created_at";
+ALTER TABLE "execution_inputs" DROP COLUMN "fence_version";

--- a/internal/session/sql/migrations/031_execution_fence_operator.sql
+++ b/internal/session/sql/migrations/031_execution_fence_operator.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Operator fence actions (#877): fencing token for conditional fence updates.
+-- fence_version increments monotonically each time an execution ENTERS the
+-- fenced state (from a non-fenced state); operator actions (resolve/abandon)
+-- must present the version they read, so concurrent operators conflict
+-- instead of double-migrating. fence_created_at records when the current
+-- fence was raised. Old rows keep version 0 / NULL created_at.
+-- Spec: docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md
+ALTER TABLE execution_inputs ADD COLUMN fence_version    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE execution_inputs ADD COLUMN fence_created_at INTEGER;
+
+CREATE INDEX idx_execution_fenced
+    ON execution_inputs(fence_created_at)
+    WHERE fence_reason <> '';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_execution_fenced;
+ALTER TABLE execution_inputs DROP COLUMN fence_created_at;
+ALTER TABLE execution_inputs DROP COLUMN fence_version;

--- a/internal/worker/claudecode/permission_test.go
+++ b/internal/worker/claudecode/permission_test.go
@@ -55,7 +55,7 @@ func TestResolvePermissionMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := resolvePermissionMode(tt.sessionMode, tt.operatorMode)
+			got := worker.ResolvePermissionMode(tt.sessionMode, tt.operatorMode)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -53,7 +53,7 @@ var permissionAutoApprove atomic.Value // []string
 // session carries no explicit override (platform/cron sessions — bridge injects "" so
 // operator config is honored, mirroring codex_cli.sandbox+approval_mode and
 // acp.auto_approve). Loaded from worker.claude_code.permission_mode via InitConfig;
-// "" = bypass (legacy default). See resolvePermissionMode.
+// "" = bypass (legacy default). See worker.ResolvePermissionMode.
 var operatorPermissionMode atomic.Value // string
 
 func init() {
@@ -325,46 +325,6 @@ func permissionModeToCCArg(mode string) (permArg string, skip bool) {
 	}
 }
 
-// resolvePermissionMode returns the effective PermissionMode tier for a session.
-// An empty session mode (platform/cron sessions — Slack/Feishu/cron, where the bridge
-// injects "") falls back to the operator-configured default (worker.claude_code.
-// permission_mode; "" = bypass). A non-empty session mode (workspace sessions) is then
-// clamped to never EXCEED the operator tier — the operator config is a permissiveness
-// ceiling, mirroring codex's codexSandboxRank/codexApprovalRank clamp, so a workspace
-// admin's permissive override (e.g. auto-edit) cannot widen past a restrictive operator
-// policy (e.g. read-only). Without the fallback CC was the only worker unable to reach
-// workspace tier under a platform session; without the clamp it was the only worker that
-// could violate the operator ceiling documented at worker.NormalizePermissionMode.
-func resolvePermissionMode(sessionMode, operatorMode string) string {
-	effective := sessionMode
-	if effective == "" {
-		effective = operatorMode
-	}
-	if operatorMode != "" && ccPermissionRank(effective) > ccPermissionRank(operatorMode) {
-		effective = operatorMode
-	}
-	return effective
-}
-
-// ccPermissionRank returns a permissiveness rank for a PermissionMode tier (higher =
-// more permissive): read-only < workspace < auto-edit < bypass. resolvePermissionMode
-// uses it to clamp a session tier down to the operator ceiling. Mirrors codexcli's
-// codexSandboxRank. Unknown values return 0 (least permissive) so any recognized
-// operator tier can clamp them.
-func ccPermissionRank(mode string) int {
-	switch mode {
-	case worker.PermissionModeReadOnly:
-		return 0
-	case worker.PermissionModeWorkspace:
-		return 1
-	case worker.PermissionModeAutoEdit:
-		return 2
-	case worker.PermissionModeBypass:
-		return 3
-	}
-	return 0
-}
-
 func (w *Worker) buildCLIArgs(session worker.SessionInfo, resume bool) ([]string, error) {
 	args := []string{
 		"--print",
@@ -409,7 +369,7 @@ func (w *Worker) buildCLIArgs(session worker.SessionInfo, resume bool) ([]string
 	//   - All ask results auto-denied by Claude Code in headless mode
 	// Permission mode: map the unified 4 tiers to CC native args (issue #789).
 	// Empty session PermissionMode (platform/cron sessions) falls back to the operator
-	// default (worker.claude_code.permission_mode) via resolvePermissionMode; an explicit
+	// default (worker.claude_code.permission_mode) via worker.ResolvePermissionMode; an explicit
 	// session tier (workspace sessions) always wins. SkipPermissions is a legacy escape hatch.
 	effectiveMode := w.effectivePermissionMode(session)
 	permArg, skip := permissionModeToCCArg(effectiveMode)
@@ -505,7 +465,7 @@ func (w *Worker) effectivePermissionMode(session worker.SessionInfo) string {
 		return ceiling
 	}
 	operatorMode, _ := operatorPermissionMode.Load().(string)
-	effectiveMode := resolvePermissionMode(session.PermissionMode, operatorMode)
+	effectiveMode := worker.ResolvePermissionMode(session.PermissionMode, operatorMode)
 	if effectiveMode == "" {
 		return worker.PermissionModeBypass
 	}

--- a/internal/worker/permission_ceiling.go
+++ b/internal/worker/permission_ceiling.go
@@ -63,6 +63,23 @@ func permissionModeRank(mode string) int {
 	}
 }
 
+// ResolvePermissionMode returns the effective permission tier for a session.
+// An empty session mode (platform/cron sessions) falls back to the
+// operator-configured default; a non-empty session mode is then clamped to
+// never exceed the operator tier, which is a permissiveness ceiling (mirrors
+// codex's codexSandboxRank/codexApprovalRank clamp). Empty results keep the
+// legacy per-worker default semantics and are interpreted by callers.
+func ResolvePermissionMode(sessionMode, operatorMode string) string {
+	effective := sessionMode
+	if effective == "" {
+		effective = operatorMode
+	}
+	if operatorMode != "" && permissionModeRank(effective) > permissionModeRank(operatorMode) {
+		effective = operatorMode
+	}
+	return effective
+}
+
 // PermissionCeiling stores a Worker session's immutable maximum permission tier.
 // Its zero value is ready for use.
 type PermissionCeiling struct {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -97,6 +97,10 @@ const (
 	ErrCodeResumeRetry             ErrorCode = "RESUME_RETRY"
 	ErrCodeNotSupported            ErrorCode = "NOT_SUPPORTED"
 	ErrCodeTurnTimeout             ErrorCode = "TURN_TIMEOUT"
+	// ErrCodeOperatorAbandoned marks a fenced execution the operator chose to
+	// abandon (#877). Additive constant only — reuses the existing
+	// runtime.execution.failed Kind, no wire-contract change.
+	ErrCodeOperatorAbandoned ErrorCode = "OPERATOR_ABANDONED"
 )
 
 // Envelope is the unified AEP v1 message envelope, shared by both client→gateway and gateway→client.


### PR DESCRIPTION
## 目标

下一迭代 runtime operations 核心闭环的实现 PR，交付 #877（fence escape hatch，完整）与 #946（EffectiveRuntimePlan shadow first slice）。设计依据：`docs/superpowers/specs/2026-08-05-runtime-operations-next-iteration-design.md`（继承 2026-08-04 Runtime Operations Contract，开工闸门五项确认全部接受）。

## 交付内容

### #877 Fence Escape Hatch（完整交付）

- **持久化**：SQLite/PostgreSQL 成对迁移新增 `fence_created_at` / `fence_version`；fence 不自动过期（operator-only 决策，避免把未知执行悄悄放行）。
- **条件更新**：resolve/abandon 以 `fence_version` 为唯一并发条件；跨实例竞争只有一个 action 成功，另一方 409 `FENCE_CONFLICT`；不自动重试、不重投旧 input、不伪装成功。
- **状态语义**：resolve 只清 fence、保留 `unknown`；abandon 写 bounded `failed/OPERATOR_ABANDONED` fact 并发射 `runtime.execution.failed`；晚到 worker done 可收敛、terminal 状态不回退。
- **Admin API**：`GET /admin/executions/fences`（runtime:read）+ `POST /admin/executions/{id}/fence-action`（runtime:write）；actor 来自鉴权上下文；`user_activity` + slog 双审计（operator reason/evidence_ref 只进审计层，不进 execution facts）。
- **CLI**：`hotplex runtime fences list/resolve/abandon`，只走 Admin API（不打开 DB）；resolve/abandon 强制 `--confirm` + `--fence-version` + `--reason`；409 时非零退出并提示重新 inspect。
- **Doctor**：`runtime.fenced_executions`（只读 SQLite PRAGMA query_only，无 FixFunc）。

### #946 EffectiveRuntimePlan（shadow first slice，read-only）

- `Resolver.ResolvePlan` → redacted view + canonical SHA-256 plan hash；fail-closed blocked codes（`ErrPlanBlocked`），blocked plan 仍是合法诊断载荷（Admin 返回 200 + blocked reasons + 空 hash）。
- WS init / REST create-session 影子解析（`ShadowResolvePlan`，nil-logger no-op + panic recovery + blocked/warnings 指标）；**dispatch 仍以 legacy `SessionStartParams` 为准，不受影响**。
- `GET /admin/sessions/{id}/runtime-plan`（runtime:read + session:read，on-demand 投影，不新增 plan 表）；doctor `runtime.effective_plan`。
- 新指标：`hotplex_runtime_fence_actions` / `fence_conflicts` / `plan_resolutions` / `plan_blocked` / `plan_observed`；plan hash 永不进入 metric label。

## 隐私边界

execution store 只保存 SHA-256 payload 指纹；response/event/log/测试不含 prompt、secret、token、完整 command、raw provider request 或 raw worker error；redaction 有显式测试断言。

## 验收结果（2026-08-05，详见 spec §12.4）

| 验证项 | 结果 |
|---|---|
| SQLite 聚焦矩阵 `go test ./internal/execution ./internal/admin ./internal/agentspec ./internal/gateway ./internal/cli/... ./cmd/hotplex -count=1 -race` | ✅ 1687 tests passed（13 packages） |
| Real PostgreSQL 16.11 `go test -tags pg -p 1 ./internal/execution ./internal/session/sql -count=1 -race` | ✅ ok（exit 0） |
| `make check`（fmt / lint / test / build / swagger） | ✅ exit 0 · golangci-lint 0 issues |
| `make docs-build` | ✅ 63 docs 无断链 |
| `git diff --check` | ✅ clean |

文档同步：`docs/reference/{metrics,admin-api,cli,configuration}.md`、`docs/v2/{ROADMAP,IMPLEMENTATION-ROADMAP,IMPLEMENTATION-STATUS-AND-PLAN,ITERATION-NEXT}.md`、spec 状态（accepted/delivered）与 §15 完成定义。

## 非目标

不引入严格隔离（#867）、EffectLedger（#947）、ExecutionQueue（#851）、Cockpit（#868）；#946 的 authoritative dispatch 切换（worker start / recipe dry-run 与四 Worker observed 报告）为后续切片。

Closes #877
Refs #946
