### PR TITLE
fix(gateway): quiesce stopped worker runs

### DIFF
--- a/docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
+++ b/docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
@@ -1,0 +1,449 @@
+# Stop Worker Run Quiescence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `control.stop` acknowledge success only after the stopped session's Worker run, frozen connection, and forwarder are permanently isolated and quiescent.
+
+**Architecture:** Serialize primary input dispatch and stop per session with a fixed striped gate. Bind every local Worker run to a private lifecycle object that owns an event read/write barrier, an irreversible stopping flag, the frozen `SessionConn`, and a forwarder completion channel; the stop path commits the barrier only after provider cancellation succeeds, disposes the wrapper/process, waits for forwarder cleanup, and fails closed on timeout.
+
+**Tech Stack:** Go 1.26, `sync`/typed atomics, HotPlex Gateway/Worker interfaces, SQLite-backed contract harness, `testify/require`, Go race detector.
+
+**Spec:** `docs/specs/Stop-Worker-Run-Quiescence-Spec.md`
+
+## Global Constraints
+
+- Preserve the AEP `control.stop` and `done(reason="stopped_by_user")` wire shapes; do not change SDKs or WebChat protocol code.
+- Do not change the public `worker.Worker` or `worker.SessionConn` interfaces.
+- Do not terminate the shared Codex app-server or OpenCode server; only release the stopped session wrapper/subscription/connection.
+- Keep `terminate`, `reset`, `delete`, GC, crash recovery, execution owner lease, and input idempotency behavior unchanged.
+- Persist only execution fingerprints/status metadata; never persist prompts, metadata values, credentials, or raw Worker errors.
+- Use explicit mutex fields, preserve the existing `m.mu -> ms.mu` lock order, and never hold the run event write lock across teardown, session-manager calls, or forwarder waiting.
+- Tests use `testify/require`, deterministic channel/`require.Eventually` synchronization, `t.Parallel()` where state is isolated, and no `time.Sleep` for asynchronous coordination.
+- Targeted Gateway/Worker modules must pass with `-count=1 -race -shuffle=on` and remain within the repository's five-second per-module budget.
+
+---
+
+### Task 1: Extend the contract harness and reproduce the quiescence failures
+
+**Files:**
+- Modify: `internal/gateway/contracttest/harness.go`
+- Modify: `internal/gateway/contracttest/worker_probe.go`
+- Modify: `internal/gateway/stop_contract_test.go`
+
+**Interfaces:**
+- Consumes: the existing `contracttest.NewHarness`, `WorkerProbe`, observer connection, execution store, and real per-profile parser/mapper fixtures.
+- Produces: controllable provider-stop/terminate/kill/wait phases, late-event injection, probe replacement inspection, and stored-event queries used by C06-C10.
+
+- [ ] **Step 1: Add observable lifecycle controls to `WorkerProbe`**
+
+Add atomics and one-shot channel gates without changing the production Worker interface:
+
+```go
+type WorkerProbe struct {
+	*noop.Worker
+	// existing fields...
+	terminateCalls atomic.Int32
+	killCalls      atomic.Int32
+	failTerminate atomic.Bool
+	failKill      atomic.Bool
+	stopEntered   chan struct{}
+	allowStop     chan struct{}
+	waitEntered   chan struct{}
+	allowWait     chan struct{}
+	blockStop     atomic.Bool
+	blockWait     atomic.Bool
+	lateOnDispose atomic.Bool
+}
+```
+
+Implement `Terminate`, `Kill`, and `Wait` so the normal path closes the probe connection, injected terminate failure leaves Kill as the fallback, and blocked Wait exits only when the test releases its channel. Add getters and arm/release methods whose names state the phase they control.
+
+- [ ] **Step 2: Inject representative late events during disposal**
+
+When `lateOnDispose` is armed, enqueue envelopes carrying unique `late_run_*` markers before the frozen connection closes:
+
+```go
+[]events.Kind{
+	events.MessageDelta,
+	events.Message,
+	events.Reasoning,
+	events.ToolCall,
+	events.PermissionRequest,
+	events.State,
+	events.Done,
+	events.Error,
+}
+```
+
+The probe records all attempted writes in its private log even after connection closure, while only open-connection writes reach `Recv`; this distinguishes Worker emission from Gateway forwarding.
+
+- [ ] **Step 3: Enable durable event assertions in the harness**
+
+Add a harness option that constructs an `eventstore.SQLiteStore` and `eventstore.Collector` over the harness's existing migrated SQLite database only when a test requests durable-event assertions. Inject the collector through `gateway.BridgeDeps`, close it before the shared DB, and expose:
+
+```go
+func (h *Harness) StoredEvents(t testing.TB) []eventstore.StoredEvent
+func (h *Harness) Probes() []*WorkerProbe
+```
+
+`StoredEvents` must flush the current session and query with `eventstore.CursorLatest` using a bounded limit.
+Existing matrix tests keep the collector disabled so their seq behavior and runtime remain unchanged; C06 opts in explicitly.
+
+- [ ] **Step 4: Write C06-C10 failing contract tests**
+
+Add deterministic tests with the following observable assertions:
+
+```go
+// C06: late_run_* markers exist in WorkerProbe.Events(), but in neither
+// Harness observer output nor StoredEvents(); exactly one stopped done exists.
+
+// C07: while Wait is blocked, no stopped done is visible; after ReleaseWait,
+// exactly one stopped done appears.
+
+// C08: while StopCurrentTurn is blocked, the concurrent next input has not
+// reached the old probe; after release, Harness.Worker() is a new pointer,
+// CurrentWorkerBinding returns a new run ID, and the next input reaches it once.
+
+// C09: injected Terminate failure increments TerminateCalls and KillCalls once,
+// closes the frozen connection, and still yields one stopped done after quiet.
+
+// C10: a short injected stop budget plus blocked Wait returns an error,
+// emits no stopped done, removes the old binding, and leaves the session Idle.
+```
+
+- [ ] **Step 5: Run the RED tests**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'WorkerRunQuiescenceContract/(C0[6-9]|C10)' -count=1 -race -shuffle=on
+```
+
+Expected: C06 exposes forwarded late markers, C07 sees the synthetic done before Wait release, C08 can dispatch to the old run, C09 observes no teardown call, and C10 lacks bounded quiescence failure behavior.
+
+---
+
+### Task 2: Add the session dispatch gate and per-run event barrier
+
+**Files:**
+- Modify: `internal/gateway/handler.go`
+- Modify: `internal/gateway/bridge.go`
+- Modify: `internal/gateway/bridge_worker.go`
+- Modify: `internal/gateway/bridge_forward.go`
+- Modify: `internal/gateway/bridge_retry.go`
+- Test: `internal/gateway/handler_test.go`
+- Test: `internal/gateway/bridge_test.go`
+
+**Interfaces:**
+- Consumes: `workerRunBinding`, frozen `SessionConn`, `forwardEvents`, `processForwardedEvent`, retry cancellation, and CAS cleanup.
+- Produces: `sessionDispatchGate`, `workerRunLifecycle`, full private binding lookup, and nil-safe event-side-effect admission.
+
+- [ ] **Step 1: Test fixed-stripe dispatch serialization**
+
+Add tests that hold one session lock and prove a second acquisition for the same session blocks until release, while a deliberately selected non-colliding session can proceed. Use channels for entered/released signals and never sleep.
+
+- [ ] **Step 2: Implement the zero-value session gate**
+
+Add a 64-stripe gate with a local allocation-free FNV-1a byte loop:
+
+```go
+type sessionDispatchGate struct {
+	stripes [64]sync.Mutex
+}
+
+func (g *sessionDispatchGate) Lock(sessionID string) func()
+```
+
+Store it directly on `Handler`. In `deliverToWorkerWithBusyHandling`, acquire it before the first session read and keep it through acceptance, binding selection, `MarkRunning`, `stopFence.BeginTurn`, and `Worker.Input`/native invocation return. If acceptance reports `execution.ErrSessionBusy`, release the dispatch gate before calling `handleSupplementOnBusy`; that function can re-enter normal delivery and would otherwise self-deadlock.
+
+- [ ] **Step 3: Add the private run lifecycle**
+
+Extend the private binding only:
+
+```go
+type workerRunLifecycle struct {
+	eventMu  sync.RWMutex
+	stopping atomic.Bool
+	done     chan struct{}
+	conn     worker.SessionConn
+}
+
+type workerRunBinding struct {
+	worker    worker.Worker
+	id        string
+	lifecycle *workerRunLifecycle
+}
+```
+
+Create a fresh lifecycle after Worker start/reset has established its connection. Pass the same pointer to the binding and forwarder; never re-read `Worker.Conn()` in the forwarder or stop path.
+
+- [ ] **Step 4: Close lifecycle completion after all cleanup**
+
+For both normal launch and connection-replacing reset, register goroutine defers in LIFO order so the effective order is:
+
+```text
+launchForwarderLocked returns
+-> clearWorkerRun(expected worker + run)
+-> close(lifecycle.done)
+-> fwdWg.Done()
+```
+
+This makes `done` proof that `handleWorkerExit`, CAS detach/Idle transition, and binding cleanup have completed.
+
+- [ ] **Step 5: Guard every old-run side-effect outlet**
+
+At the beginning of `processForwardedEvent`, acquire the lifecycle read lock and reject `stopping` before LastIO, seq, runtime, retry, Hub, or event-store work. Use the same read-side admission around:
+
+- panic synthetic error;
+- turn-timeout synthetic error/capture/terminate;
+- post-Recv pending-error flush;
+- each auto-retry notification and actual replay input (not the backoff wait);
+- the post-`Wait` crash fallback, synthetic crash event, detach, and Idle cleanup section.
+
+Direct unit tests that construct `forwardContext` without a lifecycle remain supported by a nil-safe admission helper.
+
+- [ ] **Step 6: Run focused barrier and existing forwarder tests**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'DispatchGate|WorkerRun|ForwardEvents|ProcessForwardedEvent|C06' -count=1 -race -shuffle=on
+```
+
+Expected: the new gate/barrier tests and C06 pass; existing forwarding, seq, retry, reset-generation, and stale-forwarder tests remain green.
+
+---
+
+### Task 3: Orchestrate provider cancellation, disposal, quiescence, and stop acknowledgement
+
+**Files:**
+- Modify: `internal/gateway/deps.go`
+- Modify: `internal/gateway/bridge.go`
+- Modify: `internal/gateway/bridge_worker.go`
+- Modify: `internal/gateway/commands.go`
+- Modify: `internal/gateway/handler.go`
+- Test: `internal/gateway/ctrl_test.go`
+- Test: `internal/gateway/stop_contract_test.go`
+
+**Interfaces:**
+- Consumes: full `workerRunBinding`, `StopCurrentTurn`, `Terminate`, `Kill`, frozen `SessionConn.Close`, `DetachWorkerIf`, `clearWorkerRun`, and `finishRuntimeOnStop`.
+- Produces: `Bridge.StopAndDisposeCurrentRun(ctx, sessionID, expectedRunID) error` plus internal error categories that tell the Handler whether provider cancellation took effect.
+
+- [ ] **Step 1: Add injectable server-side stop budgets**
+
+Add optional `BridgeDeps` durations and normalized Bridge fields:
+
+```go
+StopTeardownTimeout  time.Duration // default 8s
+StopForwarderTimeout time.Duration // default 1s after teardown budget
+```
+
+Zero values select production defaults. Contract harness options inject short non-zero values only for C10.
+
+- [ ] **Step 2: Implement stop/dispose with an irreversible barrier**
+
+Implement the sequence below, using `context.WithTimeout(context.WithoutCancel(ctx), stopTeardownTimeout)` so client cancellation cannot abandon cleanup:
+
+```go
+binding := currentWorkerRunBinding(sessionID, expectedRunID)
+binding.lifecycle.eventMu.Lock()
+revalidate the exact worker/run/lifecycle binding
+err := binding.worker.StopCurrentTurn(stopCtx)
+if err != nil {
+	binding.lifecycle.eventMu.Unlock()
+	return errWorkerStopNotApplied
+}
+binding.lifecycle.stopping.Store(true)
+binding.lifecycle.eventMu.Unlock()
+
+terminateErr := binding.worker.Terminate(stopCtx)
+if terminateErr != nil {
+	killErr := binding.worker.Kill()
+	// Kill success recovers Terminate failure; Kill failure is teardown failure.
+}
+_ = binding.lifecycle.conn.Close()
+wait for lifecycle.done until the teardown deadline, then for the extra
+forwarder-settle timeout
+```
+
+Never hold `eventMu` while calling `Terminate`, `Kill`, `Close`, session manager operations, or waiting. If the forwarder does not complete, CAS-detach only the expected Worker, clear only the expected run binding, and transition to Idle only when this path actually detached that Worker.
+
+- [ ] **Step 3: Distinguish pre-commit and post-commit failures**
+
+Use package-private sentinel categories with lowercase messages:
+
+```go
+errWorkerRunChanged
+errWorkerStopNotApplied
+errWorkerRunTeardown
+errWorkerRunQuiescence
+```
+
+Only run-changed/provider-stop failures allow `stopFence.Rollback`. Teardown/quiescence failures keep `stopping=true`, finish the execution runtime as failed, return a generic client error, and never send `stopped_by_user`.
+
+- [ ] **Step 4: Reorder `control.stop` under the dispatch gate**
+
+After ownership validation, hold the session dispatch gate across binding/execution resolution, stop-fence claim, retry cancel, stop/dispose, runtime convergence, and terminal send. Resolve duplicate stop after the first stop cleared the binding by using `LatestBySession.WorkerRunID` and the existing composite fence; a duplicate returns silently, while a genuinely unclaimed no-binding stop returns the current no-active-worker error.
+
+Send the synthetic done only after `StopAndDisposeCurrentRun` returns nil:
+
+```go
+h.finishRuntimeOnStop(ctx, sessionID, workerRunID, ownerID)
+doneEnv := events.NewEnvelope(
+	aep.NewID(), sessionID, 0,
+	events.Done, events.DoneData{Reason: "stopped_by_user"},
+)
+return h.hub.SendToSession(ctx, doneEnv)
+```
+
+Log stable `stop_phase`/`error_kind` categories and identifiers only; do not log or send raw Worker error strings.
+
+- [ ] **Step 5: Run C07-C10 and the complete stop contract**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'Stop|WorkerRunQuiescenceContract' -count=1 -race -shuffle=on
+```
+
+Expected: C04-C10 pass, including duplicate-stop, next-turn replacement, failed-stop retry, late-event quarantine, done-after-quiescence, stop/input race, Kill fallback, and timeout-without-fake-done.
+
+- [ ] **Step 6: Commit the Gateway slice**
+
+Run `git diff --check`, inspect the staged diff for secrets and unrelated changes, then commit:
+
+```bash
+git add internal/gateway docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
+git commit -m "fix(gateway): quiesce stopped worker runs"
+```
+
+---
+
+### Task 4: Pin four Worker teardown/resume and singleton-isolation semantics
+
+**Files:**
+- Modify: `internal/worker/claudecode/worker_test.go`
+- Modify: `internal/worker/acp/worker_stop_test.go`
+- Modify: `internal/worker/codexcli/worker_test.go`
+- Modify: `internal/worker/opencodeserver/worker_test.go`
+
+**Interfaces:**
+- Consumes: existing adapter `StopCurrentTurn`, `Terminate`, `Kill`, `Wait`, resume-identity, manager/singleton reference-count, unsubscribe, and connection-close behavior.
+- Produces: regression proof that stop+teardown releases exactly the local run and that resume uses a new wrapper without losing provider identity.
+
+- [ ] **Step 1: Add per-process adapter composition tests**
+
+For Claude Code and ACP, use existing fake process/client fixtures to verify:
+
+```text
+StopCurrentTurn succeeds
+-> Terminate is idempotent after stop
+-> Conn closes and Wait returns
+-> a separately constructed resumed Worker keeps the same provider session ID
+```
+
+The tests assert process/wrapper effects, not internal call order.
+
+- [ ] **Step 2: Add Codex two-wrapper isolation**
+
+Create two wrappers sharing the same test manager. Stop and terminate wrapper A, then assert A's thread is unsubscribed/connection closed and manager refcount decreases once, while wrapper B remains subscribed and usable; the manager process is not killed.
+
+- [ ] **Step 3: Add OpenCode Server two-wrapper isolation**
+
+Create two wrappers sharing the singleton fixture. Stop and terminate wrapper A, then assert A's SSE/subscription/connection release and one reference decrement while wrapper B's subscription and shared server remain active.
+
+- [ ] **Step 4: Run the Worker matrix**
+
+Run:
+
+```bash
+go test ./internal/worker/claudecode ./internal/worker/acp ./internal/worker/codexcli ./internal/worker/opencodeserver -run 'Stop|Terminate|Kill|Release|Resume' -count=1 -race -shuffle=on
+```
+
+Expected: all focused Worker tests pass without affecting shared services or exceeding the module time budget.
+
+- [ ] **Step 5: Commit Worker regression coverage**
+
+```bash
+git add internal/worker/claudecode/worker_test.go internal/worker/acp/worker_stop_test.go internal/worker/codexcli/worker_test.go internal/worker/opencodeserver/worker_test.go
+git commit -m "test(worker): pin stopped-run teardown isolation"
+```
+
+---
+
+### Task 5: Full verification, five-axis self-review, and PR delivery
+
+**Files:**
+- Review: every file changed from `origin/main...HEAD`
+- Modify only if verification or review finds a scoped defect.
+
+**Interfaces:**
+- Consumes: approved spec AC1-AC10, repository quality gates, WebChat stop suite, git history, and GitHub issue #971.
+- Produces: fresh verification evidence, review findings resolved, atomic commits, pushed branch, and a PR whose description maps behavior/tests to the issue.
+
+- [ ] **Step 1: Verify graph coverage and blast radius**
+
+Check index coverage for every changed/evidence file, read any missed ranges directly, and inspect inbound impact from the final diff. Confirm no AEP, SDK, migration, config, or WebChat production file changed.
+
+- [ ] **Step 2: Run focused and package-wide race tests**
+
+```bash
+go test ./internal/gateway -run 'Stop|WorkerRunQuiescenceContract' -count=1 -race -shuffle=on
+go test ./internal/worker/claudecode ./internal/worker/acp ./internal/worker/codexcli ./internal/worker/opencodeserver -run 'Stop|Terminate|Kill|Release|Resume' -count=1 -race -shuffle=on
+go test ./internal/gateway/... ./internal/worker/... -count=1 -race -shuffle=on
+```
+
+- [ ] **Step 3: Run frontend and repository gates**
+
+```bash
+cd webchat && pnpm test
+make docs-lint
+make quality
+make build
+```
+
+Record exit codes and failure counts. Do not claim completion from summaries alone; recover bounded diagnostics for any filtered/truncated failure.
+
+- [ ] **Step 4: Perform the five-axis review**
+
+Review tests first, then implementation for correctness, readability, architecture, security/privacy, and performance. Explicitly inspect:
+
+- lock order and absence of lock-held teardown/waits;
+- all event/synthetic/retry outlets after `stopping` commits;
+- duplicate stop and post-timeout fence semantics;
+- CAS protection against replacement Worker cleanup;
+- goroutine/channel exit ownership;
+- raw-error/prompt/metadata leakage;
+- Codex/OCS shared-service isolation;
+- dead code and unnecessary interface/dependency growth.
+
+Resolve every Critical/Required finding and rerun the affected verification command after each edit.
+
+- [ ] **Step 5: Reconcile requirements and commits**
+
+Map AC1-AC10 to tests or direct code evidence, run `git diff --check`, inspect `git status`, `git diff --stat`, staged patches, and commit history, then create a final scoped commit only if review fixes remain.
+
+- [ ] **Step 6: Push and create the PR**
+
+Push the non-main branch after the pre-push quality gate succeeds. Create a PR with:
+
+```text
+Title: fix(gateway): quiesce stopped worker runs
+
+Summary:
+- serialize stop with same-session input dispatch
+- quarantine every event/synthetic outlet after provider cancellation
+- dispose and await the exact frozen Worker run before stopped_by_user
+- preserve provider history and shared Codex/OCS services
+
+Testing:
+- focused Gateway stop contract under race/shuffle
+- four Worker lifecycle packages under race/shuffle
+- Gateway/Worker package-wide race suite
+- WebChat unit suite
+- docs-lint, quality, build
+
+Closes #971
+```
+
+Return the PR URL, branch/commit summary, fresh verification evidence, and any residual risk.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -27,6 +27,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+const (
+	defaultStopTeardownTimeout  = 8 * time.Second
+	defaultStopForwarderTimeout = time.Second
+)
+
 // bridgeSM is the narrow subset of SessionManager that Bridge needs.
 // Composed from canonical sub-interfaces defined in handler.go to avoid
 // duplicate method declarations.
@@ -62,6 +67,8 @@ type Bridge struct {
 
 	agentConfigDir        string                   // agent config directory path; "" = disabled
 	turnTimeout           time.Duration            // per-turn timeout; 0 = disabled
+	stopTeardownTimeout   time.Duration            // provider stop + teardown server-side budget
+	stopForwarderTimeout  time.Duration            // extra local forwarder settle budget
 	workerEnv             []string                 // extra env vars from worker.environment config
 	workerEnvBlocklist    []string                 // extra blocklist entries from worker.env_blocklist config
 	cronEnv               []string                 // env vars injected only into cron platform sessions
@@ -121,8 +128,41 @@ type Bridge struct {
 }
 
 type workerRunBinding struct {
-	worker worker.Worker
-	id     string
+	worker    worker.Worker
+	id        string
+	lifecycle *workerRunLifecycle
+}
+
+// workerRunLifecycle is private to one local Worker wrapper/process run. It
+// never survives reset or replacement, even when the provider session identity
+// is resumed by the next Worker.
+type workerRunLifecycle struct {
+	eventMu  sync.RWMutex
+	stopping atomic.Bool
+	done     chan struct{}
+	conn     worker.SessionConn
+}
+
+func newWorkerRunLifecycle(conn worker.SessionConn) *workerRunLifecycle {
+	return &workerRunLifecycle{
+		done: make(chan struct{}),
+		conn: conn,
+	}
+}
+
+// beginEvent admits one complete event-side-effect operation. A successful
+// stop takes the write side, waits for admitted work to finish, then makes the
+// rejection irreversible before releasing it.
+func (l *workerRunLifecycle) beginEvent() (func(), bool) {
+	if l == nil {
+		return func() {}, true
+	}
+	l.eventMu.RLock()
+	if l.stopping.Load() {
+		l.eventMu.RUnlock()
+		return nil, false
+	}
+	return l.eventMu.RUnlock, true
 }
 
 type crashHistory struct {
@@ -139,29 +179,39 @@ const (
 // NewBridge creates a new bridge.
 func NewBridge(deps BridgeDeps) *Bridge {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	stopTeardownTimeout := deps.StopTeardownTimeout
+	if stopTeardownTimeout <= 0 {
+		stopTeardownTimeout = defaultStopTeardownTimeout
+	}
+	stopForwarderTimeout := deps.StopForwarderTimeout
+	if stopForwarderTimeout <= 0 {
+		stopForwarderTimeout = defaultStopForwarderTimeout
+	}
 	b := &Bridge{
-		log:                deps.Log.With("component", "bridge"),
-		hub:                deps.Hub,
-		sm:                 deps.SM,
-		wf:                 defaultWorkerFactory{},
-		collector:          deps.EventCollector,
-		turnsQuerier:       deps.TurnsQuerier,
-		retryCtrl:          deps.RetryCtrl,
-		agentConfigDir:     deps.AgentConfigDir,
-		turnTimeout:        deps.TurnTimeout,
-		workerEnv:          deps.WorkerEnv,
-		workerEnvBlocklist: deps.WorkerEnvBlocklist,
-		cronEnv:            deps.CronEnv,
-		wsStore:            deps.WSStore,
-		retryCancel:        make(map[string]chan struct{}),
-		accum:              make(map[string]*sessionAccumulator),
-		crashTracker:       make(map[string]*crashHistory),
-		shutdownCtx:        shutdownCtx,
-		shutdownCancel:     shutdownCancel,
-		executionStore:     deps.ExecutionStore,
-		repairer:           deps.Repairer,
-		turnTTFT:           newTurnTTFTTracker(),
-		pending:            NewPendingBuffer(),
+		log:                  deps.Log.With("component", "bridge"),
+		hub:                  deps.Hub,
+		sm:                   deps.SM,
+		wf:                   defaultWorkerFactory{},
+		collector:            deps.EventCollector,
+		turnsQuerier:         deps.TurnsQuerier,
+		retryCtrl:            deps.RetryCtrl,
+		agentConfigDir:       deps.AgentConfigDir,
+		turnTimeout:          deps.TurnTimeout,
+		stopTeardownTimeout:  stopTeardownTimeout,
+		stopForwarderTimeout: stopForwarderTimeout,
+		workerEnv:            deps.WorkerEnv,
+		workerEnvBlocklist:   deps.WorkerEnvBlocklist,
+		cronEnv:              deps.CronEnv,
+		wsStore:              deps.WSStore,
+		retryCancel:          make(map[string]chan struct{}),
+		accum:                make(map[string]*sessionAccumulator),
+		crashTracker:         make(map[string]*crashHistory),
+		shutdownCtx:          shutdownCtx,
+		shutdownCancel:       shutdownCancel,
+		executionStore:       deps.ExecutionStore,
+		repairer:             deps.Repairer,
+		turnTTFT:             newTurnTTFTTracker(),
+		pending:              NewPendingBuffer(),
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
 	b.defaultPermissionMode.Store(worker.NormalizePermissionMode(deps.DefaultPermissionMode))
@@ -950,11 +1000,13 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 		b.pending.Clear(sessionID)
 	}
 	workerRunID := ""
+	var replacementBinding workerRunBinding
 	if result.ConnReplaced {
 		if b.sm.GetWorker(sessionID) != w {
 			return fmt.Errorf("bridge: reset worker changed before run binding")
 		}
-		workerRunID = b.bindWorkerRun(sessionID, w, "")
+		replacementBinding = b.bindWorkerRun(sessionID, w, "")
+		workerRunID = replacementBinding.id
 	} else if bindingSuspended {
 		b.restoreWorkerRun(sessionID, suspendedBinding)
 	}
@@ -998,8 +1050,9 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
+		defer close(replacementBinding.lifecycle.done)
 		defer b.clearWorkerRun(sessionID, w, workerRunID)
-		b.launchForwarderLocked(w, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
+		b.launchForwarderLocked(replacementBinding, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
 	}()
 
 	return nil

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -59,6 +59,7 @@ type forwardContext struct {
 	pendingError   *events.Envelope
 	turnTimerFired atomic.Bool
 	turnTimer      *time.Timer
+	lifecycle      *workerRunLifecycle
 	// flog carries trace_id from the forwardEvents OTel span. Helpers must
 	// use fc.flog (not b.log) to keep log lines correlatable with the span.
 	// Nil-safe via bridge.flogOf; tests build forwardContext without it.
@@ -143,7 +144,15 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 			// A panic after stream consumption must still produce one visible
 			// terminal. Without this guard the client is left indefinitely in a
 			// thinking state; a later worker cleanup has no forwarder to notify it.
-			if fc != nil && b.hub != nil && !w.IsStopped() && fc.terminalSent.CompareAndSwap(false, true) {
+			if fc == nil {
+				return
+			}
+			releaseEvent, admitted := fc.lifecycle.beginEvent()
+			if !admitted {
+				return
+			}
+			defer releaseEvent()
+			if b.hub != nil && !w.IsStopped() && fc.terminalSent.CompareAndSwap(false, true) {
 				b.sendError(sessionID, events.ErrCodeWorkerCrash, "worker event stream interrupted before terminal")
 			}
 		}
@@ -167,6 +176,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		startTime:     time.Now(),
 		turnStartTime: time.Now(),
 		firstEvent:    true,
+		lifecycle:     fb.lifecycle,
 		flog:          flog,
 	}
 
@@ -204,6 +214,11 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 
 	if b.turnTimeout > 0 {
 		fc.turnTimer = time.AfterFunc(b.turnTimeout, func() {
+			releaseEvent, admitted := fc.lifecycle.beginEvent()
+			if !admitted {
+				return
+			}
+			defer releaseEvent()
 			if !fc.turnTimerFired.CompareAndSwap(false, true) {
 				return
 			}
@@ -252,29 +267,33 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	// connection. In the defensive nil-frozen-Conn path this also preserves the
 	// input from the live fallback that actually supplied the event stream.
 	lastReplay := snapshotInputReplay(recvSource)
-	if !fc.doneReceived {
-		b.finishTurnTTFT(sessionID, "worker_exit")
-	}
+	releaseExitEvent, admitted := fc.lifecycle.beginEvent()
+	if admitted {
+		if !fc.doneReceived {
+			b.finishTurnTTFT(sessionID, "worker_exit")
+		}
 
-	// Flush buffered error that never reached a retry decision point.
-	if fc.pendingError != nil && fc.terminalSent.CompareAndSwap(false, true) {
-		releaseSeq := func() {}
-		canFlush := true
-		if b.collector != nil {
-			var ok bool
-			releaseSeq, ok = b.hub.BeginSeqOperation(sessionID)
-			if !ok {
-				canFlush = false
+		// Flush buffered error that never reached a retry decision point.
+		if fc.pendingError != nil && fc.terminalSent.CompareAndSwap(false, true) {
+			releaseSeq := func() {}
+			canFlush := true
+			if b.collector != nil {
+				var ok bool
+				releaseSeq, ok = b.hub.BeginSeqOperation(sessionID)
+				if !ok {
+					canFlush = false
+				}
 			}
-		}
-		if canFlush {
-			if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
-				flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+			if canFlush {
+				if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
+					flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+				}
+				b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, flog)
+				releaseSeq()
 			}
-			b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, flog)
-			releaseSeq()
+			fc.pendingError = nil
 		}
-		fc.pendingError = nil
+		releaseExitEvent()
 	}
 	fc.pendingError = nil
 
@@ -293,6 +312,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		resetGen:       myResetGen,
 		lastInput:      lastReplay.Content,
 		lastReplay:     lastReplay,
+		lifecycle:      fc.lifecycle,
 		flog:           flog,
 	})
 }
@@ -320,6 +340,12 @@ func snapshotInputReplay(conn worker.SessionConn) worker.InputReplay {
 
 // processForwardedEvent handles a single worker event in the forwarding loop.
 func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, opts forwardOpts, fc *forwardContext) {
+	releaseEvent, ok := fc.lifecycle.beginEvent()
+	if !ok {
+		return
+	}
+	defer releaseEvent()
+
 	sessionID := fc.sessionID
 	workerType := fc.workerType
 
@@ -514,7 +540,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 			// detects recvCh closure immediately instead of waiting for the
 			// backoff timer to expire. The goroutine uses shutdownCtx so it
 			// cancels promptly during bridge shutdown.
-			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh)
+			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh, fc.lifecycle)
 			fc.turnText.Reset()
 			if b.collector != nil {
 				b.collector.ResetSession(sessionID)
@@ -916,6 +942,7 @@ type workerExitParams struct {
 	// releases the worker's mutable live connection.
 	lastInput  string
 	lastReplay worker.InputReplay
+	lifecycle  *workerRunLifecycle
 }
 
 // rawExitCodeFields extracts the raw OS exit code from workers that implement
@@ -999,6 +1026,13 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 				"session_id", p.sessionID, "worker_type", workerType)
 		}
 	}
+
+	releaseExit, admitted := p.lifecycle.beginEvent()
+	if !admitted {
+		b.detachStoppedWorkerRun(p.sessionID, w, lg)
+		return
+	}
+	defer releaseExit()
 
 	wasStopped := w.IsStopped()
 
@@ -1128,15 +1162,19 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		if wasStopped {
 			// User-initiated stop: detach the dead worker and transition to Idle
 			// so the session stays alive for the next turn (not Terminated).
-			if b.sm != nil {
-				b.sm.DetachWorkerIf(p.sessionID, w)
-				if err := b.sm.Transition(context.Background(), p.sessionID, events.StateIdle); err != nil {
-					lg.Debug("bridge: transition to idle after stop", "session_id", p.sessionID, "err", err)
-				}
-			}
+			b.detachStoppedWorkerRun(p.sessionID, w, lg)
 		} else {
 			b.cleanupCrashedWorker(p.sessionID, w)
 		}
+	}
+}
+
+func (b *Bridge) detachStoppedWorkerRun(sessionID string, w worker.Worker, lg *slog.Logger) {
+	if b.sm == nil || !b.sm.DetachWorkerIf(sessionID, w) {
+		return
+	}
+	if err := b.sm.Transition(context.Background(), sessionID, events.StateIdle); err != nil {
+		lg.Debug("bridge: transition to idle after stop", "session_id", sessionID, "err", err)
 	}
 }
 

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -25,15 +25,8 @@ func (b *Bridge) CancelRetry(sessionID string) {
 // autoRetry performs exponential backoff then sends the retry input to the worker.
 // cancelCh is pre-registered by the caller to eliminate the race window between
 // goroutine launch and cancel channel registration.
-func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int, cancelCh chan struct{}) {
+func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int, cancelCh chan struct{}, lifecycle *workerRunLifecycle) {
 	delay := b.retryCtrl.Delay(attempt)
-
-	// Notify user if enabled.
-	if b.retryCtrl.ShouldNotify() {
-		msg := b.retryCtrl.NotifyMessage(attempt)
-		notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
-		_ = b.hub.SendToSession(ctx, notifyEnv)
-	}
 
 	// Clean up cancel channel on exit (registered by caller before goroutine launch).
 	defer func() {
@@ -41,6 +34,18 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 		delete(b.retryCancel, sessionID)
 		b.retryCancelMu.Unlock()
 	}()
+
+	// Notify user if enabled.
+	if b.retryCtrl.ShouldNotify() {
+		releaseEvent, admitted := lifecycle.beginEvent()
+		if !admitted {
+			return
+		}
+		msg := b.retryCtrl.NotifyMessage(attempt)
+		notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
+		_ = b.hub.SendToSession(ctx, notifyEnv)
+		releaseEvent()
+	}
 
 	// Wait with backoff, respecting cancellation.
 	timer := time.NewTimer(delay)
@@ -55,6 +60,11 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 	}
 
 	// Send retry input to worker.
+	releaseEvent, admitted := lifecycle.beginEvent()
+	if !admitted {
+		return
+	}
+	defer releaseEvent()
 	b.log.Info("bridge: auto-retry sending input", "session_id", sessionID, "attempt", attempt)
 	observability.RetryAttempts().Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "llm_error")))
 	if err := w.Input(ctx, b.retryCtrl.RetryInput(), nil); err != nil {

--- a/internal/gateway/bridge_stop.go
+++ b/internal/gateway/bridge_stop.go
@@ -1,0 +1,183 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+var (
+	errWorkerRunChanged     = errors.New("worker run changed")
+	errWorkerStopNotApplied = errors.New("worker stop not applied")
+	errWorkerRunTeardown    = errors.New("worker run teardown failed")
+	errWorkerRunQuiescence  = errors.New("worker run quiescence timeout")
+)
+
+// StopAndDisposeCurrentRun stops and releases exactly one local Worker run.
+// A nil result proves that the provider cancellation committed, the old event
+// stream is permanently fenced, and the forwarder completed its CAS cleanup.
+func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expectedRunID string) error {
+	started := time.Now()
+	binding, ok := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !ok || binding.lifecycle == nil {
+		b.logStopPhase(sessionID, expectedRunID, "stop_failed", started, "run_changed", "")
+		return errWorkerRunChanged
+	}
+	workerType := binding.worker.Type()
+
+	teardownTimeout := b.stopTeardownTimeout
+	if teardownTimeout <= 0 {
+		teardownTimeout = defaultStopTeardownTimeout
+	}
+	forwarderTimeout := b.stopForwarderTimeout
+	if forwarderTimeout <= 0 {
+		forwarderTimeout = defaultStopForwarderTimeout
+	}
+	stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), teardownTimeout)
+	defer cancel()
+
+	b.logStopPhase(sessionID, binding.id, "stop_requested", started, "", workerType)
+	lifecycle := binding.lifecycle
+	lifecycle.eventMu.Lock()
+	current, stillCurrent := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !stillCurrent || current.worker != binding.worker || current.lifecycle != lifecycle {
+		lifecycle.eventMu.Unlock()
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "run_changed", workerType)
+		return errWorkerRunChanged
+	}
+	if err := binding.worker.StopCurrentTurn(stopCtx); err != nil {
+		lifecycle.eventMu.Unlock()
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "provider_cancel", workerType)
+		return errWorkerStopNotApplied
+	}
+	lifecycle.stopping.Store(true)
+	lifecycle.eventMu.Unlock()
+	b.logStopPhase(sessionID, binding.id, "provider_cancelled", started, "", workerType)
+
+	b.logStopPhase(sessionID, binding.id, "worker_terminating", started, "", workerType)
+	teardownFailed := false
+	if err := binding.worker.Terminate(stopCtx); err != nil {
+		b.logStopPhase(sessionID, binding.id, "worker_kill_fallback", started, "terminate", workerType)
+		if killErr := binding.worker.Kill(); killErr != nil {
+			teardownFailed = true
+			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "kill", workerType)
+		}
+	}
+	if lifecycle.conn != nil {
+		if err := lifecycle.conn.Close(); err != nil {
+			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "conn_close", workerType)
+		}
+	}
+
+	if !waitForWorkerRun(lifecycle.done, stopCtx.Done(), forwarderTimeout) {
+		b.failClosedStoppedRun(sessionID, binding)
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "quiescence_timeout", workerType)
+		return errWorkerRunQuiescence
+	}
+	b.logStopPhase(sessionID, binding.id, "forwarder_quiesced", started, "", workerType)
+
+	if b.workerRunStillAttached(sessionID, binding) {
+		b.failClosedStoppedRun(sessionID, binding)
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "cleanup_incomplete", workerType)
+		return errWorkerRunQuiescence
+	}
+	if teardownFailed {
+		return errWorkerRunTeardown
+	}
+	b.logStopPhase(sessionID, binding.id, "stop_completed", started, "", workerType)
+	return nil
+}
+
+func (b *Bridge) currentWorkerRunBinding(sessionID, expectedRunID string) (workerRunBinding, bool) {
+	value, ok := b.workerRuns.Load(sessionID)
+	if !ok {
+		return workerRunBinding{}, false
+	}
+	binding, ok := value.(workerRunBinding)
+	if !ok || binding.worker == nil || binding.id == "" || (expectedRunID != "" && binding.id != expectedRunID) {
+		return workerRunBinding{}, false
+	}
+	if b.sm == nil || b.sm.GetWorker(sessionID) != binding.worker {
+		return workerRunBinding{}, false
+	}
+	return binding, true
+}
+
+func waitForWorkerRun(done, teardownDone <-chan struct{}, forwarderTimeout time.Duration) bool {
+	select {
+	case <-done:
+		return true
+	case <-teardownDone:
+	}
+
+	timer := time.NewTimer(forwarderTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (b *Bridge) failClosedStoppedRun(sessionID string, binding workerRunBinding) {
+	detached := b.sm != nil && b.sm.DetachWorkerIf(sessionID, binding.worker)
+	b.clearWorkerRun(sessionID, binding.worker, binding.id)
+	if !detached {
+		return
+	}
+	if err := b.sm.Transition(context.Background(), sessionID, events.StateIdle); err != nil {
+		b.log.Debug("bridge: fail-closed stopped run idle transition failed",
+			"session_id", sessionID, "worker_run_id", binding.id, "error_kind", "idle_transition")
+	}
+}
+
+func (b *Bridge) workerRunStillAttached(sessionID string, binding workerRunBinding) bool {
+	if b.sm != nil && b.sm.GetWorker(sessionID) == binding.worker {
+		return true
+	}
+	value, ok := b.workerRuns.Load(sessionID)
+	if !ok {
+		return false
+	}
+	current, ok := value.(workerRunBinding)
+	return ok && current.worker == binding.worker && current.id == binding.id && current.lifecycle == binding.lifecycle
+}
+
+func (b *Bridge) logStopPhase(sessionID, runID, phase string, started time.Time, errorKind string, workerType worker.WorkerType) {
+	attrs := []any{
+		"session_id", sessionID,
+		"worker_run_id", runID,
+		"stop_phase", phase,
+		"duration_ms", time.Since(started).Milliseconds(),
+	}
+	if workerType != "" {
+		attrs = append(attrs, "worker_type", workerType)
+	}
+	if errorKind != "" {
+		attrs = append(attrs, "error_kind", errorKind)
+	}
+	b.log.Info("bridge: worker run stop phase", attrs...)
+}
+
+func stopFailureAllowsRollback(err error) bool {
+	return errors.Is(err, errWorkerRunChanged) || errors.Is(err, errWorkerStopNotApplied)
+}
+
+func stopErrorKind(err error) string {
+	switch {
+	case errors.Is(err, errWorkerRunChanged):
+		return "run_changed"
+	case errors.Is(err, errWorkerStopNotApplied):
+		return "provider_cancel"
+	case errors.Is(err, errWorkerRunTeardown):
+		return "teardown"
+	case errors.Is(err, errWorkerRunQuiescence):
+		return "quiescence_timeout"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -103,7 +103,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		}
 		return nil, err
 	}
-	b.bindWorkerRun(sid, w, params.forwardOpts.workerRunID)
+	runBinding := b.bindWorkerRun(sid, w, params.forwardOpts.workerRunID)
 
 	// A new Worker (or a resumed/replaced one) is now the session's command
 	// authority: drop the session's cached catalog so the next assembly picks
@@ -132,8 +132,9 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
-		defer b.clearWorkerRun(sid, w, params.forwardOpts.workerRunID)
-		b.launchForwarderLocked(w, sid, *params.forwardOpts)
+		defer close(runBinding.lifecycle.done)
+		defer b.clearWorkerRun(sid, w, runBinding.id)
+		b.launchForwarderLocked(runBinding, sid, *params.forwardOpts)
 	}()
 
 	return w, nil
@@ -179,9 +180,10 @@ func (b *Bridge) capturePermissionCeiling(ctx context.Context, sessionID string,
 // after /reset and splitting the event stream with the new forwarder
 // (Turn-Integrity spec RC-1 / Fix A, invariant I-1/I-2).
 type forwarderBinding struct {
-	worker   worker.Worker
-	conn     worker.SessionConn // frozen event source; forwardEvents reads ONLY this
-	resetGen int64              // frozen reset generation for stale-exit detection
+	worker    worker.Worker
+	conn      worker.SessionConn // frozen event source; forwardEvents reads ONLY this
+	lifecycle *workerRunLifecycle
+	resetGen  int64 // frozen reset generation for stale-exit detection
 }
 
 // launchForwarderLocked is the single entry point for spawning a forwardEvents
@@ -189,22 +191,32 @@ type forwarderBinding struct {
 // the Conn is captured before any concurrent ResetContext can replace it.
 // All four launch paths — fresh Start, Resume, /reset ConnReplaced, and crash
 // recovery — route through here (Fix A).
-func (b *Bridge) launchForwarderLocked(w worker.Worker, sessionID string, opts forwardOpts) {
-	conn := w.Conn()
+func (b *Bridge) launchForwarderLocked(binding workerRunBinding, sessionID string, opts forwardOpts) {
+	w := binding.worker
 	var resetGen int64
 	if rg, ok := w.(worker.ResetGenerationer); ok {
 		resetGen = rg.LoadResetGeneration()
 	}
-	fb := forwarderBinding{worker: w, conn: conn, resetGen: resetGen}
+	fb := forwarderBinding{
+		worker:    w,
+		conn:      binding.lifecycle.conn,
+		lifecycle: binding.lifecycle,
+		resetGen:  resetGen,
+	}
 	b.forwardEvents(fb, sessionID, opts)
 }
 
-func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) string {
+func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) workerRunBinding {
 	if runID == "" {
 		runID = "run_" + uuid.NewString()
 	}
-	b.workerRuns.Store(sessionID, workerRunBinding{worker: w, id: runID})
-	return runID
+	binding := workerRunBinding{
+		worker:    w,
+		id:        runID,
+		lifecycle: newWorkerRunLifecycle(w.Conn()),
+	}
+	b.workerRuns.Store(sessionID, binding)
+	return binding
 }
 
 // RecordTurnStart stamps the current turn's start time on the session

--- a/internal/gateway/commands.go
+++ b/internal/gateway/commands.go
@@ -78,14 +78,15 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 			}
 			return h.sendErrorf(ctx, env, events.ErrCodeUnauthorized, "ownership required")
 		}
-		w := h.sm.GetWorker(env.SessionID)
-		if w == nil {
-			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop: no active worker")
-		}
+		unlockDispatch := h.dispatchGate.Lock(env.SessionID)
+		defer unlockDispatch()
 
-		var workerRunID string
+		var (
+			workerRunID string
+			bindingOK   bool
+		)
 		if h.bridge != nil {
-			_, workerRunID, _ = h.bridge.CurrentWorkerBinding(env.SessionID)
+			_, workerRunID, bindingOK = h.bridge.CurrentWorkerBinding(env.SessionID)
 		}
 
 		// The claim is keyed by the turn's execution ID (when the execution
@@ -96,11 +97,23 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 		// the first stop's finishRuntimeOnStop closes the runtime BEFORE a
 		// duplicate stop arrives, so the open-runtime query would resolve to a
 		// different (or no) record and admit the duplicate.
-		var execID string
+		var execID, persistedRunID string
 		if h.executionStore != nil {
 			if rec, err := h.executionStore.LatestBySession(ctx, env.SessionID); err == nil {
 				execID = rec.ExecutionID
+				persistedRunID = rec.WorkerRunID
 			}
+		}
+		if workerRunID == "" {
+			workerRunID = persistedRunID
+		}
+		if !bindingOK && h.stopFence.IsClaimed(env.SessionID) {
+			// The first successful stop detaches the run before a duplicate
+			// arrives. When the execution ledger is disabled (or temporarily
+			// unavailable), the original composite key cannot be reconstructed;
+			// the retained session claim still proves the stop was already applied.
+			h.log.Debug("gateway: stop already completed for detached run", "session_id", env.SessionID)
+			return nil
 		}
 
 		// Per-turn stop fence: admit exactly one effective stop per (session,
@@ -112,17 +125,36 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 				"session_id", env.SessionID, "worker_run_id", workerRunID, "execution_id", execID)
 			return nil
 		}
+		if h.bridge == nil || !bindingOK {
+			h.stopFence.Rollback(env.SessionID, workerRunID, execID)
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop: no active worker run")
+		}
 
 		// A stop supersedes any pending LLM auto-retry: the retried input must
 		// not fire after the stop and start a new turn under the fresh claim.
 		h.cancelRetryIfNeeded(env.SessionID)
 
-		if err := w.StopCurrentTurn(ctx); err != nil {
-			// The stop never took effect: roll the claim back so a manual retry
-			// can stop again (failed-abort convergence, session retained).
-			h.stopFence.Rollback(env.SessionID, workerRunID, execID)
-			h.log.Warn("gateway: stop current turn failed", "session_id", env.SessionID, "err", err)
-			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop failed: %v", err)
+		if err := h.bridge.StopAndDisposeCurrentRun(ctx, env.SessionID, workerRunID); err != nil {
+			if stopFailureAllowsRollback(err) {
+				// Provider cancellation never committed: reopen event flow and let
+				// a manual stop retry claim this same turn.
+				h.stopFence.Rollback(env.SessionID, workerRunID, execID)
+			} else {
+				// Provider cancellation committed, so the run stays isolated even
+				// when teardown/quiescence reports failure. Close its durable runtime
+				// without sending the success-only stopped done.
+				h.finishRuntimeOnStop(ctx, env.SessionID, workerRunID, env.OwnerID)
+			}
+			h.log.Warn("gateway: stop worker run failed",
+				"session_id", env.SessionID,
+				"worker_run_id", workerRunID,
+				"execution_id", execID,
+				"stop_phase", "stop_failed",
+				"error_kind", stopErrorKind(err))
+			if errors.Is(err, errWorkerRunChanged) {
+				return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "worker run changed during stop")
+			}
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker run did not stop cleanly")
 		}
 
 		// Finish the pending execution runtime immediately when stopped.

--- a/internal/gateway/contracttest/harness.go
+++ b/internal/gateway/contracttest/harness.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/dbutil"
 	"github.com/hrygo/hotplex/internal/e2econtract"
+	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/gateway"
 	"github.com/hrygo/hotplex/internal/session"
@@ -53,6 +54,7 @@ type Harness struct {
 	Hub     *gateway.Hub
 	Bridge  *gateway.Bridge
 	Handler *gateway.Handler
+	manager *session.Manager
 
 	profile   e2econtract.WorkerProfile
 	sessionID string
@@ -64,6 +66,36 @@ type Harness struct {
 	probes  []*WorkerProbe // every probe created for this harness (teardown closes all)
 
 	nextProbeBlocking atomic.Bool // arm the NEXT probe for the turn-gate mode (matrix C04)
+
+	eventCollector *eventstore.Collector
+	eventStore     eventstore.EventStore
+}
+
+type harnessOptions struct {
+	eventCollector       bool
+	stopTeardownTimeout  time.Duration
+	stopForwarderTimeout time.Duration
+}
+
+// HarnessOption enables an isolated contract-harness capability without
+// changing the default platform/worker matrix behavior.
+type HarnessOption func(*harnessOptions)
+
+// WithEventCollector enables durable forwarded-event assertions for tests
+// such as the stopped-run quarantine contract.
+func WithEventCollector() HarnessOption {
+	return func(opts *harnessOptions) {
+		opts.eventCollector = true
+	}
+}
+
+// WithStopTimeouts overrides the server-side stop budgets for deterministic
+// timeout contract tests. Production callers use Bridge defaults.
+func WithStopTimeouts(teardown, forwarder time.Duration) HarnessOption {
+	return func(opts *harnessOptions) {
+		opts.stopTeardownTimeout = teardown
+		opts.stopForwarderTimeout = forwarder
+	}
 }
 
 // NewHarness builds a full gateway stack against a temp SQLite store and
@@ -73,8 +105,13 @@ type Harness struct {
 // Bridge.MarkClosed → close every probe conn (so all forwarders exit; the
 // closed flag makes handleWorkerExit skip crash recovery) → Bridge.Shutdown →
 // Hub.Shutdown → Manager.Close → store.Close, each bounded by a 2s context.
-func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract.WorkerProfile) *Harness {
+func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract.WorkerProfile, options ...HarnessOption) *Harness {
 	t.Helper()
+
+	opts := harnessOptions{}
+	for _, option := range options {
+		option(&opts)
+	}
 
 	log := discardLogger
 	cfg := config.Default()
@@ -93,16 +130,25 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 	// resources of its own to close: store.Close() releases the shared DB.
 	execStore, err := execution.NewSQLStore(context.Background(), store.DB(), dbutil.DialectSQLite, writeMu, log)
 	require.NoError(t, err, "contracttest: open execution store")
+	var eventCollector *eventstore.Collector
+	var durableEventStore eventstore.EventStore
+	if opts.eventCollector {
+		durableEventStore = eventstore.NewSQLiteStore(store.DB(), writeMu)
+		eventCollector = eventstore.NewCollector(durableEventStore, log)
+	}
 	cfgStore := config.NewConfigStore(cfg, nil)
 	mgr, err := session.NewManager(context.Background(), log, cfg, cfgStore, store)
 	require.NoError(t, err, "contracttest: create session manager")
 
 	hub := gateway.NewHub(log, cfgStore)
 	bridge := gateway.NewBridge(gateway.BridgeDeps{
-		Log:            log,
-		Hub:            hub,
-		SM:             mgr,
-		ExecutionStore: execStore,
+		Log:                  log,
+		Hub:                  hub,
+		SM:                   mgr,
+		EventCollector:       eventCollector,
+		ExecutionStore:       execStore,
+		StopTeardownTimeout:  opts.stopTeardownTimeout,
+		StopForwarderTimeout: opts.stopForwarderTimeout,
 	})
 	handler := gateway.NewHandler(gateway.HandlerDeps{
 		Log:             log,
@@ -118,13 +164,16 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 	hub.JoinPlatformSession(sessionID, observer)
 
 	h := &Harness{
-		Hub:       hub,
-		Bridge:    bridge,
-		Handler:   handler,
-		profile:   profile,
-		sessionID: sessionID,
-		dbPath:    dbPath,
-		observer:  observer,
+		Hub:            hub,
+		Bridge:         bridge,
+		Handler:        handler,
+		manager:        mgr,
+		profile:        profile,
+		sessionID:      sessionID,
+		dbPath:         dbPath,
+		observer:       observer,
+		eventCollector: eventCollector,
+		eventStore:     durableEventStore,
 	}
 	bridge.SetWorkerFactory(&probeFactory{h: h, profile: profile, sessionID: sessionID})
 
@@ -150,6 +199,9 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 		}
 		h.Bridge.Shutdown(cleanupCtx)
 		_ = h.Hub.Shutdown(cleanupCtx)
+		if h.eventCollector != nil {
+			_ = h.eventCollector.Close()
+		}
 		_ = mgr.Close()
 		_ = store.Close()
 	})
@@ -208,6 +260,31 @@ func (h *Harness) Probes() []*WorkerProbe {
 	out := make([]*WorkerProbe, len(h.probes))
 	copy(out, h.probes)
 	return out
+}
+
+// StoredEvents flushes and returns every durable event for the harness
+// session. The harness must have been created with WithEventCollector.
+func (h *Harness) StoredEvents(t testing.TB) []*eventstore.StoredEvent {
+	t.Helper()
+	require.NotNil(t, h.eventCollector, "contracttest: event collector is not enabled")
+	require.NotNil(t, h.eventStore, "contracttest: event store is not enabled")
+	require.NoError(t, h.eventCollector.FlushSession(h.sessionID), "contracttest: flush stored events")
+	page, err := h.eventStore.QueryBySession(
+		context.Background(), h.sessionID, 0, eventstore.CursorLatest, 1000,
+	)
+	require.NoError(t, err, "contracttest: query stored events")
+	return page.Events
+}
+
+// Events returns a snapshot of every envelope observed by the platform side.
+func (h *Harness) Events() []*events.Envelope { return h.observer.Events() }
+
+// SessionState returns the current persisted/in-memory session state.
+func (h *Harness) SessionState(t testing.TB) events.SessionState {
+	t.Helper()
+	si, err := h.manager.Get(context.Background(), h.sessionID)
+	require.NoError(t, err, "contracttest: get session state")
+	return si.State
 }
 
 // WaitForKinds blocks until every event kind in kinds has been observed on the

--- a/internal/gateway/contracttest/worker_probe.go
+++ b/internal/gateway/contracttest/worker_probe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hrygo/hotplex/internal/worker/codexcli"
 	"github.com/hrygo/hotplex/internal/worker/noop"
 	"github.com/hrygo/hotplex/internal/worker/opencodeserver"
+	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -103,6 +104,18 @@ type WorkerProbe struct {
 	holdTerminal  []*events.Envelope
 
 	failNextStop atomic.Bool // arming the next StopCurrentTurn to fail (failed-abort contract)
+
+	terminateCalls atomic.Int32
+	killCalls      atomic.Int32
+	failTerminate  atomic.Bool
+	failKill       atomic.Bool
+	blockStop      atomic.Bool
+	blockWait      atomic.Bool
+	lateOnDispose  atomic.Bool
+	stopEntered    chan struct{}
+	allowStop      chan struct{}
+	waitEntered    chan struct{}
+	allowWait      chan struct{}
 }
 
 // FailNextStop arms the NEXT StopCurrentTurn to return an error, simulating a
@@ -120,6 +133,10 @@ func NewWorkerProbe(profile e2econtract.WorkerProfile, sessionID string) *Worker
 		conn:          newProbeConn(sessionID, "contract-user"),
 		enteredTurn:   make(chan struct{}, 1),
 		allowTerminal: make(chan struct{}, 1),
+		stopEntered:   make(chan struct{}, 1),
+		allowStop:     make(chan struct{}, 1),
+		waitEntered:   make(chan struct{}, 1),
+		allowWait:     make(chan struct{}, 1),
 	}
 }
 
@@ -185,15 +202,70 @@ func (p *WorkerProbe) ResetContext(_ context.Context) (worker.ResetResult, error
 	return worker.ResetResult{}, nil
 }
 
+// BlockStopCurrentTurn holds StopCurrentTurn after it marks the current turn
+// stopped. ReleaseStopCurrentTurn resumes it. The buffered signals make the
+// control deterministic regardless of which goroutine reaches the phase first.
+func (p *WorkerProbe) BlockStopCurrentTurn() { p.blockStop.Store(true) }
+
+func (p *WorkerProbe) StopEntered() <-chan struct{} { return p.stopEntered }
+
+func (p *WorkerProbe) ReleaseStopCurrentTurn() {
+	select {
+	case p.allowStop <- struct{}{}:
+	default:
+	}
+}
+
+// BlockWait holds Worker.Wait so tests can prove that stopped_by_user is sent
+// only after the old forwarder has completed handleWorkerExit.
+func (p *WorkerProbe) BlockWait() { p.blockWait.Store(true) }
+
+func (p *WorkerProbe) WaitEntered() <-chan struct{} { return p.waitEntered }
+
+func (p *WorkerProbe) ReleaseWait() {
+	select {
+	case p.allowWait <- struct{}{}:
+	default:
+	}
+}
+
+// EmitLateEventsOnDispose makes Terminate enqueue representative events from
+// the stopped run immediately before it closes the frozen connection.
+func (p *WorkerProbe) EmitLateEventsOnDispose() { p.lateOnDispose.Store(true) }
+
+// EmitLateEventsNow writes the same late-run fixture immediately. It lets a
+// contract test reproduce the pre-fix window after the early synthetic done.
+func (p *WorkerProbe) EmitLateEventsNow() {
+	p.lateOnDispose.Store(true)
+	p.emitLateEvents()
+}
+
+// FailNextTerminate and FailNextKill arm teardown fallback paths.
+func (p *WorkerProbe) FailNextTerminate() { p.failTerminate.Store(true) }
+func (p *WorkerProbe) FailNextKill()      { p.failKill.Store(true) }
+
 // StopCurrentTurn records the invocation and marks the current turn stopped.
 // The single-effective-stop guarantee is owned by the gateway's turn fence
 // (internal/gateway/stop_fence.go), not by this probe: a duplicate stop never
 // reaches the Worker call at all, so stopCalls stays 1 under the fence.
-func (p *WorkerProbe) StopCurrentTurn(_ context.Context) error {
+func (p *WorkerProbe) StopCurrentTurn(ctx context.Context) error {
 	p.stopCalls.Add(1)
 	p.stopped.Store(true)
 	p.stoppedTurn.Store(p.turnN.Load())
+	if p.blockStop.Load() {
+		select {
+		case p.stopEntered <- struct{}{}:
+		default:
+		}
+		select {
+		case <-p.allowStop:
+		case <-ctx.Done():
+			p.stopped.Store(false)
+			return ctx.Err()
+		}
+	}
 	if p.failNextStop.Swap(false) {
+		p.stopped.Store(false)
 		return errors.New("contracttest: injected stop failure")
 	}
 	return nil
@@ -201,11 +273,74 @@ func (p *WorkerProbe) StopCurrentTurn(_ context.Context) error {
 
 func (p *WorkerProbe) IsStopped() bool { return p.stopped.Load() }
 
+func (p *WorkerProbe) Terminate(_ context.Context) error {
+	p.terminateCalls.Add(1)
+	if p.failTerminate.Swap(false) {
+		return errors.New("contracttest: injected terminate failure")
+	}
+	p.emitLateEvents()
+	return p.conn.Close()
+}
+
+func (p *WorkerProbe) Kill() error {
+	p.killCalls.Add(1)
+	if p.failKill.Swap(false) {
+		return errors.New("contracttest: injected kill failure")
+	}
+	p.emitLateEvents()
+	return p.conn.Close()
+}
+
+func (p *WorkerProbe) Wait() (int, error) {
+	if p.blockWait.Load() {
+		select {
+		case p.waitEntered <- struct{}{}:
+		default:
+		}
+		<-p.allowWait
+	}
+	return 0, nil
+}
+
+func (p *WorkerProbe) emitLateEvents() {
+	if !p.lateOnDispose.Swap(false) {
+		return
+	}
+	late := []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.MessageDelta,
+			events.MessageDeltaData{MessageID: "late_run_message", Content: "late_run_delta"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Message,
+			events.MessageData{ID: "late_run_message", Role: "assistant", Content: "late_run_message"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Reasoning,
+			events.ReasoningData{ID: "late_run_reasoning", Content: "late_run_reasoning"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.ToolCall,
+			events.ToolCallData{ID: "late_run_tool", Name: "late_run_tool", Input: map[string]any{"marker": "late_run_tool"}}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.PermissionRequest,
+			events.PermissionRequestData{ID: "late_run_permission", ToolName: "late_run_permission"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.State,
+			events.StateData{State: events.StateRunning, Message: "late_run_state"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Done,
+			events.DoneData{Success: true, Reason: "late_run_done"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Error,
+			events.ErrorData{Code: events.ErrCodeInternalError, Message: "late_run_error"}),
+	}
+	for _, env := range late {
+		p.conn.write(env)
+	}
+}
+
 // InputCalls returns how many times Input was invoked.
 func (p *WorkerProbe) InputCalls() int { return int(p.inputCalls.Load()) }
 
 // StopCalls returns how many times StopCurrentTurn was invoked.
 func (p *WorkerProbe) StopCalls() int { return int(p.stopCalls.Load()) }
+
+func (p *WorkerProbe) TerminateCalls() int { return int(p.terminateCalls.Load()) }
+func (p *WorkerProbe) KillCalls() int      { return int(p.killCalls.Load()) }
+
+// Events returns every envelope the probe attempted to emit, including writes
+// rejected from the live Recv stream after the connection closed.
+func (p *WorkerProbe) Events() []*events.Envelope { return p.conn.Events() }
 
 // EmitBasicTurn drives the probe's worker-type fixture through the real
 // parser/mapper and writes every mapper-produced envelope verbatim into the
@@ -374,8 +509,8 @@ func newProbeConn(sessionID, userID string) *probeConn {
 // without blocking (a dropped mirror is fine — Events is the source of truth).
 func (c *probeConn) write(env *events.Envelope) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.events = append(c.events, env)
-	c.mu.Unlock()
 	if c.closed.Load() {
 		return
 	}
@@ -399,6 +534,8 @@ func (c *probeConn) Send(_ context.Context, _ *events.Envelope) error { return n
 func (c *probeConn) Recv() <-chan *events.Envelope { return c.recvCh }
 
 func (c *probeConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed.CompareAndSwap(false, true) {
 		close(c.recvCh)
 	}

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
+	noopworker "github.com/hrygo/hotplex/internal/worker/noop"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -484,9 +485,21 @@ func TestHandleControl_Stop_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
 	w.On("StopCurrentTurn", mock.Anything).Return(nil)
-	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil)
+	w.On("Wait").Return(0, nil)
 	mgr.AttachWorker(context.Background(), sid, w)
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	handler.bridge = bridge
+	runBinding := bridge.bindWorkerRun(sid, w, "run-stop-success")
+	bridge.fwdWg.Add(1)
+	go func() {
+		defer bridge.fwdWg.Done()
+		defer close(runBinding.lifecycle.done)
+		defer bridge.clearWorkerRun(sid, w, runBinding.id)
+		bridge.launchForwarderLocked(runBinding, sid, forwardOpts{ctx: context.Background(), workerRunID: runBinding.id})
+	}()
 
 	// The stop must converge the pending execution runtime (acceptance A3:
 	// Gateway stopped_by_user closed loop).

--- a/internal/gateway/deps.go
+++ b/internal/gateway/deps.go
@@ -43,6 +43,8 @@ type BridgeDeps struct {
 	RetryCtrl              *LLMRetryController
 	AgentConfigDir         string
 	TurnTimeout            time.Duration
+	StopTeardownTimeout    time.Duration            // optional; zero uses the 8s server-side run-stop budget
+	StopForwarderTimeout   time.Duration            // optional; zero uses the 1s post-teardown settle budget
 	WorkerEnv              []string                 // extra env vars from worker.environment config
 	WorkerEnvBlocklist     []string                 // extra blocklist entries from worker.env_blocklist config
 	CronEnv                []string                 // env vars injected only into cron platform sessions (e.g. admin API creds)

--- a/internal/gateway/dispatch_gate.go
+++ b/internal/gateway/dispatch_gate.go
@@ -1,0 +1,34 @@
+package gateway
+
+import "sync"
+
+const sessionDispatchStripeCount = 64
+
+// sessionDispatchGate serializes the short accept/dispatch critical section
+// for one session without retaining an unbounded session-keyed mutex map.
+// Hash collisions only add temporary serialization; they do not affect
+// correctness.
+type sessionDispatchGate struct {
+	stripes [sessionDispatchStripeCount]sync.Mutex
+}
+
+func (g *sessionDispatchGate) Lock(sessionID string) func() {
+	mu := &g.stripes[sessionDispatchStripe(sessionID)]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// sessionDispatchStripe uses allocation-free FNV-1a. The stripe count is a
+// power of two, so the mask is equivalent to modulo without a division.
+func sessionDispatchStripe(sessionID string) int {
+	const (
+		offset32 = uint32(2166136261)
+		prime32  = uint32(16777619)
+	)
+	hash := offset32
+	for i := 0; i < len(sessionID); i++ {
+		hash ^= uint32(sessionID[i])
+		hash *= prime32
+	}
+	return int(hash & (sessionDispatchStripeCount - 1))
+}

--- a/internal/gateway/dispatch_gate_test.go
+++ b/internal/gateway/dispatch_gate_test.go
@@ -1,0 +1,64 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionDispatchGate_SerializesSameSession(t *testing.T) {
+	t.Parallel()
+
+	var gate sessionDispatchGate
+	unlockFirst := gate.Lock("session-one")
+	secondAcquired := make(chan struct{})
+	go func() {
+		unlockSecond := gate.Lock("session-one")
+		close(secondAcquired)
+		unlockSecond()
+	}()
+
+	require.Never(t, func() bool {
+		select {
+		case <-secondAcquired:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond, "same-session acquisition must wait")
+
+	unlockFirst()
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("same-session acquisition did not proceed after release")
+	}
+}
+
+func TestSessionDispatchGate_AllowsDifferentStripes(t *testing.T) {
+	t.Parallel()
+
+	const firstSession = "session-one"
+	secondSession := "session-two"
+	for sessionDispatchStripe(firstSession) == sessionDispatchStripe(secondSession) {
+		secondSession += "-next"
+	}
+
+	var gate sessionDispatchGate
+	unlockFirst := gate.Lock(firstSession)
+	defer unlockFirst()
+
+	secondAcquired := make(chan struct{})
+	go func() {
+		unlockSecond := gate.Lock(secondSession)
+		close(secondAcquired)
+		unlockSecond()
+	}()
+
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("different dispatch stripes must not block each other")
+	}
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -35,7 +35,10 @@ import (
 
 // LevelTrace is one step below slog.LevelDebug, for high-volume protocol
 // chatter (ping/pong) that should not appear even at debug level.
-const LevelTrace = slog.Level(-8)
+const (
+	LevelTrace                 = slog.Level(-8)
+	stopRuntimeFinalizeTimeout = 500 * time.Millisecond
+)
 
 // ─── Message Handler ─────────────────────────────────────────────────────────
 
@@ -53,6 +56,7 @@ type Handler struct {
 	repairer        *execution.Repairer
 	ownerInstanceID string
 	stopFence       turnStopFence
+	dispatchGate    sessionDispatchGate
 
 	// catalogStore is the session-scoped merged command catalog (spec §5.2).
 	// catalogGen tracks the per-session generation bumped on /reset, /cd, and
@@ -1214,6 +1218,14 @@ func (h *Handler) deliverSkillToWorker(ctx context.Context, env *events.Envelope
 }
 
 func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *events.Envelope, content string, invocation *worker.NativeCommandInvocation, handleBusy bool) error {
+	unlockDispatch := h.dispatchGate.Lock(env.SessionID)
+	dispatchLocked := true
+	defer func() {
+		if dispatchLocked {
+			unlockDispatch()
+		}
+	}()
+
 	inputReceivedAt := time.Now()
 	si, err := h.sm.Get(ctx, env.SessionID)
 	if err != nil {
@@ -1236,6 +1248,11 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 			if !handleBusy {
 				return execution.ErrSessionBusy
 			}
+			// Supplement handling can re-enter normal primary delivery after
+			// re-checking the active execution. Release this non-reentrant gate
+			// before that path to avoid self-deadlock.
+			unlockDispatch()
+			dispatchLocked = false
 			return h.handleSupplementOnBusy(ctx, env, content, invocation)
 		}
 		h.log.Error("gateway: persist input acceptance failed", "err", err, "session_id", env.SessionID)
@@ -1748,7 +1765,9 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 	if h.executionStore == nil {
 		return
 	}
-	rec, err := h.executionStore.OpenBySession(ctx, sessionID)
+	finishCtx, finishCancel := context.WithTimeout(context.WithoutCancel(ctx), stopRuntimeFinalizeTimeout)
+	defer finishCancel()
+	rec, err := h.executionStore.OpenBySession(finishCtx, sessionID)
 	if err != nil {
 		return
 	}
@@ -1758,7 +1777,7 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 	errorCode := string(events.ErrCodeSessionTerminated)
 
 	err = h.executionStore.FinishRuntime(
-		context.WithoutCancel(ctx), rec.ExecutionID, workerRunID, rtStatus, errorCode,
+		finishCtx, rec.ExecutionID, workerRunID, rtStatus, errorCode,
 	)
 	if err != nil {
 		h.log.Warn("gateway: finish runtime on stop failed, enqueuing repair", "err", err, "session_id", sessionID, observability.KeyExecutionID, rec.ExecutionID)
@@ -1779,7 +1798,7 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 		ErrorCode:   events.ErrorCode(errorCode),
 	})
 	rtEnv.OwnerID = ownerID
-	_ = h.hub.SendToSession(ctx, rtEnv)
+	_ = h.hub.SendToSession(finishCtx, rtEnv)
 }
 
 func (h *Handler) sendInputAck(ctx context.Context, source *events.Envelope, record *execution.Record, duplicate bool) {

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -357,6 +358,8 @@ func (h *testableHandler) handleGC(ctx context.Context, sessionID, ownerID strin
 // mockWorkerForHandler implements worker.Worker for handler tests.
 type mockWorkerForHandler struct {
 	mock.Mock
+	conn    worker.SessionConn
+	stopped atomic.Bool
 }
 
 func (m *mockWorkerForHandler) Type() worker.WorkerType   { return worker.TypeClaudeCode }
@@ -374,6 +377,7 @@ func (m *mockWorkerForHandler) Start(ctx context.Context, session worker.Session
 	return args.Error(0)
 }
 func (m *mockWorkerForHandler) Input(ctx context.Context, content string, metadata map[string]any) error {
+	m.stopped.Store(false)
 	args := m.Called(ctx, content, metadata)
 	return args.Error(0)
 }
@@ -390,7 +394,7 @@ func (m *mockWorkerForHandler) Wait() (int, error) {
 	args := m.Called()
 	return args.Int(0), args.Error(1)
 }
-func (m *mockWorkerForHandler) Conn() worker.SessionConn { return nil }
+func (m *mockWorkerForHandler) Conn() worker.SessionConn { return m.conn }
 func (m *mockWorkerForHandler) Health() worker.WorkerHealth {
 	args := m.Called()
 	return args.Get(0).(worker.WorkerHealth)
@@ -405,10 +409,14 @@ func (m *mockWorkerForHandler) ResetContext(ctx context.Context) (worker.ResetRe
 }
 func (m *mockWorkerForHandler) StopCurrentTurn(ctx context.Context) error {
 	args := m.Called(ctx)
-	return args.Error(0)
+	err := args.Error(0)
+	if err == nil {
+		m.stopped.Store(true)
+	}
+	return err
 }
 func (m *mockWorkerForHandler) IsStopped() bool {
-	return false
+	return m.stopped.Load()
 }
 
 // ─── handleReset tests ──────────────────────────────────────────────────────

--- a/internal/gateway/stop_contract_test.go
+++ b/internal/gateway/stop_contract_test.go
@@ -12,17 +12,19 @@ package gateway_test
 // The probe blocks its fixture terminal behind a channel gate so the stops
 // deterministically arrive while the turn is live (no time.Sleep).
 //
-// C05-next-turn: after a stopped turn, the next input on the SAME session must
-// clear the per-turn stopped state (probe Input reset + gateway fence
-// BeginTurn) and complete normally — two inputs total, the second terminal's
-// reason is NOT stopped_by_user, session ID unchanged.
+// C05-next-turn: after a stopped turn, the next input on the SAME logical
+// session must create a replacement Worker/run and complete normally — two
+// inputs total, the second terminal's reason is NOT stopped_by_user, session
+// ID unchanged.
 //
 // C04-stop-failure-retry: a real StopCurrentTurn failure (worker abort error)
 // must roll the fence back and send NO stopped done; a manual retry then
 // claims again and converges to exactly one stopped_by_user terminal.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/e2econtract"
 	"github.com/hrygo/hotplex/internal/gateway/contracttest"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -52,6 +55,237 @@ func TestWorkerLifecycleContract(t *testing.T) {
 			runC04StopFailureRetry(t, profile)
 		})
 	}
+}
+
+func TestWorkerRunQuiescenceContract(t *testing.T) {
+	profile := lifecycleGatewayProfile(t)
+
+	t.Run("C06-late-event-quarantine", func(t *testing.T) {
+		runC06LateEventQuarantine(t, profile)
+	})
+	t.Run("C07-done-after-quiescence", func(t *testing.T) {
+		runC07DoneAfterQuiescence(t, profile)
+	})
+	t.Run("C08-stop-input-race", func(t *testing.T) {
+		runC08StopInputRace(t, profile)
+	})
+	t.Run("C09-teardown-fallback", func(t *testing.T) {
+		runC09TeardownFallback(t, profile)
+	})
+	t.Run("C10-quiescence-timeout", func(t *testing.T) {
+		runC10QuiescenceTimeout(t, profile)
+	})
+}
+
+func lifecycleGatewayProfile(t *testing.T) e2econtract.WorkerProfile {
+	t.Helper()
+	for _, profile := range e2econtract.WorkerProfiles() {
+		if profile.Type == worker.TypeClaudeCode {
+			return profile
+		}
+	}
+	t.Fatal("gateway lifecycle profile for claudecode not found")
+	return e2econtract.WorkerProfile{}
+}
+
+func runC06LateEventQuarantine(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile, contracttest.WithEventCollector())
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.EmitLateEventsOnDispose()
+	defer probe.ReleaseTerminal()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c06 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C06")
+	require.NoError(t, <-inputDone, "C06: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), stop), "C06: stop must quiesce the old run")
+
+	// Reproduce the pre-fix post-done window as well. After the fix the frozen
+	// connection and forwarder are already closed, so these writes remain only
+	// in the probe's private attempted-emission log.
+	probe.EmitLateEventsNow()
+	require.True(t, envelopesContainLateRun(probe.Events()), "C06: probe must attempt late-run events")
+	require.Never(t, func() bool {
+		return envelopesContainLateRun(h.Events())
+	}, 250*time.Millisecond, 5*time.Millisecond, "C06: late-run events must not reach the client")
+
+	for _, stored := range h.StoredEvents(t) {
+		require.NotContains(t, string(stored.Data), "late_run_", "C06: late-run event must not be persisted")
+	}
+	h.AssertSingleTerminal(t, "stopped_by_user")
+}
+
+func runC07DoneAfterQuiescence(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockWait()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseWait()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c07 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C07")
+	require.NoError(t, <-inputDone, "C07: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+
+	select {
+	case <-probe.WaitEntered():
+	case <-time.After(lifecycleWaitTimeout):
+		t.Fatal("C07: forwarder never reached Worker.Wait")
+	}
+	require.Never(t, func() bool {
+		return stoppedDoneCount(h.Events()) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond, "C07: stopped done must wait for forwarder exit")
+
+	probe.ReleaseWait()
+	require.NoError(t, <-stopDone, "C07: stop must complete after forwarder exit")
+	waitTerminalCount(t, h, 1, "C07: stopped done must arrive after quiescence")
+	require.Equal(t, 1, stoppedDoneCount(h.Events()), "C07: exactly one stopped done")
+}
+
+func runC08StopInputRace(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	oldProbe := h.Worker()
+	oldProbe.EnableBlocking()
+	oldProbe.BlockStopCurrentTurn()
+	defer oldProbe.ReleaseTerminal()
+	defer oldProbe.ReleaseStopCurrentTurn()
+
+	sessionID := h.SessionID()
+	input1 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c08 first"})
+	input1.OwnerID = "contract-user"
+	input1Done := make(chan error, 1)
+	go func() { input1Done <- h.Handler.Handle(context.Background(), input1) }()
+	waitEnteredTurn(t, oldProbe, "C08")
+	require.NoError(t, <-input1Done, "C08: first input must be delivered")
+	_, oldRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C08: old run binding must exist")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+	select {
+	case <-oldProbe.StopEntered():
+	case <-time.After(lifecycleWaitTimeout):
+		t.Fatal("C08: stop never reached the old Worker")
+	}
+
+	input2 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c08 second"})
+	input2.OwnerID = "contract-user"
+	input2Done := make(chan error, 1)
+	go func() { input2Done <- h.Handler.Handle(context.Background(), input2) }()
+	select {
+	case err := <-input2Done:
+		require.FailNow(t, "C08: next input bypassed the stop dispatch gate", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	oldProbe.ReleaseStopCurrentTurn()
+	require.NoError(t, <-stopDone, "C08: stop must complete")
+	require.NoError(t, <-input2Done, "C08: next input must dispatch after stop")
+
+	require.Eventually(t, func() bool {
+		return h.Worker() != oldProbe
+	}, lifecycleWaitTimeout, lifecycleWaitPoll, "C08: next input must create a replacement Worker")
+	newProbe := h.Worker()
+	boundWorker, newRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C08: replacement run binding must exist")
+	require.Same(t, newProbe, boundWorker, "C08: replacement binding must own the next input")
+	require.NotEqual(t, oldRunID, newRunID, "C08: replacement run ID must change")
+	require.Equal(t, 1, oldProbe.InputCalls(), "C08: old Worker must receive only the first input")
+	require.Equal(t, 1, newProbe.InputCalls(), "C08: replacement Worker must receive the second input once")
+}
+
+func runC09TeardownFallback(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.FailNextTerminate()
+	defer probe.ReleaseTerminal()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c09 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C09")
+	require.NoError(t, <-inputDone, "C09: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), stop), "C09: Kill fallback must quiesce the run")
+	require.Equal(t, 1, probe.TerminateCalls(), "C09: Terminate must be attempted once")
+	require.Equal(t, 1, probe.KillCalls(), "C09: failed Terminate must trigger one Kill")
+	h.AssertSingleTerminal(t, "stopped_by_user")
+}
+
+func runC10QuiescenceTimeout(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(
+		t, e2econtract.PlatformWebChat, profile,
+		contracttest.WithStopTimeouts(50*time.Millisecond, 50*time.Millisecond),
+	)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockWait()
+	probe.EmitLateEventsOnDispose()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseWait()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c10 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C10")
+	require.NoError(t, <-inputDone, "C10: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	err := h.Handler.Handle(context.Background(), stop)
+	require.Error(t, err, "C10: quiescence timeout must surface an error")
+	require.Zero(t, stoppedDoneCount(h.Events()), "C10: timeout must not send a fake stopped done")
+	_, _, bound := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.False(t, bound, "C10: timed-out old run must be fail-closed and detached")
+	require.Equal(t, events.StateIdle, h.SessionState(t), "C10: logical session must remain resumable")
+	require.Never(t, func() bool {
+		return envelopesContainLateRun(h.Events())
+	}, 100*time.Millisecond, 5*time.Millisecond, "C10: isolated late events must remain invisible")
+}
+
+func envelopesContainLateRun(envelopes []*events.Envelope) bool {
+	for _, env := range envelopes {
+		data, err := json.Marshal(env.Event.Data)
+		if err == nil && bytes.Contains(data, []byte("late_run_")) {
+			return true
+		}
+	}
+	return false
+}
+
+func stoppedDoneCount(envelopes []*events.Envelope) int {
+	count := 0
+	for _, env := range envelopes {
+		if env.Event.Type == events.Done && lifecycleDoneReason(env) == "stopped_by_user" {
+			count++
+		}
+	}
+	return count
 }
 
 // runC04DoubleStop implements the C04 contract: one effective stop, one
@@ -115,6 +349,8 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
 	probe := h.Worker()
 	probe.EnableBlocking()
+	h.EnableProbeBlocking()
+	defer h.DisableProbeBlocking()
 	defer probe.ReleaseTerminal()
 
 	sessionID := h.SessionID()
@@ -126,6 +362,8 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	input1Done := make(chan error, 1)
 	go func() { input1Done <- h.Handler.Handle(context.Background(), input1) }()
 	waitEnteredTurn(t, probe, "C05")
+	_, firstRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C05: first run binding must exist")
 
 	stopEnv := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
 	stopEnv.OwnerID = "contract-user"
@@ -135,21 +373,31 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	require.NoError(t, <-input1Done, "C05: first input must settle")
 	waitTerminalCount(t, h, 1, "C05: the stopped turn must produce exactly one terminal")
 
-	// Turn 2: a NEW input ID on the same session; no stop this turn — the
-	// probe's per-turn stopped state was cleared by the new primary turn, so
-	// the fixture turn completes normally.
+	// Turn 2: a NEW input ID on the same logical session; no stop this turn.
+	// The stopped local wrapper was disposed, so auto-resume must attach a fresh
+	// Worker/run while preserving the provider conversation identity.
 	input2 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c05 second"})
 	input2.OwnerID = "contract-user"
 	input2Done := make(chan error, 1)
 	go func() { input2Done <- h.Handler.Handle(context.Background(), input2) }()
-	waitEnteredTurn(t, probe, "C05")
-	probe.ReleaseTerminal()
+	require.Eventually(t, func() bool {
+		return h.Worker() != probe
+	}, lifecycleWaitTimeout, lifecycleWaitPoll, "C05: next turn must attach a replacement Worker")
+	replacement := h.Worker()
+	defer replacement.ReleaseTerminal()
+	waitEnteredTurn(t, replacement, "C05")
+	_, secondRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C05: replacement run binding must exist")
+	require.NotEqual(t, firstRunID, secondRunID, "C05: stopped and resumed runs must have different IDs")
+	replacement.ReleaseTerminal()
 	require.NoError(t, <-input2Done, "C05: second input must deliver")
 
 	log := waitTerminalCount(t, h, 2, "C05: two turns must produce exactly two terminals")
 
-	// Worker input total 2 across the two turns.
-	require.Equal(t, 2, probe.InputCalls(), "C05: Worker input total must be 2")
+	// Each local Worker receives exactly one turn; the stopped wrapper is never
+	// reused for the next input.
+	require.Equal(t, 1, probe.InputCalls(), "C05: stopped Worker must receive only turn 1")
+	require.Equal(t, 1, replacement.InputCalls(), "C05: replacement Worker must receive only turn 2")
 
 	// Session identity is stable across both turns.
 	for _, env := range log {

--- a/internal/gateway/stop_fence.go
+++ b/internal/gateway/stop_fence.go
@@ -54,6 +54,17 @@ func (f *turnStopFence) Claim(sessionID, workerRunID, execID string) bool {
 	return true
 }
 
+// IsClaimed reports whether any successful stop claim remains for sessionID.
+// It is used only after the run binding disappeared: without an execution
+// ledger there is no longer enough identity to rebuild the original composite
+// key, but a repeated stop must still stay idempotent.
+func (f *turnStopFence) IsClaimed(sessionID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.claimed[sessionID]
+	return ok
+}
+
 // Rollback releases the claim after a FAILED StopCurrentTurn so a manual retry
 // can stop again. It only clears when the claim still belongs to the given
 // run/execution — an old run's rollback must not clear a newer claim.

--- a/internal/gateway/stop_fence_test.go
+++ b/internal/gateway/stop_fence_test.go
@@ -46,6 +46,7 @@ func TestTurnStopFence_Sequential(t *testing.T) {
 	t.Run("duplicate claim rejected", func(t *testing.T) {
 		f := turnStopFence{}
 		require.True(t, f.Claim("s", "r", "e"), "first claim admitted")
+		require.True(t, f.IsClaimed("s"), "held claim remains observable after its run detaches")
 		require.False(t, f.Claim("s", "r", "e"), "duplicate claim rejected")
 	})
 

--- a/internal/worker/acp/worker_stop_test.go
+++ b/internal/worker/acp/worker_stop_test.go
@@ -182,3 +182,27 @@ func TestWorker_StopCurrentTurn_CancelErrorStillFails(t *testing.T) {
 	require.Contains(t, err.Error(), "acp cancel")
 	require.False(t, w.IsStopped(), "stopped marker must clear so the gateway can roll back its stop fence")
 }
+
+func TestWorker_StopThenTerminateClosesOnlyCurrentRun(t *testing.T) {
+	t.Parallel()
+
+	live := newACPConn("user-1", "session-1", slog.Default())
+	stopped := &Worker{BaseWorker: base.NewBaseWorker(slog.Default(), nil), conn: live}
+	stopped.SetWorkerSessionID("provider-session-1")
+
+	require.NoError(t, stopped.StopCurrentTurn(context.Background()))
+	require.True(t, stopped.IsStopped())
+	require.NoError(t, stopped.Terminate(context.Background()))
+	require.NoError(t, stopped.Terminate(context.Background()), "teardown must be idempotent after stop")
+	_, open := <-live.Recv()
+	require.False(t, open, "teardown must close the stopped run connection")
+
+	resumed := &Worker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		conn:       newACPConn("user-1", "session-1", slog.Default()),
+	}
+	resumed.SetWorkerSessionID(stopped.GetWorkerSessionID())
+	require.NotSame(t, stopped, resumed)
+	require.Equal(t, "provider-session-1", resumed.GetWorkerSessionID())
+	require.False(t, resumed.IsStopped(), "stopped state must not leak into a fresh run")
+}

--- a/internal/worker/claudecode/worker_test.go
+++ b/internal/worker/claudecode/worker_test.go
@@ -87,6 +87,26 @@ func TestClaudeCodeWorker_KillWithoutStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClaudeCodeWorker_StopThenTerminateAllowsFreshRun(t *testing.T) {
+	t.Parallel()
+
+	stopped := NewWithMocks()
+	stopped.sessionID = "session-1"
+	stopped.testConn = newMockConn("user-1", "session-1")
+
+	require.NoError(t, stopped.StopCurrentTurn(context.Background()))
+	require.True(t, stopped.IsStopped())
+	require.NoError(t, stopped.Terminate(context.Background()))
+	require.NoError(t, stopped.Terminate(context.Background()), "teardown must be idempotent after stop")
+
+	resumed := NewWithMocks()
+	resumed.sessionID = stopped.sessionID
+	resumed.testConn = newMockConn("user-1", "session-1")
+	require.NotSame(t, stopped, resumed)
+	require.Equal(t, stopped.sessionID, resumed.sessionID, "fresh run must preserve HotPlex session identity")
+	require.False(t, resumed.IsStopped(), "stopped state must not leak into a fresh run")
+}
+
 func TestClaudeCodeWorker_WaitWithoutStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -564,6 +564,70 @@ func TestAppServerWorkerTerminate(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAppServerWorker_StopThenTerminatePreservesSiblingWrapper(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{IdleDrainPeriod: time.Hour})
+	var output strings.Builder
+	mgr.stdin = struct {
+		io.Writer
+		io.Closer
+	}{
+		Writer: &output,
+		Closer: io.NopCloser(nil),
+	}
+	mgr.mu.Lock()
+	mgr.refs = 2
+	mgr.state = stateRunning
+	mgr.mu.Unlock()
+	t.Cleanup(func() { mgr.Shutdown(context.Background()) })
+
+	recvA := mgr.Subscribe("thread-a", "session-a")
+	recvB := mgr.Subscribe("thread-b", "session-b")
+	connA := &appConn{userID: "user-1", sessionID: "session-a", recvCh: recvA, manager: mgr}
+	connB := &appConn{userID: "user-1", sessionID: "session-b", recvCh: recvB, manager: mgr}
+	workerA := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-a",
+		turnID:     "turn-a",
+		doneCh:     make(chan struct{}),
+		conn:       connA,
+	}
+	workerB := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-b",
+		turnID:     "turn-b",
+		doneCh:     make(chan struct{}),
+		conn:       connB,
+	}
+
+	require.NoError(t, workerA.StopCurrentTurn(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()), "wrapper release must be idempotent")
+	_, open := <-connA.Recv()
+	require.False(t, open, "terminated wrapper connection must close")
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.refs, "only the stopped wrapper reference must be released")
+	require.Equal(t, stateRunning, mgr.state, "terminating one wrapper must not stop the shared app-server")
+	mgr.mu.Unlock()
+	mgr.subMu.Lock()
+	_, hasA := mgr.subscribers["thread-a"]
+	_, hasB := mgr.subscribers["thread-b"]
+	mgr.subMu.Unlock()
+	require.False(t, hasA)
+	require.True(t, hasB, "sibling wrapper subscription must remain active")
+
+	want := &events.Envelope{SessionID: "session-b", Event: events.Event{Type: events.State}}
+	require.True(t, connB.TrySend(want), "sibling wrapper connection must remain usable")
+	require.Same(t, want, <-connB.Recv())
+	require.Contains(t, output.String(), `"method":"turn/interrupt"`)
+
+	require.NoError(t, workerB.Terminate(context.Background()))
+}
+
 func TestAppServerWorkerKill(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -1043,6 +1043,56 @@ func TestWorker_StopCurrentTurn_AbortsWithoutReleasingSession(t *testing.T) {
 	assertStopTurnRetention(t, w, mgr, live, sseCtx, true)
 }
 
+func TestWorker_StopThenTerminatePreservesSiblingWrapper(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/session/ses-a/abort", r.URL.Path)
+		_, _ = rw.Write([]byte("true"))
+	}))
+	t.Cleanup(server.Close)
+
+	mgr := newRunningSingleton(t)
+	mgr.mu.Lock()
+	mgr.refs = 2
+	mgr.mu.Unlock()
+	workerA, connA := stopTurnTestWorker(t, server, mgr, "ses-a", "/tmp/a")
+	workerB, connB := stopTurnTestWorker(t, server, mgr, "ses-b", "/tmp/b")
+	mgr.Subscribe("ses-a")
+	mgr.Subscribe("ses-b")
+	ctxA, cancelA := context.WithCancel(context.Background())
+	ctxB, cancelB := context.WithCancel(context.Background())
+	workerA.Mu.Lock()
+	workerA.sseCancel = cancelA
+	workerA.Mu.Unlock()
+	workerB.Mu.Lock()
+	workerB.sseCancel = cancelB
+	workerB.Mu.Unlock()
+
+	require.NoError(t, workerA.StopCurrentTurn(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()))
+	require.NoError(t, workerA.Kill(), "wrapper release must be idempotent")
+	require.Error(t, ctxA.Err(), "stopped wrapper SSE context must be cancelled")
+	_, open := <-connA.Recv()
+	require.False(t, open, "terminated wrapper connection must close")
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.refs, "only the stopped wrapper reference must be released")
+	require.Equal(t, stateRunning, mgr.state, "terminating one wrapper must not stop the shared server")
+	mgr.mu.Unlock()
+	mgr.busMu.Lock()
+	_, hasA := mgr.subscribers["ses-a"]
+	_, hasB := mgr.subscribers["ses-b"]
+	mgr.busMu.Unlock()
+	require.False(t, hasA)
+	require.True(t, hasB, "sibling wrapper subscription must remain active")
+	require.Nil(t, ctxB.Err(), "sibling wrapper SSE context must remain active")
+	require.Same(t, connB, workerB.Conn())
+
+	require.NoError(t, workerB.Terminate(context.Background()))
+}
+
 func TestWorker_StopCurrentTurn_NoActiveConn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- serialize same-session stop and input accept/dispatch with a bounded, fixed-stripe gate
- add a per-Worker-run lifecycle barrier that quarantines late events, retry/replay side effects, and crash fallbacks after cancellation commits
- terminate and release the stopped wrapper, close its frozen connection, wait for forwarder/CAS cleanup, and emit `stopped_by_user` only after quiescence
- preserve provider resume identity while proving Codex and OpenCode shared-service isolation

## Behavior and safety

- failed provider cancellation rolls back the stop claim and remains retryable
- teardown failure uses `Kill` fallback; quiescence timeout fails closed without emitting a false success terminal
- duplicate stops remain single-effect with or without the execution ledger
- stop logs expose bounded phase/error categories without persisting prompts, metadata, credentials, or raw Worker errors
- no AEP/SDK, WebChat production, migration, configuration, or shared Worker interface change

## Verification

- `go test ./internal/gateway/... ./internal/worker/... -count=1 -race -shuffle=on` — 2314 passed across 11 packages
- focused stop/quiescence suite — 25 passed
- focused four-Worker lifecycle matrix — 70 passed
- `cd webchat && pnpm test` — 173 passed
- `make docs-lint`
- `make quality`
- `make build`
- pre-push quality gate — formatting, vet, module verification, lint, build, and tests all passed

## Rollback

The change has no wire or storage migration. Reverting the implementation commit restores the previous soft-stop behavior.

Closes #971
