### PR TITLE
docs(checker): correct configPath atomicity rationale in comments (#976)

### DIFF
--- a/internal/cli/checkers/config.go
+++ b/internal/cli/checkers/config.go
@@ -25,8 +25,9 @@ func SetConfigPath(path string) {
 // getConfigPath returns the configured config file path ("" when unset).
 // The value is stored atomically: production writes it once at doctor/onboard
 // entry, while tests may swap it between serial tests. Atomic access keeps
-// concurrent checker reads race-free under -race when a parallel test body
-// overlaps a non-parallel test (Go 1.26 scheduling).
+// concurrent reads race-free even when multiple parallel tests exercise
+// checkers at once. Writers must still stay serial: a mid-check swap would
+// only produce a logically inconsistent diagnostic, which no lock can fix.
 func getConfigPath() string {
 	v := configPath.Load()
 	if s, ok := v.(string); ok {

--- a/internal/cli/checkers/security_test.go
+++ b/internal/cli/checkers/security_test.go
@@ -11,7 +11,9 @@ import (
 
 // Tests using t.Setenv or modifying configPath cannot use t.Parallel because:
 //   - t.Setenv is incompatible with t.Parallel in Go's testing framework
-//   - configPath is a package-level mutable variable subject to data races
+//   - configPath is a package-level mutable variable: writes must stay serial
+//     so parallel checker reads never observe a mid-test swap (atomic access
+//     makes the reads race-free, but not logically consistent)
 
 func TestAdminToken_Empty(t *testing.T) {
 	t.Setenv("ADMIN_TOKEN", "")


### PR DESCRIPTION
## 背景

PR #977 的 code review（Agent #5 深度验证）发现 `getConfigPath` 注释对 race 根因的归因**不准确**：

- 原注释声称 "Go 1.26 scheduling" 允许 parallel 测试体与非 parallel 测试并发——与 Go 测试契约矛盾（parallel 测试永不与 sequential 测试并发，1.26.4 源码 + 实证 16+ 种子均无此行为）
- 真实根因（`git show 310232b7` 确认）：race 发生时 `TestFeishuCreds_NoCreds` 与 `TestMultiBotConfig_NoConfigPath` **都是 t.Parallel**（parallel-vs-parallel 普通 data race，任何 Go 版本都会发生）；`t.Setenv` 与 `t.Parallel` 不兼容（denyParallel，Go 1.26 引入）被误读为调度变化
- `security_test.go` 的 "subject to data races" 注释在原子化后已过时（atomic 读无 race，但写方仍须 serial——逻辑一致性而非数据竞争）

## 变更（纯注释）

1. `config.go` `getConfigPath` 注释：改为真实归因（parallel 测试并发读安全；写方仍须 serial，mid-check swap 只会产生逻辑不一致诊断）
2. `security_test.go` 注释："subject to data races" → 原子化后的真实理由（写方 serial 保证逻辑一致性）

Fixes #976（原子化本身由 #977 修复；本 PR 仅修正归因描述，生产代码与测试逻辑均未改动）