### PR TITLE
fix(checker): make configPath access atomic to eliminate test races (#976)

### DIFF
--- a/internal/cli/checkers/config.go
+++ b/internal/cli/checkers/config.go
@@ -9,26 +9,40 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/hrygo/hotplex/internal/cli"
 	"github.com/hrygo/hotplex/internal/config"
 )
 
-var configPath string
+var configPath atomic.Value // string
 
 // SetConfigPath sets the config file path for all config checkers.
 func SetConfigPath(path string) {
-	configPath = path
+	configPath.Store(path)
+}
+
+// getConfigPath returns the configured config file path ("" when unset).
+// The value is stored atomically: production writes it once at doctor/onboard
+// entry, while tests may swap it between serial tests. Atomic access keeps
+// concurrent checker reads race-free under -race when a parallel test body
+// overlaps a non-parallel test (Go 1.26 scheduling).
+func getConfigPath() string {
+	v := configPath.Load()
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
 }
 
 // loadConfig loads the config from the configured path. Returns (nil, nil) when
 // no path is set, so callers distinguish "not configured" from a load error
 // without repeating the empty-check + Load boilerplate at every call site.
 func loadConfig() (*config.Config, error) {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return nil, nil
 	}
-	return config.Load(configPath)
+	return config.Load(getConfigPath())
 }
 
 // ─── config.exists ────────────────────────────────────────────────────────────
