### PR TITLE
fix(checker): doctor skills native root contract divergence (#974)

### DIFF
--- a/internal/cli/checkers/builtin_skills.go
+++ b/internal/cli/checkers/builtin_skills.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -144,21 +143,21 @@ func defaultBuiltinSkillsStatus(ctx context.Context) (reconcile.Report, error) {
 	if err != nil {
 		return reconcile.Report{}, err
 	}
-	runner, err := reconcile.New(registry, reconcile.Paths{
-		UserHome:     userHome,
-		HotplexHome:  hotplexHome,
-		InventoryDir: filepath.Join(hotplexHome, "skills", "builtin"),
-		StateDir:     filepath.Join(hotplexHome, "state", "skills"),
-		NativeRoots: map[reconcile.WorkerType]string{
-			reconcile.WorkerClaude:   filepath.Join(userHome, ".claude", "skills"),
-			reconcile.WorkerCodex:    filepath.Join(userHome, ".agents", "skills"),
-			reconcile.WorkerOpenCode: filepath.Join(userHome, ".agents", "skills"),
-		},
-	}, reconcile.NewOSFileSystem())
+	runner, err := reconcile.New(registry, builtinSkillsPaths(userHome, hotplexHome), reconcile.NewOSFileSystem())
 	if err != nil {
 		return reconcile.Report{}, err
 	}
 	return runner.Status(ctx, reconcile.Options{Profile: builtin.ProfileRuntime, WorkerTypes: workerTypes})
+}
+
+// builtinSkillsPaths keeps the doctor checker on the same root contract as
+// skills status/sync and onboard: the .agents root is canonical and Claude
+// receives per-package links under .claude. A hand-rolled Paths literal here
+// once set Claude's native root to .claude/skills, which normalizePaths
+// rejects, so doctor kept failing with ErrRootOutsideHome even after a clean
+// sync.
+func builtinSkillsPaths(userHome, hotplexHome string) reconcile.Paths {
+	return reconcile.DefaultPaths(userHome, hotplexHome)
 }
 
 func parseConfiguredWorkerTypes(values []string) ([]reconcile.WorkerType, error) {

--- a/internal/cli/checkers/builtin_skills_test.go
+++ b/internal/cli/checkers/builtin_skills_test.go
@@ -3,6 +3,7 @@ package checkers
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,6 +63,21 @@ func TestBuiltinSkillsCheckerMapsStatusErrorToStableFailure(t *testing.T) {
 	require.Contains(t, diagnostic.Message, "status_unavailable")
 	require.NotContains(t, diagnostic.Message, "/Users/private")
 	require.NotContains(t, diagnostic.Detail, "/Users/private")
+}
+
+func TestBuiltinSkillsPathsMatchesReconcileDefaultContract(t *testing.T) {
+	t.Parallel()
+	const (
+		userHome    = "/home/user"
+		hotplexHome = "/home/user/.hotplex"
+	)
+	paths := builtinSkillsPaths(userHome, hotplexHome)
+	require.Equal(t, reconcile.DefaultPaths(userHome, hotplexHome), paths)
+	// The .agents root is canonical; Claude receives per-package links under
+	// .claude. Pointing Claude's native root at .claude/skills made normalizePaths
+	// reject the layout and doctor fail with ErrRootOutsideHome after a clean sync.
+	require.Equal(t, filepath.Join(userHome, ".agents", "skills"), paths.NativeRoots[reconcile.WorkerClaude])
+	require.Equal(t, filepath.Join(userHome, ".claude", "skills"), paths.AliasRoots[reconcile.WorkerClaude])
 }
 
 func TestBuiltinSkillsCheckerIsRegisteredUnderSkills(t *testing.T) {

--- a/internal/cli/checkers/messaging_test.go
+++ b/internal/cli/checkers/messaging_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestSlackCreds_NoTokens(t *testing.T) {
-	t.Parallel()
+	// Reads the package-level configPath; must remain serial (see
+	// withConfigPath in config_test.go).
 
 	c := slackCredsChecker{}
 	d := c.Check(context.Background())
@@ -48,7 +49,15 @@ func TestSlackCreds_InvalidPrefix(t *testing.T) {
 }
 
 func TestFeishuCreds_NoCreds(t *testing.T) {
-	t.Parallel()
+	// Reads the package-level configPath and falls back to process env;
+	// must remain serial and pin the env to stay hermetic (a half-set
+	// FEISHU_APP_SECRET in the developer shell would otherwise flip
+	// enabled=true and fail the check).
+
+	t.Setenv("HOTPLEX_MESSAGING_FEISHU_APP_ID", "")
+	t.Setenv("HOTPLEX_MESSAGING_FEISHU_APP_SECRET", "")
+	t.Setenv("FEISHU_APP_ID", "")
+	t.Setenv("FEISHU_APP_SECRET", "")
 
 	c := feishuCredsChecker{}
 	d := c.Check(context.Background())
@@ -128,7 +137,8 @@ func TestFeishuCreds_WhitespaceOnly(t *testing.T) {
 }
 
 func TestMultiBotConfig_NoConfigPath(t *testing.T) {
-	t.Parallel()
+	// Writes the package-level configPath; must remain serial (see
+	// withConfigPath in config_test.go).
 
 	orig := configPath
 	configPath = ""


### PR DESCRIPTION
## 背景

Closes #974

v1.42.1 中 `hotplex doctor` 的 skills 检查恒失败（`✗ skills native root outside approved home`），即使 `hotplex skills sync` 已干净对账。

## 根因

`internal/cli/checkers/builtin_skills.go` 的 `defaultBuiltinSkillsStatus` 手写 `reconcile.Paths` 时把 claude_code 的 native root 配为 `~/.claude/skills`，而 `normalizePaths`（`internal/skills/reconcile/paths.go`）强制 native root 必须位于 `~/.agents` 内（canonical），Claude 仅通过 `AliasRoots` 接收 `~/.claude/skills` 逐包链接。

- `skills status/sync`（`cmd/hotplex/skills_cmd.go`）走 `reconcile.DefaultPaths` → 契约正确
- doctor checker 走手写 Paths → `normalizePaths` 恒拒绝 → 永远报错

## 变更

1. **builtin_skills.go**：checker 改用 `reconcile.DefaultPaths`（提取 `builtinSkillsPaths` seam），与 status/sync/onboard 同一契约源
2. **builtin_skills_test.go**：新增 `TestBuiltinSkillsPathsMatchesReconcileDefaultContract` 契约回归测试
3. **messaging_test.go**（伴生）：移除三个读/写包级 `configPath` 测试的 `t.Parallel()`（Go 1.26 调度下 parallel 测试体与非 parallel 测试并发 → 随机种子下 `DATA RACE`），`TestFeishuCreds_NoCreds` 显式清空 feishu env（消除 shell 半套凭据的环境敏感）

## 验证

- `go test ./internal/cli/checkers/ -count=1 -race` 多种子 7+ 次全绿（含此前必现 race 种子）
- `make test-short` 全仓 59 包全绿
- pre-commit（gofmt + golangci-lint）与 pre-push 门禁均通过
- 部署后 `hotplex doctor`：skills `✓ unchanged`，32 checks 0 failed（此前 1 failed）