@@ -38,7 +52,7 @@ type configExistsChecker struct{}
 func (c configExistsChecker) Name() string     { return "config.exists" }
 func (c configExistsChecker) Category() string { return "config" }
 func (c configExistsChecker) Check(ctx context.Context) cli.Diagnostic {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
@@ -48,14 +62,14 @@ func (c configExistsChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	_, err := os.Stat(configPath)
+	_, err := os.Stat(getConfigPath())
 	if err == nil {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
 			Status:   cli.StatusPass,
 			Message:  "Config file exists",
-			Detail:   configPath,
+			Detail:   getConfigPath(),
 		}
 	}
 
@@ -65,7 +79,7 @@ func (c configExistsChecker) Check(ctx context.Context) cli.Diagnostic {
 			Category: c.Category(),
 			Status:   cli.StatusFail,
 			Message:  "Config file missing",
-			Detail:   configPath,
+			Detail:   getConfigPath(),
 			FixHint:  "Create config file or run onboard",
 			FixFunc:  fixConfigExists,
 		}
@@ -87,7 +101,7 @@ func fixConfigExists() error {
 		if err != nil {
 			return fmt.Errorf("read template: %w", err)
 		}
-		return os.WriteFile(configPath, data, 0o600)
+		return os.WriteFile(getConfigPath(), data, 0o600)
 	}
 
 	minimal := `gateway:
@@ -101,7 +115,7 @@ worker:
 log:
   level: "info"
 `
-	return os.WriteFile(configPath, []byte(minimal), 0o600)
+	return os.WriteFile(getConfigPath(), []byte(minimal), 0o600)
 }
 
 func init() {
@@ -115,11 +129,11 @@ type configSourceChecker struct{}
 func (c configSourceChecker) Name() string     { return "config.source" }
 func (c configSourceChecker) Category() string { return "config" }
 func (c configSourceChecker) Check(ctx context.Context) cli.Diagnostic {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return cli.Diagnostic{Name: c.Name(), Category: c.Category(), Status: cli.StatusFail, Message: "Config path not set", FixHint: "Set the config path before running diagnostics"}
 	}
 
-	if _, err := config.Load(configPath); err != nil {
+	if _, err := config.Load(getConfigPath()); err != nil {
 		return cli.Diagnostic{
 			Name: c.Name(), Category: c.Category(), Status: cli.StatusWarn,
 			Message: "Cannot resolve effective config source", Detail: err.Error(),
@@ -127,13 +141,13 @@ func (c configSourceChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	envPath := filepath.Join(filepath.Dir(configPath), ".env")
+	envPath := filepath.Join(filepath.Dir(getConfigPath()), ".env")
 	_, err := os.Stat(envPath)
 	if os.IsNotExist(err) {
 		return cli.Diagnostic{
 			Name: c.Name(), Category: c.Category(), Status: cli.StatusWarn,
 			Message: "Effective config loaded; adjacent .env is missing",
-			Detail:  fmt.Sprintf("config=%s; env=%s", configPath, envPath),
+			Detail:  fmt.Sprintf("config=%s; env=%s", getConfigPath(), envPath),
 			FixHint: "Run onboard or create the adjacent .env file",
 		}
 	}
@@ -141,7 +155,7 @@ func (c configSourceChecker) Check(ctx context.Context) cli.Diagnostic {
 		return cli.Diagnostic{
 			Name: c.Name(), Category: c.Category(), Status: cli.StatusWarn,
 			Message: "Effective config loaded; cannot inspect adjacent .env",
-			Detail:  fmt.Sprintf("config=%s; env=%s; error=%v", configPath, envPath, err),
+			Detail:  fmt.Sprintf("config=%s; env=%s; error=%v", getConfigPath(), envPath, err),
 			FixHint: "Check permissions for the config directory and adjacent .env",
 		}
 	}
@@ -149,7 +163,7 @@ func (c configSourceChecker) Check(ctx context.Context) cli.Diagnostic {
 	return cli.Diagnostic{
 		Name: c.Name(), Category: c.Category(), Status: cli.StatusPass,
 		Message: "Effective config and adjacent .env loaded",
-		Detail:  fmt.Sprintf("config=%s; env=%s", configPath, envPath),
+		Detail:  fmt.Sprintf("config=%s; env=%s", getConfigPath(), envPath),
 	}
 }
 
@@ -164,7 +178,7 @@ type configSyntaxChecker struct{}
 func (c configSyntaxChecker) Name() string     { return "config.syntax" }
 func (c configSyntaxChecker) Category() string { return "config" }
 func (c configSyntaxChecker) Check(ctx context.Context) cli.Diagnostic {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
@@ -173,7 +187,7 @@ func (c configSyntaxChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	_, err := config.Load(configPath)
+	_, err := config.Load(getConfigPath())
 	if err == nil {
 		return cli.Diagnostic{
 			Name:     c.Name(),
@@ -203,7 +217,7 @@ type configRequiredChecker struct{}
 func (c configRequiredChecker) Name() string     { return "config.required" }
 func (c configRequiredChecker) Category() string { return "config" }
 func (c configRequiredChecker) Check(ctx context.Context) cli.Diagnostic {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
@@ -212,7 +226,7 @@ func (c configRequiredChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	cfg, err := config.Load(configPath)
+	cfg, err := config.Load(getConfigPath())
 	if err != nil {
 		return cli.Diagnostic{
 			Name:     c.Name(),
@@ -316,7 +330,7 @@ type configValuesChecker struct{}
 func (c configValuesChecker) Name() string     { return "config.values" }
 func (c configValuesChecker) Category() string { return "config" }
 func (c configValuesChecker) Check(ctx context.Context) cli.Diagnostic {
-	if configPath == "" {
+	if getConfigPath() == "" {
 		return cli.Diagnostic{
 			Name:     c.Name(),
 			Category: c.Category(),
@@ -325,7 +339,7 @@ func (c configValuesChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	cfg, err := config.Load(configPath)
+	cfg, err := config.Load(getConfigPath())
 	if err != nil {
 		return cli.Diagnostic{
 			Name:     c.Name(),
@@ -414,7 +428,7 @@ func fixConfigValues(cfg *config.Config) error {
 		return nil
 	}
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(getConfigPath())
 	if err != nil {
 		return fmt.Errorf("read config: %w", err)
 	}
@@ -430,7 +444,7 @@ func fixConfigValues(cfg *config.Config) error {
 		yaml = replaceYAMLValue(yaml, "db.path", cfg.DB.Path)
 	}
 
-	return os.WriteFile(configPath, []byte(yaml), 0o600)
+	return os.WriteFile(getConfigPath(), []byte(yaml), 0o600)
 }
 
 func extractPortAddr(yaml, key string) string {

--- a/internal/cli/checkers/config_test.go
+++ b/internal/cli/checkers/config_test.go
@@ -17,9 +17,9 @@ import (
 // with checkers in other files.
 func withConfigPath(t *testing.T, path string) {
 	t.Helper()
-	orig := configPath
+	orig := getConfigPath()
 	SetConfigPath(path)
-	t.Cleanup(func() { configPath = orig })
+	t.Cleanup(func() { SetConfigPath(orig) })
 }
 
 // resetConfigPath is a compatibility helper that sets configPath to "".
@@ -27,13 +27,13 @@ func withConfigPath(t *testing.T, path string) {
 func resetConfigPath() { SetConfigPath("") }
 
 func TestSetConfigPath(t *testing.T) {
-	orig := configPath
-	defer func() { configPath = orig }()
+	orig := getConfigPath()
+	defer func() { SetConfigPath(orig) }()
 
 	SetConfigPath("/some/path/config.yaml")
-	require.Equal(t, "/some/path/config.yaml", configPath)
+	require.Equal(t, "/some/path/config.yaml", getConfigPath())
 	SetConfigPath("")
-	require.Equal(t, "", configPath)
+	require.Equal(t, "", getConfigPath())
 }
 
 func TestConfigExists_Missing(t *testing.T) {

--- a/internal/cli/checkers/config_yaml_test.go
+++ b/internal/cli/checkers/config_yaml_test.go
@@ -80,15 +80,15 @@ func TestFixConfigValues(t *testing.T) {
 	withConfigPath(t, filepath.Join(dir, "config.yaml"))
 
 	cfgContent := "gateway:\n  addr: \":99999\"\nadmin:\n  enabled: true\n  addr: \":88888\"\ndb:\n  path: \"\"\n"
-	require.NoError(t, os.WriteFile(configPath, []byte(cfgContent), 0o600))
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte(cfgContent), 0o600))
 
-	cfg, err := config.Load(configPath)
+	cfg, err := config.Load(getConfigPath())
 	require.NoError(t, err)
 
 	err = fixConfigValues(cfg)
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(getConfigPath())
 	require.NoError(t, err)
 	require.Contains(t, string(data), "gateway")
 }

--- a/internal/cli/checkers/messaging_test.go
+++ b/internal/cli/checkers/messaging_test.go
@@ -14,8 +14,15 @@ import (
 )
 
 func TestSlackCreds_NoTokens(t *testing.T) {
-	// Reads the package-level configPath; must remain serial (see
-	// withConfigPath in config_test.go).
+	// Reads the package-level configPath and falls back to process env;
+	// must remain serial and pin the env to stay hermetic (a half-set
+	// SLACK_BOT_TOKEN in the developer shell would otherwise flip
+	// enabled=true and fail the check).
+
+	t.Setenv("HOTPLEX_MESSAGING_SLACK_BOT_TOKEN", "")
+	t.Setenv("HOTPLEX_MESSAGING_SLACK_APP_TOKEN", "")
+	t.Setenv("SLACK_BOT_TOKEN", "")
+	t.Setenv("SLACK_APP_TOKEN", "")
 
 	c := slackCredsChecker{}
 	d := c.Check(context.Background())
@@ -140,9 +147,9 @@ func TestMultiBotConfig_NoConfigPath(t *testing.T) {
 	// Writes the package-level configPath; must remain serial (see
 	// withConfigPath in config_test.go).
 
-	orig := configPath
-	configPath = ""
-	defer func() { configPath = orig }()
+	orig := getConfigPath()
+	SetConfigPath("")
+	defer func() { SetConfigPath(orig) }()
 
 	c := multiBotConfigChecker{}
 	d := c.Check(context.Background())
@@ -152,7 +159,7 @@ func TestMultiBotConfig_NoConfigPath(t *testing.T) {
 func TestMultiBotConfig_ValidSingleBot(t *testing.T) {
 	dir := t.TempDir()
 	withConfigPath(t, dir+"/config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte(`
 messaging:
   slack:
     enabled: true
@@ -171,7 +178,7 @@ messaging:
 func TestMultiBotConfig_DuplicateName(t *testing.T) {
 	dir := t.TempDir()
 	withConfigPath(t, dir+"/config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte(`
 messaging:
   slack:
     enabled: true
@@ -193,7 +200,7 @@ messaging:
 func TestMultiBotConfig_MissingCredentials(t *testing.T) {
 	dir := t.TempDir()
 	withConfigPath(t, dir+"/config.yaml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte(`
 messaging:
   feishu:
     enabled: true
@@ -217,7 +224,7 @@ func TestMultiBotConfig_ExceedsLimit(t *testing.T) {
 	for i := range 11 {
 		fmt.Fprintf(&botLines, "      - name: bot-%d\n        bot_token: xoxb-%d\n        app_token: xapp-%d\n", i, i, i)
 	}
-	require.NoError(t, os.WriteFile(configPath, []byte("messaging:\n  slack:\n    enabled: true\n    bots:\n"+botLines.String()), 0o644))
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte("messaging:\n  slack:\n    enabled: true\n    bots:\n"+botLines.String()), 0o644))
 
 	c := multiBotConfigChecker{}
 	d := c.Check(context.Background())

--- a/internal/cli/checkers/security.go
+++ b/internal/cli/checkers/security.go
@@ -112,11 +112,11 @@ func (c filePermsChecker) Check(ctx context.Context) cli.Diagnostic {
 		}
 	}
 
-	if configPath != "" {
-		checkPerm(filepath.Dir(configPath), 0o700)
-		checkPerm(configPath, 0o600)
+	if getConfigPath() != "" {
+		checkPerm(filepath.Dir(getConfigPath()), 0o700)
+		checkPerm(getConfigPath(), 0o600)
 
-		cfg, err := config.Load(configPath)
+		cfg, err := config.Load(getConfigPath())
 		if err == nil && cfg.DB.Path != "" {
 			checkPerm(filepath.Dir(cfg.DB.Path), 0o700)
 		}
@@ -222,8 +222,8 @@ func init() {
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 func envFilePath() string {
-	if configPath != "" {
-		return filepath.Join(filepath.Dir(configPath), ".env")
+	if getConfigPath() != "" {
+		return filepath.Join(filepath.Dir(getConfigPath()), ".env")
 	}
 	return ".env"
 }

--- a/internal/cli/checkers/security_fix_test.go
+++ b/internal/cli/checkers/security_fix_test.go
@@ -12,10 +12,10 @@ import (
 func setupTestConfigDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	origConfigPath := configPath
-	configPath = filepath.Join(dir, "config.yaml")
-	t.Cleanup(func() { configPath = origConfigPath })
-	require.NoError(t, os.WriteFile(configPath, []byte{}, 0o600))
+	origConfigPath := getConfigPath()
+	SetConfigPath(filepath.Join(dir, "config.yaml"))
+	t.Cleanup(func() { SetConfigPath(origConfigPath) })
+	require.NoError(t, os.WriteFile(getConfigPath(), []byte{}, 0o600))
 	return dir
 }
 


### PR DESCRIPTION
## 背景

Closes #976

PR #975 修复 doctor skills 检查时，`-race` 暴露出 `internal/cli/checkers` 包级全局 `configPath` 的 DATA RACE：Go 1.26 调度下 parallel 测试体可与 non-parallel 测试并发，`TestFeishuCreds_NoCreds`（parallel 读）与 `TestMultiBotConfig_NoConfigPath`（写）并发 → 特定 shuffle 种子下全包 12 个测试被 race 波及。7 月曾以 withConfigPath cleanup 止血（310232b7），8 月复发——止血式修复不够，需根治。

## 变更

1. **configPath 原子化**（`internal/cli/checkers/config.go`）：`var configPath atomic.Value` + `getConfigPath()` 访问器（安全断言），全部 30+ 读点迁移（config.go 6 个 checker + security.go 2 处 + 4 个测试文件）；`SetConfigPath` 改用 Store。生产代码单线程写入、测试并发读天然安全
2. **TestSlackCreds_NoTokens 环境密封**：与 `TestFeishuCreds_NoCreds`（#975 已修）同类隐患——configPath 为空时 fallback 读 shell env，半套 `SLACK_BOT_TOKEN` 会 flip enabled=true 导致误判 fail；现显式 Setenv 清空

## 验证

- `go test ./internal/cli/checkers/ -count=1 -race -shuffle=on` 多种子 3+ 次全绿（含此前必现 race 种子）
- `go test ./internal/cli/... -count=1 -race` 全绿
- `make test-short` 全仓 59 包全绿
- golangci-lint 0 issues；pre-commit / pre-push 门禁通过