### PR TITLE
fix(gateway): quiesce stopped worker runs

### DIFF
--- a/docs/specs/Stop-Worker-Run-Quiescence-Spec.md
+++ b/docs/specs/Stop-Worker-Run-Quiescence-Spec.md
@@ -82,7 +82,7 @@ control.stop
 
 ### I2：每轮只有一个停止终态
 
-同一 `(session_id, worker_run_id, execution_id)` 最多执行一次有效停止、一次 runtime finish 和一次 synthetic done。重复 stop 静默返回，不调用第二次 Worker stop，也不发送第二个 terminal。
+同一 `(session_id, worker_run_id, execution_id)` 最多执行一次有效停止、一次 runtime finish 和一次 synthetic done。重复 stop 静默返回，不调用第二次 Worker stop，也不发送第二个 terminal。若自然 `Done/Error` 在 stop 等待事件屏障期间先提交，stop 同样静默返回：不再调用 provider stop、teardown 或发送 `stopped_by_user`。
 
 ### I3：停止失败不伪装成功
 
@@ -164,7 +164,7 @@ func (g *sessionDispatchGate) Lock(sessionID string) func()
 - `deliverToWorkerWithBusyHandling`：从读取 Session、`acceptInputExecutionWithRetry` 开始，覆盖 binding 选择、`MarkRunning`、`stopFence.BeginTurn`，直到 Worker 明确确认请求已被 provider 接受。
 - `control.stop`：从解析当前 binding/execution 开始，覆盖 stop、teardown、forwarder 等待、runtime finish 和 synthetic done。
 
-不持锁等待整个模型 turn。对于返回即代表投递完成的 Worker，成功的 `Worker.Input` 返回是 acceptance point；对于 ACP 等 `Input` 会阻塞至整轮结束的适配器，新增可选 `InputDispatchAcknowledger`，在请求不可再被 stop 超越时回调确认，Gateway 随即释放 gate、继续在锁外等待 `Input` 结果。OpenCode 普通输入改用 `POST /session/{id}/prompt_async`，以 204/2xx acknowledgement 作为 acceptance point，后续输出仍由 SSE 提供。不同 stripe 上的 session 不互相影响；哈希碰撞只会造成短暂串行，不改变语义。
+不持锁等待整个模型 turn。对于返回即代表投递完成的 Worker，成功的 `Worker.Input` 返回是 acceptance point；对于 ACP 等 `Input` 会阻塞至整轮结束的适配器，新增可选 `InputDispatchAcknowledger`，在请求不可再被 stop 超越时回调确认。Gateway 在释放 gate 前同步完成 inbound event/turn 捕获、worker-accepted 标记、delivery 状态、最终 `input.ack` 和 delivery audit，随后才允许 stop 进入，并继续在锁外等待 `Input` 的整轮结果。这样客户端收到 `stopped_by_user` 后不会再看到旧输入的 ACK，event store 也不会在该 terminal 之后才接受旧输入。OpenCode 普通输入改用 `POST /session/{id}/prompt_async`，以 204/2xx acknowledgement 作为 acceptance point，后续输出仍由 SSE 提供。不同 stripe 上的 session 不互相影响；哈希碰撞只会造成短暂串行，不改变语义。
 
 该能力是可选接口，不修改 `worker.Worker` 主接口：
 
@@ -184,10 +184,11 @@ ACP 在完整 `session/prompt` JSON-RPC frame 写入并释放 stdin write lock �
 
 ```go
 type workerRunLifecycle struct {
-	eventMu  sync.RWMutex
-	stopping atomic.Bool
-	done     chan struct{}
-	conn     worker.SessionConn
+	eventMu          sync.RWMutex
+	stopping         atomic.Bool
+	terminalCommitted atomic.Bool
+	done             chan struct{}
+	conn             worker.SessionConn
 }
 
 type workerRunBinding struct {
@@ -201,6 +202,7 @@ type workerRunBinding struct {
 
 - lifecycle 在 `createAndLaunchWorker` 成功启动 Worker、冻结 Conn 时创建；binding 与 forwarder 共享同一个指针。
 - `conn` 必须是 forwarder 启动时冻结的 Conn，停止路径不得重新读取可能已被 reset 替换的 `Worker.Conn()`。
+- `terminalCommitted` 与 forwarder 的 per-turn terminal fence 同步；自然 `Done/Error`、timeout 或 crash terminal 一旦取得 terminal claim 即置位。新 primary turn 在 dispatch 前取得 event write barrier，排空前一轮事件后清零；retry 或明确的 Worker 新轮次边界也同步清零。
 - forwarder goroutine 最外层注册 `defer close(lifecycle.done)`，并通过 defer 注册顺序保证 run binding 清理先执行；close 发生在 `handleWorkerExit` 返回和 `clearWorkerRun` 完成之后。
 - `done` 只关闭一次；生命周期对象不复用于 replacement run。
 
@@ -220,6 +222,10 @@ stop 路径执行：
 
 ```go
 lifecycle.eventMu.Lock()
+if lifecycle.terminalCommitted.Load() {
+	lifecycle.eventMu.Unlock()
+	return errWorkerRunTerminal
+}
 err := w.StopCurrentTurn(ctx)
 if err != nil {
 	lifecycle.eventMu.Unlock()
@@ -232,6 +238,7 @@ lifecycle.eventMu.Unlock()
 该顺序提供两个性质：
 
 - stop 失败时，没有事件被永久丢弃；等待 event write lock 的事件会在解锁后继续处理。
+- 自然 terminal 先完成时，stop 在 write barrier 内重新检查并返回内部 already-terminal 结果；Handler 回滚 stop claim 且不生成第二个 terminal。
 - stop 成功时，所有已经进入 `processForwardedEvent` 的事件先完成；`stopping=true` 建立后，新旧缓冲事件全部被拒绝，因此屏障后不存在并发转发。
 
 下列不经过 `processForwardedEvent` 的出口也必须检查 `lifecycle.stopping`：
@@ -386,7 +393,7 @@ session gate 使两个 stop 串行，`stopFence` 保持每轮 single-effect。�
 - **C08 stop-input race**：并发 stop 和 input，新 input 的 execution/run ID 只能指向 replacement Worker。
 - **C09 teardown fallback**：Terminate 失败触发 Kill 和 frozen Conn close；成功静默后仍只发一个 done。
 - **C10 quiescence timeout**：旧 run 被隔离并 CAS detach，但客户端收到 error 而非假 done。
-- **C11 blocking-input stop**：Worker 已接受输入但 `Input` 仍等待整轮结果时，stop 必须进入 `StopCurrentTurn`，不得被 dispatch gate 阻塞；adapter 随后返回的 cancellation error 必须等待 stop 决策，成功 stop 不得把它误报为 input failure。
+- **C11 blocking-input stop**：Worker 已接受输入但 `Input` 仍等待整轮结果时，stop 必须进入 `StopCurrentTurn`，不得被 dispatch gate 阻塞；接受后的 event-store 捕获和 delivered ACK 必须先于 `stopped_by_user`，terminal 后不得再出现旧输入 ACK；adapter 随后返回的 cancellation error 必须等待 stop 决策，成功 stop 不得把它误报为 input failure。
 - **C12 stale-stop-claim**：旧 turn 的 retained claim 不得让新 execution 在 binding 丢失后静默返回成功；已配置 execution ledger 时仅精确 `(session, run, execution)` 匹配可判定重复 stop，ledger-disabled 模式才允许 session-only fallback。
 - **C13 accepted-input stop failure**：已接受 RPC 的 adapter error 必须等待并发 stop 决策；stop 成功时吸收取消错误，stop 失败并 rollback 时保留真实 input error。
 
@@ -439,6 +446,7 @@ cd webchat && pnpm test
 - **AC10**：目标 Gateway/Worker 测试在 `-race -count=1 -shuffle=on` 下通过，单模块不超过 5 秒；显式超时测试使用缩短的可注入 duration。
 - **AC11**：ACP/OCS 普通输入、ACP/OCS 原生命令及 LLM retry 在 provider acceptance 后不再持有 stop 所需的 dispatch/event admission；Codex interrupt 与 unsubscribe 使用调用方 teardown context。
 - **AC12**：detached-run 重复 stop 只在已知 run/execution 精确命中 retained claim 时幂等成功；旧 claim 不掩盖新 turn 的 binding 丢失。
+- **AC13**：自然 `Done/Error` 与 stop 竞态时只保留自然 terminal；provider stop/teardown 不执行，stop claim 回滚，下一轮仍可正常开始。
 
 ---
 

--- a/docs/specs/Stop-Worker-Run-Quiescence-Spec.md
+++ b/docs/specs/Stop-Worker-Run-Quiescence-Spec.md
@@ -9,7 +9,7 @@ issue: 971
 
 **Issue**: [#971](https://github.com/hrygo/hotplex/issues/971)
 **Severity**: P2（停止反馈失真，旧任务输出可污染下一轮会话）
-**Scope**: `internal/gateway/{commands,handler,bridge,bridge_worker,bridge_forward}.go`、停止契约测试与四类 Worker 生命周期回归测试
+**Scope**: `internal/gateway/{commands,handler,bridge,bridge_worker,bridge_forward,dispatch_acceptance}.go`、`internal/worker/{worker,native_commands}.go`、ACP/OCS/Codex 适配器、停止契约测试与四类 Worker 生命周期回归测试
 **Related**: `docs/specs/Stop-Current-Turn-Spec.md`、Issue #880
 
 本 Spec 是 Issue #880 和 `Stop-Current-Turn-Spec.md` 的可靠性补强。旧 Spec 已建立 `control.stop`、`StopCurrentTurn` 和 `done(reason="stopped_by_user")` 的基础语义；本 Spec 取代其中“`StopCurrentTurn` 返回后立即发送 done”的停止确认时序。其余 `control.stop` wire contract 和前端确认协议保持不变。
@@ -161,10 +161,20 @@ func (g *sessionDispatchGate) Lock(sessionID string) func()
 
 锁定范围：
 
-- `deliverToWorkerWithBusyHandling`：从读取 Session、`acceptInputExecutionWithRetry` 开始，覆盖 binding 选择、`MarkRunning`、`stopFence.BeginTurn` 和 `Worker.Input` / native invocation 返回。
+- `deliverToWorkerWithBusyHandling`：从读取 Session、`acceptInputExecutionWithRetry` 开始，覆盖 binding 选择、`MarkRunning`、`stopFence.BeginTurn`，直到 Worker 明确确认请求已被 provider 接受。
 - `control.stop`：从解析当前 binding/execution 开始，覆盖 stop、teardown、forwarder 等待、runtime finish 和 synthetic done。
 
-不持锁等待整个模型 turn；`Worker.Input` 完成投递后立即释放。不同 stripe 上的 session 不互相影响；哈希碰撞只会造成短暂串行，不改变语义。
+不持锁等待整个模型 turn。对于返回即代表投递完成的 Worker，成功的 `Worker.Input` 返回是 acceptance point；对于 ACP 等 `Input` 会阻塞至整轮结束的适配器，新增可选 `InputDispatchAcknowledger`，在请求不可再被 stop 超越时回调确认，Gateway 随即释放 gate、继续在锁外等待 `Input` 结果。OpenCode 普通输入改用 `POST /session/{id}/prompt_async`，以 204/2xx acknowledgement 作为 acceptance point，后续输出仍由 SSE 提供。不同 stripe 上的 session 不互相影响；哈希碰撞只会造成短暂串行，不改变语义。
+
+该能力是可选接口，不修改 `worker.Worker` 主接口：
+
+```go
+type InputDispatchAcknowledger interface {
+    InputWithDispatchAccepted(ctx context.Context, content string, metadata map[string]any, accepted func()) error
+}
+```
+
+ACP 在完整 `session/prompt` JSON-RPC frame 写入并释放 stdin write lock 后确认，确保随后发出的 `session/cancel` 不会越过 prompt。OCS 原生 `/command` 没有异步端点，因此在该请求仍等待响应时，以同 session SSE 的 `session.status(busy)` / `state(running)` 作为 provider acceptance signal；session gate 保证前一轮 terminal 已处理且同一 Worker 只有一个待确认 command，callback 又在发出 HTTP 请求前即时注册。LLM auto-retry 复用相同协议：run event read admission 只持有到 acceptance point，避免 retry 已投递后仍以整轮阻塞 stop 的 event write barrier。
 
 `reset`、`terminate` 和 `delete` 本期保持现状。后续若需要统一所有 lifecycle command，可复用同一 gate，但不得在本 Issue 顺手扩大范围。
 
@@ -325,7 +335,7 @@ func (b *Bridge) StopAndDisposeCurrentRun(
 
 stop 和 input accept/dispatch 使用同一个 session dispatch gate：
 
-- input 先取得 gate：输入完成 Worker 投递并绑定 execution 后，stop 才解析并停止该轮；
+- input 先取得 gate：输入完成 execution 绑定并到达 provider acceptance point 后释放 gate，stop 随后解析并停止该轮；adapter 可继续在 gate 外等待整轮 RPC 结果；
 - stop 先取得 gate：旧 run 静默并 detach 后，input 才能 accept/resolve binding，因而只能 resume 新 run。
 
 不存在“新 execution 已 accept，但 stop 仍按旧 binding finish 新 execution”的中间状态。
@@ -376,6 +386,9 @@ session gate 使两个 stop 串行，`stopFence` 保持每轮 single-effect。�
 - **C08 stop-input race**：并发 stop 和 input，新 input 的 execution/run ID 只能指向 replacement Worker。
 - **C09 teardown fallback**：Terminate 失败触发 Kill 和 frozen Conn close；成功静默后仍只发一个 done。
 - **C10 quiescence timeout**：旧 run 被隔离并 CAS detach，但客户端收到 error 而非假 done。
+- **C11 blocking-input stop**：Worker 已接受输入但 `Input` 仍等待整轮结果时，stop 必须进入 `StopCurrentTurn`，不得被 dispatch gate 阻塞；adapter 随后返回的 cancellation error 必须等待 stop 决策，成功 stop 不得把它误报为 input failure。
+- **C12 stale-stop-claim**：旧 turn 的 retained claim 不得让新 execution 在 binding 丢失后静默返回成功；已配置 execution ledger 时仅精确 `(session, run, execution)` 匹配可判定重复 stop，ledger-disabled 模式才允许 session-only fallback。
+- **C13 accepted-input stop failure**：已接受 RPC 的 adapter error 必须等待并发 stop 决策；stop 成功时吸收取消错误，stop 失败并 rollback 时保留真实 input error。
 
 ### 8.2 Stop 失败回归
 
@@ -424,6 +437,8 @@ cd webchat && pnpm test
 - **AC8**：现有 `terminate`、`reset`、`delete`、GC、crash fallback、execution owner lease 和输入幂等合同不变。
 - **AC9**：AEP 和 WebChat wire contract 无变化，现有前端 stop suite 全部通过。
 - **AC10**：目标 Gateway/Worker 测试在 `-race -count=1 -shuffle=on` 下通过，单模块不超过 5 秒；显式超时测试使用缩短的可注入 duration。
+- **AC11**：ACP/OCS 普通输入、ACP/OCS 原生命令及 LLM retry 在 provider acceptance 后不再持有 stop 所需的 dispatch/event admission；Codex interrupt 与 unsubscribe 使用调用方 teardown context。
+- **AC12**：detached-run 重复 stop 只在已知 run/execution 精确命中 retained claim 时幂等成功；旧 claim 不掩盖新 turn 的 binding 丢失。
 
 ---
 
@@ -431,14 +446,15 @@ cd webchat && pnpm test
 
 | 文件 | 责任 |
 |---|---|
-| `internal/gateway/handler.go` | session dispatch gate；input accept/dispatch 临界区 |
+| `internal/gateway/handler.go`、`dispatch_acceptance.go` | session dispatch gate；两阶段 input accept/dispatch 临界区 |
 | `internal/gateway/commands.go` | stop 编排、重复 stop、错误与 done 时序 |
 | `internal/gateway/bridge.go` | run lifecycle 类型、完整 binding 查询、stop/dispose API |
 | `internal/gateway/bridge_worker.go` | lifecycle 创建、frozen Conn、forwarder done 屏障 |
 | `internal/gateway/bridge_forward.go` | 全事件隔离和非主事件出口收敛 |
-| `internal/gateway/stop_contract_test.go` | C06-C10 Gateway 契约 |
+| `internal/gateway/stop_contract_test.go` | C06-C13 Gateway 契约 |
 | `internal/gateway/contracttest/worker_probe.go` | 晚到事件、teardown 和 forwarder 可控探针 |
-| 四类 Worker 测试 | stop + teardown + resume 与共享单例隔离回归 |
+| `internal/worker/{worker,native_commands}.go` | 可选 dispatch-acceptance 能力；`Worker` 主接口保持不变 |
+| ACP / OCS / Codex Worker 与测试 | ACP 精确写入确认、OCS async prompt、Codex deadline 传播与共享单例隔离回归 |
 
 除上述文件及必要的同目录测试辅助代码外，不修改前端、AEP、SDK、数据库 migration、配置、版本或 changelog。
 

--- a/docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
+++ b/docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
@@ -1,0 +1,449 @@
+# Stop Worker Run Quiescence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `control.stop` acknowledge success only after the stopped session's Worker run, frozen connection, and forwarder are permanently isolated and quiescent.
+
+**Architecture:** Serialize primary input dispatch and stop per session with a fixed striped gate. Bind every local Worker run to a private lifecycle object that owns an event read/write barrier, an irreversible stopping flag, the frozen `SessionConn`, and a forwarder completion channel; the stop path commits the barrier only after provider cancellation succeeds, disposes the wrapper/process, waits for forwarder cleanup, and fails closed on timeout.
+
+**Tech Stack:** Go 1.26, `sync`/typed atomics, HotPlex Gateway/Worker interfaces, SQLite-backed contract harness, `testify/require`, Go race detector.
+
+**Spec:** `docs/specs/Stop-Worker-Run-Quiescence-Spec.md`
+
+## Global Constraints
+
+- Preserve the AEP `control.stop` and `done(reason="stopped_by_user")` wire shapes; do not change SDKs or WebChat protocol code.
+- Do not change the public `worker.Worker` or `worker.SessionConn` interfaces.
+- Do not terminate the shared Codex app-server or OpenCode server; only release the stopped session wrapper/subscription/connection.
+- Keep `terminate`, `reset`, `delete`, GC, crash recovery, execution owner lease, and input idempotency behavior unchanged.
+- Persist only execution fingerprints/status metadata; never persist prompts, metadata values, credentials, or raw Worker errors.
+- Use explicit mutex fields, preserve the existing `m.mu -> ms.mu` lock order, and never hold the run event write lock across teardown, session-manager calls, or forwarder waiting.
+- Tests use `testify/require`, deterministic channel/`require.Eventually` synchronization, `t.Parallel()` where state is isolated, and no `time.Sleep` for asynchronous coordination.
+- Targeted Gateway/Worker modules must pass with `-count=1 -race -shuffle=on` and remain within the repository's five-second per-module budget.
+
+---
+
+### Task 1: Extend the contract harness and reproduce the quiescence failures
+
+**Files:**
+- Modify: `internal/gateway/contracttest/harness.go`
+- Modify: `internal/gateway/contracttest/worker_probe.go`
+- Modify: `internal/gateway/stop_contract_test.go`
+
+**Interfaces:**
+- Consumes: the existing `contracttest.NewHarness`, `WorkerProbe`, observer connection, execution store, and real per-profile parser/mapper fixtures.
+- Produces: controllable provider-stop/terminate/kill/wait phases, late-event injection, probe replacement inspection, and stored-event queries used by C06-C10.
+
+- [ ] **Step 1: Add observable lifecycle controls to `WorkerProbe`**
+
+Add atomics and one-shot channel gates without changing the production Worker interface:
+
+```go
+type WorkerProbe struct {
+	*noop.Worker
+	// existing fields...
+	terminateCalls atomic.Int32
+	killCalls      atomic.Int32
+	failTerminate atomic.Bool
+	failKill      atomic.Bool
+	stopEntered   chan struct{}
+	allowStop     chan struct{}
+	waitEntered   chan struct{}
+	allowWait     chan struct{}
+	blockStop     atomic.Bool
+	blockWait     atomic.Bool
+	lateOnDispose atomic.Bool
+}
+```
+
+Implement `Terminate`, `Kill`, and `Wait` so the normal path closes the probe connection, injected terminate failure leaves Kill as the fallback, and blocked Wait exits only when the test releases its channel. Add getters and arm/release methods whose names state the phase they control.
+
+- [ ] **Step 2: Inject representative late events during disposal**
+
+When `lateOnDispose` is armed, enqueue envelopes carrying unique `late_run_*` markers before the frozen connection closes:
+
+```go
+[]events.Kind{
+	events.MessageDelta,
+	events.Message,
+	events.Reasoning,
+	events.ToolCall,
+	events.PermissionRequest,
+	events.State,
+	events.Done,
+	events.Error,
+}
+```
+
+The probe records all attempted writes in its private log even after connection closure, while only open-connection writes reach `Recv`; this distinguishes Worker emission from Gateway forwarding.
+
+- [ ] **Step 3: Enable durable event assertions in the harness**
+
+Add a harness option that constructs an `eventstore.SQLiteStore` and `eventstore.Collector` over the harness's existing migrated SQLite database only when a test requests durable-event assertions. Inject the collector through `gateway.BridgeDeps`, close it before the shared DB, and expose:
+
+```go
+func (h *Harness) StoredEvents(t testing.TB) []eventstore.StoredEvent
+func (h *Harness) Probes() []*WorkerProbe
+```
+
+`StoredEvents` must flush the current session and query with `eventstore.CursorLatest` using a bounded limit.
+Existing matrix tests keep the collector disabled so their seq behavior and runtime remain unchanged; C06 opts in explicitly.
+
+- [ ] **Step 4: Write C06-C10 failing contract tests**
+
+Add deterministic tests with the following observable assertions:
+
+```go
+// C06: late_run_* markers exist in WorkerProbe.Events(), but in neither
+// Harness observer output nor StoredEvents(); exactly one stopped done exists.
+
+// C07: while Wait is blocked, no stopped done is visible; after ReleaseWait,
+// exactly one stopped done appears.
+
+// C08: while StopCurrentTurn is blocked, the concurrent next input has not
+// reached the old probe; after release, Harness.Worker() is a new pointer,
+// CurrentWorkerBinding returns a new run ID, and the next input reaches it once.
+
+// C09: injected Terminate failure increments TerminateCalls and KillCalls once,
+// closes the frozen connection, and still yields one stopped done after quiet.
+
+// C10: a short injected stop budget plus blocked Wait returns an error,
+// emits no stopped done, removes the old binding, and leaves the session Idle.
+```
+
+- [ ] **Step 5: Run the RED tests**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'WorkerRunQuiescenceContract/(C0[6-9]|C10)' -count=1 -race -shuffle=on
+```
+
+Expected: C06 exposes forwarded late markers, C07 sees the synthetic done before Wait release, C08 can dispatch to the old run, C09 observes no teardown call, and C10 lacks bounded quiescence failure behavior.
+
+---
+
+### Task 2: Add the session dispatch gate and per-run event barrier
+
+**Files:**
+- Modify: `internal/gateway/handler.go`
+- Modify: `internal/gateway/bridge.go`
+- Modify: `internal/gateway/bridge_worker.go`
+- Modify: `internal/gateway/bridge_forward.go`
+- Modify: `internal/gateway/bridge_retry.go`
+- Test: `internal/gateway/handler_test.go`
+- Test: `internal/gateway/bridge_test.go`
+
+**Interfaces:**
+- Consumes: `workerRunBinding`, frozen `SessionConn`, `forwardEvents`, `processForwardedEvent`, retry cancellation, and CAS cleanup.
+- Produces: `sessionDispatchGate`, `workerRunLifecycle`, full private binding lookup, and nil-safe event-side-effect admission.
+
+- [ ] **Step 1: Test fixed-stripe dispatch serialization**
+
+Add tests that hold one session lock and prove a second acquisition for the same session blocks until release, while a deliberately selected non-colliding session can proceed. Use channels for entered/released signals and never sleep.
+
+- [ ] **Step 2: Implement the zero-value session gate**
+
+Add a 64-stripe gate with a local allocation-free FNV-1a byte loop:
+
+```go
+type sessionDispatchGate struct {
+	stripes [64]sync.Mutex
+}
+
+func (g *sessionDispatchGate) Lock(sessionID string) func()
+```
+
+Store it directly on `Handler`. In `deliverToWorkerWithBusyHandling`, acquire it before the first session read and keep it through acceptance, binding selection, `MarkRunning`, `stopFence.BeginTurn`, and `Worker.Input`/native invocation return. If acceptance reports `execution.ErrSessionBusy`, release the dispatch gate before calling `handleSupplementOnBusy`; that function can re-enter normal delivery and would otherwise self-deadlock.
+
+- [ ] **Step 3: Add the private run lifecycle**
+
+Extend the private binding only:
+
+```go
+type workerRunLifecycle struct {
+	eventMu  sync.RWMutex
+	stopping atomic.Bool
+	done     chan struct{}
+	conn     worker.SessionConn
+}
+
+type workerRunBinding struct {
+	worker    worker.Worker
+	id        string
+	lifecycle *workerRunLifecycle
+}
+```
+
+Create a fresh lifecycle after Worker start/reset has established its connection. Pass the same pointer to the binding and forwarder; never re-read `Worker.Conn()` in the forwarder or stop path.
+
+- [ ] **Step 4: Close lifecycle completion after all cleanup**
+
+For both normal launch and connection-replacing reset, register goroutine defers in LIFO order so the effective order is:
+
+```text
+launchForwarderLocked returns
+-> clearWorkerRun(expected worker + run)
+-> close(lifecycle.done)
+-> fwdWg.Done()
+```
+
+This makes `done` proof that `handleWorkerExit`, CAS detach/Idle transition, and binding cleanup have completed.
+
+- [ ] **Step 5: Guard every old-run side-effect outlet**
+
+At the beginning of `processForwardedEvent`, acquire the lifecycle read lock and reject `stopping` before LastIO, seq, runtime, retry, Hub, or event-store work. Use the same read-side admission around:
+
+- panic synthetic error;
+- turn-timeout synthetic error/capture/terminate;
+- post-Recv pending-error flush;
+- each auto-retry notification and actual replay input (not the backoff wait);
+- the post-`Wait` crash fallback, synthetic crash event, detach, and Idle cleanup section.
+
+Direct unit tests that construct `forwardContext` without a lifecycle remain supported by a nil-safe admission helper.
+
+- [ ] **Step 6: Run focused barrier and existing forwarder tests**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'DispatchGate|WorkerRun|ForwardEvents|ProcessForwardedEvent|C06' -count=1 -race -shuffle=on
+```
+
+Expected: the new gate/barrier tests and C06 pass; existing forwarding, seq, retry, reset-generation, and stale-forwarder tests remain green.
+
+---
+
+### Task 3: Orchestrate provider cancellation, disposal, quiescence, and stop acknowledgement
+
+**Files:**
+- Modify: `internal/gateway/deps.go`
+- Modify: `internal/gateway/bridge.go`
+- Modify: `internal/gateway/bridge_worker.go`
+- Modify: `internal/gateway/commands.go`
+- Modify: `internal/gateway/handler.go`
+- Test: `internal/gateway/ctrl_test.go`
+- Test: `internal/gateway/stop_contract_test.go`
+
+**Interfaces:**
+- Consumes: full `workerRunBinding`, `StopCurrentTurn`, `Terminate`, `Kill`, frozen `SessionConn.Close`, `DetachWorkerIf`, `clearWorkerRun`, and `finishRuntimeOnStop`.
+- Produces: `Bridge.StopAndDisposeCurrentRun(ctx, sessionID, expectedRunID) error` plus internal error categories that tell the Handler whether provider cancellation took effect.
+
+- [ ] **Step 1: Add injectable server-side stop budgets**
+
+Add optional `BridgeDeps` durations and normalized Bridge fields:
+
+```go
+StopTeardownTimeout  time.Duration // default 8s
+StopForwarderTimeout time.Duration // default 1s after teardown budget
+```
+
+Zero values select production defaults. Contract harness options inject short non-zero values only for C10.
+
+- [ ] **Step 2: Implement stop/dispose with an irreversible barrier**
+
+Implement the sequence below, using `context.WithTimeout(context.WithoutCancel(ctx), stopTeardownTimeout)` so client cancellation cannot abandon cleanup:
+
+```go
+binding := currentWorkerRunBinding(sessionID, expectedRunID)
+binding.lifecycle.eventMu.Lock()
+revalidate the exact worker/run/lifecycle binding
+err := binding.worker.StopCurrentTurn(stopCtx)
+if err != nil {
+	binding.lifecycle.eventMu.Unlock()
+	return errWorkerStopNotApplied
+}
+binding.lifecycle.stopping.Store(true)
+binding.lifecycle.eventMu.Unlock()
+
+terminateErr := binding.worker.Terminate(stopCtx)
+if terminateErr != nil {
+	killErr := binding.worker.Kill()
+	// Kill success recovers Terminate failure; Kill failure is teardown failure.
+}
+_ = binding.lifecycle.conn.Close()
+wait for lifecycle.done until the teardown deadline, then for the extra
+forwarder-settle timeout
+```
+
+Never hold `eventMu` while calling `Terminate`, `Kill`, `Close`, session manager operations, or waiting. If the forwarder does not complete, CAS-detach only the expected Worker, clear only the expected run binding, and transition to Idle only when this path actually detached that Worker.
+
+- [ ] **Step 3: Distinguish pre-commit and post-commit failures**
+
+Use package-private sentinel categories with lowercase messages:
+
+```go
+errWorkerRunChanged
+errWorkerStopNotApplied
+errWorkerRunTeardown
+errWorkerRunQuiescence
+```
+
+Only run-changed/provider-stop failures allow `stopFence.Rollback`. Teardown/quiescence failures keep `stopping=true`, finish the execution runtime as failed, return a generic client error, and never send `stopped_by_user`.
+
+- [ ] **Step 4: Reorder `control.stop` under the dispatch gate**
+
+After ownership validation, hold the session dispatch gate across binding/execution resolution, stop-fence claim, retry cancel, stop/dispose, runtime convergence, and terminal send. Resolve duplicate stop after the first stop cleared the binding by using `LatestBySession.WorkerRunID` and the existing composite fence; a duplicate returns silently, while a genuinely unclaimed no-binding stop returns the current no-active-worker error.
+
+Send the synthetic done only after `StopAndDisposeCurrentRun` returns nil:
+
+```go
+h.finishRuntimeOnStop(ctx, sessionID, workerRunID, ownerID)
+doneEnv := events.NewEnvelope(
+	aep.NewID(), sessionID, 0,
+	events.Done, events.DoneData{Reason: "stopped_by_user"},
+)
+return h.hub.SendToSession(ctx, doneEnv)
+```
+
+Log stable `stop_phase`/`error_kind` categories and identifiers only; do not log or send raw Worker error strings.
+
+- [ ] **Step 5: Run C07-C10 and the complete stop contract**
+
+Run:
+
+```bash
+go test ./internal/gateway -run 'Stop|WorkerRunQuiescenceContract' -count=1 -race -shuffle=on
+```
+
+Expected: C04-C10 pass, including duplicate-stop, next-turn replacement, failed-stop retry, late-event quarantine, done-after-quiescence, stop/input race, Kill fallback, and timeout-without-fake-done.
+
+- [ ] **Step 6: Commit the Gateway slice**
+
+Run `git diff --check`, inspect the staged diff for secrets and unrelated changes, then commit:
+
+```bash
+git add internal/gateway docs/superpowers/plans/2026-08-25-stop-worker-run-quiescence.md
+git commit -m "fix(gateway): quiesce stopped worker runs"
+```
+
+---
+
+### Task 4: Pin four Worker teardown/resume and singleton-isolation semantics
+
+**Files:**
+- Modify: `internal/worker/claudecode/worker_test.go`
+- Modify: `internal/worker/acp/worker_stop_test.go`
+- Modify: `internal/worker/codexcli/worker_test.go`
+- Modify: `internal/worker/opencodeserver/worker_test.go`
+
+**Interfaces:**
+- Consumes: existing adapter `StopCurrentTurn`, `Terminate`, `Kill`, `Wait`, resume-identity, manager/singleton reference-count, unsubscribe, and connection-close behavior.
+- Produces: regression proof that stop+teardown releases exactly the local run and that resume uses a new wrapper without losing provider identity.
+
+- [ ] **Step 1: Add per-process adapter composition tests**
+
+For Claude Code and ACP, use existing fake process/client fixtures to verify:
+
+```text
+StopCurrentTurn succeeds
+-> Terminate is idempotent after stop
+-> Conn closes and Wait returns
+-> a separately constructed resumed Worker keeps the same provider session ID
+```
+
+The tests assert process/wrapper effects, not internal call order.
+
+- [ ] **Step 2: Add Codex two-wrapper isolation**
+
+Create two wrappers sharing the same test manager. Stop and terminate wrapper A, then assert A's thread is unsubscribed/connection closed and manager refcount decreases once, while wrapper B remains subscribed and usable; the manager process is not killed.
+
+- [ ] **Step 3: Add OpenCode Server two-wrapper isolation**
+
+Create two wrappers sharing the singleton fixture. Stop and terminate wrapper A, then assert A's SSE/subscription/connection release and one reference decrement while wrapper B's subscription and shared server remain active.
+
+- [ ] **Step 4: Run the Worker matrix**
+
+Run:
+
+```bash
+go test ./internal/worker/claudecode ./internal/worker/acp ./internal/worker/codexcli ./internal/worker/opencodeserver -run 'Stop|Terminate|Kill|Release|Resume' -count=1 -race -shuffle=on
+```
+
+Expected: all focused Worker tests pass without affecting shared services or exceeding the module time budget.
+
+- [ ] **Step 5: Commit Worker regression coverage**
+
+```bash
+git add internal/worker/claudecode/worker_test.go internal/worker/acp/worker_stop_test.go internal/worker/codexcli/worker_test.go internal/worker/opencodeserver/worker_test.go
+git commit -m "test(worker): pin stopped-run teardown isolation"
+```
+
+---
+
+### Task 5: Full verification, five-axis self-review, and PR delivery
+
+**Files:**
+- Review: every file changed from `origin/main...HEAD`
+- Modify only if verification or review finds a scoped defect.
+
+**Interfaces:**
+- Consumes: approved spec AC1-AC10, repository quality gates, WebChat stop suite, git history, and GitHub issue #971.
+- Produces: fresh verification evidence, review findings resolved, atomic commits, pushed branch, and a PR whose description maps behavior/tests to the issue.
+
+- [ ] **Step 1: Verify graph coverage and blast radius**
+
+Check index coverage for every changed/evidence file, read any missed ranges directly, and inspect inbound impact from the final diff. Confirm no AEP, SDK, migration, config, or WebChat production file changed.
+
+- [ ] **Step 2: Run focused and package-wide race tests**
+
+```bash
+go test ./internal/gateway -run 'Stop|WorkerRunQuiescenceContract' -count=1 -race -shuffle=on
+go test ./internal/worker/claudecode ./internal/worker/acp ./internal/worker/codexcli ./internal/worker/opencodeserver -run 'Stop|Terminate|Kill|Release|Resume' -count=1 -race -shuffle=on
+go test ./internal/gateway/... ./internal/worker/... -count=1 -race -shuffle=on
+```
+
+- [ ] **Step 3: Run frontend and repository gates**
+
+```bash
+cd webchat && pnpm test
+make docs-lint
+make quality
+make build
+```
+
+Record exit codes and failure counts. Do not claim completion from summaries alone; recover bounded diagnostics for any filtered/truncated failure.
+
+- [ ] **Step 4: Perform the five-axis review**
+
+Review tests first, then implementation for correctness, readability, architecture, security/privacy, and performance. Explicitly inspect:
+
+- lock order and absence of lock-held teardown/waits;
+- all event/synthetic/retry outlets after `stopping` commits;
+- duplicate stop and post-timeout fence semantics;
+- CAS protection against replacement Worker cleanup;
+- goroutine/channel exit ownership;
+- raw-error/prompt/metadata leakage;
+- Codex/OCS shared-service isolation;
+- dead code and unnecessary interface/dependency growth.
+
+Resolve every Critical/Required finding and rerun the affected verification command after each edit.
+
+- [ ] **Step 5: Reconcile requirements and commits**
+
+Map AC1-AC10 to tests or direct code evidence, run `git diff --check`, inspect `git status`, `git diff --stat`, staged patches, and commit history, then create a final scoped commit only if review fixes remain.
+
+- [ ] **Step 6: Push and create the PR**
+
+Push the non-main branch after the pre-push quality gate succeeds. Create a PR with:
+
+```text
+Title: fix(gateway): quiesce stopped worker runs
+
+Summary:
+- serialize stop with same-session input dispatch
+- quarantine every event/synthetic outlet after provider cancellation
+- dispose and await the exact frozen Worker run before stopped_by_user
+- preserve provider history and shared Codex/OCS services
+
+Testing:
+- focused Gateway stop contract under race/shuffle
+- four Worker lifecycle packages under race/shuffle
+- Gateway/Worker package-wide race suite
+- WebChat unit suite
+- docs-lint, quality, build
+
+Closes #971
+```
+
+Return the PR URL, branch/commit summary, fresh verification evidence, and any residual risk.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -137,11 +137,12 @@ type workerRunBinding struct {
 // never survives reset or replacement, even when the provider session identity
 // is resumed by the next Worker.
 type workerRunLifecycle struct {
-	eventMu        sync.RWMutex
-	eventAdmission chan struct{}
-	stopping       atomic.Bool
-	done           chan struct{}
-	conn           worker.SessionConn
+	eventMu           sync.RWMutex
+	eventAdmission    chan struct{}
+	stopping          atomic.Bool
+	terminalCommitted atomic.Bool
+	done              chan struct{}
+	conn              worker.SessionConn
 }
 
 func newWorkerRunLifecycle(conn worker.SessionConn) *workerRunLifecycle {

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -27,6 +27,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+const (
+	defaultStopTeardownTimeout  = 8 * time.Second
+	defaultStopForwarderTimeout = time.Second
+)
+
 // bridgeSM is the narrow subset of SessionManager that Bridge needs.
 // Composed from canonical sub-interfaces defined in handler.go to avoid
 // duplicate method declarations.
@@ -62,6 +67,8 @@ type Bridge struct {
 
 	agentConfigDir        string                   // agent config directory path; "" = disabled
 	turnTimeout           time.Duration            // per-turn timeout; 0 = disabled
+	stopTeardownTimeout   time.Duration            // provider stop + teardown server-side budget
+	stopForwarderTimeout  time.Duration            // extra local forwarder settle budget
 	workerEnv             []string                 // extra env vars from worker.environment config
 	workerEnvBlocklist    []string                 // extra blocklist entries from worker.env_blocklist config
 	cronEnv               []string                 // env vars injected only into cron platform sessions
@@ -121,8 +128,41 @@ type Bridge struct {
 }
 
 type workerRunBinding struct {
-	worker worker.Worker
-	id     string
+	worker    worker.Worker
+	id        string
+	lifecycle *workerRunLifecycle
+}
+
+// workerRunLifecycle is private to one local Worker wrapper/process run. It
+// never survives reset or replacement, even when the provider session identity
+// is resumed by the next Worker.
+type workerRunLifecycle struct {
+	eventMu  sync.RWMutex
+	stopping atomic.Bool
+	done     chan struct{}
+	conn     worker.SessionConn
+}
+
+func newWorkerRunLifecycle(conn worker.SessionConn) *workerRunLifecycle {
+	return &workerRunLifecycle{
+		done: make(chan struct{}),
+		conn: conn,
+	}
+}
+
+// beginEvent admits one complete event-side-effect operation. A successful
+// stop takes the write side, waits for admitted work to finish, then makes the
+// rejection irreversible before releasing it.
+func (l *workerRunLifecycle) beginEvent() (func(), bool) {
+	if l == nil {
+		return func() {}, true
+	}
+	l.eventMu.RLock()
+	if l.stopping.Load() {
+		l.eventMu.RUnlock()
+		return nil, false
+	}
+	return l.eventMu.RUnlock, true
 }
 
 type crashHistory struct {
@@ -139,29 +179,39 @@ const (
 // NewBridge creates a new bridge.
 func NewBridge(deps BridgeDeps) *Bridge {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	stopTeardownTimeout := deps.StopTeardownTimeout
+	if stopTeardownTimeout <= 0 {
+		stopTeardownTimeout = defaultStopTeardownTimeout
+	}
+	stopForwarderTimeout := deps.StopForwarderTimeout
+	if stopForwarderTimeout <= 0 {
+		stopForwarderTimeout = defaultStopForwarderTimeout
+	}
 	b := &Bridge{
-		log:                deps.Log.With("component", "bridge"),
-		hub:                deps.Hub,
-		sm:                 deps.SM,
-		wf:                 defaultWorkerFactory{},
-		collector:          deps.EventCollector,
-		turnsQuerier:       deps.TurnsQuerier,
-		retryCtrl:          deps.RetryCtrl,
-		agentConfigDir:     deps.AgentConfigDir,
-		turnTimeout:        deps.TurnTimeout,
-		workerEnv:          deps.WorkerEnv,
-		workerEnvBlocklist: deps.WorkerEnvBlocklist,
-		cronEnv:            deps.CronEnv,
-		wsStore:            deps.WSStore,
-		retryCancel:        make(map[string]chan struct{}),
-		accum:              make(map[string]*sessionAccumulator),
-		crashTracker:       make(map[string]*crashHistory),
-		shutdownCtx:        shutdownCtx,
-		shutdownCancel:     shutdownCancel,
-		executionStore:     deps.ExecutionStore,
-		repairer:           deps.Repairer,
-		turnTTFT:           newTurnTTFTTracker(),
-		pending:            NewPendingBuffer(),
+		log:                  deps.Log.With("component", "bridge"),
+		hub:                  deps.Hub,
+		sm:                   deps.SM,
+		wf:                   defaultWorkerFactory{},
+		collector:            deps.EventCollector,
+		turnsQuerier:         deps.TurnsQuerier,
+		retryCtrl:            deps.RetryCtrl,
+		agentConfigDir:       deps.AgentConfigDir,
+		turnTimeout:          deps.TurnTimeout,
+		stopTeardownTimeout:  stopTeardownTimeout,
+		stopForwarderTimeout: stopForwarderTimeout,
+		workerEnv:            deps.WorkerEnv,
+		workerEnvBlocklist:   deps.WorkerEnvBlocklist,
+		cronEnv:              deps.CronEnv,
+		wsStore:              deps.WSStore,
+		retryCancel:          make(map[string]chan struct{}),
+		accum:                make(map[string]*sessionAccumulator),
+		crashTracker:         make(map[string]*crashHistory),
+		shutdownCtx:          shutdownCtx,
+		shutdownCancel:       shutdownCancel,
+		executionStore:       deps.ExecutionStore,
+		repairer:             deps.Repairer,
+		turnTTFT:             newTurnTTFTTracker(),
+		pending:              NewPendingBuffer(),
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
 	b.defaultPermissionMode.Store(worker.NormalizePermissionMode(deps.DefaultPermissionMode))
@@ -950,11 +1000,13 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 		b.pending.Clear(sessionID)
 	}
 	workerRunID := ""
+	var replacementBinding workerRunBinding
 	if result.ConnReplaced {
 		if b.sm.GetWorker(sessionID) != w {
 			return fmt.Errorf("bridge: reset worker changed before run binding")
 		}
-		workerRunID = b.bindWorkerRun(sessionID, w, "")
+		replacementBinding = b.bindWorkerRun(sessionID, w, "")
+		workerRunID = replacementBinding.id
 	} else if bindingSuspended {
 		b.restoreWorkerRun(sessionID, suspendedBinding)
 	}
@@ -998,8 +1050,9 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
+		defer close(replacementBinding.lifecycle.done)
 		defer b.clearWorkerRun(sessionID, w, workerRunID)
-		b.launchForwarderLocked(w, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
+		b.launchForwarderLocked(replacementBinding, sessionID, forwardOpts{ctx: context.Background(), workerRunID: workerRunID})
 	}()
 
 	return nil

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -174,6 +174,16 @@ func (l *workerRunLifecycle) beginEvent() (func(), bool) {
 	return l.eventMu.RUnlock, true
 }
 
+func (l *workerRunLifecycle) withEvent(run func()) bool {
+	releaseEvent, admitted := l.beginEvent()
+	if !admitted {
+		return false
+	}
+	defer releaseEvent()
+	run()
+	return true
+}
+
 // lockEventBarrier prevents new event admissions, then waits for already
 // admitted side effects to drain. Holding the admission token makes TryLock
 // starvation-free without spawning an orphan goroutine when ctx expires.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -137,17 +137,21 @@ type workerRunBinding struct {
 // never survives reset or replacement, even when the provider session identity
 // is resumed by the next Worker.
 type workerRunLifecycle struct {
-	eventMu  sync.RWMutex
-	stopping atomic.Bool
-	done     chan struct{}
-	conn     worker.SessionConn
+	eventMu        sync.RWMutex
+	eventAdmission chan struct{}
+	stopping       atomic.Bool
+	done           chan struct{}
+	conn           worker.SessionConn
 }
 
 func newWorkerRunLifecycle(conn worker.SessionConn) *workerRunLifecycle {
-	return &workerRunLifecycle{
-		done: make(chan struct{}),
-		conn: conn,
+	lifecycle := &workerRunLifecycle{
+		eventAdmission: make(chan struct{}, 1),
+		done:           make(chan struct{}),
+		conn:           conn,
 	}
+	lifecycle.eventAdmission <- struct{}{}
+	return lifecycle
 }
 
 // beginEvent admits one complete event-side-effect operation. A successful
@@ -157,12 +161,47 @@ func (l *workerRunLifecycle) beginEvent() (func(), bool) {
 	if l == nil {
 		return func() {}, true
 	}
+	if l.stopping.Load() {
+		return nil, false
+	}
+	<-l.eventAdmission
 	l.eventMu.RLock()
+	l.eventAdmission <- struct{}{}
 	if l.stopping.Load() {
 		l.eventMu.RUnlock()
 		return nil, false
 	}
 	return l.eventMu.RUnlock, true
+}
+
+// lockEventBarrier prevents new event admissions, then waits for already
+// admitted side effects to drain. Holding the admission token makes TryLock
+// starvation-free without spawning an orphan goroutine when ctx expires.
+func (l *workerRunLifecycle) lockEventBarrier(ctx context.Context) bool {
+	select {
+	case <-l.eventAdmission:
+	case <-ctx.Done():
+		return false
+	}
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if l.eventMu.TryLock() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			l.eventAdmission <- struct{}{}
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func (l *workerRunLifecycle) unlockEventBarrier() {
+	l.eventMu.Unlock()
+	l.eventAdmission <- struct{}{}
 }
 
 type crashHistory struct {

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -267,8 +267,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	// connection. In the defensive nil-frozen-Conn path this also preserves the
 	// input from the live fallback that actually supplied the event stream.
 	lastReplay := snapshotInputReplay(recvSource)
-	releaseExitEvent, admitted := fc.lifecycle.beginEvent()
-	if admitted {
+	fc.lifecycle.withEvent(func() {
 		if !fc.doneReceived {
 			b.finishTurnTTFT(sessionID, "worker_exit")
 		}
@@ -293,8 +292,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 			}
 			fc.pendingError = nil
 		}
-		releaseExitEvent()
-	}
+	})
 	fc.pendingError = nil
 
 	b.handleWorkerExit(w, workerExitParams{

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -66,6 +66,26 @@ type forwardContext struct {
 	flog *slog.Logger
 }
 
+func (fc *forwardContext) claimTerminal() bool {
+	if fc == nil || !fc.terminalSent.CompareAndSwap(false, true) {
+		return false
+	}
+	if fc.lifecycle != nil {
+		fc.lifecycle.terminalCommitted.Store(true)
+	}
+	return true
+}
+
+func (fc *forwardContext) reopenTerminal() {
+	if fc == nil {
+		return
+	}
+	fc.terminalSent.Store(false)
+	if fc.lifecycle != nil {
+		fc.lifecycle.terminalCommitted.Store(false)
+	}
+}
+
 // flogOf returns fc.flog or b.log when fc is nil or fc.flog is unset.
 func (b *Bridge) flogOf(fc *forwardContext) *slog.Logger {
 	if fc != nil && fc.flog != nil {
@@ -152,7 +172,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 				return
 			}
 			defer releaseEvent()
-			if b.hub != nil && !w.IsStopped() && fc.terminalSent.CompareAndSwap(false, true) {
+			if b.hub != nil && !w.IsStopped() && fc.claimTerminal() {
 				b.sendError(sessionID, events.ErrCodeWorkerCrash, "worker event stream interrupted before terminal")
 			}
 		}
@@ -222,7 +242,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 			if !fc.turnTimerFired.CompareAndSwap(false, true) {
 				return
 			}
-			if !fc.terminalSent.CompareAndSwap(false, true) {
+			if !fc.claimTerminal() {
 				return
 			}
 			flog.Warn("bridge: turn timeout exceeded, terminating worker",
@@ -273,7 +293,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		}
 
 		// Flush buffered error that never reached a retry decision point.
-		if fc.pendingError != nil && fc.terminalSent.CompareAndSwap(false, true) {
+		if fc.pendingError != nil && fc.claimTerminal() {
 			releaseSeq := func() {}
 			canFlush := true
 			if b.collector != nil {
@@ -430,7 +450,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		// state(running) event. A post-terminal content event is therefore the
 		// next turn boundary; reopen the terminal fence before processing it.
 		fc.doneReceived = false
-		fc.terminalSent.Store(false)
+		fc.reopenTerminal()
 	}
 
 	// A worker stream may emit a duplicate Done/Error (or emit Done after a
@@ -438,7 +458,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	// before any stats/runtime side effects so exactly one terminal is visible.
 	// Retryable errors return above as pending and claim only when flushed.
 	if env.Event.Type == events.Done || env.Event.Type == events.Error {
-		if w.IsStopped() || !fc.terminalSent.CompareAndSwap(false, true) {
+		if w.IsStopped() || !fc.claimTerminal() {
 			return
 		}
 	}
@@ -460,10 +480,10 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		fc.doneReceived = false
 		if stateData, ok := env.Event.Data.(events.StateData); ok && stateData.State == events.StateRunning {
 			fc.turnStartTime = time.Now()
-			fc.terminalSent.Store(false)
+			fc.reopenTerminal()
 		} else if m, ok := env.Event.Data.(map[string]any); ok && m["state"] == string(events.StateRunning) {
 			fc.turnStartTime = time.Now()
-			fc.terminalSent.Store(false)
+			fc.reopenTerminal()
 		}
 	}
 
@@ -525,7 +545,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	if env.Event.Type == events.Done && b.retryCtrl != nil && (!opts.resumed || fc.turnText.Len() > 0) {
 		if shouldRetry, attempt := b.retryCtrl.ShouldRetry(context.TODO(), sessionID, fc.lastError); shouldRetry {
 			fc.pendingError = nil
-			fc.terminalSent.Store(false)
+			fc.reopenTerminal()
 			// Pre-register cancel channel before launching goroutine to close
 			// the race window where CancelRetry can't find the channel.
 			cancelCh := make(chan struct{})
@@ -905,7 +925,7 @@ func (b *Bridge) flushPendingError(fc *forwardContext, skipOnDone bool) {
 	if skipOnDone && fc.doneReceived {
 		return
 	}
-	if !fc.terminalSent.CompareAndSwap(false, true) {
+	if !fc.claimTerminal() {
 		fc.pendingError = nil
 		return
 	}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -59,6 +59,7 @@ type forwardContext struct {
 	pendingError   *events.Envelope
 	turnTimerFired atomic.Bool
 	turnTimer      *time.Timer
+	lifecycle      *workerRunLifecycle
 	// flog carries trace_id from the forwardEvents OTel span. Helpers must
 	// use fc.flog (not b.log) to keep log lines correlatable with the span.
 	// Nil-safe via bridge.flogOf; tests build forwardContext without it.
@@ -143,7 +144,15 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 			// A panic after stream consumption must still produce one visible
 			// terminal. Without this guard the client is left indefinitely in a
 			// thinking state; a later worker cleanup has no forwarder to notify it.
-			if fc != nil && b.hub != nil && !w.IsStopped() && fc.terminalSent.CompareAndSwap(false, true) {
+			if fc == nil {
+				return
+			}
+			releaseEvent, admitted := fc.lifecycle.beginEvent()
+			if !admitted {
+				return
+			}
+			defer releaseEvent()
+			if b.hub != nil && !w.IsStopped() && fc.terminalSent.CompareAndSwap(false, true) {
 				b.sendError(sessionID, events.ErrCodeWorkerCrash, "worker event stream interrupted before terminal")
 			}
 		}
@@ -167,6 +176,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		startTime:     time.Now(),
 		turnStartTime: time.Now(),
 		firstEvent:    true,
+		lifecycle:     fb.lifecycle,
 		flog:          flog,
 	}
 
@@ -204,6 +214,11 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 
 	if b.turnTimeout > 0 {
 		fc.turnTimer = time.AfterFunc(b.turnTimeout, func() {
+			releaseEvent, admitted := fc.lifecycle.beginEvent()
+			if !admitted {
+				return
+			}
+			defer releaseEvent()
 			if !fc.turnTimerFired.CompareAndSwap(false, true) {
 				return
 			}
@@ -252,29 +267,33 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 	// connection. In the defensive nil-frozen-Conn path this also preserves the
 	// input from the live fallback that actually supplied the event stream.
 	lastReplay := snapshotInputReplay(recvSource)
-	if !fc.doneReceived {
-		b.finishTurnTTFT(sessionID, "worker_exit")
-	}
+	releaseExitEvent, admitted := fc.lifecycle.beginEvent()
+	if admitted {
+		if !fc.doneReceived {
+			b.finishTurnTTFT(sessionID, "worker_exit")
+		}
 
-	// Flush buffered error that never reached a retry decision point.
-	if fc.pendingError != nil && fc.terminalSent.CompareAndSwap(false, true) {
-		releaseSeq := func() {}
-		canFlush := true
-		if b.collector != nil {
-			var ok bool
-			releaseSeq, ok = b.hub.BeginSeqOperation(sessionID)
-			if !ok {
-				canFlush = false
+		// Flush buffered error that never reached a retry decision point.
+		if fc.pendingError != nil && fc.terminalSent.CompareAndSwap(false, true) {
+			releaseSeq := func() {}
+			canFlush := true
+			if b.collector != nil {
+				var ok bool
+				releaseSeq, ok = b.hub.BeginSeqOperation(sessionID)
+				if !ok {
+					canFlush = false
+				}
 			}
-		}
-		if canFlush {
-			if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
-				flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+			if canFlush {
+				if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
+					flog.Warn("bridge: flush pending error on exit failed", "session_id", sessionID, "err", err)
+				}
+				b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, flog)
+				releaseSeq()
 			}
-			b.captureEvent(sessionID, fc.pendingError.Seq, fc.pendingError.Event.Type, fc.pendingError.Event.Data, flog)
-			releaseSeq()
+			fc.pendingError = nil
 		}
-		fc.pendingError = nil
+		releaseExitEvent()
 	}
 	fc.pendingError = nil
 
@@ -293,6 +312,7 @@ func (b *Bridge) forwardEvents(fb forwarderBinding, sessionID string, opts forwa
 		resetGen:       myResetGen,
 		lastInput:      lastReplay.Content,
 		lastReplay:     lastReplay,
+		lifecycle:      fc.lifecycle,
 		flog:           flog,
 	})
 }
@@ -320,6 +340,12 @@ func snapshotInputReplay(conn worker.SessionConn) worker.InputReplay {
 
 // processForwardedEvent handles a single worker event in the forwarding loop.
 func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, opts forwardOpts, fc *forwardContext) {
+	releaseEvent, ok := fc.lifecycle.beginEvent()
+	if !ok {
+		return
+	}
+	defer releaseEvent()
+
 	sessionID := fc.sessionID
 	workerType := fc.workerType
 
@@ -514,7 +540,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 			// detects recvCh closure immediately instead of waiting for the
 			// backoff timer to expire. The goroutine uses shutdownCtx so it
 			// cancels promptly during bridge shutdown.
-			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh)
+			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh, fc.lifecycle)
 			fc.turnText.Reset()
 			if b.collector != nil {
 				b.collector.ResetSession(sessionID)
@@ -916,6 +942,7 @@ type workerExitParams struct {
 	// releases the worker's mutable live connection.
 	lastInput  string
 	lastReplay worker.InputReplay
+	lifecycle  *workerRunLifecycle
 }
 
 // rawExitCodeFields extracts the raw OS exit code from workers that implement
@@ -999,6 +1026,13 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 				"session_id", p.sessionID, "worker_type", workerType)
 		}
 	}
+
+	releaseExit, admitted := p.lifecycle.beginEvent()
+	if !admitted {
+		b.detachStoppedWorkerRun(p.sessionID, w, lg)
+		return
+	}
+	defer releaseExit()
 
 	wasStopped := w.IsStopped()
 
@@ -1128,15 +1162,19 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		if wasStopped {
 			// User-initiated stop: detach the dead worker and transition to Idle
 			// so the session stays alive for the next turn (not Terminated).
-			if b.sm != nil {
-				b.sm.DetachWorkerIf(p.sessionID, w)
-				if err := b.sm.Transition(context.Background(), p.sessionID, events.StateIdle); err != nil {
-					lg.Debug("bridge: transition to idle after stop", "session_id", p.sessionID, "err", err)
-				}
-			}
+			b.detachStoppedWorkerRun(p.sessionID, w, lg)
 		} else {
 			b.cleanupCrashedWorker(p.sessionID, w)
 		}
+	}
+}
+
+func (b *Bridge) detachStoppedWorkerRun(sessionID string, w worker.Worker, lg *slog.Logger) {
+	if b.sm == nil || !b.sm.DetachWorkerIf(sessionID, w) {
+		return
+	}
+	if err := b.sm.Transition(context.Background(), sessionID, events.StateIdle); err != nil {
+		lg.Debug("bridge: transition to idle after stop", "session_id", sessionID, "err", err)
 	}
 }
 

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -25,15 +25,8 @@ func (b *Bridge) CancelRetry(sessionID string) {
 // autoRetry performs exponential backoff then sends the retry input to the worker.
 // cancelCh is pre-registered by the caller to eliminate the race window between
 // goroutine launch and cancel channel registration.
-func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int, cancelCh chan struct{}) {
+func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int, cancelCh chan struct{}, lifecycle *workerRunLifecycle) {
 	delay := b.retryCtrl.Delay(attempt)
-
-	// Notify user if enabled.
-	if b.retryCtrl.ShouldNotify() {
-		msg := b.retryCtrl.NotifyMessage(attempt)
-		notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
-		_ = b.hub.SendToSession(ctx, notifyEnv)
-	}
 
 	// Clean up cancel channel on exit (registered by caller before goroutine launch).
 	defer func() {
@@ -41,6 +34,18 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 		delete(b.retryCancel, sessionID)
 		b.retryCancelMu.Unlock()
 	}()
+
+	// Notify user if enabled.
+	if b.retryCtrl.ShouldNotify() {
+		releaseEvent, admitted := lifecycle.beginEvent()
+		if !admitted {
+			return
+		}
+		msg := b.retryCtrl.NotifyMessage(attempt)
+		notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
+		_ = b.hub.SendToSession(ctx, notifyEnv)
+		releaseEvent()
+	}
 
 	// Wait with backoff, respecting cancellation.
 	timer := time.NewTimer(delay)
@@ -55,6 +60,11 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 	}
 
 	// Send retry input to worker.
+	releaseEvent, admitted := lifecycle.beginEvent()
+	if !admitted {
+		return
+	}
+	defer releaseEvent()
 	b.log.Info("bridge: auto-retry sending input", "session_id", sessionID, "attempt", attempt)
 	observability.RetryAttempts().Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "llm_error")))
 	if err := w.Input(ctx, b.retryCtrl.RetryInput(), nil); err != nil {

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -67,7 +67,7 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 	observability.RetryAttempts().Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "llm_error")))
 	if _, err := runAcceptedDispatch(func(accepted func()) error {
 		return worker.DispatchInput(ctx, w, b.retryCtrl.RetryInput(), nil, accepted)
-	}, releaseEvent); err != nil {
+	}, nil, releaseEvent); err != nil {
 		b.log.Warn("bridge: auto-retry input failed", "session_id", sessionID, "err", err)
 	}
 }

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -64,10 +64,11 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 	if !admitted {
 		return
 	}
-	defer releaseEvent()
 	b.log.Info("bridge: auto-retry sending input", "session_id", sessionID, "attempt", attempt)
 	observability.RetryAttempts().Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "llm_error")))
-	if err := w.Input(ctx, b.retryCtrl.RetryInput(), nil); err != nil {
+	if _, err := runAcceptedDispatch(func(accepted func()) error {
+		return worker.DispatchInput(ctx, w, b.retryCtrl.RetryInput(), nil, accepted)
+	}, releaseEvent); err != nil {
 		b.log.Warn("bridge: auto-retry input failed", "session_id", sessionID, "err", err)
 	}
 }

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -37,14 +37,13 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 
 	// Notify user if enabled.
 	if b.retryCtrl.ShouldNotify() {
-		releaseEvent, admitted := lifecycle.beginEvent()
-		if !admitted {
+		if !lifecycle.withEvent(func() {
+			msg := b.retryCtrl.NotifyMessage(attempt)
+			notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
+			_ = b.hub.SendToSession(ctx, notifyEnv)
+		}) {
 			return
 		}
-		msg := b.retryCtrl.NotifyMessage(attempt)
-		notifyEnv := buildNotifyEnvelope(sessionID, msg, 0)
-		_ = b.hub.SendToSession(ctx, notifyEnv)
-		releaseEvent()
 	}
 
 	// Wait with backoff, respecting cancellation.

--- a/internal/gateway/bridge_retry_test.go
+++ b/internal/gateway/bridge_retry_test.go
@@ -1,0 +1,95 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+type blockingRetryDispatchWorker struct {
+	mockWorkerForHandler
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+}
+
+func (w *blockingRetryDispatchWorker) Input(ctx context.Context, content string, metadata map[string]any) error {
+	return w.input(ctx, content, metadata, nil)
+}
+
+func (w *blockingRetryDispatchWorker) InputWithDispatchAccepted(
+	ctx context.Context,
+	content string,
+	metadata map[string]any,
+	accepted func(),
+) error {
+	return w.input(ctx, content, metadata, accepted)
+}
+
+func (w *blockingRetryDispatchWorker) input(
+	ctx context.Context,
+	_ string,
+	_ map[string]any,
+	accepted func(),
+) error {
+	w.enteredOnce.Do(func() { close(w.entered) })
+	if accepted != nil {
+		accepted()
+	}
+	select {
+	case <-w.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestAutoRetryReleasesEventAdmissionAfterDispatchAccepted(t *testing.T) {
+	retryCtrl := NewLLMRetryController(config.AutoRetryConfig{Enabled: true}, slog.Default())
+	retryCtrl.config.BaseDelay = time.Nanosecond
+	retryCtrl.config.NotifyUser = false
+	b := &Bridge{
+		log:         slog.Default(),
+		retryCtrl:   retryCtrl,
+		retryCancel: make(map[string]chan struct{}),
+	}
+	lifecycle := newWorkerRunLifecycle(nil)
+	w := &blockingRetryDispatchWorker{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cancelCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.autoRetry(context.Background(), w, "retry-session", 1, cancelCh, lifecycle)
+	}()
+	defer func() {
+		close(w.release)
+		<-done
+	}()
+
+	select {
+	case <-w.entered:
+	case <-time.After(time.Second):
+		t.Fatal("retry input was not dispatched")
+	}
+
+	writeLockAcquired := make(chan struct{})
+	go func() {
+		lifecycle.eventMu.Lock()
+		close(writeLockAcquired)
+		lifecycle.eventMu.Unlock()
+	}()
+	select {
+	case <-writeLockAcquired:
+	case <-time.After(250 * time.Millisecond):
+		require.FailNow(t, "stop event barrier remained blocked by the full retry turn")
+	}
+}

--- a/internal/gateway/bridge_stop.go
+++ b/internal/gateway/bridge_stop.go
@@ -12,6 +12,7 @@ import (
 var (
 	errWorkerRunChanged     = errors.New("worker run changed")
 	errWorkerEventBarrier   = errors.New("worker event barrier timeout")
+	errWorkerRunTerminal    = errors.New("worker run turn already terminal")
 	errWorkerStopNotApplied = errors.New("worker stop not applied")
 	errWorkerRunTeardown    = errors.New("worker run teardown failed")
 	errWorkerRunQuiescence  = errors.New("worker run quiescence timeout")
@@ -52,6 +53,11 @@ func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expect
 		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "run_changed", workerType)
 		return errWorkerRunChanged
 	}
+	if lifecycle.terminalCommitted.Load() {
+		lifecycle.unlockEventBarrier()
+		b.logStopPhase(sessionID, binding.id, "stop_completed", started, "already_terminal", workerType)
+		return errWorkerRunTerminal
+	}
 	if err := stopCurrentTurnUnderEventBarrier(lifecycle, func() error {
 		return binding.worker.StopCurrentTurn(stopCtx)
 	}); err != nil {
@@ -91,6 +97,29 @@ func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expect
 		return errWorkerRunTeardown
 	}
 	b.logStopPhase(sessionID, binding.id, "stop_completed", started, "", workerType)
+	return nil
+}
+
+// beginWorkerRunTurn reopens the per-turn terminal state only after every
+// event admitted for the preceding turn has completed. The caller holds the
+// session dispatch gate, so a stop cannot observe the reopened state before
+// the new provider dispatch begins.
+func (b *Bridge) beginWorkerRunTurn(ctx context.Context, sessionID, expectedRunID string) error {
+	binding, ok := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !ok || binding.lifecycle == nil {
+		return errWorkerRunChanged
+	}
+	lifecycle := binding.lifecycle
+	if !lifecycle.lockEventBarrier(ctx) {
+		return errWorkerEventBarrier
+	}
+	defer lifecycle.unlockEventBarrier()
+
+	current, stillCurrent := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !stillCurrent || current.worker != binding.worker || current.lifecycle != lifecycle {
+		return errWorkerRunChanged
+	}
+	lifecycle.terminalCommitted.Store(false)
 	return nil
 }
 
@@ -192,6 +221,7 @@ func (b *Bridge) logStopPhase(sessionID, runID, phase string, started time.Time,
 func stopFailureAllowsRollback(err error) bool {
 	return errors.Is(err, errWorkerRunChanged) ||
 		errors.Is(err, errWorkerEventBarrier) ||
+		errors.Is(err, errWorkerRunTerminal) ||
 		errors.Is(err, errWorkerStopNotApplied)
 }
 
@@ -201,6 +231,8 @@ func stopErrorKind(err error) string {
 		return "run_changed"
 	case errors.Is(err, errWorkerEventBarrier):
 		return "event_barrier"
+	case errors.Is(err, errWorkerRunTerminal):
+		return "already_terminal"
 	case errors.Is(err, errWorkerStopNotApplied):
 		return "provider_cancel"
 	case errors.Is(err, errWorkerRunTeardown):

--- a/internal/gateway/bridge_stop.go
+++ b/internal/gateway/bridge_stop.go
@@ -1,0 +1,183 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+var (
+	errWorkerRunChanged     = errors.New("worker run changed")
+	errWorkerStopNotApplied = errors.New("worker stop not applied")
+	errWorkerRunTeardown    = errors.New("worker run teardown failed")
+	errWorkerRunQuiescence  = errors.New("worker run quiescence timeout")
+)
+
+// StopAndDisposeCurrentRun stops and releases exactly one local Worker run.
+// A nil result proves that the provider cancellation committed, the old event
+// stream is permanently fenced, and the forwarder completed its CAS cleanup.
+func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expectedRunID string) error {
+	started := time.Now()
+	binding, ok := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !ok || binding.lifecycle == nil {
+		b.logStopPhase(sessionID, expectedRunID, "stop_failed", started, "run_changed", "")
+		return errWorkerRunChanged
+	}
+	workerType := binding.worker.Type()
+
+	teardownTimeout := b.stopTeardownTimeout
+	if teardownTimeout <= 0 {
+		teardownTimeout = defaultStopTeardownTimeout
+	}
+	forwarderTimeout := b.stopForwarderTimeout
+	if forwarderTimeout <= 0 {
+		forwarderTimeout = defaultStopForwarderTimeout
+	}
+	stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), teardownTimeout)
+	defer cancel()
+
+	b.logStopPhase(sessionID, binding.id, "stop_requested", started, "", workerType)
+	lifecycle := binding.lifecycle
+	lifecycle.eventMu.Lock()
+	current, stillCurrent := b.currentWorkerRunBinding(sessionID, expectedRunID)
+	if !stillCurrent || current.worker != binding.worker || current.lifecycle != lifecycle {
+		lifecycle.eventMu.Unlock()
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "run_changed", workerType)
+		return errWorkerRunChanged
+	}
+	if err := binding.worker.StopCurrentTurn(stopCtx); err != nil {
+		lifecycle.eventMu.Unlock()
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "provider_cancel", workerType)
+		return errWorkerStopNotApplied
+	}
+	lifecycle.stopping.Store(true)
+	lifecycle.eventMu.Unlock()
+	b.logStopPhase(sessionID, binding.id, "provider_cancelled", started, "", workerType)
+
+	b.logStopPhase(sessionID, binding.id, "worker_terminating", started, "", workerType)
+	teardownFailed := false
+	if err := binding.worker.Terminate(stopCtx); err != nil {
+		b.logStopPhase(sessionID, binding.id, "worker_kill_fallback", started, "terminate", workerType)
+		if killErr := binding.worker.Kill(); killErr != nil {
+			teardownFailed = true
+			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "kill", workerType)
+		}
+	}
+	if lifecycle.conn != nil {
+		if err := lifecycle.conn.Close(); err != nil {
+			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "conn_close", workerType)
+		}
+	}
+
+	if !waitForWorkerRun(lifecycle.done, stopCtx.Done(), forwarderTimeout) {
+		b.failClosedStoppedRun(sessionID, binding)
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "quiescence_timeout", workerType)
+		return errWorkerRunQuiescence
+	}
+	b.logStopPhase(sessionID, binding.id, "forwarder_quiesced", started, "", workerType)
+
+	if b.workerRunStillAttached(sessionID, binding) {
+		b.failClosedStoppedRun(sessionID, binding)
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "cleanup_incomplete", workerType)
+		return errWorkerRunQuiescence
+	}
+	if teardownFailed {
+		return errWorkerRunTeardown
+	}
+	b.logStopPhase(sessionID, binding.id, "stop_completed", started, "", workerType)
+	return nil
+}
+
+func (b *Bridge) currentWorkerRunBinding(sessionID, expectedRunID string) (workerRunBinding, bool) {
+	value, ok := b.workerRuns.Load(sessionID)
+	if !ok {
+		return workerRunBinding{}, false
+	}
+	binding, ok := value.(workerRunBinding)
+	if !ok || binding.worker == nil || binding.id == "" || (expectedRunID != "" && binding.id != expectedRunID) {
+		return workerRunBinding{}, false
+	}
+	if b.sm == nil || b.sm.GetWorker(sessionID) != binding.worker {
+		return workerRunBinding{}, false
+	}
+	return binding, true
+}
+
+func waitForWorkerRun(done, teardownDone <-chan struct{}, forwarderTimeout time.Duration) bool {
+	select {
+	case <-done:
+		return true
+	case <-teardownDone:
+	}
+
+	timer := time.NewTimer(forwarderTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (b *Bridge) failClosedStoppedRun(sessionID string, binding workerRunBinding) {
+	detached := b.sm != nil && b.sm.DetachWorkerIf(sessionID, binding.worker)
+	b.clearWorkerRun(sessionID, binding.worker, binding.id)
+	if !detached {
+		return
+	}
+	if err := b.sm.Transition(context.Background(), sessionID, events.StateIdle); err != nil {
+		b.log.Debug("bridge: fail-closed stopped run idle transition failed",
+			"session_id", sessionID, "worker_run_id", binding.id, "error_kind", "idle_transition")
+	}
+}
+
+func (b *Bridge) workerRunStillAttached(sessionID string, binding workerRunBinding) bool {
+	if b.sm != nil && b.sm.GetWorker(sessionID) == binding.worker {
+		return true
+	}
+	value, ok := b.workerRuns.Load(sessionID)
+	if !ok {
+		return false
+	}
+	current, ok := value.(workerRunBinding)
+	return ok && current.worker == binding.worker && current.id == binding.id && current.lifecycle == binding.lifecycle
+}
+
+func (b *Bridge) logStopPhase(sessionID, runID, phase string, started time.Time, errorKind string, workerType worker.WorkerType) {
+	attrs := []any{
+		"session_id", sessionID,
+		"worker_run_id", runID,
+		"stop_phase", phase,
+		"duration_ms", time.Since(started).Milliseconds(),
+	}
+	if workerType != "" {
+		attrs = append(attrs, "worker_type", workerType)
+	}
+	if errorKind != "" {
+		attrs = append(attrs, "error_kind", errorKind)
+	}
+	b.log.Info("bridge: worker run stop phase", attrs...)
+}
+
+func stopFailureAllowsRollback(err error) bool {
+	return errors.Is(err, errWorkerRunChanged) || errors.Is(err, errWorkerStopNotApplied)
+}
+
+func stopErrorKind(err error) string {
+	switch {
+	case errors.Is(err, errWorkerRunChanged):
+		return "run_changed"
+	case errors.Is(err, errWorkerStopNotApplied):
+		return "provider_cancel"
+	case errors.Is(err, errWorkerRunTeardown):
+		return "teardown"
+	case errors.Is(err, errWorkerRunQuiescence):
+		return "quiescence_timeout"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/gateway/bridge_stop.go
+++ b/internal/gateway/bridge_stop.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	errWorkerRunChanged     = errors.New("worker run changed")
+	errWorkerEventBarrier   = errors.New("worker event barrier timeout")
 	errWorkerStopNotApplied = errors.New("worker stop not applied")
 	errWorkerRunTeardown    = errors.New("worker run teardown failed")
 	errWorkerRunQuiescence  = errors.New("worker run quiescence timeout")
@@ -41,20 +42,23 @@ func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expect
 
 	b.logStopPhase(sessionID, binding.id, "stop_requested", started, "", workerType)
 	lifecycle := binding.lifecycle
-	lifecycle.eventMu.Lock()
+	if !lifecycle.lockEventBarrier(stopCtx) {
+		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "event_barrier", workerType)
+		return errWorkerEventBarrier
+	}
 	current, stillCurrent := b.currentWorkerRunBinding(sessionID, expectedRunID)
 	if !stillCurrent || current.worker != binding.worker || current.lifecycle != lifecycle {
-		lifecycle.eventMu.Unlock()
+		lifecycle.unlockEventBarrier()
 		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "run_changed", workerType)
 		return errWorkerRunChanged
 	}
 	if err := binding.worker.StopCurrentTurn(stopCtx); err != nil {
-		lifecycle.eventMu.Unlock()
+		lifecycle.unlockEventBarrier()
 		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "provider_cancel", workerType)
 		return errWorkerStopNotApplied
 	}
 	lifecycle.stopping.Store(true)
-	lifecycle.eventMu.Unlock()
+	lifecycle.unlockEventBarrier()
 	b.logStopPhase(sessionID, binding.id, "provider_cancelled", started, "", workerType)
 
 	b.logStopPhase(sessionID, binding.id, "worker_terminating", started, "", workerType)
@@ -164,13 +168,17 @@ func (b *Bridge) logStopPhase(sessionID, runID, phase string, started time.Time,
 }
 
 func stopFailureAllowsRollback(err error) bool {
-	return errors.Is(err, errWorkerRunChanged) || errors.Is(err, errWorkerStopNotApplied)
+	return errors.Is(err, errWorkerRunChanged) ||
+		errors.Is(err, errWorkerEventBarrier) ||
+		errors.Is(err, errWorkerStopNotApplied)
 }
 
 func stopErrorKind(err error) string {
 	switch {
 	case errors.Is(err, errWorkerRunChanged):
 		return "run_changed"
+	case errors.Is(err, errWorkerEventBarrier):
+		return "event_barrier"
 	case errors.Is(err, errWorkerStopNotApplied):
 		return "provider_cancel"
 	case errors.Is(err, errWorkerRunTeardown):

--- a/internal/gateway/bridge_stop.go
+++ b/internal/gateway/bridge_stop.go
@@ -52,26 +52,25 @@ func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expect
 		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "run_changed", workerType)
 		return errWorkerRunChanged
 	}
-	if err := binding.worker.StopCurrentTurn(stopCtx); err != nil {
-		lifecycle.unlockEventBarrier()
+	if err := stopCurrentTurnUnderEventBarrier(lifecycle, func() error {
+		return binding.worker.StopCurrentTurn(stopCtx)
+	}); err != nil {
 		b.logStopPhase(sessionID, binding.id, "stop_failed", started, "provider_cancel", workerType)
-		return errWorkerStopNotApplied
+		return err
 	}
-	lifecycle.stopping.Store(true)
-	lifecycle.unlockEventBarrier()
 	b.logStopPhase(sessionID, binding.id, "provider_cancelled", started, "", workerType)
 
 	b.logStopPhase(sessionID, binding.id, "worker_terminating", started, "", workerType)
 	teardownFailed := false
-	if err := binding.worker.Terminate(stopCtx); err != nil {
+	if err := invokeWorkerTeardown(func() error { return binding.worker.Terminate(stopCtx) }); err != nil {
 		b.logStopPhase(sessionID, binding.id, "worker_kill_fallback", started, "terminate", workerType)
-		if killErr := binding.worker.Kill(); killErr != nil {
+		if killErr := invokeWorkerTeardown(binding.worker.Kill); killErr != nil {
 			teardownFailed = true
 			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "kill", workerType)
 		}
 	}
 	if lifecycle.conn != nil {
-		if err := lifecycle.conn.Close(); err != nil {
+		if err := invokeWorkerTeardown(lifecycle.conn.Close); err != nil {
 			b.logStopPhase(sessionID, binding.id, "stop_failed", started, "conn_close", workerType)
 		}
 	}
@@ -93,6 +92,29 @@ func (b *Bridge) StopAndDisposeCurrentRun(ctx context.Context, sessionID, expect
 	}
 	b.logStopPhase(sessionID, binding.id, "stop_completed", started, "", workerType)
 	return nil
+}
+
+func stopCurrentTurnUnderEventBarrier(lifecycle *workerRunLifecycle, stop func() error) (err error) {
+	defer lifecycle.unlockEventBarrier()
+	defer func() {
+		if recover() != nil {
+			err = errWorkerStopNotApplied
+		}
+	}()
+	if err := stop(); err != nil {
+		return errWorkerStopNotApplied
+	}
+	lifecycle.stopping.Store(true)
+	return nil
+}
+
+func invokeWorkerTeardown(teardown func() error) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errWorkerRunTeardown
+		}
+	}()
+	return teardown()
 }
 
 func (b *Bridge) currentWorkerRunBinding(sessionID, expectedRunID string) (workerRunBinding, bool) {

--- a/internal/gateway/bridge_stop_test.go
+++ b/internal/gateway/bridge_stop_test.go
@@ -1,0 +1,63 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/worker"
+	noopworker "github.com/hrygo/hotplex/internal/worker/noop"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func TestBridge_StopAndDisposeCurrentRun_EventBarrierHonorsTeardownTimeout(t *testing.T) {
+	_, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_stop_event_barrier_timeout"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Return(errors.New("stop must not be called")).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{
+		Log:                  slog.Default(),
+		Hub:                  hub,
+		SM:                   mgr,
+		StopTeardownTimeout:  50 * time.Millisecond,
+		StopForwarderTimeout: 50 * time.Millisecond,
+	})
+	binding := bridge.bindWorkerRun(sid, w, "run-event-barrier-timeout")
+	releaseEvent, admitted := binding.lifecycle.beginEvent()
+	require.True(t, admitted)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- bridge.StopAndDisposeCurrentRun(context.Background(), sid, binding.id)
+	}()
+
+	var stopErr error
+	select {
+	case stopErr = <-done:
+	case <-time.After(250 * time.Millisecond):
+		releaseEvent()
+		stopErr = <-done
+		require.FailNow(t, "event barrier acquisition exceeded the teardown budget")
+	}
+	releaseEvent()
+
+	require.Error(t, stopErr)
+	require.Contains(t, stopErr.Error(), "event barrier")
+	w.AssertNotCalled(t, "StopCurrentTurn", mock.Anything)
+	_, _, stillBound := bridge.CurrentWorkerBinding(sid)
+	require.True(t, stillBound, "a pre-cancel barrier timeout must retain the live run")
+}

--- a/internal/gateway/bridge_stop_test.go
+++ b/internal/gateway/bridge_stop_test.go
@@ -21,6 +21,89 @@ type teardownPanicWorker struct {
 	killCalls int
 }
 
+func TestBridge_StopAndDisposeCurrentRun_NaturalTerminalSkipsProviderStop(t *testing.T) {
+	t.Parallel()
+
+	_, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_natural_terminal_before_stop"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Return(nil).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	binding := bridge.bindWorkerRun(sid, w, "run-natural-terminal")
+	binding.lifecycle.terminalCommitted.Store(true)
+	close(binding.lifecycle.done)
+
+	stopErr := bridge.StopAndDisposeCurrentRun(context.Background(), sid, binding.id)
+	require.ErrorIs(t, stopErr, errWorkerRunTerminal)
+	w.AssertNotCalled(t, "StopCurrentTurn", mock.Anything)
+	w.AssertNotCalled(t, "Terminate", mock.Anything)
+	require.False(t, binding.lifecycle.stopping.Load())
+	_, _, stillBound := bridge.CurrentWorkerBinding(sid)
+	require.True(t, stillBound, "natural completion must retain the reusable worker run")
+}
+
+func TestBridge_BeginWorkerRunTurn_DrainsPriorEventBeforeReopen(t *testing.T) {
+	t.Parallel()
+
+	_, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_begin_turn_event_barrier"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	binding := bridge.bindWorkerRun(sid, w, "run-begin-turn-barrier")
+	releaseEvent, admitted := binding.lifecycle.beginEvent()
+	require.True(t, admitted)
+	binding.lifecycle.terminalCommitted.Store(true)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- bridge.beginWorkerRunTurn(context.Background(), sid, binding.id)
+	}()
+	select {
+	case err := <-done:
+		require.FailNow(t, "new turn reopened before the preceding event drained", "error: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseEvent()
+	require.NoError(t, <-done)
+	require.False(t, binding.lifecycle.terminalCommitted.Load())
+}
+
+func TestForwardContext_TerminalStateMirrorsLifecycle(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := newWorkerRunLifecycle(nil)
+	fc := &forwardContext{lifecycle: lifecycle}
+
+	require.True(t, fc.claimTerminal())
+	require.True(t, fc.terminalSent.Load())
+	require.True(t, lifecycle.terminalCommitted.Load())
+	require.False(t, fc.claimTerminal(), "one turn may claim only one terminal")
+
+	fc.reopenTerminal()
+	require.False(t, fc.terminalSent.Load())
+	require.False(t, lifecycle.terminalCommitted.Load())
+	require.True(t, fc.claimTerminal(), "the next turn must be able to claim a terminal")
+}
+
 func (w *teardownPanicWorker) Kill() error {
 	w.killCalls++
 	return nil

--- a/internal/gateway/bridge_stop_test.go
+++ b/internal/gateway/bridge_stop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,16 @@ import (
 	noopworker "github.com/hrygo/hotplex/internal/worker/noop"
 	"github.com/hrygo/hotplex/pkg/events"
 )
+
+type teardownPanicWorker struct {
+	mockWorkerForHandler
+	killCalls int
+}
+
+func (w *teardownPanicWorker) Kill() error {
+	w.killCalls++
+	return nil
+}
 
 func TestBridge_StopAndDisposeCurrentRun_EventBarrierHonorsTeardownTimeout(t *testing.T) {
 	_, mgr, hub, _ := newHandlerWithRealStore(t)
@@ -60,4 +71,108 @@ func TestBridge_StopAndDisposeCurrentRun_EventBarrierHonorsTeardownTimeout(t *te
 	w.AssertNotCalled(t, "StopCurrentTurn", mock.Anything)
 	_, _, stillBound := bridge.CurrentWorkerBinding(sid)
 	require.True(t, stillBound, "a pre-cancel barrier timeout must retain the live run")
+}
+
+func TestBridge_StopAndDisposeCurrentRun_StopPanicReleasesBarrier(t *testing.T) {
+	t.Parallel()
+
+	_, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_stop_panic"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Run(func(mock.Arguments) {
+		panic("injected stop panic")
+	}).Return(nil).Once()
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{
+		Log:                  slog.Default(),
+		Hub:                  hub,
+		SM:                   mgr,
+		StopTeardownTimeout:  50 * time.Millisecond,
+		StopForwarderTimeout: 50 * time.Millisecond,
+	})
+	binding := bridge.bindWorkerRun(sid, w, "run-stop-panic")
+
+	stopErr := bridge.StopAndDisposeCurrentRun(context.Background(), sid, binding.id)
+	require.ErrorIs(t, stopErr, errWorkerStopNotApplied)
+	require.True(t, stopFailureAllowsRollback(stopErr))
+	require.False(t, binding.lifecycle.stopping.Load())
+
+	eventAdmitted := make(chan bool, 1)
+	go func() {
+		releaseEvent, admitted := binding.lifecycle.beginEvent()
+		if admitted {
+			releaseEvent()
+		}
+		eventAdmitted <- admitted
+	}()
+
+	select {
+	case admitted := <-eventAdmitted:
+		require.True(t, admitted, "a recovered stop panic must reopen event admission")
+	case <-time.After(250 * time.Millisecond):
+		require.FailNow(t, "event barrier remained locked after a recovered stop panic")
+	}
+
+	_, _, stillBound := bridge.CurrentWorkerBinding(sid)
+	require.True(t, stillBound, "a pre-commit stop panic must retain the live run")
+}
+
+func TestBridge_StopAndDisposeCurrentRun_TerminatePanicFallsBackAndFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_terminate_panic"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(teardownPanicWorker)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Return(nil).Once()
+	var panicOnce sync.Once
+	w.On("Terminate", mock.Anything).Run(func(mock.Arguments) {
+		panicOnce.Do(func() { panic("injected terminate panic") })
+	}).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{
+		Log:                  slog.Default(),
+		Hub:                  hub,
+		SM:                   mgr,
+		StopTeardownTimeout:  50 * time.Millisecond,
+		StopForwarderTimeout: 50 * time.Millisecond,
+	})
+	binding := bridge.bindWorkerRun(sid, w, "run-terminate-panic")
+	close(binding.lifecycle.done)
+
+	stopErr := bridge.StopAndDisposeCurrentRun(context.Background(), sid, binding.id)
+	require.ErrorIs(t, stopErr, errWorkerRunQuiescence)
+	require.Equal(t, 1, w.killCalls, "a recovered terminate panic must use the kill fallback")
+	_, _, stillBound := bridge.CurrentWorkerBinding(sid)
+	require.False(t, stillBound, "post-commit teardown failure must fail closed")
+}
+
+func TestWorkerRunLifecycle_WithEventReleasesAfterPanic(t *testing.T) {
+	t.Parallel()
+
+	lifecycle := newWorkerRunLifecycle(nil)
+	require.Panics(t, func() {
+		lifecycle.withEvent(func() {
+			panic("injected event panic")
+		})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.True(t, lifecycle.lockEventBarrier(ctx), "event panic must not leak the admission or read lock")
+	lifecycle.unlockEventBarrier()
 }

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -103,7 +103,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		}
 		return nil, err
 	}
-	b.bindWorkerRun(sid, w, params.forwardOpts.workerRunID)
+	runBinding := b.bindWorkerRun(sid, w, params.forwardOpts.workerRunID)
 
 	// A new Worker (or a resumed/replaced one) is now the session's command
 	// authority: drop the session's cached catalog so the next assembly picks
@@ -132,8 +132,9 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
-		defer b.clearWorkerRun(sid, w, params.forwardOpts.workerRunID)
-		b.launchForwarderLocked(w, sid, *params.forwardOpts)
+		defer close(runBinding.lifecycle.done)
+		defer b.clearWorkerRun(sid, w, runBinding.id)
+		b.launchForwarderLocked(runBinding, sid, *params.forwardOpts)
 	}()
 
 	return w, nil
@@ -179,9 +180,10 @@ func (b *Bridge) capturePermissionCeiling(ctx context.Context, sessionID string,
 // after /reset and splitting the event stream with the new forwarder
 // (Turn-Integrity spec RC-1 / Fix A, invariant I-1/I-2).
 type forwarderBinding struct {
-	worker   worker.Worker
-	conn     worker.SessionConn // frozen event source; forwardEvents reads ONLY this
-	resetGen int64              // frozen reset generation for stale-exit detection
+	worker    worker.Worker
+	conn      worker.SessionConn // frozen event source; forwardEvents reads ONLY this
+	lifecycle *workerRunLifecycle
+	resetGen  int64 // frozen reset generation for stale-exit detection
 }
 
 // launchForwarderLocked is the single entry point for spawning a forwardEvents
@@ -189,22 +191,32 @@ type forwarderBinding struct {
 // the Conn is captured before any concurrent ResetContext can replace it.
 // All four launch paths — fresh Start, Resume, /reset ConnReplaced, and crash
 // recovery — route through here (Fix A).
-func (b *Bridge) launchForwarderLocked(w worker.Worker, sessionID string, opts forwardOpts) {
-	conn := w.Conn()
+func (b *Bridge) launchForwarderLocked(binding workerRunBinding, sessionID string, opts forwardOpts) {
+	w := binding.worker
 	var resetGen int64
 	if rg, ok := w.(worker.ResetGenerationer); ok {
 		resetGen = rg.LoadResetGeneration()
 	}
-	fb := forwarderBinding{worker: w, conn: conn, resetGen: resetGen}
+	fb := forwarderBinding{
+		worker:    w,
+		conn:      binding.lifecycle.conn,
+		lifecycle: binding.lifecycle,
+		resetGen:  resetGen,
+	}
 	b.forwardEvents(fb, sessionID, opts)
 }
 
-func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) string {
+func (b *Bridge) bindWorkerRun(sessionID string, w worker.Worker, runID string) workerRunBinding {
 	if runID == "" {
 		runID = "run_" + uuid.NewString()
 	}
-	b.workerRuns.Store(sessionID, workerRunBinding{worker: w, id: runID})
-	return runID
+	binding := workerRunBinding{
+		worker:    w,
+		id:        runID,
+		lifecycle: newWorkerRunLifecycle(w.Conn()),
+	}
+	b.workerRuns.Store(sessionID, binding)
+	return binding
 }
 
 // RecordTurnStart stamps the current turn's start time on the session

--- a/internal/gateway/commands.go
+++ b/internal/gateway/commands.go
@@ -78,14 +78,15 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 			}
 			return h.sendErrorf(ctx, env, events.ErrCodeUnauthorized, "ownership required")
 		}
-		w := h.sm.GetWorker(env.SessionID)
-		if w == nil {
-			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop: no active worker")
-		}
+		unlockDispatch := h.dispatchGate.Lock(env.SessionID)
+		defer unlockDispatch()
 
-		var workerRunID string
+		var (
+			workerRunID string
+			bindingOK   bool
+		)
 		if h.bridge != nil {
-			_, workerRunID, _ = h.bridge.CurrentWorkerBinding(env.SessionID)
+			_, workerRunID, bindingOK = h.bridge.CurrentWorkerBinding(env.SessionID)
 		}
 
 		// The claim is keyed by the turn's execution ID (when the execution
@@ -96,11 +97,23 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 		// the first stop's finishRuntimeOnStop closes the runtime BEFORE a
 		// duplicate stop arrives, so the open-runtime query would resolve to a
 		// different (or no) record and admit the duplicate.
-		var execID string
+		var execID, persistedRunID string
 		if h.executionStore != nil {
 			if rec, err := h.executionStore.LatestBySession(ctx, env.SessionID); err == nil {
 				execID = rec.ExecutionID
+				persistedRunID = rec.WorkerRunID
 			}
+		}
+		if workerRunID == "" {
+			workerRunID = persistedRunID
+		}
+		if !bindingOK && h.stopFence.IsClaimed(env.SessionID) {
+			// The first successful stop detaches the run before a duplicate
+			// arrives. When the execution ledger is disabled (or temporarily
+			// unavailable), the original composite key cannot be reconstructed;
+			// the retained session claim still proves the stop was already applied.
+			h.log.Debug("gateway: stop already completed for detached run", "session_id", env.SessionID)
+			return nil
 		}
 
 		// Per-turn stop fence: admit exactly one effective stop per (session,
@@ -112,17 +125,36 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 				"session_id", env.SessionID, "worker_run_id", workerRunID, "execution_id", execID)
 			return nil
 		}
+		if h.bridge == nil || !bindingOK {
+			h.stopFence.Rollback(env.SessionID, workerRunID, execID)
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop: no active worker run")
+		}
 
 		// A stop supersedes any pending LLM auto-retry: the retried input must
 		// not fire after the stop and start a new turn under the fresh claim.
 		h.cancelRetryIfNeeded(env.SessionID)
 
-		if err := w.StopCurrentTurn(ctx); err != nil {
-			// The stop never took effect: roll the claim back so a manual retry
-			// can stop again (failed-abort convergence, session retained).
-			h.stopFence.Rollback(env.SessionID, workerRunID, execID)
-			h.log.Warn("gateway: stop current turn failed", "session_id", env.SessionID, "err", err)
-			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop failed: %v", err)
+		if err := h.bridge.StopAndDisposeCurrentRun(ctx, env.SessionID, workerRunID); err != nil {
+			if stopFailureAllowsRollback(err) {
+				// Provider cancellation never committed: reopen event flow and let
+				// a manual stop retry claim this same turn.
+				h.stopFence.Rollback(env.SessionID, workerRunID, execID)
+			} else {
+				// Provider cancellation committed, so the run stays isolated even
+				// when teardown/quiescence reports failure. Close its durable runtime
+				// without sending the success-only stopped done.
+				h.finishRuntimeOnStop(ctx, env.SessionID, workerRunID, env.OwnerID)
+			}
+			h.log.Warn("gateway: stop worker run failed",
+				"session_id", env.SessionID,
+				"worker_run_id", workerRunID,
+				"execution_id", execID,
+				"stop_phase", "stop_failed",
+				"error_kind", stopErrorKind(err))
+			if errors.Is(err, errWorkerRunChanged) {
+				return h.sendErrorf(ctx, env, events.ErrCodeSessionBusy, "worker run changed during stop")
+			}
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker run did not stop cleanly")
 		}
 
 		// Finish the pending execution runtime immediately when stopped.

--- a/internal/gateway/commands.go
+++ b/internal/gateway/commands.go
@@ -152,6 +152,17 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 		h.cancelRetryIfNeeded(env.SessionID)
 
 		if err := h.bridge.StopAndDisposeCurrentRun(ctx, env.SessionID, workerRunID); err != nil {
+			if errors.Is(err, errWorkerRunTerminal) {
+				// A natural Done/Error committed while this stop waited for the
+				// event barrier. It already settled the turn, so neither provider
+				// cancellation nor a second synthetic terminal is appropriate.
+				h.stopFence.Rollback(env.SessionID, workerRunID, execID)
+				h.log.Debug("gateway: stop lost race to natural terminal",
+					"session_id", env.SessionID,
+					"worker_run_id", workerRunID,
+					"execution_id", execID)
+				return nil
+			}
 			if stopFailureAllowsRollback(err) {
 				// Provider cancellation never committed: reopen event flow and let
 				// a manual stop retry claim this same turn.

--- a/internal/gateway/commands.go
+++ b/internal/gateway/commands.go
@@ -107,13 +107,21 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 		if workerRunID == "" {
 			workerRunID = persistedRunID
 		}
-		if !bindingOK && h.stopFence.IsClaimed(env.SessionID) {
-			// The first successful stop detaches the run before a duplicate
-			// arrives. When the execution ledger is disabled (or temporarily
-			// unavailable), the original composite key cannot be reconstructed;
-			// the retained session claim still proves the stop was already applied.
-			h.log.Debug("gateway: stop already completed for detached run", "session_id", env.SessionID)
-			return nil
+		if !bindingOK {
+			claimMatches := false
+			if workerRunID != "" || execID != "" {
+				claimMatches = h.stopFence.Matches(env.SessionID, workerRunID, execID)
+			} else if h.executionStore == nil {
+				// Only the ledger-disabled mode may use a session-only fallback.
+				// A configured ledger lookup failure is ambiguous and must fail
+				// closed instead of inheriting an older turn's stop claim.
+				claimMatches = h.stopFence.HasAny(env.SessionID)
+			}
+			if claimMatches {
+				h.log.Debug("gateway: stop already completed for detached run",
+					"session_id", env.SessionID, "worker_run_id", workerRunID, "execution_id", execID)
+				return nil
+			}
 		}
 
 		// Per-turn stop fence: admit exactly one effective stop per (session,

--- a/internal/gateway/commands.go
+++ b/internal/gateway/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -99,10 +100,18 @@ func (h *Handler) handleControl(ctx context.Context, env *events.Envelope) error
 		// different (or no) record and admit the duplicate.
 		var execID, persistedRunID string
 		if h.executionStore != nil {
-			if rec, err := h.executionStore.LatestBySession(ctx, env.SessionID); err == nil {
-				execID = rec.ExecutionID
-				persistedRunID = rec.WorkerRunID
+			rec, lookupErr := h.executionStore.LatestBySession(ctx, env.SessionID)
+			if lookupErr != nil || rec == nil {
+				errorKind := "lookup_failed"
+				if errors.Is(lookupErr, execution.ErrNotFound) {
+					errorKind = "not_found"
+				}
+				h.log.Warn("gateway: stop execution identity unavailable",
+					"session_id", env.SessionID, "error_kind", errorKind)
+				return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "stop execution identity unavailable")
 			}
+			execID = rec.ExecutionID
+			persistedRunID = rec.WorkerRunID
 		}
 		if workerRunID == "" {
 			workerRunID = persistedRunID

--- a/internal/gateway/contracttest/harness.go
+++ b/internal/gateway/contracttest/harness.go
@@ -232,6 +232,14 @@ func (h *Harness) Worker() *WorkerProbe {
 	return h.probe
 }
 
+// DetachWorkerForTest removes the SessionManager attachment while leaving the
+// bridge's historical run metadata intact. It models a crash/detach window in
+// which control.stop must rely on persisted execution identity rather than a
+// live Worker binding.
+func (h *Harness) DetachWorkerForTest() {
+	h.manager.DetachWorker(h.sessionID)
+}
+
 func (h *Harness) setProbe(p *WorkerProbe) {
 	h.probeMu.Lock()
 	defer h.probeMu.Unlock()

--- a/internal/gateway/contracttest/harness.go
+++ b/internal/gateway/contracttest/harness.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/dbutil"
 	"github.com/hrygo/hotplex/internal/e2econtract"
+	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/execution"
 	"github.com/hrygo/hotplex/internal/gateway"
 	"github.com/hrygo/hotplex/internal/session"
@@ -53,6 +54,7 @@ type Harness struct {
 	Hub     *gateway.Hub
 	Bridge  *gateway.Bridge
 	Handler *gateway.Handler
+	manager *session.Manager
 
 	profile   e2econtract.WorkerProfile
 	sessionID string
@@ -64,6 +66,36 @@ type Harness struct {
 	probes  []*WorkerProbe // every probe created for this harness (teardown closes all)
 
 	nextProbeBlocking atomic.Bool // arm the NEXT probe for the turn-gate mode (matrix C04)
+
+	eventCollector *eventstore.Collector
+	eventStore     eventstore.EventStore
+}
+
+type harnessOptions struct {
+	eventCollector       bool
+	stopTeardownTimeout  time.Duration
+	stopForwarderTimeout time.Duration
+}
+
+// HarnessOption enables an isolated contract-harness capability without
+// changing the default platform/worker matrix behavior.
+type HarnessOption func(*harnessOptions)
+
+// WithEventCollector enables durable forwarded-event assertions for tests
+// such as the stopped-run quarantine contract.
+func WithEventCollector() HarnessOption {
+	return func(opts *harnessOptions) {
+		opts.eventCollector = true
+	}
+}
+
+// WithStopTimeouts overrides the server-side stop budgets for deterministic
+// timeout contract tests. Production callers use Bridge defaults.
+func WithStopTimeouts(teardown, forwarder time.Duration) HarnessOption {
+	return func(opts *harnessOptions) {
+		opts.stopTeardownTimeout = teardown
+		opts.stopForwarderTimeout = forwarder
+	}
 }
 
 // NewHarness builds a full gateway stack against a temp SQLite store and
@@ -73,8 +105,13 @@ type Harness struct {
 // Bridge.MarkClosed → close every probe conn (so all forwarders exit; the
 // closed flag makes handleWorkerExit skip crash recovery) → Bridge.Shutdown →
 // Hub.Shutdown → Manager.Close → store.Close, each bounded by a 2s context.
-func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract.WorkerProfile) *Harness {
+func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract.WorkerProfile, options ...HarnessOption) *Harness {
 	t.Helper()
+
+	opts := harnessOptions{}
+	for _, option := range options {
+		option(&opts)
+	}
 
 	log := discardLogger
 	cfg := config.Default()
@@ -93,16 +130,25 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 	// resources of its own to close: store.Close() releases the shared DB.
 	execStore, err := execution.NewSQLStore(context.Background(), store.DB(), dbutil.DialectSQLite, writeMu, log)
 	require.NoError(t, err, "contracttest: open execution store")
+	var eventCollector *eventstore.Collector
+	var durableEventStore eventstore.EventStore
+	if opts.eventCollector {
+		durableEventStore = eventstore.NewSQLiteStore(store.DB(), writeMu)
+		eventCollector = eventstore.NewCollector(durableEventStore, log)
+	}
 	cfgStore := config.NewConfigStore(cfg, nil)
 	mgr, err := session.NewManager(context.Background(), log, cfg, cfgStore, store)
 	require.NoError(t, err, "contracttest: create session manager")
 
 	hub := gateway.NewHub(log, cfgStore)
 	bridge := gateway.NewBridge(gateway.BridgeDeps{
-		Log:            log,
-		Hub:            hub,
-		SM:             mgr,
-		ExecutionStore: execStore,
+		Log:                  log,
+		Hub:                  hub,
+		SM:                   mgr,
+		EventCollector:       eventCollector,
+		ExecutionStore:       execStore,
+		StopTeardownTimeout:  opts.stopTeardownTimeout,
+		StopForwarderTimeout: opts.stopForwarderTimeout,
 	})
 	handler := gateway.NewHandler(gateway.HandlerDeps{
 		Log:             log,
@@ -118,13 +164,16 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 	hub.JoinPlatformSession(sessionID, observer)
 
 	h := &Harness{
-		Hub:       hub,
-		Bridge:    bridge,
-		Handler:   handler,
-		profile:   profile,
-		sessionID: sessionID,
-		dbPath:    dbPath,
-		observer:  observer,
+		Hub:            hub,
+		Bridge:         bridge,
+		Handler:        handler,
+		manager:        mgr,
+		profile:        profile,
+		sessionID:      sessionID,
+		dbPath:         dbPath,
+		observer:       observer,
+		eventCollector: eventCollector,
+		eventStore:     durableEventStore,
 	}
 	bridge.SetWorkerFactory(&probeFactory{h: h, profile: profile, sessionID: sessionID})
 
@@ -150,6 +199,9 @@ func NewHarness(t testing.TB, platform e2econtract.Platform, profile e2econtract
 		}
 		h.Bridge.Shutdown(cleanupCtx)
 		_ = h.Hub.Shutdown(cleanupCtx)
+		if h.eventCollector != nil {
+			_ = h.eventCollector.Close()
+		}
 		_ = mgr.Close()
 		_ = store.Close()
 	})
@@ -208,6 +260,31 @@ func (h *Harness) Probes() []*WorkerProbe {
 	out := make([]*WorkerProbe, len(h.probes))
 	copy(out, h.probes)
 	return out
+}
+
+// StoredEvents flushes and returns every durable event for the harness
+// session. The harness must have been created with WithEventCollector.
+func (h *Harness) StoredEvents(t testing.TB) []*eventstore.StoredEvent {
+	t.Helper()
+	require.NotNil(t, h.eventCollector, "contracttest: event collector is not enabled")
+	require.NotNil(t, h.eventStore, "contracttest: event store is not enabled")
+	require.NoError(t, h.eventCollector.FlushSession(h.sessionID), "contracttest: flush stored events")
+	page, err := h.eventStore.QueryBySession(
+		context.Background(), h.sessionID, 0, eventstore.CursorLatest, 1000,
+	)
+	require.NoError(t, err, "contracttest: query stored events")
+	return page.Events
+}
+
+// Events returns a snapshot of every envelope observed by the platform side.
+func (h *Harness) Events() []*events.Envelope { return h.observer.Events() }
+
+// SessionState returns the current persisted/in-memory session state.
+func (h *Harness) SessionState(t testing.TB) events.SessionState {
+	t.Helper()
+	si, err := h.manager.Get(context.Background(), h.sessionID)
+	require.NoError(t, err, "contracttest: get session state")
+	return si.State
 }
 
 // WaitForKinds blocks until every event kind in kinds has been observed on the

--- a/internal/gateway/contracttest/worker_probe.go
+++ b/internal/gateway/contracttest/worker_probe.go
@@ -99,8 +99,11 @@ type WorkerProbe struct {
 	// non-blocking: the platform matrix flows emit the full turn synchronously
 	// with Input, exactly as before.
 	blocking      atomic.Bool
+	blockInputEnd atomic.Bool
+	failInputEnd  atomic.Bool
 	enteredTurn   chan struct{} // buffered(1): probe signals the pre-terminal content was emitted
 	allowTerminal chan struct{} // buffered(1): test releases the held terminal
+	allowInputEnd chan struct{} // buffered(1): test releases a production-style blocking Input call
 	holdTerminal  []*events.Envelope
 
 	failNextStop atomic.Bool // arming the next StopCurrentTurn to fail (failed-abort contract)
@@ -133,6 +136,7 @@ func NewWorkerProbe(profile e2econtract.WorkerProfile, sessionID string) *Worker
 		conn:          newProbeConn(sessionID, "contract-user"),
 		enteredTurn:   make(chan struct{}, 1),
 		allowTerminal: make(chan struct{}, 1),
+		allowInputEnd: make(chan struct{}, 1),
 		stopEntered:   make(chan struct{}, 1),
 		allowStop:     make(chan struct{}, 1),
 		waitEntered:   make(chan struct{}, 1),
@@ -145,6 +149,24 @@ func NewWorkerProbe(profile e2econtract.WorkerProfile, sessionID string) *Worker
 // was emitted. Only the lifecycle contract tests enable it; the platform
 // matrix flows keep the synchronous full-turn emission.
 func (p *WorkerProbe) EnableBlocking() { p.blocking.Store(true) }
+
+// BlockInputCompletion makes Input remain blocked after the worker has
+// accepted the prompt. ACP and the legacy OpenCode /message endpoint have
+// this shape: delivery is committed before the adapter returns from Input.
+func (p *WorkerProbe) BlockInputCompletion() { p.blockInputEnd.Store(true) }
+
+// FailInputAfterAccepted makes the blocking Input return an adapter error once
+// released. It models ACP/OCS RPC completion after a successful concurrent
+// provider stop; Gateway must not surface that cancellation as input failure.
+func (p *WorkerProbe) FailInputAfterAccepted() { p.failInputEnd.Store(true) }
+
+// ReleaseInputCompletion lets a production-style blocking Input return.
+func (p *WorkerProbe) ReleaseInputCompletion() {
+	select {
+	case p.allowInputEnd <- struct{}{}:
+	default:
+	}
+}
 
 // MarkExitIntentional flags the probe's upcoming conn close as an intentional
 // scenario teardown rather than a crash. The bridge's handleWorkerExit then
@@ -189,11 +211,42 @@ func (p *WorkerProbe) Resume(_ context.Context, _ worker.SessionInfo) error {
 // semantics: BaseWorker.BeginTurn clears the user-stop marker before each
 // primary turn), then emits one fixture-driven turn through the real
 // parser/mapper of the probe's worker type.
-func (p *WorkerProbe) Input(_ context.Context, _ string, _ map[string]any) error {
+func (p *WorkerProbe) Input(ctx context.Context, content string, metadata map[string]any) error {
+	return p.input(ctx, content, metadata, nil)
+}
+
+// InputWithDispatchAccepted exposes the optional two-phase dispatch contract
+// used by production adapters whose Input call outlives request acceptance.
+func (p *WorkerProbe) InputWithDispatchAccepted(
+	ctx context.Context,
+	content string,
+	metadata map[string]any,
+	accepted func(),
+) error {
+	return p.input(ctx, content, metadata, accepted)
+}
+
+func (p *WorkerProbe) input(ctx context.Context, _ string, _ map[string]any, accepted func()) error {
 	p.inputCalls.Add(1)
 	p.turnN.Add(1)
 	p.stopped.Store(false)
-	return p.EmitBasicTurn(context.Background())
+	if err := p.EmitBasicTurn(ctx); err != nil {
+		return err
+	}
+	if accepted != nil {
+		accepted()
+	}
+	if p.blockInputEnd.Load() {
+		select {
+		case <-p.allowInputEnd:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if p.failInputEnd.Load() {
+		return errors.New("contracttest: accepted input interrupted by stop")
+	}
+	return nil
 }
 
 func (p *WorkerProbe) Conn() worker.SessionConn { return p.conn }
@@ -345,14 +398,12 @@ func (p *WorkerProbe) Events() []*events.Envelope { return p.conn.Events() }
 // EmitBasicTurn drives the probe's worker-type fixture through the real
 // parser/mapper and writes every mapper-produced envelope verbatim into the
 // probe connection. When the turn gate is armed (EnableBlocking), the terminal
-// envelopes are held off the wire and Input returns right after the
-// pre-terminal content — exactly like a production worker whose Input is a
-// delivery while the turn keeps running. The held terminal is released by
-// ReleaseTerminal: a turn stopped in the meantime (StopCurrentTurn before the
-// release) has its terminal suppressed, so the interrupted turn never
-// completes on the wire. Platform queues (feishu chatQueue, slack event
-// goroutines, webchat async dispatch) therefore stay free to process the stop
-// while the fixture turn is still live.
+// envelopes are held off the wire. By default Input returns after this
+// pre-terminal delivery point, modeling adapters with acknowledgement-style
+// Input. BlockInputCompletion instead keeps Input waiting while
+// InputWithDispatchAccepted reports the same acceptance point, modeling ACP's
+// blocking prompt RPC. ReleaseTerminal emits the held terminal unless that
+// turn was stopped in the meantime.
 func (p *WorkerProbe) EmitBasicTurn(_ context.Context) error {
 	switch p.profile.Type {
 	case worker.TypeClaudeCode:

--- a/internal/gateway/contracttest/worker_probe.go
+++ b/internal/gateway/contracttest/worker_probe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hrygo/hotplex/internal/worker/codexcli"
 	"github.com/hrygo/hotplex/internal/worker/noop"
 	"github.com/hrygo/hotplex/internal/worker/opencodeserver"
+	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
@@ -103,6 +104,18 @@ type WorkerProbe struct {
 	holdTerminal  []*events.Envelope
 
 	failNextStop atomic.Bool // arming the next StopCurrentTurn to fail (failed-abort contract)
+
+	terminateCalls atomic.Int32
+	killCalls      atomic.Int32
+	failTerminate  atomic.Bool
+	failKill       atomic.Bool
+	blockStop      atomic.Bool
+	blockWait      atomic.Bool
+	lateOnDispose  atomic.Bool
+	stopEntered    chan struct{}
+	allowStop      chan struct{}
+	waitEntered    chan struct{}
+	allowWait      chan struct{}
 }
 
 // FailNextStop arms the NEXT StopCurrentTurn to return an error, simulating a
@@ -120,6 +133,10 @@ func NewWorkerProbe(profile e2econtract.WorkerProfile, sessionID string) *Worker
 		conn:          newProbeConn(sessionID, "contract-user"),
 		enteredTurn:   make(chan struct{}, 1),
 		allowTerminal: make(chan struct{}, 1),
+		stopEntered:   make(chan struct{}, 1),
+		allowStop:     make(chan struct{}, 1),
+		waitEntered:   make(chan struct{}, 1),
+		allowWait:     make(chan struct{}, 1),
 	}
 }
 
@@ -185,15 +202,70 @@ func (p *WorkerProbe) ResetContext(_ context.Context) (worker.ResetResult, error
 	return worker.ResetResult{}, nil
 }
 
+// BlockStopCurrentTurn holds StopCurrentTurn after it marks the current turn
+// stopped. ReleaseStopCurrentTurn resumes it. The buffered signals make the
+// control deterministic regardless of which goroutine reaches the phase first.
+func (p *WorkerProbe) BlockStopCurrentTurn() { p.blockStop.Store(true) }
+
+func (p *WorkerProbe) StopEntered() <-chan struct{} { return p.stopEntered }
+
+func (p *WorkerProbe) ReleaseStopCurrentTurn() {
+	select {
+	case p.allowStop <- struct{}{}:
+	default:
+	}
+}
+
+// BlockWait holds Worker.Wait so tests can prove that stopped_by_user is sent
+// only after the old forwarder has completed handleWorkerExit.
+func (p *WorkerProbe) BlockWait() { p.blockWait.Store(true) }
+
+func (p *WorkerProbe) WaitEntered() <-chan struct{} { return p.waitEntered }
+
+func (p *WorkerProbe) ReleaseWait() {
+	select {
+	case p.allowWait <- struct{}{}:
+	default:
+	}
+}
+
+// EmitLateEventsOnDispose makes Terminate enqueue representative events from
+// the stopped run immediately before it closes the frozen connection.
+func (p *WorkerProbe) EmitLateEventsOnDispose() { p.lateOnDispose.Store(true) }
+
+// EmitLateEventsNow writes the same late-run fixture immediately. It lets a
+// contract test reproduce the pre-fix window after the early synthetic done.
+func (p *WorkerProbe) EmitLateEventsNow() {
+	p.lateOnDispose.Store(true)
+	p.emitLateEvents()
+}
+
+// FailNextTerminate and FailNextKill arm teardown fallback paths.
+func (p *WorkerProbe) FailNextTerminate() { p.failTerminate.Store(true) }
+func (p *WorkerProbe) FailNextKill()      { p.failKill.Store(true) }
+
 // StopCurrentTurn records the invocation and marks the current turn stopped.
 // The single-effective-stop guarantee is owned by the gateway's turn fence
 // (internal/gateway/stop_fence.go), not by this probe: a duplicate stop never
 // reaches the Worker call at all, so stopCalls stays 1 under the fence.
-func (p *WorkerProbe) StopCurrentTurn(_ context.Context) error {
+func (p *WorkerProbe) StopCurrentTurn(ctx context.Context) error {
 	p.stopCalls.Add(1)
 	p.stopped.Store(true)
 	p.stoppedTurn.Store(p.turnN.Load())
+	if p.blockStop.Load() {
+		select {
+		case p.stopEntered <- struct{}{}:
+		default:
+		}
+		select {
+		case <-p.allowStop:
+		case <-ctx.Done():
+			p.stopped.Store(false)
+			return ctx.Err()
+		}
+	}
 	if p.failNextStop.Swap(false) {
+		p.stopped.Store(false)
 		return errors.New("contracttest: injected stop failure")
 	}
 	return nil
@@ -201,11 +273,74 @@ func (p *WorkerProbe) StopCurrentTurn(_ context.Context) error {
 
 func (p *WorkerProbe) IsStopped() bool { return p.stopped.Load() }
 
+func (p *WorkerProbe) Terminate(_ context.Context) error {
+	p.terminateCalls.Add(1)
+	if p.failTerminate.Swap(false) {
+		return errors.New("contracttest: injected terminate failure")
+	}
+	p.emitLateEvents()
+	return p.conn.Close()
+}
+
+func (p *WorkerProbe) Kill() error {
+	p.killCalls.Add(1)
+	if p.failKill.Swap(false) {
+		return errors.New("contracttest: injected kill failure")
+	}
+	p.emitLateEvents()
+	return p.conn.Close()
+}
+
+func (p *WorkerProbe) Wait() (int, error) {
+	if p.blockWait.Load() {
+		select {
+		case p.waitEntered <- struct{}{}:
+		default:
+		}
+		<-p.allowWait
+	}
+	return 0, nil
+}
+
+func (p *WorkerProbe) emitLateEvents() {
+	if !p.lateOnDispose.Swap(false) {
+		return
+	}
+	late := []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.MessageDelta,
+			events.MessageDeltaData{MessageID: "late_run_message", Content: "late_run_delta"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Message,
+			events.MessageData{ID: "late_run_message", Role: "assistant", Content: "late_run_message"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Reasoning,
+			events.ReasoningData{ID: "late_run_reasoning", Content: "late_run_reasoning"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.ToolCall,
+			events.ToolCallData{ID: "late_run_tool", Name: "late_run_tool", Input: map[string]any{"marker": "late_run_tool"}}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.PermissionRequest,
+			events.PermissionRequestData{ID: "late_run_permission", ToolName: "late_run_permission"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.State,
+			events.StateData{State: events.StateRunning, Message: "late_run_state"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Done,
+			events.DoneData{Success: true, Reason: "late_run_done"}),
+		events.NewEnvelope(aep.NewID(), p.conn.sessionID, 0, events.Error,
+			events.ErrorData{Code: events.ErrCodeInternalError, Message: "late_run_error"}),
+	}
+	for _, env := range late {
+		p.conn.write(env)
+	}
+}
+
 // InputCalls returns how many times Input was invoked.
 func (p *WorkerProbe) InputCalls() int { return int(p.inputCalls.Load()) }
 
 // StopCalls returns how many times StopCurrentTurn was invoked.
 func (p *WorkerProbe) StopCalls() int { return int(p.stopCalls.Load()) }
+
+func (p *WorkerProbe) TerminateCalls() int { return int(p.terminateCalls.Load()) }
+func (p *WorkerProbe) KillCalls() int      { return int(p.killCalls.Load()) }
+
+// Events returns every envelope the probe attempted to emit, including writes
+// rejected from the live Recv stream after the connection closed.
+func (p *WorkerProbe) Events() []*events.Envelope { return p.conn.Events() }
 
 // EmitBasicTurn drives the probe's worker-type fixture through the real
 // parser/mapper and writes every mapper-produced envelope verbatim into the
@@ -374,8 +509,8 @@ func newProbeConn(sessionID, userID string) *probeConn {
 // without blocking (a dropped mirror is fine — Events is the source of truth).
 func (c *probeConn) write(env *events.Envelope) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.events = append(c.events, env)
-	c.mu.Unlock()
 	if c.closed.Load() {
 		return
 	}
@@ -399,6 +534,8 @@ func (c *probeConn) Send(_ context.Context, _ *events.Envelope) error { return n
 func (c *probeConn) Recv() <-chan *events.Envelope { return c.recvCh }
 
 func (c *probeConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed.CompareAndSwap(false, true) {
 		close(c.recvCh)
 	}

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -545,6 +545,37 @@ func TestHandleControl_Stop_Success(t *testing.T) {
 	require.Equal(t, "stopped_by_user", doneData["reason"])
 }
 
+func TestHandleControl_Stop_AfterNaturalTerminalIsSilent(t *testing.T) {
+	t.Parallel()
+
+	handler, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_stop_after_natural_terminal"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Return(nil).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	handler.bridge = bridge
+	binding := bridge.bindWorkerRun(sid, w, "run-stop-after-natural-terminal")
+	binding.lifecycle.terminalCommitted.Store(true)
+
+	env := controlEnvelope(sid, string(events.ControlActionStop))
+	env.OwnerID = "user1"
+	require.NoError(t, handler.handleControl(context.Background(), env),
+		"a natural terminal that won the event barrier must make the racing stop a silent no-op")
+	w.AssertNotCalled(t, "StopCurrentTurn", mock.Anything)
+	w.AssertNotCalled(t, "Terminate", mock.Anything)
+	require.True(t, handler.stopFence.Claim(sid, binding.id, ""),
+		"the no-op stop must roll back its claim instead of fencing the next turn")
+}
+
 func TestHandleControl_Stop_LedgerLookupFailureFailsClosed(t *testing.T) {
 	t.Parallel()
 	handler, mgr, hub, _ := newHandlerWithRealStore(t)

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
+	noopworker "github.com/hrygo/hotplex/internal/worker/noop"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -484,9 +485,21 @@ func TestHandleControl_Stop_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
 	w.On("StopCurrentTurn", mock.Anything).Return(nil)
-	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil)
+	w.On("Wait").Return(0, nil)
 	mgr.AttachWorker(context.Background(), sid, w)
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	handler.bridge = bridge
+	runBinding := bridge.bindWorkerRun(sid, w, "run-stop-success")
+	bridge.fwdWg.Add(1)
+	go func() {
+		defer bridge.fwdWg.Done()
+		defer close(runBinding.lifecycle.done)
+		defer bridge.clearWorkerRun(sid, w, runBinding.id)
+		bridge.launchForwarderLocked(runBinding, sid, forwardOpts{ctx: context.Background(), workerRunID: runBinding.id})
+	}()
 
 	// The stop must converge the pending execution runtime (acceptance A3:
 	// Gateway stopped_by_user closed loop).

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -542,6 +543,36 @@ func TestHandleControl_Stop_Success(t *testing.T) {
 	doneData, ok := doneEnv.Event.Data.(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "stopped_by_user", doneData["reason"])
+}
+
+func TestHandleControl_Stop_LedgerLookupFailureFailsClosed(t *testing.T) {
+	t.Parallel()
+	handler, mgr, hub, _ := newHandlerWithRealStore(t)
+
+	const sid = "sess_stop_ledger_lookup_failure"
+	_, err := mgr.Create(context.Background(), sid, "user1", worker.TypeClaudeCode, nil, "", "")
+	require.NoError(t, err)
+	require.NoError(t, mgr.Transition(context.Background(), sid, events.StateRunning))
+
+	w := new(mockWorkerForHandler)
+	w.conn = noopworker.NewConn(sid, "user1")
+	w.On("StopCurrentTurn", mock.Anything).Return(errors.New("stop must not be called")).Maybe()
+	w.On("Terminate", mock.Anything).Return(nil).Maybe()
+	mgr.AttachWorker(context.Background(), sid, w)
+
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: hub, SM: mgr})
+	handler.bridge = bridge
+	bridge.bindWorkerRun(sid, w, "run-stop-ledger-failure")
+	handler.executionStore = &fakeExecutionStore{latestErr: errors.New("injected ledger outage")}
+
+	env := controlEnvelope(sid, string(events.ControlActionStop))
+	env.OwnerID = "user1"
+	err = handler.handleControl(context.Background(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop execution identity unavailable")
+	w.AssertNotCalled(t, "StopCurrentTurn", mock.Anything)
+	require.True(t, handler.stopFence.Claim(sid, "run-stop-ledger-failure", "exec-stop-ledger-failure"),
+		"lookup failure must not mutate the exact stop fence")
 }
 
 func TestHandleControl_Terminate_Unauthorized(t *testing.T) {

--- a/internal/gateway/deps.go
+++ b/internal/gateway/deps.go
@@ -43,6 +43,8 @@ type BridgeDeps struct {
 	RetryCtrl              *LLMRetryController
 	AgentConfigDir         string
 	TurnTimeout            time.Duration
+	StopTeardownTimeout    time.Duration            // optional; zero uses the 8s server-side run-stop budget
+	StopForwarderTimeout   time.Duration            // optional; zero uses the 1s post-teardown settle budget
 	WorkerEnv              []string                 // extra env vars from worker.environment config
 	WorkerEnvBlocklist     []string                 // extra blocklist entries from worker.env_blocklist config
 	CronEnv                []string                 // env vars injected only into cron platform sessions (e.g. admin API creds)

--- a/internal/gateway/dispatch_acceptance.go
+++ b/internal/gateway/dispatch_acceptance.go
@@ -1,0 +1,38 @@
+package gateway
+
+import "sync"
+
+// runAcceptedDispatch releases an orchestration admission as soon as the
+// provider has accepted a turn, while still returning the adapter's eventual
+// completion result to the caller. The result channel is buffered so an
+// adapter completing concurrently with acceptance never leaks its goroutine.
+func runAcceptedDispatch(dispatch func(accepted func()) error, release func()) (bool, error) {
+	acceptedCh := make(chan struct{})
+	resultCh := make(chan error, 1)
+	var acceptedOnce sync.Once
+	accepted := func() {
+		acceptedOnce.Do(func() { close(acceptedCh) })
+	}
+
+	go func() {
+		resultCh <- dispatch(accepted)
+	}()
+
+	select {
+	case <-acceptedCh:
+		release()
+		return true, <-resultCh
+	case err := <-resultCh:
+		// A fast success without an explicit callback is still a completed
+		// delivery. An error means the request was not accepted. Either way,
+		// this admission no longer protects useful work.
+		wasAccepted := false
+		select {
+		case <-acceptedCh:
+			wasAccepted = true
+		default:
+		}
+		release()
+		return wasAccepted, err
+	}
+}

--- a/internal/gateway/dispatch_acceptance.go
+++ b/internal/gateway/dispatch_acceptance.go
@@ -1,6 +1,11 @@
 package gateway
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
+
+var errWorkerDispatchPanic = errors.New("worker dispatch panicked")
 
 // runAcceptedDispatch releases an orchestration admission as soon as the
 // provider has accepted a turn, while still returning the adapter's eventual
@@ -15,7 +20,7 @@ func runAcceptedDispatch(dispatch func(accepted func()) error, release func()) (
 	}
 
 	go func() {
-		resultCh <- dispatch(accepted)
+		resultCh <- invokeAcceptedDispatch(dispatch, accepted)
 	}()
 
 	select {
@@ -35,4 +40,13 @@ func runAcceptedDispatch(dispatch func(accepted func()) error, release func()) (
 		release()
 		return wasAccepted, err
 	}
+}
+
+func invokeAcceptedDispatch(dispatch func(accepted func()) error, accepted func()) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errWorkerDispatchPanic
+		}
+	}()
+	return dispatch(accepted)
 }

--- a/internal/gateway/dispatch_acceptance.go
+++ b/internal/gateway/dispatch_acceptance.go
@@ -7,11 +7,13 @@ import (
 
 var errWorkerDispatchPanic = errors.New("worker dispatch panicked")
 
-// runAcceptedDispatch releases an orchestration admission as soon as the
-// provider has accepted a turn, while still returning the adapter's eventual
-// completion result to the caller. The result channel is buffered so an
-// adapter completing concurrently with acceptance never leaks its goroutine.
-func runAcceptedDispatch(dispatch func(accepted func()) error, release func()) (bool, error) {
+// runAcceptedDispatch finalizes provider acceptance before releasing an
+// orchestration admission, while still returning the adapter's eventual
+// completion result to the caller. This ordering prevents a concurrent stop
+// from publishing its terminal before the accepted input's durable side
+// effects. The result channel is buffered so an adapter completing concurrently
+// with acceptance never leaks its goroutine.
+func runAcceptedDispatch(dispatch func(accepted func()) error, onAccepted, release func()) (bool, error) {
 	acceptedCh := make(chan struct{})
 	resultCh := make(chan error, 1)
 	var acceptedOnce sync.Once
@@ -25,20 +27,31 @@ func runAcceptedDispatch(dispatch func(accepted func()) error, release func()) (
 
 	select {
 	case <-acceptedCh:
-		release()
+		finalizeAcceptedDispatch(onAccepted, release)
 		return true, <-resultCh
 	case err := <-resultCh:
 		// A fast success without an explicit callback is still a completed
-		// delivery. An error means the request was not accepted. Either way,
-		// this admission no longer protects useful work.
-		wasAccepted := false
+		// delivery. An error without a callback means the request was not
+		// accepted. Either way, this admission no longer protects useful work.
+		wasAccepted := err == nil
 		select {
 		case <-acceptedCh:
 			wasAccepted = true
 		default:
 		}
-		release()
+		if wasAccepted {
+			finalizeAcceptedDispatch(onAccepted, release)
+		} else {
+			release()
+		}
 		return wasAccepted, err
+	}
+}
+
+func finalizeAcceptedDispatch(onAccepted, release func()) {
+	defer release()
+	if onAccepted != nil {
+		onAccepted()
 	}
 }
 

--- a/internal/gateway/dispatch_acceptance_test.go
+++ b/internal/gateway/dispatch_acceptance_test.go
@@ -28,7 +28,7 @@ func TestRunAcceptedDispatch_RecoversDispatchPanic(t *testing.T) {
 					markAccepted()
 				}
 				panic("injected dispatch panic")
-			}, func() {
+			}, nil, func() {
 				releases.Add(1)
 			})
 
@@ -37,4 +37,54 @@ func TestRunAcceptedDispatch_RecoversDispatchPanic(t *testing.T) {
 			require.EqualValues(t, 1, releases.Load())
 		})
 	}
+}
+
+func TestRunAcceptedDispatch_FinalizesAcceptanceBeforeRelease(t *testing.T) {
+	t.Parallel()
+
+	var finalized atomic.Bool
+	accepted, err := runAcceptedDispatch(func(markAccepted func()) error {
+		markAccepted()
+		return nil
+	}, func() {
+		finalized.Store(true)
+	}, func() {
+		require.True(t, finalized.Load(), "acceptance side effects must precede admission release")
+	})
+
+	require.True(t, accepted)
+	require.NoError(t, err)
+}
+
+func TestRunAcceptedDispatch_FastSuccessFinalizesAcceptance(t *testing.T) {
+	t.Parallel()
+
+	var finalized atomic.Bool
+	accepted, err := runAcceptedDispatch(func(func()) error {
+		return nil
+	}, func() {
+		finalized.Store(true)
+	}, func() {
+		require.True(t, finalized.Load(), "successful return is completed delivery")
+	})
+
+	require.True(t, accepted)
+	require.NoError(t, err)
+}
+
+func TestRunAcceptedDispatch_AcceptancePanicStillReleases(t *testing.T) {
+	t.Parallel()
+
+	var releases atomic.Int32
+	require.Panics(t, func() {
+		_, _ = runAcceptedDispatch(func(markAccepted func()) error {
+			markAccepted()
+			return nil
+		}, func() {
+			panic("injected acceptance finalization panic")
+		}, func() {
+			releases.Add(1)
+		})
+	})
+	require.EqualValues(t, 1, releases.Load())
 }

--- a/internal/gateway/dispatch_acceptance_test.go
+++ b/internal/gateway/dispatch_acceptance_test.go
@@ -1,0 +1,40 @@
+package gateway
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunAcceptedDispatch_RecoversDispatchPanic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		acceptBefore bool
+	}{
+		{name: "before acceptance"},
+		{name: "after acceptance", acceptBefore: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var releases atomic.Int32
+			accepted, err := runAcceptedDispatch(func(markAccepted func()) error {
+				if tt.acceptBefore {
+					markAccepted()
+				}
+				panic("injected dispatch panic")
+			}, func() {
+				releases.Add(1)
+			})
+
+			require.Equal(t, tt.acceptBefore, accepted)
+			require.ErrorIs(t, err, errWorkerDispatchPanic)
+			require.EqualValues(t, 1, releases.Load())
+		})
+	}
+}

--- a/internal/gateway/dispatch_gate.go
+++ b/internal/gateway/dispatch_gate.go
@@ -1,0 +1,34 @@
+package gateway
+
+import "sync"
+
+const sessionDispatchStripeCount = 64
+
+// sessionDispatchGate serializes the short accept/dispatch critical section
+// for one session without retaining an unbounded session-keyed mutex map.
+// Hash collisions only add temporary serialization; they do not affect
+// correctness.
+type sessionDispatchGate struct {
+	stripes [sessionDispatchStripeCount]sync.Mutex
+}
+
+func (g *sessionDispatchGate) Lock(sessionID string) func() {
+	mu := &g.stripes[sessionDispatchStripe(sessionID)]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// sessionDispatchStripe uses allocation-free FNV-1a. The stripe count is a
+// power of two, so the mask is equivalent to modulo without a division.
+func sessionDispatchStripe(sessionID string) int {
+	const (
+		offset32 = uint32(2166136261)
+		prime32  = uint32(16777619)
+	)
+	hash := offset32
+	for i := 0; i < len(sessionID); i++ {
+		hash ^= uint32(sessionID[i])
+		hash *= prime32
+	}
+	return int(hash & (sessionDispatchStripeCount - 1))
+}

--- a/internal/gateway/dispatch_gate_test.go
+++ b/internal/gateway/dispatch_gate_test.go
@@ -1,0 +1,64 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionDispatchGate_SerializesSameSession(t *testing.T) {
+	t.Parallel()
+
+	var gate sessionDispatchGate
+	unlockFirst := gate.Lock("session-one")
+	secondAcquired := make(chan struct{})
+	go func() {
+		unlockSecond := gate.Lock("session-one")
+		close(secondAcquired)
+		unlockSecond()
+	}()
+
+	require.Never(t, func() bool {
+		select {
+		case <-secondAcquired:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond, "same-session acquisition must wait")
+
+	unlockFirst()
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("same-session acquisition did not proceed after release")
+	}
+}
+
+func TestSessionDispatchGate_AllowsDifferentStripes(t *testing.T) {
+	t.Parallel()
+
+	const firstSession = "session-one"
+	secondSession := "session-two"
+	for sessionDispatchStripe(firstSession) == sessionDispatchStripe(secondSession) {
+		secondSession += "-next"
+	}
+
+	var gate sessionDispatchGate
+	unlockFirst := gate.Lock(firstSession)
+	defer unlockFirst()
+
+	secondAcquired := make(chan struct{})
+	go func() {
+		unlockSecond := gate.Lock(secondSession)
+		close(secondAcquired)
+		unlockSecond()
+	}()
+
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("different dispatch stripes must not block each other")
+	}
+}

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -35,7 +35,10 @@ import (
 
 // LevelTrace is one step below slog.LevelDebug, for high-volume protocol
 // chatter (ping/pong) that should not appear even at debug level.
-const LevelTrace = slog.Level(-8)
+const (
+	LevelTrace                 = slog.Level(-8)
+	stopRuntimeFinalizeTimeout = 500 * time.Millisecond
+)
 
 // ─── Message Handler ─────────────────────────────────────────────────────────
 
@@ -53,6 +56,7 @@ type Handler struct {
 	repairer        *execution.Repairer
 	ownerInstanceID string
 	stopFence       turnStopFence
+	dispatchGate    sessionDispatchGate
 
 	// catalogStore is the session-scoped merged command catalog (spec §5.2).
 	// catalogGen tracks the per-session generation bumped on /reset, /cd, and
@@ -1214,6 +1218,14 @@ func (h *Handler) deliverSkillToWorker(ctx context.Context, env *events.Envelope
 }
 
 func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *events.Envelope, content string, invocation *worker.NativeCommandInvocation, handleBusy bool) error {
+	unlockDispatch := h.dispatchGate.Lock(env.SessionID)
+	dispatchLocked := true
+	defer func() {
+		if dispatchLocked {
+			unlockDispatch()
+		}
+	}()
+
 	inputReceivedAt := time.Now()
 	si, err := h.sm.Get(ctx, env.SessionID)
 	if err != nil {
@@ -1236,6 +1248,11 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 			if !handleBusy {
 				return execution.ErrSessionBusy
 			}
+			// Supplement handling can re-enter normal primary delivery after
+			// re-checking the active execution. Release this non-reentrant gate
+			// before that path to avoid self-deadlock.
+			unlockDispatch()
+			dispatchLocked = false
 			return h.handleSupplementOnBusy(ctx, env, content, invocation)
 		}
 		h.log.Error("gateway: persist input acceptance failed", "err", err, "session_id", env.SessionID)
@@ -1748,7 +1765,9 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 	if h.executionStore == nil {
 		return
 	}
-	rec, err := h.executionStore.OpenBySession(ctx, sessionID)
+	finishCtx, finishCancel := context.WithTimeout(context.WithoutCancel(ctx), stopRuntimeFinalizeTimeout)
+	defer finishCancel()
+	rec, err := h.executionStore.OpenBySession(finishCtx, sessionID)
 	if err != nil {
 		return
 	}
@@ -1758,7 +1777,7 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 	errorCode := string(events.ErrCodeSessionTerminated)
 
 	err = h.executionStore.FinishRuntime(
-		context.WithoutCancel(ctx), rec.ExecutionID, workerRunID, rtStatus, errorCode,
+		finishCtx, rec.ExecutionID, workerRunID, rtStatus, errorCode,
 	)
 	if err != nil {
 		h.log.Warn("gateway: finish runtime on stop failed, enqueuing repair", "err", err, "session_id", sessionID, observability.KeyExecutionID, rec.ExecutionID)
@@ -1779,7 +1798,7 @@ func (h *Handler) finishRuntimeOnStop(ctx context.Context, sessionID, workerRunI
 		ErrorCode:   events.ErrorCode(errorCode),
 	})
 	rtEnv.OwnerID = ownerID
-	_ = h.hub.SendToSession(ctx, rtEnv)
+	_ = h.hub.SendToSession(finishCtx, rtEnv)
 }
 
 func (h *Handler) sendInputAck(ctx context.Context, source *events.Envelope, record *execution.Record, duplicate bool) {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -1362,9 +1362,11 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 
 	var w worker.Worker
 	workerRunID := ""
+	workerRunBound := false
 	if h.bridge != nil {
 		var ok bool
 		w, workerRunID, ok = h.bridge.CurrentWorkerBinding(env.SessionID)
+		workerRunBound = ok
 		if !ok && si.State.IsActive() && h.bridge.sm != nil {
 			h.log.Info("gateway: auto-resuming active session lacking worker binding", "session_id", env.SessionID, "state", si.State)
 			resumeCtx, resumeCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -1385,6 +1387,7 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 				return h.sendErrorf(ctx, env, events.ErrCodeSessionNotFound, "session not found after resume")
 			}
 			w, workerRunID, ok = h.bridge.CurrentWorkerBinding(env.SessionID)
+			workerRunBound = ok
 		}
 		if !ok {
 			if h.executionStore != nil {
@@ -1438,6 +1441,13 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 		}
 		h.log.Debug("gateway: delivering input to worker", "session_id", env.SessionID, "content_len", len(content), "preview", preview)
 	}
+	if h.bridge != nil && workerRunBound {
+		if err := h.bridge.beginWorkerRunTurn(ctx, env.SessionID, workerRunID); err != nil {
+			h.finishRuntimeWithoutDispatch(ctx, execRecord, workerRunID, events.ErrCodeInternalError)
+			finishOutcome(execution.StatusFailed, events.ErrCodeInternalError)
+			return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "worker turn admission failed")
+		}
+	}
 
 	// Stamp the turn start immediately before delivery so the Done-bound timer
 	// measures only this turn's processing, excluding inter-turn idle
@@ -1470,6 +1480,29 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 			unlockDispatch()
 			dispatchLocked = false
 		}
+	}
+	var acceptanceErr error
+	finalizeAcceptance := func() {
+		captureInbound()
+		if h.bridge != nil && execRecord != nil {
+			h.bridge.markTurnWorkerAccepted(env.SessionID, execRecord.ExecutionID)
+		}
+		if err := h.finishInputExecution(ctx, execRecord, execution.StatusDelivered, ""); err != nil {
+			h.log.Error("gateway: persist delivered input status failed", "err", err,
+				"session_id", env.SessionID, observability.KeyExecutionID, execRecord.ExecutionID)
+			// The worker accepted the input but the durable status write failed —
+			// treat the outcome as ambiguous for the client.
+			execRecord.Status = execution.StatusUnknown
+			execRecord.ErrorCode = string(events.ErrCodeInternalError)
+			finalized = true
+			h.sendInputAck(ctx, env, execRecord, false)
+			acceptanceErr = h.sendErrorf(ctx, env, events.ErrCodeInternalError, "input delivery status is unknown")
+			return
+		}
+		finalized = true
+		h.sendInputAck(ctx, env, execRecord, false)
+		h.log.Debug("gateway: input delivered to worker", "session_id", env.SessionID)
+		h.emitAudit(audit.OutcomeSuccess, env.OwnerID, si.Platform, env.SessionID, content)
 	}
 	if invocation != nil {
 		resolvedInvocation := *invocation
@@ -1538,11 +1571,14 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 		}
 		dispatchAccepted, inputErr = runAcceptedDispatch(func(accepted func()) error {
 			return worker.DispatchNativeCommand(ctx, w, invoker, *invocation, accepted)
-		}, releaseDispatch)
+		}, finalizeAcceptance, releaseDispatch)
 	} else {
 		dispatchAccepted, inputErr = runAcceptedDispatch(func(accepted func()) error {
 			return worker.DispatchInput(ctx, w, content, nil, accepted)
-		}, releaseDispatch)
+		}, finalizeAcceptance, releaseDispatch)
+	}
+	if acceptanceErr != nil {
+		return acceptanceErr
 	}
 	if inputErr != nil && dispatchAccepted {
 		// A stop may make a blocking adapter's already-accepted RPC return a
@@ -1555,8 +1591,22 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 		unlockStopDecision()
 		if stopped {
 			h.log.Debug("gateway: accepted input ended by successful stop", "session_id", env.SessionID)
-			inputErr = nil
+			return nil
 		}
+		var we *worker.WorkerError
+		if errors.As(inputErr, &we) && we.Kind == worker.ErrKindTimeout {
+			h.log.Info("gateway: accepted worker input timed out (worker still processing)", "session_id", env.SessionID)
+			return nil
+		}
+		h.log.Warn("gateway: accepted worker input failed", "err", inputErr, "session_id", env.SessionID)
+		code := classifyWorkerError(inputErr)
+		if code == events.ErrCodeSessionTerminated && h.bridge != nil {
+			h.bridge.cleanupCrashedWorker(env.SessionID, w)
+		}
+		// Provider acceptance already committed and audited the delivery as
+		// successful. Surface the later turn error without emitting a conflicting
+		// second audit outcome for the same input action.
+		return h.sendErrorf(ctx, env, code, "worker input failed: %v", inputErr)
 	}
 	if inputErr != nil {
 		var we *worker.WorkerError
@@ -1586,29 +1636,6 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 		h.emitAudit(audit.OutcomeFailure, env.OwnerID, si.Platform, env.SessionID, content)
 		return h.sendErrorf(ctx, env, code, "worker input failed: %v", inputErr)
 	}
-	// Worker.Input returned successfully, so this is the first point at which
-	// the accepted input is known to have reached the worker. Capture exactly
-	// once here; timeout paths call the same guard above, while hard failures do
-	// not create an unmatched user turn.
-	captureInbound()
-	if h.bridge != nil && execRecord != nil {
-		h.bridge.markTurnWorkerAccepted(env.SessionID, execRecord.ExecutionID)
-	}
-	if err := h.finishInputExecution(ctx, execRecord, execution.StatusDelivered, ""); err != nil {
-		h.log.Error("gateway: persist delivered input status failed", "err", err,
-			"session_id", env.SessionID, observability.KeyExecutionID, execRecord.ExecutionID)
-		// The worker accepted the input but the durable status write failed —
-		// treat the outcome as ambiguous for the client.
-		execRecord.Status = execution.StatusUnknown
-		execRecord.ErrorCode = string(events.ErrCodeInternalError)
-		finalized = true
-		h.sendInputAck(ctx, env, execRecord, false)
-		return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "input delivery status is unknown")
-	}
-	finalized = true
-	h.sendInputAck(ctx, env, execRecord, false)
-	h.log.Debug("gateway: input delivered to worker", "session_id", env.SessionID)
-	h.emitAudit(audit.OutcomeSuccess, env.OwnerID, si.Platform, env.SessionID, content)
 	return nil
 }
 

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -1461,7 +1461,16 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 	}
 	h.stopFence.BeginTurn(env.SessionID, workerRunID, execID)
 
-	var inputErr error
+	var (
+		dispatchAccepted bool
+		inputErr         error
+	)
+	releaseDispatch := func() {
+		if dispatchLocked {
+			unlockDispatch()
+			dispatchLocked = false
+		}
+	}
 	if invocation != nil {
 		resolvedInvocation := *invocation
 		if resolvedInvocation.Mode == "" {
@@ -1527,9 +1536,27 @@ func (h *Handler) deliverToWorkerWithBusyHandling(ctx context.Context, env *even
 			return h.sendErrorf(ctx, env, events.ErrCodeNotSupported,
 				"worker %s does not support native Skill invocation", w.Type())
 		}
-		inputErr = invoker.InvokeNativeCommand(ctx, *invocation)
+		dispatchAccepted, inputErr = runAcceptedDispatch(func(accepted func()) error {
+			return worker.DispatchNativeCommand(ctx, w, invoker, *invocation, accepted)
+		}, releaseDispatch)
 	} else {
-		inputErr = w.Input(ctx, content, nil)
+		dispatchAccepted, inputErr = runAcceptedDispatch(func(accepted func()) error {
+			return worker.DispatchInput(ctx, w, content, nil, accepted)
+		}, releaseDispatch)
+	}
+	if inputErr != nil && dispatchAccepted {
+		// A stop may make a blocking adapter's already-accepted RPC return a
+		// cancellation error. Re-enter the session gate so an in-flight stop
+		// reaches a stable success/failure decision before classifying it. A
+		// successful stop keeps the old Worker's marker set; a failed stop clears
+		// it and the real input error remains visible.
+		unlockStopDecision := h.dispatchGate.Lock(env.SessionID)
+		stopped := w.IsStopped()
+		unlockStopDecision()
+		if stopped {
+			h.log.Debug("gateway: accepted input ended by successful stop", "session_id", env.SessionID)
+			inputErr = nil
+		}
 	}
 	if inputErr != nil {
 		var we *worker.WorkerError

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -357,6 +358,8 @@ func (h *testableHandler) handleGC(ctx context.Context, sessionID, ownerID strin
 // mockWorkerForHandler implements worker.Worker for handler tests.
 type mockWorkerForHandler struct {
 	mock.Mock
+	conn    worker.SessionConn
+	stopped atomic.Bool
 }
 
 func (m *mockWorkerForHandler) Type() worker.WorkerType   { return worker.TypeClaudeCode }
@@ -374,6 +377,7 @@ func (m *mockWorkerForHandler) Start(ctx context.Context, session worker.Session
 	return args.Error(0)
 }
 func (m *mockWorkerForHandler) Input(ctx context.Context, content string, metadata map[string]any) error {
+	m.stopped.Store(false)
 	args := m.Called(ctx, content, metadata)
 	return args.Error(0)
 }
@@ -390,7 +394,7 @@ func (m *mockWorkerForHandler) Wait() (int, error) {
 	args := m.Called()
 	return args.Int(0), args.Error(1)
 }
-func (m *mockWorkerForHandler) Conn() worker.SessionConn { return nil }
+func (m *mockWorkerForHandler) Conn() worker.SessionConn { return m.conn }
 func (m *mockWorkerForHandler) Health() worker.WorkerHealth {
 	args := m.Called()
 	return args.Get(0).(worker.WorkerHealth)
@@ -405,10 +409,14 @@ func (m *mockWorkerForHandler) ResetContext(ctx context.Context) (worker.ResetRe
 }
 func (m *mockWorkerForHandler) StopCurrentTurn(ctx context.Context) error {
 	args := m.Called(ctx)
-	return args.Error(0)
+	err := args.Error(0)
+	if err == nil {
+		m.stopped.Store(true)
+	}
+	return err
 }
 func (m *mockWorkerForHandler) IsStopped() bool {
-	return false
+	return m.stopped.Load()
 }
 
 // ─── handleReset tests ──────────────────────────────────────────────────────

--- a/internal/gateway/input_execution_test.go
+++ b/internal/gateway/input_execution_test.go
@@ -215,7 +215,11 @@ func TestInputExecution_HardWorkerFailureDoesNotCaptureUserTurn(t *testing.T) {
 	w := new(mockWorkerForHandler)
 	sm.On("Get", "s-exec").Return(&session.SessionInfo{State: events.StateRunning, Platform: "webchat"}, nil).Maybe()
 	sm.On("GetWorker", "s-exec").Return(w).Maybe()
-	bridge.workerRuns.Store("s-exec", workerRunBinding{worker: w, id: "run-worker"})
+	bridge.workerRuns.Store("s-exec", workerRunBinding{
+		worker:    w,
+		id:        "run-worker",
+		lifecycle: newWorkerRunLifecycle(nil),
+	})
 	w.On("Input", mock.Anything, "hello", mock.Anything).Return(errors.New("worker rejected input"))
 
 	h := &Handler{
@@ -253,7 +257,11 @@ func TestInputExecution_SuccessCapturesUserTurnOnce(t *testing.T) {
 	w := new(mockWorkerForHandler)
 	sm.On("Get", "s-exec").Return(&session.SessionInfo{State: events.StateRunning, Platform: "webchat"}, nil).Maybe()
 	sm.On("GetWorker", "s-exec").Return(w).Maybe()
-	bridge.workerRuns.Store("s-exec", workerRunBinding{worker: w, id: "run-worker"})
+	bridge.workerRuns.Store("s-exec", workerRunBinding{
+		worker:    w,
+		id:        "run-worker",
+		lifecycle: newWorkerRunLifecycle(nil),
+	})
 	w.On("Input", mock.Anything, "hello", mock.Anything).Return(nil)
 
 	h := &Handler{
@@ -303,7 +311,11 @@ func TestInputExecution_DispatchUsesAtomicBridgeBinding(t *testing.T) {
 	bridgeSM.On("GetWorker", "s-exec").Return(boundWorker)
 	boundWorker.On("Input", mock.Anything, "hello", mock.Anything).Return(nil)
 	b := &Bridge{sm: bridgeSM, log: testLogger(t)}
-	b.workerRuns.Store("s-exec", workerRunBinding{worker: boundWorker, id: "run-bound"})
+	b.workerRuns.Store("s-exec", workerRunBinding{
+		worker:    boundWorker,
+		id:        "run-bound",
+		lifecycle: newWorkerRunLifecycle(nil),
+	})
 
 	hub := newTestHub(t)
 	conn := &mockPlatformConn{}
@@ -335,7 +347,11 @@ func TestInputExecution_RefreshesSessionStateAfterAcceptance(t *testing.T) {
 	sm.On("GetWorker", "s-exec").Return(w)
 	w.On("Input", mock.Anything, "hello", mock.Anything).Return(nil)
 	b := &Bridge{sm: sm, log: testLogger(t)}
-	b.workerRuns.Store("s-exec", workerRunBinding{worker: w, id: "run-fresh"})
+	b.workerRuns.Store("s-exec", workerRunBinding{
+		worker:    w,
+		id:        "run-fresh",
+		lifecycle: newWorkerRunLifecycle(nil),
+	})
 
 	hub := newTestHub(t)
 	conn := &mockPlatformConn{}
@@ -481,7 +497,11 @@ func TestInputExecution_TimeoutStillCapturesInboundTurn(t *testing.T) {
 	}, nil).Maybe()
 	sm.On("GetWorker", "s-exec").Return(w).Maybe()
 	bridge.sm = sm
-	bridge.workerRuns.Store("s-exec", workerRunBinding{worker: w, id: "run-worker"})
+	bridge.workerRuns.Store("s-exec", workerRunBinding{
+		worker:    w,
+		id:        "run-worker",
+		lifecycle: newWorkerRunLifecycle(nil),
+	})
 
 	allowAssistant := make(chan struct{})
 	assistantDone := make(chan struct{})

--- a/internal/gateway/input_execution_test.go
+++ b/internal/gateway/input_execution_test.go
@@ -36,6 +36,7 @@ type fakeExecutionStore struct {
 	finishRunID   string
 	finishStatus  execution.RuntimeStatus
 	finishErr     error
+	latestErr     error
 }
 
 func (s *fakeExecutionStore) Accept(_ context.Context, req execution.AcceptRequest) (*execution.Record, bool, error) {
@@ -105,6 +106,9 @@ func (s *fakeExecutionStore) OpenBySession(context.Context, string) (*execution.
 func (s *fakeExecutionStore) LatestBySession(context.Context, string) (*execution.Record, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.latestErr != nil {
+		return nil, s.latestErr
+	}
 	if s.openRecord != nil {
 		return s.openRecord, nil
 	}

--- a/internal/gateway/stop_contract_test.go
+++ b/internal/gateway/stop_contract_test.go
@@ -278,7 +278,7 @@ func runC10QuiescenceTimeout(t *testing.T, profile e2econtract.WorkerProfile) {
 }
 
 func runC11BlockingInputStop(t *testing.T, profile e2econtract.WorkerProfile) {
-	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile, contracttest.WithEventCollector())
 	probe := h.Worker()
 	probe.EnableBlocking()
 	probe.BlockInputCompletion()
@@ -321,7 +321,43 @@ func runC11BlockingInputStop(t *testing.T, profile e2econtract.WorkerProfile) {
 	probe.ReleaseStopCurrentTurn()
 	require.NoError(t, <-stopDone, "C11: stop must complete after dispatch acceptance")
 	require.NoError(t, <-inputDone, "C11: successful stop must absorb the accepted input's cancellation result")
-	require.Zero(t, lifecycleCount(h.Events(), events.Error), "C11: accepted-input cancellation must not emit an error after stop")
+	var log []*events.Envelope
+	require.Eventually(t, func() bool {
+		log = h.Events()
+		for _, env := range log {
+			if env.Event.Type != events.InputAck {
+				continue
+			}
+			ack, ok := env.Event.Data.(events.InputAckData)
+			if ok && ack.Status == events.ExecutionStatusDelivered {
+				return true
+			}
+		}
+		return false
+	}, lifecycleWaitTimeout, lifecycleWaitPoll,
+		"C11: provider acceptance must eventually emit delivered input.ack")
+	require.Zero(t, lifecycleCount(log, events.Error), "C11: accepted-input cancellation must not emit an error after stop")
+	stoppedIndex := -1
+	deliveredIndex := -1
+	for i, env := range log {
+		if env.Event.Type == events.Done && lifecycleDoneReason(env) == "stopped_by_user" {
+			stoppedIndex = i
+		}
+		if env.Event.Type == events.InputAck {
+			ack, ok := env.Event.Data.(events.InputAckData)
+			if ok && ack.Status == events.ExecutionStatusDelivered {
+				deliveredIndex = i
+			}
+		}
+	}
+	require.NotEqual(t, -1, stoppedIndex, "C11: stop must emit stopped_by_user done")
+	require.NotEqual(t, -1, deliveredIndex, "C11: provider acceptance must emit delivered input.ack")
+	require.Less(t, deliveredIndex, stoppedIndex,
+		"C11: accepted-input delivery side effects must commit before the stop terminal")
+	for _, env := range log[stoppedIndex+1:] {
+		require.NotEqual(t, events.InputAck, env.Event.Type,
+			"C11: an accepted input must not emit input.ack after stopped_by_user done")
+	}
 }
 
 func runC12StaleStopClaim(t *testing.T, profile e2econtract.WorkerProfile) {

--- a/internal/gateway/stop_contract_test.go
+++ b/internal/gateway/stop_contract_test.go
@@ -12,17 +12,19 @@ package gateway_test
 // The probe blocks its fixture terminal behind a channel gate so the stops
 // deterministically arrive while the turn is live (no time.Sleep).
 //
-// C05-next-turn: after a stopped turn, the next input on the SAME session must
-// clear the per-turn stopped state (probe Input reset + gateway fence
-// BeginTurn) and complete normally — two inputs total, the second terminal's
-// reason is NOT stopped_by_user, session ID unchanged.
+// C05-next-turn: after a stopped turn, the next input on the SAME logical
+// session must create a replacement Worker/run and complete normally — two
+// inputs total, the second terminal's reason is NOT stopped_by_user, session
+// ID unchanged.
 //
 // C04-stop-failure-retry: a real StopCurrentTurn failure (worker abort error)
 // must roll the fence back and send NO stopped done; a manual retry then
 // claims again and converges to exactly one stopped_by_user terminal.
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/e2econtract"
 	"github.com/hrygo/hotplex/internal/gateway/contracttest"
+	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -52,6 +55,237 @@ func TestWorkerLifecycleContract(t *testing.T) {
 			runC04StopFailureRetry(t, profile)
 		})
 	}
+}
+
+func TestWorkerRunQuiescenceContract(t *testing.T) {
+	profile := lifecycleGatewayProfile(t)
+
+	t.Run("C06-late-event-quarantine", func(t *testing.T) {
+		runC06LateEventQuarantine(t, profile)
+	})
+	t.Run("C07-done-after-quiescence", func(t *testing.T) {
+		runC07DoneAfterQuiescence(t, profile)
+	})
+	t.Run("C08-stop-input-race", func(t *testing.T) {
+		runC08StopInputRace(t, profile)
+	})
+	t.Run("C09-teardown-fallback", func(t *testing.T) {
+		runC09TeardownFallback(t, profile)
+	})
+	t.Run("C10-quiescence-timeout", func(t *testing.T) {
+		runC10QuiescenceTimeout(t, profile)
+	})
+}
+
+func lifecycleGatewayProfile(t *testing.T) e2econtract.WorkerProfile {
+	t.Helper()
+	for _, profile := range e2econtract.WorkerProfiles() {
+		if profile.Type == worker.TypeClaudeCode {
+			return profile
+		}
+	}
+	t.Fatal("gateway lifecycle profile for claudecode not found")
+	return e2econtract.WorkerProfile{}
+}
+
+func runC06LateEventQuarantine(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile, contracttest.WithEventCollector())
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.EmitLateEventsOnDispose()
+	defer probe.ReleaseTerminal()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c06 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C06")
+	require.NoError(t, <-inputDone, "C06: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), stop), "C06: stop must quiesce the old run")
+
+	// Reproduce the pre-fix post-done window as well. After the fix the frozen
+	// connection and forwarder are already closed, so these writes remain only
+	// in the probe's private attempted-emission log.
+	probe.EmitLateEventsNow()
+	require.True(t, envelopesContainLateRun(probe.Events()), "C06: probe must attempt late-run events")
+	require.Never(t, func() bool {
+		return envelopesContainLateRun(h.Events())
+	}, 250*time.Millisecond, 5*time.Millisecond, "C06: late-run events must not reach the client")
+
+	for _, stored := range h.StoredEvents(t) {
+		require.NotContains(t, string(stored.Data), "late_run_", "C06: late-run event must not be persisted")
+	}
+	h.AssertSingleTerminal(t, "stopped_by_user")
+}
+
+func runC07DoneAfterQuiescence(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockWait()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseWait()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c07 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C07")
+	require.NoError(t, <-inputDone, "C07: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+
+	select {
+	case <-probe.WaitEntered():
+	case <-time.After(lifecycleWaitTimeout):
+		t.Fatal("C07: forwarder never reached Worker.Wait")
+	}
+	require.Never(t, func() bool {
+		return stoppedDoneCount(h.Events()) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond, "C07: stopped done must wait for forwarder exit")
+
+	probe.ReleaseWait()
+	require.NoError(t, <-stopDone, "C07: stop must complete after forwarder exit")
+	waitTerminalCount(t, h, 1, "C07: stopped done must arrive after quiescence")
+	require.Equal(t, 1, stoppedDoneCount(h.Events()), "C07: exactly one stopped done")
+}
+
+func runC08StopInputRace(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	oldProbe := h.Worker()
+	oldProbe.EnableBlocking()
+	oldProbe.BlockStopCurrentTurn()
+	defer oldProbe.ReleaseTerminal()
+	defer oldProbe.ReleaseStopCurrentTurn()
+
+	sessionID := h.SessionID()
+	input1 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c08 first"})
+	input1.OwnerID = "contract-user"
+	input1Done := make(chan error, 1)
+	go func() { input1Done <- h.Handler.Handle(context.Background(), input1) }()
+	waitEnteredTurn(t, oldProbe, "C08")
+	require.NoError(t, <-input1Done, "C08: first input must be delivered")
+	_, oldRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C08: old run binding must exist")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+	select {
+	case <-oldProbe.StopEntered():
+	case <-time.After(lifecycleWaitTimeout):
+		t.Fatal("C08: stop never reached the old Worker")
+	}
+
+	input2 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c08 second"})
+	input2.OwnerID = "contract-user"
+	input2Done := make(chan error, 1)
+	go func() { input2Done <- h.Handler.Handle(context.Background(), input2) }()
+	select {
+	case err := <-input2Done:
+		require.FailNow(t, "C08: next input bypassed the stop dispatch gate", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	oldProbe.ReleaseStopCurrentTurn()
+	require.NoError(t, <-stopDone, "C08: stop must complete")
+	require.NoError(t, <-input2Done, "C08: next input must dispatch after stop")
+
+	require.Eventually(t, func() bool {
+		return h.Worker() != oldProbe
+	}, lifecycleWaitTimeout, lifecycleWaitPoll, "C08: next input must create a replacement Worker")
+	newProbe := h.Worker()
+	boundWorker, newRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C08: replacement run binding must exist")
+	require.Same(t, newProbe, boundWorker, "C08: replacement binding must own the next input")
+	require.NotEqual(t, oldRunID, newRunID, "C08: replacement run ID must change")
+	require.Equal(t, 1, oldProbe.InputCalls(), "C08: old Worker must receive only the first input")
+	require.Equal(t, 1, newProbe.InputCalls(), "C08: replacement Worker must receive the second input once")
+}
+
+func runC09TeardownFallback(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.FailNextTerminate()
+	defer probe.ReleaseTerminal()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c09 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C09")
+	require.NoError(t, <-inputDone, "C09: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), stop), "C09: Kill fallback must quiesce the run")
+	require.Equal(t, 1, probe.TerminateCalls(), "C09: Terminate must be attempted once")
+	require.Equal(t, 1, probe.KillCalls(), "C09: failed Terminate must trigger one Kill")
+	h.AssertSingleTerminal(t, "stopped_by_user")
+}
+
+func runC10QuiescenceTimeout(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(
+		t, e2econtract.PlatformWebChat, profile,
+		contracttest.WithStopTimeouts(50*time.Millisecond, 50*time.Millisecond),
+	)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockWait()
+	probe.EmitLateEventsOnDispose()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseWait()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c10 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C10")
+	require.NoError(t, <-inputDone, "C10: input must be delivered before stop")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	err := h.Handler.Handle(context.Background(), stop)
+	require.Error(t, err, "C10: quiescence timeout must surface an error")
+	require.Zero(t, stoppedDoneCount(h.Events()), "C10: timeout must not send a fake stopped done")
+	_, _, bound := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.False(t, bound, "C10: timed-out old run must be fail-closed and detached")
+	require.Equal(t, events.StateIdle, h.SessionState(t), "C10: logical session must remain resumable")
+	require.Never(t, func() bool {
+		return envelopesContainLateRun(h.Events())
+	}, 100*time.Millisecond, 5*time.Millisecond, "C10: isolated late events must remain invisible")
+}
+
+func envelopesContainLateRun(envelopes []*events.Envelope) bool {
+	for _, env := range envelopes {
+		data, err := json.Marshal(env.Event.Data)
+		if err == nil && bytes.Contains(data, []byte("late_run_")) {
+			return true
+		}
+	}
+	return false
+}
+
+func stoppedDoneCount(envelopes []*events.Envelope) int {
+	count := 0
+	for _, env := range envelopes {
+		if env.Event.Type == events.Done && lifecycleDoneReason(env) == "stopped_by_user" {
+			count++
+		}
+	}
+	return count
 }
 
 // runC04DoubleStop implements the C04 contract: one effective stop, one
@@ -115,6 +349,8 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
 	probe := h.Worker()
 	probe.EnableBlocking()
+	h.EnableProbeBlocking()
+	defer h.DisableProbeBlocking()
 	defer probe.ReleaseTerminal()
 
 	sessionID := h.SessionID()
@@ -126,6 +362,8 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	input1Done := make(chan error, 1)
 	go func() { input1Done <- h.Handler.Handle(context.Background(), input1) }()
 	waitEnteredTurn(t, probe, "C05")
+	_, firstRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C05: first run binding must exist")
 
 	stopEnv := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
 	stopEnv.OwnerID = "contract-user"
@@ -135,21 +373,31 @@ func runC05NextTurn(t *testing.T, profile e2econtract.WorkerProfile) {
 	require.NoError(t, <-input1Done, "C05: first input must settle")
 	waitTerminalCount(t, h, 1, "C05: the stopped turn must produce exactly one terminal")
 
-	// Turn 2: a NEW input ID on the same session; no stop this turn — the
-	// probe's per-turn stopped state was cleared by the new primary turn, so
-	// the fixture turn completes normally.
+	// Turn 2: a NEW input ID on the same logical session; no stop this turn.
+	// The stopped local wrapper was disposed, so auto-resume must attach a fresh
+	// Worker/run while preserving the provider conversation identity.
 	input2 := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c05 second"})
 	input2.OwnerID = "contract-user"
 	input2Done := make(chan error, 1)
 	go func() { input2Done <- h.Handler.Handle(context.Background(), input2) }()
-	waitEnteredTurn(t, probe, "C05")
-	probe.ReleaseTerminal()
+	require.Eventually(t, func() bool {
+		return h.Worker() != probe
+	}, lifecycleWaitTimeout, lifecycleWaitPoll, "C05: next turn must attach a replacement Worker")
+	replacement := h.Worker()
+	defer replacement.ReleaseTerminal()
+	waitEnteredTurn(t, replacement, "C05")
+	_, secondRunID, ok := h.Bridge.CurrentWorkerBinding(sessionID)
+	require.True(t, ok, "C05: replacement run binding must exist")
+	require.NotEqual(t, firstRunID, secondRunID, "C05: stopped and resumed runs must have different IDs")
+	replacement.ReleaseTerminal()
 	require.NoError(t, <-input2Done, "C05: second input must deliver")
 
 	log := waitTerminalCount(t, h, 2, "C05: two turns must produce exactly two terminals")
 
-	// Worker input total 2 across the two turns.
-	require.Equal(t, 2, probe.InputCalls(), "C05: Worker input total must be 2")
+	// Each local Worker receives exactly one turn; the stopped wrapper is never
+	// reused for the next input.
+	require.Equal(t, 1, probe.InputCalls(), "C05: stopped Worker must receive only turn 1")
+	require.Equal(t, 1, replacement.InputCalls(), "C05: replacement Worker must receive only turn 2")
 
 	// Session identity is stable across both turns.
 	for _, env := range log {

--- a/internal/gateway/stop_contract_test.go
+++ b/internal/gateway/stop_contract_test.go
@@ -75,6 +75,15 @@ func TestWorkerRunQuiescenceContract(t *testing.T) {
 	t.Run("C10-quiescence-timeout", func(t *testing.T) {
 		runC10QuiescenceTimeout(t, profile)
 	})
+	t.Run("C11-blocking-input-stop", func(t *testing.T) {
+		runC11BlockingInputStop(t, profile)
+	})
+	t.Run("C12-stale-stop-claim", func(t *testing.T) {
+		runC12StaleStopClaim(t, profile)
+	})
+	t.Run("C13-accepted-input-stop-failure", func(t *testing.T) {
+		runC13AcceptedInputStopFailure(t, profile)
+	})
 }
 
 func lifecycleGatewayProfile(t *testing.T) e2econtract.WorkerProfile {
@@ -266,6 +275,125 @@ func runC10QuiescenceTimeout(t *testing.T, profile e2econtract.WorkerProfile) {
 	require.Never(t, func() bool {
 		return envelopesContainLateRun(h.Events())
 	}, 100*time.Millisecond, 5*time.Millisecond, "C10: isolated late events must remain invisible")
+}
+
+func runC11BlockingInputStop(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockInputCompletion()
+	probe.FailInputAfterAccepted()
+	probe.BlockStopCurrentTurn()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseInputCompletion()
+	defer probe.ReleaseStopCurrentTurn()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c11 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C11")
+
+	select {
+	case err := <-inputDone:
+		require.FailNow(t, "C11: blocking Input returned before its completion gate", "error: %v", err)
+	default:
+	}
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+
+	select {
+	case <-probe.StopEntered():
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("C11: stop was blocked behind the adapter's full-turn Input call")
+	}
+
+	probe.ReleaseInputCompletion()
+	select {
+	case err := <-inputDone:
+		require.FailNow(t, "C11: accepted-input cancellation bypassed the in-flight stop", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	probe.ReleaseStopCurrentTurn()
+	require.NoError(t, <-stopDone, "C11: stop must complete after dispatch acceptance")
+	require.NoError(t, <-inputDone, "C11: successful stop must absorb the accepted input's cancellation result")
+	require.Zero(t, lifecycleCount(h.Events(), events.Error), "C11: accepted-input cancellation must not emit an error after stop")
+}
+
+func runC12StaleStopClaim(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	firstProbe := h.Worker()
+	firstProbe.EnableBlocking()
+	defer firstProbe.ReleaseTerminal()
+
+	sessionID := h.SessionID()
+	firstInput := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c12 first"})
+	firstInput.OwnerID = "contract-user"
+	firstInputDone := make(chan error, 1)
+	go func() { firstInputDone <- h.Handler.Handle(context.Background(), firstInput) }()
+	waitEnteredTurn(t, firstProbe, "C12")
+	require.NoError(t, <-firstInputDone)
+
+	firstStop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	firstStop.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), firstStop), "C12: first turn must establish a retained stop claim")
+
+	secondInput := events.NewEnvelope(aep.NewID(), sessionID, 2, events.Input, map[string]any{"content": "c12 second"})
+	secondInput.OwnerID = "contract-user"
+	require.NoError(t, h.Handler.Handle(context.Background(), secondInput), "C12: next turn must create a new execution")
+	require.NotSame(t, firstProbe, h.Worker(), "C12: next turn must use a replacement Worker")
+
+	// Lose the live binding after the new execution exists. The first turn's
+	// retained claim is stale and must not make this stop look successful.
+	h.DetachWorkerForTest()
+	secondStop := events.NewEnvelope(aep.NewID(), sessionID, 2, events.Control, events.ControlData{Action: events.ControlActionStop})
+	secondStop.OwnerID = "contract-user"
+	err := h.Handler.Handle(context.Background(), secondStop)
+	require.ErrorContains(t, err, "stop: no active worker run")
+}
+
+func runC13AcceptedInputStopFailure(t *testing.T, profile e2econtract.WorkerProfile) {
+	h := contracttest.NewHarness(t, e2econtract.PlatformWebChat, profile)
+	probe := h.Worker()
+	probe.EnableBlocking()
+	probe.BlockInputCompletion()
+	probe.FailInputAfterAccepted()
+	probe.BlockStopCurrentTurn()
+	probe.FailNextStop()
+	defer probe.ReleaseTerminal()
+	defer probe.ReleaseInputCompletion()
+	defer probe.ReleaseStopCurrentTurn()
+
+	sessionID := h.SessionID()
+	input := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Input, map[string]any{"content": "c13 content"})
+	input.OwnerID = "contract-user"
+	inputDone := make(chan error, 1)
+	go func() { inputDone <- h.Handler.Handle(context.Background(), input) }()
+	waitEnteredTurn(t, probe, "C13")
+
+	stop := events.NewEnvelope(aep.NewID(), sessionID, 1, events.Control, events.ControlData{Action: events.ControlActionStop})
+	stop.OwnerID = "contract-user"
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- h.Handler.Handle(context.Background(), stop) }()
+	select {
+	case <-probe.StopEntered():
+	case <-time.After(lifecycleWaitTimeout):
+		t.Fatal("C13: stop never reached the Worker")
+	}
+
+	probe.ReleaseInputCompletion()
+	select {
+	case err := <-inputDone:
+		require.FailNow(t, "C13: input classified before the in-flight stop failed", "error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	probe.ReleaseStopCurrentTurn()
+	require.Error(t, <-stopDone, "C13: injected provider stop failure must surface")
+	require.ErrorContains(t, <-inputDone, "worker input failed", "C13: failed stop must preserve the accepted input error")
 }
 
 func envelopesContainLateRun(envelopes []*events.Envelope) bool {

--- a/internal/gateway/stop_fence.go
+++ b/internal/gateway/stop_fence.go
@@ -54,6 +54,17 @@ func (f *turnStopFence) Claim(sessionID, workerRunID, execID string) bool {
 	return true
 }
 
+// IsClaimed reports whether any successful stop claim remains for sessionID.
+// It is used only after the run binding disappeared: without an execution
+// ledger there is no longer enough identity to rebuild the original composite
+// key, but a repeated stop must still stay idempotent.
+func (f *turnStopFence) IsClaimed(sessionID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.claimed[sessionID]
+	return ok
+}
+
 // Rollback releases the claim after a FAILED StopCurrentTurn so a manual retry
 // can stop again. It only clears when the claim still belongs to the given
 // run/execution — an old run's rollback must not clear a newer claim.

--- a/internal/gateway/stop_fence.go
+++ b/internal/gateway/stop_fence.go
@@ -54,11 +54,21 @@ func (f *turnStopFence) Claim(sessionID, workerRunID, execID string) bool {
 	return true
 }
 
-// IsClaimed reports whether any successful stop claim remains for sessionID.
-// It is used only after the run binding disappeared: without an execution
-// ledger there is no longer enough identity to rebuild the original composite
-// key, but a repeated stop must still stay idempotent.
-func (f *turnStopFence) IsClaimed(sessionID string) bool {
+// Matches reports whether the retained claim belongs to the exact run and
+// execution. Detached-run idempotence must use this whenever either identity
+// is known; a stale claim from an older turn is not evidence that the latest
+// turn was stopped.
+func (f *turnStopFence) Matches(sessionID, workerRunID, execID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	claim, ok := f.claimed[sessionID]
+	return ok && claim == stopClaimKey(workerRunID, execID)
+}
+
+// HasAny is the identity-free fallback for ledger-disabled operation after a
+// detached run leaves no live run ID. Configured-ledger lookup failures must
+// fail closed rather than call this method.
+func (f *turnStopFence) HasAny(sessionID string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	_, ok := f.claimed[sessionID]

--- a/internal/gateway/stop_fence_test.go
+++ b/internal/gateway/stop_fence_test.go
@@ -46,6 +46,7 @@ func TestTurnStopFence_Sequential(t *testing.T) {
 	t.Run("duplicate claim rejected", func(t *testing.T) {
 		f := turnStopFence{}
 		require.True(t, f.Claim("s", "r", "e"), "first claim admitted")
+		require.True(t, f.IsClaimed("s"), "held claim remains observable after its run detaches")
 		require.False(t, f.Claim("s", "r", "e"), "duplicate claim rejected")
 	})
 

--- a/internal/gateway/stop_fence_test.go
+++ b/internal/gateway/stop_fence_test.go
@@ -46,7 +46,9 @@ func TestTurnStopFence_Sequential(t *testing.T) {
 	t.Run("duplicate claim rejected", func(t *testing.T) {
 		f := turnStopFence{}
 		require.True(t, f.Claim("s", "r", "e"), "first claim admitted")
-		require.True(t, f.IsClaimed("s"), "held claim remains observable after its run detaches")
+		require.True(t, f.Matches("s", "r", "e"), "held claim remains observable after its run detaches")
+		require.False(t, f.Matches("s", "r", "next"), "a later execution must not match a stale stop claim")
+		require.True(t, f.HasAny("s"), "identity-free fallback can still observe a retained claim")
 		require.False(t, f.Claim("s", "r", "e"), "duplicate claim rejected")
 	})
 

--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -121,6 +121,21 @@ func (c *ACPClient) ResumeSession(ctx context.Context, sessionID, cwd string, mc
 // Prompt sends a user message to the active session and waits for the response.
 // Notifications received during the prompt are dispatched to NotificationCh.
 func (c *ACPClient) Prompt(ctx context.Context, sessionID, content string) (*PromptResult, error) {
+	return c.prompt(ctx, sessionID, content, nil)
+}
+
+// PromptWithDispatchAccepted is Prompt with an exact JSON-RPC write boundary.
+// The callback runs after the complete session/prompt frame is serialized to
+// the agent stdin, before waiting for the turn's response.
+func (c *ACPClient) PromptWithDispatchAccepted(
+	ctx context.Context,
+	sessionID, content string,
+	accepted func(),
+) (*PromptResult, error) {
+	return c.prompt(ctx, sessionID, content, accepted)
+}
+
+func (c *ACPClient) prompt(ctx context.Context, sessionID, content string, accepted func()) (*PromptResult, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("acp prompt: empty sessionId")
 	}
@@ -130,7 +145,7 @@ func (c *ACPClient) Prompt(ctx context.Context, sessionID, content string) (*Pro
 			{"type": "text", "text": content},
 		},
 	}
-	resp, err := c.call(ctx, "session/prompt", params)
+	resp, err := c.callWithDispatchAccepted(ctx, "session/prompt", params, accepted)
 	if err != nil {
 		return nil, fmt.Errorf("acp prompt: %w", err)
 	}
@@ -299,6 +314,15 @@ func (c *ACPClient) Done() <-chan struct{} { return c.done }
 
 // call sends a JSON-RPC request and blocks until the response arrives or ctx expires.
 func (c *ACPClient) call(ctx context.Context, method string, params any) (*JSONRPCResponse, error) {
+	return c.callWithDispatchAccepted(ctx, method, params, nil)
+}
+
+func (c *ACPClient) callWithDispatchAccepted(
+	ctx context.Context,
+	method string,
+	params any,
+	accepted func(),
+) (*JSONRPCResponse, error) {
 	id := c.nextID.Add(1)
 	idRaw := mustMarshal(id)
 
@@ -331,6 +355,9 @@ func (c *ACPClient) call(ctx context.Context, method string, params any) (*JSONR
 	})
 	if err != nil {
 		return nil, err
+	}
+	if accepted != nil {
+		accepted()
 	}
 
 	select {

--- a/internal/worker/acp/skill.go
+++ b/internal/worker/acp/skill.go
@@ -74,6 +74,18 @@ func (w *Worker) ListInvokableSkills(_ context.Context, _ string) ([]worker.Skil
 // advertised that command. Unknown commands deliberately never fall through
 // to the LLM as ordinary user text.
 func (w *Worker) InvokeSkill(ctx context.Context, invocation worker.SkillInvocation) error {
+	return w.invokeSkill(ctx, invocation, nil)
+}
+
+func (w *Worker) InvokeNativeCommandWithDispatchAccepted(
+	ctx context.Context,
+	invocation worker.NativeCommandInvocation,
+	accepted func(),
+) error {
+	return w.invokeSkill(ctx, worker.SkillInvocation(invocation), accepted)
+}
+
+func (w *Worker) invokeSkill(ctx context.Context, invocation worker.SkillInvocation, accepted func()) error {
 	w.skillMu.RLock()
 	_, advertised := w.availableCommands[invocation.Name]
 	w.skillMu.RUnlock()
@@ -87,5 +99,5 @@ func (w *Worker) InvokeSkill(ctx context.Context, invocation worker.SkillInvocat
 	// Keep explicit invocation payloads intact. ACP's compatibility rules are
 	// only sent with ordinary user text because a prefix could prevent an agent
 	// from recognizing the advertised slash command.
-	return w.input(ctx, command, nil, false)
+	return w.input(ctx, command, nil, false, accepted)
 }

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -539,12 +539,27 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 // ─── Input ───────────────────────────────────────────────────────────────────
 
 func (w *Worker) Input(ctx context.Context, content string, metadata map[string]any) error {
-	return w.input(ctx, content, metadata, true)
+	return w.input(ctx, content, metadata, true, nil)
+}
+
+func (w *Worker) InputWithDispatchAccepted(
+	ctx context.Context,
+	content string,
+	metadata map[string]any,
+	accepted func(),
+) error {
+	return w.input(ctx, content, metadata, true, accepted)
 }
 
 // input is the shared send path for ordinary user turns and explicit skill
 // invocations. Only ordinary text receives the ACP compatibility prefix.
-func (w *Worker) input(ctx context.Context, content string, metadata map[string]any, includeCompatibility bool) error {
+func (w *Worker) input(
+	ctx context.Context,
+	content string,
+	metadata map[string]any,
+	includeCompatibility bool,
+	accepted func(),
+) error {
 	// Check for control responses (permission/question/elicitation).
 	handled, err := base.DispatchMetadata(ctx, metadata, w)
 	if handled {
@@ -598,7 +613,7 @@ func (w *Worker) input(ctx context.Context, content string, metadata map[string]
 	if tw := w.trace.Load(); tw != nil {
 		tw.Log("→", map[string]any{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "contentLen": len(content)})
 	}
-	result, promptErr := w.client.Prompt(pctx, w.GetWorkerSessionID(), content)
+	result, promptErr := w.client.PromptWithDispatchAccepted(pctx, w.GetWorkerSessionID(), content, accepted)
 	if promptErr != nil {
 		// The prompt failed — the new turn never started. If the worker had a
 		// pending user-stop, restore the marker so the previous stop is not

--- a/internal/worker/acp/worker_stop_test.go
+++ b/internal/worker/acp/worker_stop_test.go
@@ -182,3 +182,27 @@ func TestWorker_StopCurrentTurn_CancelErrorStillFails(t *testing.T) {
 	require.Contains(t, err.Error(), "acp cancel")
 	require.False(t, w.IsStopped(), "stopped marker must clear so the gateway can roll back its stop fence")
 }
+
+func TestWorker_StopThenTerminateClosesOnlyCurrentRun(t *testing.T) {
+	t.Parallel()
+
+	live := newACPConn("user-1", "session-1", slog.Default())
+	stopped := &Worker{BaseWorker: base.NewBaseWorker(slog.Default(), nil), conn: live}
+	stopped.SetWorkerSessionID("provider-session-1")
+
+	require.NoError(t, stopped.StopCurrentTurn(context.Background()))
+	require.True(t, stopped.IsStopped())
+	require.NoError(t, stopped.Terminate(context.Background()))
+	require.NoError(t, stopped.Terminate(context.Background()), "teardown must be idempotent after stop")
+	_, open := <-live.Recv()
+	require.False(t, open, "teardown must close the stopped run connection")
+
+	resumed := &Worker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		conn:       newACPConn("user-1", "session-1", slog.Default()),
+	}
+	resumed.SetWorkerSessionID(stopped.GetWorkerSessionID())
+	require.NotSame(t, stopped, resumed)
+	require.Equal(t, "provider-session-1", resumed.GetWorkerSessionID())
+	require.False(t, resumed.IsStopped(), "stopped state must not leak into a fresh run")
+}

--- a/internal/worker/acp/worker_stop_test.go
+++ b/internal/worker/acp/worker_stop_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -92,6 +93,74 @@ func TestWorker_Input_ClearsStoppedOnlyForPrimaryTurn(t *testing.T) {
 		// the conn cached the prompt content for crash recovery.
 		require.Equal(t, acpCompatibilityRules+"\n\nhello again", w.conn.LastInput())
 	})
+}
+
+func TestWorker_InputDispatchAcceptedBeforePromptResponse(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	requestSeen := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		if !scanner.Scan() {
+			return
+		}
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		_ = json.Unmarshal(scanner.Bytes(), &req)
+		close(requestSeen)
+		<-releaseResponse
+		_ = WriteMessage(agentStdoutW, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  mustMarshal(PromptResult{StopReason: "end_turn"}),
+		})
+	}()
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.mapper = newTestMapper()
+	w.conn = newACPConn("user_1", "sess_dispatch", slog.Default())
+	w.SetWorkerSessionID("sess_dispatch")
+	w.drainCh = make(chan struct{}, 1)
+	w.drainDoneCh = make(chan struct{})
+	close(w.drainDoneCh)
+
+	accepted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- w.InputWithDispatchAccepted(ctx, "hello", nil, func() { close(accepted) })
+	}()
+
+	select {
+	case <-requestSeen:
+	case <-time.After(time.Second):
+		t.Fatal("agent did not receive session/prompt")
+	}
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch acceptance was not reported after the prompt write")
+	}
+	select {
+	case err := <-done:
+		require.FailNow(t, "Input returned before the prompt response", "error: %v", err)
+	default:
+	}
+
+	close(releaseResponse)
+	require.NoError(t, <-done)
 }
 
 // TestWorker_StopCurrentTurn_CancelMethodNotFoundDegradesToKill verifies that a

--- a/internal/worker/claudecode/worker_test.go
+++ b/internal/worker/claudecode/worker_test.go
@@ -87,6 +87,26 @@ func TestClaudeCodeWorker_KillWithoutStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClaudeCodeWorker_StopThenTerminateAllowsFreshRun(t *testing.T) {
+	t.Parallel()
+
+	stopped := NewWithMocks()
+	stopped.sessionID = "session-1"
+	stopped.testConn = newMockConn("user-1", "session-1")
+
+	require.NoError(t, stopped.StopCurrentTurn(context.Background()))
+	require.True(t, stopped.IsStopped())
+	require.NoError(t, stopped.Terminate(context.Background()))
+	require.NoError(t, stopped.Terminate(context.Background()), "teardown must be idempotent after stop")
+
+	resumed := NewWithMocks()
+	resumed.sessionID = stopped.sessionID
+	resumed.testConn = newMockConn("user-1", "session-1")
+	require.NotSame(t, stopped, resumed)
+	require.Equal(t, stopped.sessionID, resumed.sessionID, "fresh run must preserve HotPlex session identity")
+	require.False(t, resumed.IsStopped(), "stopped state must not leak into a fresh run")
+}
+
 func TestClaudeCodeWorker_WaitWithoutStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -34,6 +34,8 @@ const (
 
 const (
 	defaultCallTimeout       = 30 * time.Second
+	codexWriteFallbackGrace  = time.Second
+	codexDeadlineWriteGrace  = time.Nanosecond
 	criticalEventSendTimeout = 5 * time.Second
 	scannerInitSize          = 64 * 1024        // 64 KB
 	scannerMaxSize           = 10 * 1024 * 1024 // 10 MB
@@ -488,19 +490,33 @@ func (m *CodexAppServerManager) handshake(ctx context.Context) error {
 // is especially important for Notify, which has no response-wait timeout
 // unlike Call.
 func (m *CodexAppServerManager) writeFrame(ctx context.Context, v any) error {
+	_, callerHasDeadline := ctx.Deadline()
 	// The mutex MUST be acquired inside the closure, not at the call site:
-	// if ctx cancels and WriteWithCtxBounded bails out, an orphaned goroutine
+	// if ctx cancels and WriteWithCtx bails out, an orphaned goroutine
 	// may still be blocked inside Encode → syscall.Write. By locking/unlocking
 	// inside the closure (which runs in the helper's goroutine), the orphan
 	// holds writeMu until the write completes (child exits → EPIPE),
 	// preventing the next writer from racing on the shared stdin fd. This is
 	// especially critical for codexcli: the manager is a singleton, so an
 	// interleaved write would corrupt the protocol stream for ALL sessions.
-	err := base.WriteWithCtxBounded(ctx, func() error {
+	writeCtx := ctx
+	if _, ok := writeCtx.Deadline(); !ok && writeCtx.Err() == nil {
+		var cancel context.CancelFunc
+		writeCtx, cancel = context.WithTimeout(writeCtx, base.DefaultWriteTimeout)
+		defer cancel()
+	}
+	fallbackGrace := codexWriteFallbackGrace
+	if callerHasDeadline {
+		// The caller already budgeted the operation. Do not extend that
+		// deadline: Bridge reserves its following one-second window for local
+		// forwarder quiescence, not for a blocked singleton stdin write.
+		fallbackGrace = codexDeadlineWriteGrace
+	}
+	err := base.WriteWithCtx(writeCtx, func() error {
 		m.writeMu.Lock()
 		defer m.writeMu.Unlock()
 		return json.NewEncoder(m.stdin).Encode(v)
-	})
+	}, fallbackGrace)
 	// An orphaned write (ctx cancelled while syscall.Write is blocked) leaves
 	// the goroutine holding writeMu until the child exits. Because the manager
 	// is a singleton shared across all codex sessions, this wedges EVERY
@@ -1106,8 +1122,8 @@ func (m *CodexAppServerManager) SteerTurn(threadID, expectedTurnID, text string)
 
 // InterruptTurn interrupts the running turn in the specified thread.
 // Upstream TurnInterruptParams (turn.rs:188) requires both threadId and turnId.
-func (m *CodexAppServerManager) InterruptTurn(threadID, turnID string) error {
-	err := m.Notify(context.Background(), "turn/interrupt", map[string]any{
+func (m *CodexAppServerManager) InterruptTurn(ctx context.Context, threadID, turnID string) error {
+	err := m.Notify(ctx, "turn/interrupt", map[string]any{
 		"threadId": threadID,
 		"turnId":   turnID,
 	})

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -431,7 +431,7 @@ func (w *AppServerWorker) closeAndMarkDone() {
 
 // cleanupOldThread closes the old connection and unsubscribes from the
 // old thread. Shared by Resume and ResetContext.
-func (w *AppServerWorker) cleanupOldThread() {
+func (w *AppServerWorker) cleanupOldThread(ctx context.Context) {
 	w.mu.Lock()
 	oldConn := w.conn
 	oldThreadID := w.threadID
@@ -445,7 +445,7 @@ func (w *AppServerWorker) cleanupOldThread() {
 		_ = oldConn.Close()
 	}
 	if oldThreadID != "" && w.manager != nil {
-		_ = w.manager.Notify(context.Background(), "thread/unsubscribe", ThreadUnsubscribeParams{ThreadID: oldThreadID})
+		_ = w.manager.Notify(ctx, "thread/unsubscribe", ThreadUnsubscribeParams{ThreadID: oldThreadID})
 		w.manager.Unsubscribe(oldThreadID)
 	}
 }
@@ -626,7 +626,7 @@ func (w *AppServerWorker) Resume(ctx context.Context, session worker.SessionInfo
 	w.state = appStateStarting
 	w.mu.Unlock()
 
-	w.cleanupOldThread()
+	w.cleanupOldThread(ctx)
 	w.resetLifecycleState()
 	if err := w.startNewThread(session, "resume"); err != nil {
 		return err
@@ -638,11 +638,11 @@ func (w *AppServerWorker) Resume(ctx context.Context, session worker.SessionInfo
 }
 
 func (w *AppServerWorker) Terminate(ctx context.Context) error {
-	w.shutdown()
+	err := w.shutdown(ctx)
 	w.mu.Lock()
 	w.state = appStateTerminated
 	w.mu.Unlock()
-	return nil
+	return err
 }
 
 // StopCurrentTurn stops the current running turn on codex app-server using InterruptTurn.
@@ -655,7 +655,7 @@ func (w *AppServerWorker) StopCurrentTurn(ctx context.Context) error {
 		return nil
 	}
 	w.MarkStopped()
-	if err := w.manager.InterruptTurn(tid, turnID); err != nil {
+	if err := w.manager.InterruptTurn(ctx, tid, turnID); err != nil {
 		// The interrupt never took effect — the turn is still running and the
 		// gateway rolls back its stop fence. Unmark so the turn's completion
 		// is not misread as a user-stop (crash fallback preserved correctly).
@@ -690,11 +690,13 @@ func (w *AppServerWorker) InjectMidTurn(ctx context.Context, content string, met
 }
 
 func (w *AppServerWorker) Kill() error {
-	w.shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), codexWriteFallbackGrace)
+	defer cancel()
+	err := w.shutdown(ctx)
 	w.mu.Lock()
 	w.state = appStateTerminated
 	w.mu.Unlock()
-	return nil
+	return err
 }
 
 // shutdown releases the worker's manager subscription and decrements the
@@ -702,8 +704,8 @@ func (w *AppServerWorker) Kill() error {
 // singleton process is NOT killed here — it stops via idle drain or
 // explicit ShutdownSingleton(). This prevents GC from killing a shared
 // process when reclaiming sessions.
-func (w *AppServerWorker) shutdown() {
-	w.release()
+func (w *AppServerWorker) shutdown(ctx context.Context) error {
+	return w.release(ctx)
 }
 
 func (w *AppServerWorker) Wait() (int, error) {
@@ -726,11 +728,11 @@ func (w *AppServerWorker) Wait() (int, error) {
 	}
 }
 
-func (w *AppServerWorker) release() {
+func (w *AppServerWorker) release(ctx context.Context) error {
 	w.mu.Lock()
 	if w.released || w.closed {
 		w.mu.Unlock()
-		return
+		return nil
 	}
 	w.released = true
 	w.closed = true
@@ -747,8 +749,9 @@ func (w *AppServerWorker) release() {
 		close(doneCh)
 	}
 
+	var unsubscribeErr error
 	if mgr != nil && tid != "" {
-		_ = mgr.Notify(context.Background(), "thread/unsubscribe", ThreadUnsubscribeParams{
+		unsubscribeErr = mgr.Notify(ctx, "thread/unsubscribe", ThreadUnsubscribeParams{
 			ThreadID: tid,
 		})
 		mgr.Unsubscribe(tid)
@@ -760,6 +763,7 @@ func (w *AppServerWorker) release() {
 		}
 		mgr.Release()
 	}
+	return unsubscribeErr
 }
 
 func (w *AppServerWorker) ResetContext(ctx context.Context) (worker.ResetResult, error) {
@@ -771,7 +775,7 @@ func (w *AppServerWorker) ResetContext(ctx context.Context) (worker.ResetResult,
 	origSess := w.origSession
 	w.mu.Unlock()
 
-	w.cleanupOldThread()
+	w.cleanupOldThread(ctx)
 	w.resetLifecycleState()
 
 	// If the process crashed between turns, bail out — bridge will Terminate+Start.
@@ -866,7 +870,7 @@ func (w *AppServerWorker) Clear(ctx context.Context) error {
 	}
 	// Only interrupt when a turn is in flight; turn/interrupt requires a turnId.
 	if turnID != "" {
-		_ = w.manager.InterruptTurn(tid, turnID)
+		_ = w.manager.InterruptTurn(ctx, tid, turnID)
 	}
 	// ConnReplaced is ignored: Clear is invoked over WorkerCommander (HTTP REST),
 	// bridge doesn't restart forwardEvents on Clear.

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -564,6 +564,70 @@ func TestAppServerWorkerTerminate(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAppServerWorker_StopThenTerminatePreservesSiblingWrapper(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{IdleDrainPeriod: time.Hour})
+	var output strings.Builder
+	mgr.stdin = struct {
+		io.Writer
+		io.Closer
+	}{
+		Writer: &output,
+		Closer: io.NopCloser(nil),
+	}
+	mgr.mu.Lock()
+	mgr.refs = 2
+	mgr.state = stateRunning
+	mgr.mu.Unlock()
+	t.Cleanup(func() { mgr.Shutdown(context.Background()) })
+
+	recvA := mgr.Subscribe("thread-a", "session-a")
+	recvB := mgr.Subscribe("thread-b", "session-b")
+	connA := &appConn{userID: "user-1", sessionID: "session-a", recvCh: recvA, manager: mgr}
+	connB := &appConn{userID: "user-1", sessionID: "session-b", recvCh: recvB, manager: mgr}
+	workerA := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-a",
+		turnID:     "turn-a",
+		doneCh:     make(chan struct{}),
+		conn:       connA,
+	}
+	workerB := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-b",
+		turnID:     "turn-b",
+		doneCh:     make(chan struct{}),
+		conn:       connB,
+	}
+
+	require.NoError(t, workerA.StopCurrentTurn(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()), "wrapper release must be idempotent")
+	_, open := <-connA.Recv()
+	require.False(t, open, "terminated wrapper connection must close")
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.refs, "only the stopped wrapper reference must be released")
+	require.Equal(t, stateRunning, mgr.state, "terminating one wrapper must not stop the shared app-server")
+	mgr.mu.Unlock()
+	mgr.subMu.Lock()
+	_, hasA := mgr.subscribers["thread-a"]
+	_, hasB := mgr.subscribers["thread-b"]
+	mgr.subMu.Unlock()
+	require.False(t, hasA)
+	require.True(t, hasB, "sibling wrapper subscription must remain active")
+
+	want := &events.Envelope{SessionID: "session-b", Event: events.Event{Type: events.State}}
+	require.True(t, connB.TrySend(want), "sibling wrapper connection must remain usable")
+	require.Same(t, want, <-connB.Recv())
+	require.Contains(t, output.String(), `"method":"turn/interrupt"`)
+
+	require.NoError(t, workerB.Terminate(context.Background()))
+}
+
 func TestAppServerWorkerKill(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -512,6 +512,132 @@ func TestManagerShutdown(t *testing.T) {
 
 // ─── AppServerWorker Tests ──────────────────────────────────────────────
 
+type blockingFrameWriter struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingFrameWriter() *blockingFrameWriter {
+	return &blockingFrameWriter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (w *blockingFrameWriter) Write(p []byte) (int, error) {
+	w.enteredOnce.Do(func() { close(w.entered) })
+	<-w.release
+	return len(p), nil
+}
+
+func (w *blockingFrameWriter) Close() error { return nil }
+
+func (w *blockingFrameWriter) Release() {
+	w.releaseOnce.Do(func() { close(w.release) })
+}
+
+func TestAppServerWorkerStopCurrentTurnPropagatesContext(t *testing.T) {
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{IdleDrainPeriod: time.Minute})
+	writer := newBlockingFrameWriter()
+	mgr.stdin = writer
+	w := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-stop-context",
+		turnID:     "turn-stop-context",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.StopCurrentTurn(ctx) }()
+	select {
+	case <-writer.entered:
+	case <-time.After(time.Second):
+		t.Fatal("turn interrupt notification was not written")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		writer.Release()
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		writer.Release()
+		<-done
+		t.Fatal("turn interrupt ignored the caller context")
+	}
+}
+
+func TestAppServerWorkerStopCurrentTurnDoesNotExtendCallerDeadline(t *testing.T) {
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{IdleDrainPeriod: time.Minute})
+	writer := newBlockingFrameWriter()
+	mgr.stdin = writer
+	w := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-stop-deadline",
+		turnID:     "turn-stop-deadline",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- w.StopCurrentTurn(ctx) }()
+	select {
+	case <-writer.entered:
+	case <-time.After(time.Second):
+		t.Fatal("turn interrupt notification was not written")
+	}
+
+	select {
+	case err := <-done:
+		writer.Release()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(500 * time.Millisecond):
+		writer.Release()
+		<-done
+		t.Fatal("turn interrupt extended the caller deadline with fallback grace")
+	}
+}
+
+func TestAppServerWorkerTerminatePropagatesContextToUnsubscribe(t *testing.T) {
+	mgr := NewCodexAppServerManager(slog.Default(), config.CodexCLIConfig{IdleDrainPeriod: time.Minute})
+	writer := newBlockingFrameWriter()
+	mgr.stdin = writer
+	mgr.mu.Lock()
+	mgr.refs = 1
+	mgr.state = stateRunning
+	mgr.mu.Unlock()
+	w := &AppServerWorker{
+		BaseWorker: base.NewBaseWorker(slog.Default(), nil),
+		manager:    mgr,
+		threadID:   "thread-unsubscribe-context",
+		doneCh:     make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Terminate(ctx) }()
+	select {
+	case <-writer.entered:
+	case <-time.After(time.Second):
+		t.Fatal("thread unsubscribe notification was not written")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		writer.Release()
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		writer.Release()
+		<-done
+		t.Fatal("thread unsubscribe ignored the caller context")
+	}
+}
+
 func TestAppServerWorkerCapabilities(t *testing.T) {
 	t.Parallel()
 
@@ -2193,7 +2319,7 @@ func TestWaitAfterReleaseReturnsImmediately(t *testing.T) {
 	}
 
 	// Simulate the zombie GC path: Terminate -> shutdown -> release().
-	w.release()
+	require.NoError(t, w.release(context.Background()))
 
 	// Wait() must return immediately, not block on nil channel.
 	code, err := w.Wait()
@@ -2227,7 +2353,7 @@ func TestWaitBlocksUntilRelease(t *testing.T) {
 	}, 50*time.Millisecond, 5*time.Millisecond, "Wait should block before release")
 
 	// Release unblocks Wait.
-	w.release()
+	require.NoError(t, w.release(context.Background()))
 
 	select {
 	case code := <-waitDone:
@@ -2752,7 +2878,7 @@ func TestInjectHistoryPrefixCleanupOldThreadReset(t *testing.T) {
 		historyInjected: false,
 	}
 
-	w.cleanupOldThread()
+	w.cleanupOldThread(context.Background())
 
 	require.Nil(t, w.pendingHistory)
 	require.False(t, w.historyInjected)

--- a/internal/worker/native_commands.go
+++ b/internal/worker/native_commands.go
@@ -74,6 +74,41 @@ type NativeCommandInvoker interface {
 	InvokeNativeCommand(ctx context.Context, invocation NativeCommandInvocation) error
 }
 
+// NativeCommandDispatchAcknowledger is the native-command counterpart of
+// InputDispatchAcknowledger. It is optional because some Worker protocols have
+// no distinct provider-acceptance signal for native commands. Its callback
+// ordering contract is identical to InputDispatchAcknowledger.
+type NativeCommandDispatchAcknowledger interface {
+	InvokeNativeCommandWithDispatchAccepted(
+		ctx context.Context,
+		invocation NativeCommandInvocation,
+		accepted func(),
+	) error
+}
+
+// DispatchNativeCommand invokes a native command and reports its provider
+// acceptance point when the Worker exposes one. The already-resolved invoker
+// remains the fallback so legacy SkillInvoker compatibility is preserved.
+func DispatchNativeCommand(
+	ctx context.Context,
+	w Worker,
+	invoker NativeCommandInvoker,
+	invocation NativeCommandInvocation,
+	accepted func(),
+) error {
+	if accepted == nil {
+		accepted = func() {}
+	}
+	if acknowledger, ok := w.(NativeCommandDispatchAcknowledger); ok {
+		return acknowledger.InvokeNativeCommandWithDispatchAccepted(ctx, invocation, accepted)
+	}
+	if err := invoker.InvokeNativeCommand(ctx, invocation); err != nil {
+		return err
+	}
+	accepted()
+	return nil
+}
+
 // NativeModeForType maps a WorkerType to the native SkillInvocationMode it
 // uses for an explicitly resolved command.
 func NativeModeForType(t WorkerType) SkillInvocationMode {

--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -32,10 +32,9 @@ const (
 // It handles both V2 events (session.next.* prefix) and legacy V1 events
 // (session.status, session.error, permission.asked, question.asked).
 //
-// Thread safety: Convert and Reset are NOT safe for concurrent use. They must
-// only be called from the readGlobalSSE goroutine (which also calls
-// dispatchToAllSubscribers). If future callers need concurrent access, add a
-// mutex to Converter.
+// Thread safety: Convert and Reset are NOT safe for concurrent use. The
+// SingletonProcessManager serializes SSE dispatch and deferred retry expiry
+// through eventMu. If future callers bypass the manager, add a mutex here.
 type Converter struct {
 	states map[string]*turnState // sessionID → state
 }
@@ -465,6 +464,24 @@ func (c *Converter) handleSessionIdle(sessionID string) []*events.Envelope {
 	return []*events.Envelope{
 		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
 			events.DoneData{Success: true, Stats: stats}),
+	}
+}
+
+func (c *Converter) handleRetryExhausted(sessionID, message string) []*events.Envelope {
+	if message == "" {
+		message = "opencode retry did not resume"
+	}
+	stats, first := c.consumeDone(sessionID)
+	if !first {
+		return nil
+	}
+	return []*events.Envelope{
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{
+			Code:    events.ErrCodeInternalError,
+			Message: message,
+		}),
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
+			events.DoneData{Success: false, Stats: stats}),
 	}
 }
 

--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -477,12 +477,33 @@ func (c *Converter) handleRetryExhausted(sessionID, message string) []*events.En
 	}
 	return []*events.Envelope{
 		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{
-			Code:    events.ErrCodeInternalError,
+			Code:    retryErrorCode(message),
 			Message: message,
 		}),
 		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
 			events.DoneData{Success: false, Stats: stats}),
 	}
+}
+
+func retryErrorCode(message string) events.ErrorCode {
+	normalized := strings.ToLower(message)
+	for _, marker := range []string{
+		"rate limit",
+		"rate-limit",
+		"usage limit",
+		"quota",
+		"too many requests",
+	} {
+		if strings.Contains(normalized, marker) {
+			return events.ErrCodeRateLimited
+		}
+	}
+	for _, field := range strings.Fields(normalized) {
+		if strings.Trim(field, "()[]{}:;,") == "429" {
+			return events.ErrCodeRateLimited
+		}
+	}
+	return events.ErrCodeInternalError
 }
 
 func (c *Converter) handleSessionError(sessionID string, props json.RawMessage) []*events.Envelope {

--- a/internal/worker/opencodeserver/retry_terminal.go
+++ b/internal/worker/opencodeserver/retry_terminal.go
@@ -1,0 +1,146 @@
+package opencodeserver
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// OpenCode's built-in retry stays in retry state until status.next and then
+// resumes directly. A retry followed by idle is instead an abort/fallback
+// handoff (for example, a plugin switching models), whose next busy event is
+// expected promptly. Do not extend this grace to status.next: quota errors can
+// put that timestamp days in the future.
+const retryTerminalGracePeriod = time.Second
+
+type retryTimer interface {
+	Stop() bool
+}
+
+type retryAfterFunc func(time.Duration, func()) retryTimer
+
+type pendingRetryTerminal struct {
+	message string
+	timer   retryTimer
+}
+
+// retryTerminalArbiter distinguishes a transient idle between OpenCode retry
+// attempts from the idle that actually terminates a failed turn.
+type retryTerminalArbiter struct {
+	mu        sync.Mutex
+	afterFunc retryAfterFunc
+	pending   map[string]*pendingRetryTerminal
+}
+
+func newRetryTerminalArbiter(afterFunc retryAfterFunc) *retryTerminalArbiter {
+	return &retryTerminalArbiter{
+		afterFunc: afterFunc,
+		pending:   make(map[string]*pendingRetryTerminal),
+	}
+}
+
+// deferEvent records retry metadata and reports whether an idle event must be
+// held during the grace period. Any continuation event cancels the pending
+// terminal because OpenCode has started its fallback attempt.
+func (a *retryTerminalArbiter) deferEvent(
+	sessionID, eventType string,
+	props json.RawMessage,
+	onExpired func(*pendingRetryTerminal),
+) bool {
+	statusType, message, hasStatus := parseRetryStatus(eventType, props)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if hasStatus && statusType == "retry" {
+		pending := a.pending[sessionID]
+		if pending == nil {
+			pending = &pendingRetryTerminal{}
+			a.pending[sessionID] = pending
+		}
+		if pending.timer != nil {
+			pending.timer.Stop()
+			pending.timer = nil
+		}
+		if message != "" {
+			pending.message = message
+		}
+		return false
+	}
+	if eventType == ocsSessionStatus && !hasStatus {
+		return false
+	}
+
+	isIdle := eventType == ocsSessionIdle || hasStatus && statusType == "idle"
+	pending := a.pending[sessionID]
+	if isIdle && pending != nil {
+		if pending.timer == nil {
+			token := pending
+			pending.timer = a.afterFunc(retryTerminalGracePeriod, func() { onExpired(token) })
+		}
+		return true
+	}
+
+	if pending != nil {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(a.pending, sessionID)
+	}
+	return false
+}
+
+func (a *retryTerminalArbiter) consumeExpired(
+	sessionID string,
+	token *pendingRetryTerminal,
+) (string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	pending := a.pending[sessionID]
+	if pending == nil || pending != token || pending.timer == nil {
+		return "", false
+	}
+	delete(a.pending, sessionID)
+	return pending.message, true
+}
+
+func (a *retryTerminalArbiter) cancel(sessionID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if pending := a.pending[sessionID]; pending != nil {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(a.pending, sessionID)
+	}
+}
+
+func (a *retryTerminalArbiter) cancelAll() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for sessionID, pending := range a.pending {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(a.pending, sessionID)
+	}
+}
+
+func parseRetryStatus(eventType string, props json.RawMessage) (statusType, message string, ok bool) {
+	if eventType != ocsSessionStatus {
+		return "", "", false
+	}
+	var data struct {
+		Status struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(props, &data); err != nil || data.Status.Type == "" {
+		return "", "", false
+	}
+	return data.Status.Type, data.Status.Message, true
+}

--- a/internal/worker/opencodeserver/retry_terminal_test.go
+++ b/internal/worker/opencodeserver/retry_terminal_test.go
@@ -1,0 +1,168 @@
+package opencodeserver
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+type manualRetryTimer struct {
+	stopped bool
+}
+
+func (t *manualRetryTimer) Stop() bool {
+	wasActive := !t.stopped
+	t.stopped = true
+	return wasActive
+}
+
+func TestRetryTerminal_ExpiryReturnsOriginalError(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newSingletonWithSSE(t, func(http.ResponseWriter, *http.Request) {})
+	var expire func()
+	s.retryTerminal = newRetryTerminalArbiter(func(_ time.Duration, fn func()) retryTimer {
+		expire = fn
+		return &manualRetryTimer{}
+	})
+	ch := s.Subscribe("ses_retry_failure")
+	t.Cleanup(func() { s.Unsubscribe("ses_retry_failure") })
+
+	dispatch := func(eventType string, props map[string]any) {
+		t.Helper()
+		data := strings.TrimSpace(strings.TrimPrefix(ocsEvent(t, eventType, props), "data: "))
+		s.dispatchOCSEvent([]byte(data))
+	}
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_failure",
+		"status": map[string]any{
+			"type":    "retry",
+			"attempt": 1,
+			"message": "Monthly usage limit reached",
+		},
+	})
+	require.Equal(t, events.State, collectN(t, ch, 1)[0].Event.Type)
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_failure",
+		"status":    map[string]any{"type": "idle"},
+	})
+	require.NotNil(t, expire)
+	select {
+	case env := <-ch:
+		t.Fatalf("unexpected event before retry grace expiry: %s", env.Event.Type)
+	default:
+	}
+
+	expire()
+	got := collectN(t, ch, 2)
+	require.Equal(t, events.Error, got[0].Event.Type)
+	errData := got[0].Event.Data.(events.ErrorData)
+	require.Equal(t, "Monthly usage limit reached", errData.Message)
+	require.Equal(t, events.Done, got[1].Event.Type)
+	done := got[1].Event.Data.(events.DoneData)
+	require.False(t, done.Success)
+}
+
+func TestRetryTerminal_FallbackCancelsStaleExpiry(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newSingletonWithSSE(t, func(http.ResponseWriter, *http.Request) {})
+	var expire func()
+	s.retryTerminal = newRetryTerminalArbiter(func(_ time.Duration, fn func()) retryTimer {
+		expire = fn
+		return &manualRetryTimer{}
+	})
+	ch := s.Subscribe("ses_retry_recovered")
+	t.Cleanup(func() { s.Unsubscribe("ses_retry_recovered") })
+
+	dispatch := func(eventType string, props map[string]any) {
+		t.Helper()
+		data := strings.TrimSpace(strings.TrimPrefix(ocsEvent(t, eventType, props), "data: "))
+		s.dispatchOCSEvent([]byte(data))
+	}
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_recovered",
+		"status": map[string]any{
+			"type":    "retry",
+			"message": "provider quota reached",
+		},
+	})
+	require.Equal(t, events.State, collectN(t, ch, 1)[0].Event.Type)
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_recovered",
+		"status":    map[string]any{"type": "idle"},
+	})
+	require.NotNil(t, expire)
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_recovered",
+		"status":    map[string]any{"type": "busy"},
+	})
+	require.Equal(t, events.State, collectN(t, ch, 1)[0].Event.Type)
+
+	expire()
+	select {
+	case env := <-ch:
+		t.Fatalf("stale retry expiry emitted event after fallback resumed: %s", env.Event.Type)
+	default:
+	}
+}
+
+func TestRetryTerminal_BroadcastErrorCancelsStaleExpiry(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newSingletonWithSSE(t, func(http.ResponseWriter, *http.Request) {})
+	var expire func()
+	s.retryTerminal = newRetryTerminalArbiter(func(_ time.Duration, fn func()) retryTimer {
+		expire = fn
+		return &manualRetryTimer{}
+	})
+	ch := s.Subscribe("ses_retry_broadcast_error")
+	t.Cleanup(func() { s.Unsubscribe("ses_retry_broadcast_error") })
+
+	dispatch := func(eventType string, props map[string]any) {
+		t.Helper()
+		data := strings.TrimSpace(strings.TrimPrefix(ocsEvent(t, eventType, props), "data: "))
+		s.dispatchOCSEvent([]byte(data))
+	}
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_broadcast_error",
+		"status": map[string]any{
+			"type":    "retry",
+			"message": "provider unavailable",
+		},
+	})
+	require.Equal(t, events.State, collectN(t, ch, 1)[0].Event.Type)
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry_broadcast_error",
+		"status":    map[string]any{"type": "idle"},
+	})
+	require.NotNil(t, expire)
+
+	dispatch(ocsSessionError, map[string]any{
+		"error": map[string]any{
+			"name": "ProviderError",
+			"data": map[string]any{"message": "provider failed permanently"},
+		},
+	})
+	got := collectN(t, ch, 2)
+	require.Equal(t, events.Error, got[0].Event.Type)
+	require.Equal(t, "provider failed permanently", got[0].Event.Data.(events.ErrorData).Message)
+	require.Equal(t, events.Done, got[1].Event.Type)
+
+	expire()
+	select {
+	case env := <-ch:
+		t.Fatalf("stale retry expiry emitted event after broadcast error: %s", env.Event.Type)
+	default:
+	}
+}

--- a/internal/worker/opencodeserver/retry_terminal_test.go
+++ b/internal/worker/opencodeserver/retry_terminal_test.go
@@ -64,10 +64,31 @@ func TestRetryTerminal_ExpiryReturnsOriginalError(t *testing.T) {
 	got := collectN(t, ch, 2)
 	require.Equal(t, events.Error, got[0].Event.Type)
 	errData := got[0].Event.Data.(events.ErrorData)
+	require.Equal(t, events.ErrCodeRateLimited, errData.Code)
 	require.Equal(t, "Monthly usage limit reached", errData.Message)
 	require.Equal(t, events.Done, got[1].Event.Type)
 	done := got[1].Event.Data.(events.DoneData)
 	require.False(t, done.Success)
+}
+
+func TestRetryErrorCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    events.ErrorCode
+	}{
+		{name: "monthly usage limit", message: "Monthly usage limit reached", want: events.ErrCodeRateLimited},
+		{name: "http 429", message: "provider returned 429", want: events.ErrCodeRateLimited},
+		{name: "generic provider failure", message: "provider connection failed", want: events.ErrCodeInternalError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, retryErrorCode(tt.message))
+		})
+	}
 }
 
 func TestRetryTerminal_FallbackCancelsStaleExpiry(t *testing.T) {

--- a/internal/worker/opencodeserver/singleton.go
+++ b/internal/worker/opencodeserver/singleton.go
@@ -55,12 +55,16 @@ type SingletonProcessManager struct {
 	crashCh  chan struct{} // closed when process exits unexpectedly
 
 	// EventBus dispatches events from the global SSE stream to individual sessions.
+	// eventMu serializes converter access with deferred retry expiry. Lock order:
+	// mu (when held) → eventMu → retryTerminal.mu → busMu.
+	eventMu     sync.Mutex
 	busMu       sync.RWMutex
 	subscribers map[string]chan *events.Envelope
 	sseCancel   context.CancelFunc
 
 	// Converter maps OCS BusEvents to AEP envelopes.
-	converter *Converter
+	converter     *Converter
+	retryTerminal *retryTerminalArbiter
 
 	idleTimer *time.Timer
 
@@ -96,7 +100,7 @@ func NewSingletonProcessManager(log *slog.Logger, cfg config.OpenCodeServerConfi
 		MaxIdleConnsPerHost: 100,
 		IdleConnTimeout:     90 * time.Second,
 	}
-	return &SingletonProcessManager{
+	manager := &SingletonProcessManager{
 		log:         log.With("component", "opencode-server-singleton"),
 		client:      &http.Client{Timeout: cfg.HTTPTimeout, Transport: transport},
 		sseClient:   &http.Client{Transport: transport}, // no Timeout for SSE
@@ -106,6 +110,9 @@ func NewSingletonProcessManager(log *slog.Logger, cfg config.OpenCodeServerConfi
 		converter:   NewConverter(),
 		stderrRing:  newRingBuffer(stderrRingCapacity),
 	}
+	manager.retryTerminal = newRetryTerminalArbiter(
+		func(delay time.Duration, fn func()) retryTimer { return time.AfterFunc(delay, fn) })
+	return manager
 }
 
 // Acquire increments the reference count and starts the process if needed.
@@ -185,6 +192,12 @@ func (s *SingletonProcessManager) Subscribe(sessionID string) chan *events.Envel
 // Failure to do so may leave a goroutine that sends to the removed channel
 // (handled gracefully by trySendEnvelope's recover, but still a leak).
 func (s *SingletonProcessManager) Unsubscribe(sessionID string) {
+	s.eventMu.Lock()
+	if s.retryTerminal != nil {
+		s.retryTerminal.cancel(sessionID)
+	}
+	s.eventMu.Unlock()
+
 	s.busMu.Lock()
 	defer s.busMu.Unlock()
 
@@ -316,7 +329,12 @@ func (s *SingletonProcessManager) startupFailureError(phase string, err error) e
 // startProcessLocked starts the opencode serve process. Caller must hold s.mu.
 func (s *SingletonProcessManager) startProcessLocked(ctx context.Context) error {
 	s.state = stateStarting
+	s.eventMu.Lock()
 	s.converter.Reset()
+	if s.retryTerminal != nil {
+		s.retryTerminal.cancelAll()
+	}
+	s.eventMu.Unlock()
 	s.stderrRing.Reset() // clear previous lifecycle's tail (pointer stays stable → no race with readStderr)
 	s.lastExitCode = 0   // clear stale exit code from a previous lifecycle
 	s.hasExitCode = false
@@ -749,17 +767,44 @@ func (s *SingletonProcessManager) dispatchOCSEvent(data []byte) {
 		return
 	}
 	sessionID := props.SessionID
+
+	s.eventMu.Lock()
+	defer s.eventMu.Unlock()
+	if s.retryTerminal == nil {
+		s.retryTerminal = newRetryTerminalArbiter(
+			func(delay time.Duration, fn func()) retryTimer { return time.AfterFunc(delay, fn) })
+	}
+
 	if sessionID == "" {
 		// session.error can have optional sessionID — dispatch to all subscribers.
 		if evt.Payload.Type == ocsSessionError {
+			s.retryTerminal.cancelAll()
 			s.dispatchToAllSubscribers(evt.Payload.Properties)
 		}
+		return
+	}
+
+	if s.retryTerminal.deferEvent(sessionID, evt.Payload.Type, evt.Payload.Properties,
+		func(token *pendingRetryTerminal) { s.flushRetryTerminal(sessionID, token) }) {
 		return
 	}
 
 	// Delegate to converter.
 	envs := s.converter.Convert(sessionID, evt.Payload.Type, evt.Payload.Properties)
 	for _, env := range envs {
+		s.sendToSubscriber(sessionID, env)
+	}
+}
+
+func (s *SingletonProcessManager) flushRetryTerminal(sessionID string, token *pendingRetryTerminal) {
+	s.eventMu.Lock()
+	defer s.eventMu.Unlock()
+
+	message, ok := s.retryTerminal.consumeExpired(sessionID, token)
+	if !ok {
+		return
+	}
+	for _, env := range s.converter.handleRetryExhausted(sessionID, message) {
 		s.sendToSubscriber(sessionID, env)
 	}
 }
@@ -905,6 +950,12 @@ func isDroppable(kind events.Kind) bool {
 // Invariant: after the process transitions to stopped, no new subscribers can be
 // added because Acquire rejects stateStopped. This guarantees the map only shrinks.
 func (s *SingletonProcessManager) closeAllSubscribers() {
+	s.eventMu.Lock()
+	defer s.eventMu.Unlock()
+	if s.retryTerminal != nil {
+		s.retryTerminal.cancelAll()
+	}
+
 	s.busMu.Lock()
 	n := len(s.subscribers)
 	for id, ch := range s.subscribers {

--- a/internal/worker/opencodeserver/sse_test.go
+++ b/internal/worker/opencodeserver/sse_test.go
@@ -200,6 +200,65 @@ func TestReadGlobalSSE_DispatchesSessionStatus(t *testing.T) {
 	s.Unsubscribe("ses_1")
 }
 
+func TestDispatchOCSEvent_RetryIdleFallbackDoesNotEmitPrematureDone(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newSingletonWithSSE(t, func(http.ResponseWriter, *http.Request) {})
+	ch := s.Subscribe("ses_retry")
+	t.Cleanup(func() { s.Unsubscribe("ses_retry") })
+
+	dispatch := func(eventType string, props map[string]any) {
+		t.Helper()
+		data := strings.TrimSpace(strings.TrimPrefix(ocsEvent(t, eventType, props), "data: "))
+		s.dispatchOCSEvent([]byte(data))
+	}
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry",
+		"status": map[string]any{
+			"type":    "retry",
+			"attempt": 1,
+			"message": "Monthly usage limit reached",
+		},
+	})
+	retryState := collectN(t, ch, 1)
+	require.Equal(t, events.State, retryState[0].Event.Type)
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry",
+		"status":    map[string]any{"type": "idle"},
+	})
+	select {
+	case env := <-ch:
+		require.NotEqual(t, events.Done, env.Event.Type,
+			"retry followed by transient idle must not terminate the turn before fallback")
+	default:
+	}
+
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry",
+		"status":    map[string]any{"type": "busy"},
+	})
+	dispatch(ocsPartDelta, map[string]any{
+		"sessionID": "ses_retry",
+		"messageID": "msg_fallback",
+		"partID":    "part_fallback",
+		"field":     "text",
+		"delta":     "fallback succeeded",
+	})
+	dispatch(ocsSessionStatus, map[string]any{
+		"sessionID": "ses_retry",
+		"status":    map[string]any{"type": "idle"},
+	})
+
+	got := collectN(t, ch, 3)
+	require.Equal(t, events.State, got[0].Event.Type)
+	require.Equal(t, events.MessageDelta, got[1].Event.Type)
+	require.Equal(t, events.Done, got[2].Event.Type)
+	done := got[2].Event.Data.(events.DoneData)
+	require.True(t, done.Success)
+}
+
 func TestReadGlobalSSE_DispatchesPartDelta(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -85,10 +85,9 @@ const (
 	// httpClientTimeout is the timeout for general HTTP client operations.
 	httpClientTimeout = 30 * time.Second
 
-	// sendTimeout is the timeout for sending user input to the OCS server.
-	// The OCS POST /session/{id}/message blocks until the turn completes,
-	// so this must be long enough for the longest expected turn.
-	sendTimeout = 5 * time.Minute
+	// sendTimeout bounds acknowledgement of an asynchronous OCS prompt. The
+	// model turn itself continues over SSE and is not covered by this timeout.
+	sendTimeout = httpClientTimeout
 )
 
 // Worker implements the OpenCode Server worker adapter.
@@ -133,13 +132,20 @@ type Worker struct {
 	// permissionCeiling is immutable for this Worker session and survives
 	// in-place reset/clear operations.
 	permissionCeiling worker.PermissionCeiling
+
+	// nativeDispatchAccepted bridges the blocking /command response with the
+	// earlier session.status(busy) acceptance signal from the SSE event stream.
+	nativeDispatchMu       sync.Mutex
+	nativeDispatchGen      uint64
+	nativeDispatchAccepted func()
 }
 
 var (
-	_ worker.WorkerSessionIDHandler           = (*Worker)(nil)
-	_ worker.PermissionCeilingReporter        = (*Worker)(nil)
-	_ base.MetadataHandler                    = (*Worker)(nil)
-	_ base.MultiAnswerQuestionResponseHandler = (*Worker)(nil)
+	_ worker.WorkerSessionIDHandler            = (*Worker)(nil)
+	_ worker.PermissionCeilingReporter         = (*Worker)(nil)
+	_ worker.NativeCommandDispatchAcknowledger = (*Worker)(nil)
+	_ base.MetadataHandler                     = (*Worker)(nil)
+	_ base.MultiAnswerQuestionResponseHandler  = (*Worker)(nil)
 )
 
 func (w *Worker) GetWorkerSessionID() string {
@@ -192,9 +198,8 @@ func newHTTPClient() *http.Client {
 	}
 }
 
-// newSendClient creates an HTTP client with a longer timeout for sending
-// user input. The OCS POST /session/{id}/message blocks until the turn
-// completes, so the default 30s timeout causes false "server unreachable" errors.
+// newSendClient creates the HTTP client used for asynchronous prompt delivery.
+// The response is only an acceptance acknowledgement; turn output uses SSE.
 func newSendClient() *http.Client {
 	return &http.Client{
 		Timeout: sendTimeout,
@@ -283,13 +288,9 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 		return nil
 	}
 
-	// A new primary turn begins here. OCS's conn.Send blocks until the turn
-	// completes, so the marker cannot be cleared after the send returns — the
-	// next turn's Done (emitted by the converter when the server reaches idle)
-	// would race the clear and get suppressed. Instead capture the current
-	// stopped state, clear it before the send, and restore it if the send
-	// fails: a failed send means the new turn never started, so the previous
-	// turn's stopped marker must be preserved.
+	// A new primary turn begins here. Clear the stopped marker before dispatch;
+	// prompt_async returns once the server accepts the turn while output and the
+	// terminal continue over SSE. Restore the previous marker if delivery fails.
 	wasStopped := w.IsStopped()
 	w.BeginTurn()
 
@@ -317,8 +318,20 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 
 // InvokeSkill sends a resolved Skill through OpenCode's native command API.
 // It intentionally does not route through conn.Send, whose contract is the
-// ordinary /message input path.
+// ordinary /prompt_async input path.
 func (w *Worker) InvokeSkill(ctx context.Context, invocation worker.SkillInvocation) error {
+	return w.invokeSkill(ctx, invocation, nil)
+}
+
+func (w *Worker) InvokeNativeCommandWithDispatchAccepted(
+	ctx context.Context,
+	invocation worker.NativeCommandInvocation,
+	accepted func(),
+) error {
+	return w.invokeSkill(ctx, worker.SkillInvocation(invocation), accepted)
+}
+
+func (w *Worker) invokeSkill(ctx context.Context, invocation worker.SkillInvocation, accepted func()) error {
 	w.Mu.Lock()
 	commander := w.cmd
 	conn := w.httpConn
@@ -332,6 +345,14 @@ func (w *Worker) InvokeSkill(ctx context.Context, invocation worker.SkillInvocat
 	if conn != nil {
 		conn.setSkillReplay(worker.NativeInvocationFromSkill(invocation))
 	}
+	dispatchGen, err := w.armNativeDispatchAccepted(accepted)
+	if err != nil {
+		if wasStopped {
+			w.MarkStopped()
+		}
+		return err
+	}
+	defer w.disarmNativeDispatchAccepted(dispatchGen)
 	if err := commander.InvokeSkill(ctx, invocation); err != nil {
 		if wasStopped {
 			w.MarkStopped()
@@ -340,6 +361,41 @@ func (w *Worker) InvokeSkill(ctx context.Context, invocation worker.SkillInvocat
 	}
 	w.SetLastIO(time.Now())
 	return nil
+}
+
+func (w *Worker) armNativeDispatchAccepted(accepted func()) (uint64, error) {
+	if accepted == nil {
+		return 0, nil
+	}
+	w.nativeDispatchMu.Lock()
+	defer w.nativeDispatchMu.Unlock()
+	if w.nativeDispatchAccepted != nil {
+		return 0, fmt.Errorf("opencodeserver: native command dispatch already pending")
+	}
+	w.nativeDispatchGen++
+	w.nativeDispatchAccepted = accepted
+	return w.nativeDispatchGen, nil
+}
+
+func (w *Worker) disarmNativeDispatchAccepted(generation uint64) {
+	if generation == 0 {
+		return
+	}
+	w.nativeDispatchMu.Lock()
+	defer w.nativeDispatchMu.Unlock()
+	if w.nativeDispatchGen == generation {
+		w.nativeDispatchAccepted = nil
+	}
+}
+
+func (w *Worker) acceptNativeDispatch() {
+	w.nativeDispatchMu.Lock()
+	accepted := w.nativeDispatchAccepted
+	w.nativeDispatchAccepted = nil
+	w.nativeDispatchMu.Unlock()
+	if accepted != nil {
+		accepted()
+	}
 }
 
 // ListInvokableSkills delegates the OpenCode command catalog query to the
@@ -1019,6 +1075,9 @@ func (w *Worker) forwardBusEvents(ctx context.Context, sessionID string, busCh c
 			}
 
 			w.SetLastIO(time.Now())
+			if isRunningStateEnvelope(env) {
+				w.acceptNativeDispatch()
+			}
 
 			w.Mu.Lock()
 			ch := w.httpConn
@@ -1072,6 +1131,21 @@ func (w *Worker) forwardBusEvents(ctx context.Context, sessionID string, busCh c
 				return
 			}
 		}
+	}
+}
+
+func isRunningStateEnvelope(env *events.Envelope) bool {
+	if env == nil || env.Event.Type != events.State {
+		return false
+	}
+	switch data := env.Event.Data.(type) {
+	case events.StateData:
+		return data.State == events.StateRunning
+	case map[string]any:
+		state, _ := data["state"].(string)
+		return state == string(events.StateRunning)
+	default:
+		return false
 	}
 }
 
@@ -1282,7 +1356,7 @@ type conn struct {
 	sessionID    string
 	httpAddr     string
 	client       *http.Client
-	sendClient   *http.Client // longer timeout for input delivery (OCS blocks until turn completes)
+	sendClient   *http.Client // bounded client for prompt acceptance
 	recvCh       chan *events.Envelope
 	log          *slog.Logger
 	systemPrompt string
@@ -1400,14 +1474,14 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return fmt.Errorf("opencodeserver: marshal input: %w", err)
 	}
 
-	msgURL := fmt.Sprintf("%s/session/%s/message", c.httpAddr, url.PathEscape(sessionID))
+	msgURL := fmt.Sprintf("%s/session/%s/prompt_async", c.httpAddr, url.PathEscape(sessionID))
 	req, err := http.NewRequestWithContext(ctx, "POST", msgURL, strings.NewReader(string(payload)))
 	if err != nil {
 		return fmt.Errorf("opencodeserver: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// Use sendClient (long timeout) for input delivery; fall back to client for tests.
+	// Use the prompt-delivery client; fall back to the general client for tests.
 	sendCl := c.sendClient
 	if sendCl == nil {
 		sendCl = c.client
@@ -1430,7 +1504,7 @@ func (c *conn) Send(ctx context.Context, msg *events.Envelope) error {
 		return &worker.WorkerError{Kind: worker.ErrKindUnavailable, Message: fmt.Sprintf("opencodeserver: input failed: status %d, body: %s", resp.StatusCode, string(respBody))}
 	}
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusNoContent {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("opencodeserver: input failed: status %d, body: %s",
 			resp.StatusCode, string(respBody))

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -1268,7 +1268,7 @@ func TestWorker_Input_ClearsStoppedOnlyForPrimaryTurn(t *testing.T) {
 		var receivedPath string
 		w, _ := newWorkerWithMockServer(t, func(rw http.ResponseWriter, r *http.Request) {
 			receivedPath = r.URL.Path
-			rw.WriteHeader(http.StatusOK)
+			rw.WriteHeader(http.StatusNoContent)
 		})
 		w.MarkStopped()
 
@@ -1276,9 +1276,67 @@ func TestWorker_Input_ClearsStoppedOnlyForPrimaryTurn(t *testing.T) {
 		require.NoError(t, err)
 
 		require.False(t, w.IsStopped(), "a new primary turn must clear the stopped marker")
-		// The protocol fake observed the primary send (message POST).
-		require.Equal(t, "/session/test-session/message", receivedPath)
+		// The async endpoint acknowledges delivery without holding Input for the
+		// entire model turn; output continues over SSE.
+		require.Equal(t, "/session/test-session/prompt_async", receivedPath)
 	})
+}
+
+func TestWorker_NativeDispatchAcceptedOnRunningStateBeforeCommandResponse(t *testing.T) {
+	requestSeen := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	w, srv := newWorkerWithMockServer(t, func(rw http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/session/test-session/command", r.URL.Path)
+		close(requestSeen)
+		<-releaseResponse
+		rw.WriteHeader(http.StatusOK)
+	})
+	w.cmd = &ServerCommander{
+		client:    srv.Client(),
+		baseURL:   srv.URL,
+		sessionID: "test-session",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	busCh := make(chan *events.Envelope, 1)
+	go w.forwardBusEvents(ctx, "test-session", busCh)
+
+	accepted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- w.InvokeNativeCommandWithDispatchAccepted(ctx, worker.NativeCommandInvocation{
+			Name: "review",
+			Args: "current diff",
+		}, func() { close(accepted) })
+	}()
+
+	select {
+	case <-requestSeen:
+	case <-time.After(time.Second):
+		t.Fatal("native command request was not sent")
+	}
+	select {
+	case <-accepted:
+		require.FailNow(t, "native dispatch was accepted before the Worker entered running state")
+	default:
+	}
+
+	busCh <- events.NewEnvelope(aep.NewID(), "test-session", 0, events.State,
+		events.StateData{State: events.StateRunning})
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("running state did not acknowledge native dispatch")
+	}
+	select {
+	case err := <-done:
+		require.FailNow(t, "native command returned before its HTTP response", "error: %v", err)
+	default:
+	}
+
+	close(releaseResponse)
+	require.NoError(t, <-done)
 }
 
 // TestForwardBusEvents_SuppressesTerminalWhileStopped is the regression test

--- a/internal/worker/opencodeserver/worker_test.go
+++ b/internal/worker/opencodeserver/worker_test.go
@@ -1043,6 +1043,56 @@ func TestWorker_StopCurrentTurn_AbortsWithoutReleasingSession(t *testing.T) {
 	assertStopTurnRetention(t, w, mgr, live, sseCtx, true)
 }
 
+func TestWorker_StopThenTerminatePreservesSiblingWrapper(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/session/ses-a/abort", r.URL.Path)
+		_, _ = rw.Write([]byte("true"))
+	}))
+	t.Cleanup(server.Close)
+
+	mgr := newRunningSingleton(t)
+	mgr.mu.Lock()
+	mgr.refs = 2
+	mgr.mu.Unlock()
+	workerA, connA := stopTurnTestWorker(t, server, mgr, "ses-a", "/tmp/a")
+	workerB, connB := stopTurnTestWorker(t, server, mgr, "ses-b", "/tmp/b")
+	mgr.Subscribe("ses-a")
+	mgr.Subscribe("ses-b")
+	ctxA, cancelA := context.WithCancel(context.Background())
+	ctxB, cancelB := context.WithCancel(context.Background())
+	workerA.Mu.Lock()
+	workerA.sseCancel = cancelA
+	workerA.Mu.Unlock()
+	workerB.Mu.Lock()
+	workerB.sseCancel = cancelB
+	workerB.Mu.Unlock()
+
+	require.NoError(t, workerA.StopCurrentTurn(context.Background()))
+	require.NoError(t, workerA.Terminate(context.Background()))
+	require.NoError(t, workerA.Kill(), "wrapper release must be idempotent")
+	require.Error(t, ctxA.Err(), "stopped wrapper SSE context must be cancelled")
+	_, open := <-connA.Recv()
+	require.False(t, open, "terminated wrapper connection must close")
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.refs, "only the stopped wrapper reference must be released")
+	require.Equal(t, stateRunning, mgr.state, "terminating one wrapper must not stop the shared server")
+	mgr.mu.Unlock()
+	mgr.busMu.Lock()
+	_, hasA := mgr.subscribers["ses-a"]
+	_, hasB := mgr.subscribers["ses-b"]
+	mgr.busMu.Unlock()
+	require.False(t, hasA)
+	require.True(t, hasB, "sibling wrapper subscription must remain active")
+	require.Nil(t, ctxB.Err(), "sibling wrapper SSE context must remain active")
+	require.Same(t, connB, workerB.Conn())
+
+	require.NoError(t, workerB.Terminate(context.Background()))
+}
+
 func TestWorker_StopCurrentTurn_NoActiveConn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -185,6 +185,47 @@ type MidTurnInjector interface {
 	InjectMidTurn(ctx context.Context, content string, metadata map[string]any) error
 }
 
+// InputDispatchAcknowledger is an optional two-phase input capability for
+// adapters whose Input call can remain blocked after the provider has accepted
+// the request. accepted MUST be called exactly when a successful stop can no
+// longer overtake this input at the provider boundary. The callback must run
+// at most once and before the method returns. The method may continue waiting
+// for the turn result after that callback.
+//
+// Workers that do not implement this capability retain the Worker.Input
+// contract: a successful return is treated as the acceptance point.
+type InputDispatchAcknowledger interface {
+	InputWithDispatchAccepted(
+		ctx context.Context,
+		content string,
+		metadata map[string]any,
+		accepted func(),
+	) error
+}
+
+// DispatchInput invokes the strongest input-delivery contract exposed by w.
+// The callback is never synthesized for an error: in that case the caller
+// learns the outcome from the returned error instead.
+func DispatchInput(
+	ctx context.Context,
+	w Worker,
+	content string,
+	metadata map[string]any,
+	accepted func(),
+) error {
+	if accepted == nil {
+		accepted = func() {}
+	}
+	if acknowledger, ok := w.(InputDispatchAcknowledger); ok {
+		return acknowledger.InputWithDispatchAccepted(ctx, content, metadata, accepted)
+	}
+	if err := w.Input(ctx, content, metadata); err != nil {
+		return err
+	}
+	accepted()
+	return nil
+}
+
 // ResetResult describes the outcome of a ResetContext call.
 // Gateway reads this to decide orchestration without knowing Worker internals.
 type ResetResult struct {

--- a/webchat/lib/adapters/error-mapping.test.ts
+++ b/webchat/lib/adapters/error-mapping.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    mapErrorToNotice,
     isExpectedCommandRejection,
     mapErrorToMessage,
 } from "./error-mapping";
+import { ErrorCode } from "@/lib/ai-sdk-transport/client/constants";
 
 describe("mapErrorToMessage", () => {
     it.each([
@@ -19,19 +21,104 @@ describe("mapErrorToMessage", () => {
             "The coding agent crashed unexpectedly. Please try again or reset the session.",
         ],
         [
+            "WORKER_START_FAILED",
+            undefined,
+            "The coding agent could not start. Try again or choose a different worker.",
+        ],
+        [
+            "WORKER_TIMEOUT",
+            undefined,
+            "The coding agent stopped responding. Try again or start a new session.",
+        ],
+        [
+            "WORKER_OOM",
+            undefined,
+            "The coding agent ran out of memory. Try a smaller request or start a new session.",
+        ],
+        [
+            "PROCESS_SIGKILL",
+            undefined,
+            "The coding agent was force-stopped. Try again or start a new session.",
+        ],
+        [
+            "SESSION_NOT_FOUND",
+            "no worker attached to session",
+            "This session is no longer available. Start a new session and try again.",
+        ],
+        [
             "SESSION_EXPIRED",
             undefined,
             "This session has expired due to inactivity. Please start a new session.",
         ],
         [
+            "SESSION_TERMINATED",
+            undefined,
+            "This session has ended. Start a new session to continue.",
+        ],
+        [
+            "SESSION_INVALIDATED",
+            undefined,
+            "This session is no longer valid. Start a new session to continue.",
+        ],
+        [
+            "SESSION_BUSY",
+            undefined,
+            "This session is still processing another request. Wait for it to finish, then try again.",
+        ],
+        [
+            "SESSION_ALREADY_CONNECTED",
+            undefined,
+            "This session is open in another connection. Close the other connection or wait, then try again.",
+        ],
+        [
             "RATE_LIMITED",
             undefined,
-            "You've reached the rate limit. Please wait a moment before sending more messages.",
+            "Rate limit exceeded (429): The upstream AI provider is rate-limiting requests or quota is exhausted. Please try again later or check your API key/quota limits.",
         ],
         [
             "UNAUTHORIZED",
             undefined,
-            "Authentication failed: 401 — Check your API key configuration or consult the documentation.",
+            "You are signed out or do not have access to this session. Sign in again or choose another session.",
+        ],
+        [
+            "AUTH_REQUIRED",
+            undefined,
+            "Sign in to continue.",
+        ],
+        [
+            "INTERNAL_ERROR",
+            "database connection details",
+            "HotPlex encountered an internal error. Try again; if it continues, contact your administrator.",
+        ],
+        [
+            "PROTOCOL_VIOLATION",
+            "unknown control action foo",
+            "The client sent or received an invalid protocol message. Refresh the page and try again.",
+        ],
+        [
+            "VERSION_MISMATCH",
+            "version mismatch: expected 1, got 0",
+            "This WebChat version is incompatible with the Gateway. Refresh the page or update HotPlex.",
+        ],
+        [
+            "CONFIG_INVALID",
+            "invalid path: /private/internal/path",
+            "The requested configuration is invalid. Check the command or workspace settings and try again.",
+        ],
+        [
+            "GATEWAY_OVERLOAD",
+            undefined,
+            "HotPlex is temporarily overloaded. Wait a moment and try again.",
+        ],
+        [
+            "EXECUTION_TIMEOUT",
+            undefined,
+            "Delivery timed out and the result is unknown. Check the session before sending the request again.",
+        ],
+        [
+            "RECONNECT_REQUIRED",
+            undefined,
+            "The Gateway requires a new connection. Wait for WebChat to reconnect or refresh the page.",
         ],
         [
             "WORKER_OUTPUT_LIMIT",
@@ -41,7 +128,7 @@ describe("mapErrorToMessage", () => {
         [
             "RESUME_RETRY",
             "Recovering session...",
-            "🔄 Recovering session...",
+            "🔄 Recovering the session after an unexpected interruption...",
         ],
         [
             "NOT_SUPPORTED",
@@ -58,12 +145,39 @@ describe("mapErrorToMessage", () => {
             "invalid permission mode: permission mode required",
             "Permission mode is required. Use /perm <mode> to choose one.",
         ],
+        [
+            "OPERATOR_ABANDONED",
+            undefined,
+            "This pending execution was abandoned by an administrator. Check the session before trying again.",
+        ],
     ])(
         "maps known code %s to its friendly message",
         (code, message, expected) => {
             expect(mapErrorToMessage(code, message)).toBe(expected);
         },
     );
+
+    it("renders session recovery as a neutral notice instead of an error", () => {
+        expect(mapErrorToNotice("RESUME_RETRY", "Recovering session...")).toEqual({
+            text: "🔄 Recovering the session after an unexpected interruption...",
+            status: "complete",
+        });
+    });
+
+    it("renders terminal failures as warning-prefixed error notices", () => {
+        expect(mapErrorToNotice("SESSION_NOT_FOUND", "gone")).toEqual({
+            text: "⚠️ This session is no longer available. Start a new session and try again.",
+            status: "error",
+        });
+    });
+
+    it("does not expose raw Gateway details for canonical error codes", () => {
+        for (const code of Object.values(ErrorCode)) {
+            const message = mapErrorToMessage(code, "RAW_GATEWAY_DETAIL");
+            expect(message).not.toContain("RAW_GATEWAY_DETAIL");
+            expect(message).not.toBe(`Error: ${code}`);
+        }
+    });
 
     describe("CODEX_ERROR", () => {
         it.each([
@@ -130,6 +244,15 @@ describe("mapErrorToMessage", () => {
             expect(
                 mapErrorToMessage("INVALID_MESSAGE", "ambiguous Skill invocation"),
             ).toBe("That Skill command is ambiguous. Choose a specific command and try again.");
+        });
+
+        it("does not expose malformed protocol details", () => {
+            expect(
+                mapErrorToMessage(
+                    "INVALID_MESSAGE",
+                    "malformed input data: parse failed at private field",
+                ),
+            ).toBe("The command could not be processed. Check its format and try again.");
         });
     });
 

--- a/webchat/lib/adapters/error-mapping.ts
+++ b/webchat/lib/adapters/error-mapping.ts
@@ -7,6 +7,8 @@
  * instead of being dumped into the chat verbatim.
  */
 
+import { ErrorCode } from "@/lib/ai-sdk-transport/client/constants";
+
 const RATE_LIMIT_MESSAGE =
     "Rate limit exceeded (429): The upstream AI provider is rate-limiting requests or quota is exhausted. Please try again later or check your API key/quota limits.";
 
@@ -33,13 +35,21 @@ export function isExpectedCommandRejection(
     message: string | undefined,
 ): boolean {
     const msg = message || "";
-    if (code === "CONFIG_INVALID" || code === "NOT_SUPPORTED") return true;
-    // Legacy gateways may have emitted capability failures as INTERNAL_ERROR;
-    // keep protocol/version errors with similar wording as real errors.
-    if (code === "INTERNAL_ERROR" && CAPABILITY_REJECTION_PATTERN.test(msg)) {
+    if (code === ErrorCode.ConfigInvalid || code === ErrorCode.NotSupported) {
         return true;
     }
-    return code === "INVALID_MESSAGE" && USER_COMMAND_VALIDATION_PATTERN.test(msg);
+    // Legacy gateways may have emitted capability failures as INTERNAL_ERROR;
+    // keep protocol/version errors with similar wording as real errors.
+    if (
+        code === ErrorCode.InternalError &&
+        CAPABILITY_REJECTION_PATTERN.test(msg)
+    ) {
+        return true;
+    }
+    return (
+        code === ErrorCode.InvalidMessage &&
+        USER_COMMAND_VALIDATION_PATTERN.test(msg)
+    );
 }
 
 export function mapErrorToMessage(
@@ -56,21 +66,55 @@ export function mapErrorToMessage(
     }
 
     switch (code) {
-        case "TURN_TIMEOUT":
-            return "Session timeout: The agent took too long to respond (limit: 15m). You may want to break your request into smaller steps.";
-        case "WORKER_CRASH":
+        case ErrorCode.WorkerStartFailed:
+            return "The coding agent could not start. Try again or choose a different worker.";
+        case ErrorCode.WorkerCrash:
             return "The coding agent crashed unexpectedly. Please try again or reset the session.";
-        case "SESSION_EXPIRED":
+        case ErrorCode.WorkerTimeout:
+            return "The coding agent stopped responding. Try again or start a new session.";
+        case ErrorCode.WorkerOOM:
+            return "The coding agent ran out of memory. Try a smaller request or start a new session.";
+        case ErrorCode.WorkerSIGKILL:
+            return "The coding agent was force-stopped. Try again or start a new session.";
+        case ErrorCode.TurnTimeout:
+            return "Session timeout: The agent took too long to respond (limit: 15m). You may want to break your request into smaller steps.";
+        case ErrorCode.SessionNotFound:
+            return "This session is no longer available. Start a new session and try again.";
+        case ErrorCode.SessionExpired:
             return "This session has expired due to inactivity. Please start a new session.";
-        case "RATE_LIMITED":
-            return "You've reached the rate limit. Please wait a moment before sending more messages.";
-        case "UNAUTHORIZED":
-            return "Authentication failed: 401 — Check your API key configuration or consult the documentation.";
-        case "WORKER_OUTPUT_LIMIT":
+        case ErrorCode.SessionTerminated:
+            return "This session has ended. Start a new session to continue.";
+        case ErrorCode.SessionInvalidated:
+            return "This session is no longer valid. Start a new session to continue.";
+        case ErrorCode.SessionBusy:
+            return "This session is still processing another request. Wait for it to finish, then try again.";
+        case ErrorCode.SessionAlreadyConnected:
+            return "This session is open in another connection. Close the other connection or wait, then try again.";
+        case ErrorCode.Unauthorized:
+            return "You are signed out or do not have access to this session. Sign in again or choose another session.";
+        case ErrorCode.AuthRequired:
+            return "Sign in to continue.";
+        case ErrorCode.InternalError:
+            return "HotPlex encountered an internal error. Try again; if it continues, contact your administrator.";
+        case ErrorCode.ProtocolViolation:
+            return "The client sent or received an invalid protocol message. Refresh the page and try again.";
+        case ErrorCode.VersionMismatch:
+            return "This WebChat version is incompatible with the Gateway. Refresh the page or update HotPlex.";
+        case ErrorCode.ConfigInvalid:
+            return "The requested configuration is invalid. Check the command or workspace settings and try again.";
+        case ErrorCode.RateLimited:
+            return RATE_LIMIT_MESSAGE;
+        case ErrorCode.GatewayOverload:
+            return "HotPlex is temporarily overloaded. Wait a moment and try again.";
+        case ErrorCode.ExecutionTimeout:
+            return "Delivery timed out and the result is unknown. Check the session before sending the request again.";
+        case ErrorCode.ReconnectRequired:
+            return "The Gateway requires a new connection. Wait for WebChat to reconnect or refresh the page.";
+        case ErrorCode.WorkerOutputLimit:
             return "The agent produced too much output and was terminated. Try to narrow down your request.";
-        case "RESUME_RETRY":
-            return `🔄 ${message || "Recovering session after unexpected crash..."}`;
-        case "INVALID_MESSAGE":
+        case ErrorCode.ResumeRetry:
+            return "🔄 Recovering the session after an unexpected interruption...";
+        case ErrorCode.InvalidMessage:
             if (
                 msgLower.includes("invalid permission mode") ||
                 msgLower.includes("permission mode required")
@@ -83,8 +127,8 @@ export function mapErrorToMessage(
             if (msgLower.includes("ambiguous skill invocation")) {
                 return "That Skill command is ambiguous. Choose a specific command and try again.";
             }
-            return message || "The command could not be processed. Check its format and try again.";
-        case "NOT_SUPPORTED":
+            return "The command could not be processed. Check its format and try again.";
+        case ErrorCode.NotSupported:
             if (
                 msgLower.includes("clear:") &&
                 msgLower.includes("not implemented")
@@ -92,6 +136,8 @@ export function mapErrorToMessage(
                 return "This worker does not support /clear. Use /reset or /new instead.";
             }
             return "This command is not supported by the current worker.";
+        case ErrorCode.OperatorAbandoned:
+            return "This pending execution was abandoned by an administrator. Check the session before trying again.";
         case "CODEX_ERROR": {
             if (CODEX_AUTH_PATTERNS.some((p) => msgLower.includes(p))) {
                 return "Your Codex login has expired. Please sign out and sign in again in the Codex CLI, then retry.";
@@ -112,4 +158,20 @@ export function mapErrorToMessage(
             );
         }
     }
+}
+
+export interface ErrorNotice {
+    text: string;
+    status: "complete" | "error";
+}
+
+export function mapErrorToNotice(
+    code: string | undefined,
+    message: string | undefined,
+): ErrorNotice {
+    const text = mapErrorToMessage(code, message);
+    if (code === ErrorCode.ResumeRetry) {
+        return { text, status: "complete" };
+    }
+    return { text: `⚠️ ${text}`, status: "error" };
 }

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -48,8 +48,9 @@ import { getSessionHistory, type ConversationRecord } from "@/lib/api/sessions";
 import { conversationTurnsToMessages } from "@/lib/utils/turn-replay";
 import {
     isExpectedCommandRejection,
-    mapErrorToMessage,
+    mapErrorToNotice,
 } from "@/lib/adapters/error-mapping";
+import { isExpectedClientError } from "@/lib/ai-sdk-transport/client/error-policy";
 import { logger } from "@/lib/logger";
 import i18n from "@/lib/i18n/config";
 import type {
@@ -1208,7 +1209,8 @@ export function useHotPlexRuntime({
                 data?.code,
                 data?.message,
             );
-            const isNotSupported = (data?.code as string) === "NOT_SUPPORTED";
+            const isExpectedClientErrorCode = isExpectedClientError(data?.code);
+            const errorNotice = mapErrorToNotice(data?.code, data?.message);
 
             // SESSION_BUSY is a transient state handled internally by auto-retry, so do not show it to the user and don't log as error.
             if (isBusy) {
@@ -1313,22 +1315,23 @@ export function useHotPlexRuntime({
                         details: data.details,
                         eventId: env?.id,
                     });
-                } else if (isExpectedCommandRejectionError) {
+                } else if (
+                    isExpectedCommandRejectionError ||
+                    isExpectedClientErrorCode
+                ) {
                     logger.warn(
                         "RuntimeAdapter",
-                        isNotSupported
-                            ? "Command not supported"
-                            : "Command rejected",
+                        errorNotice.text,
                         {
                             code: data.code,
-                            message: data.message,
+                            reason: data.message,
                             eventId: env?.id,
                         },
                     );
                 } else {
-                    logger.error("RuntimeAdapter", "Error received", {
+                    logger.error("RuntimeAdapter", errorNotice.text, {
                         code: data.code || "unknown",
-                        message: data.message || "none",
+                        reason: data.message || "none",
                         details: data.details,
                         eventId: env?.id,
                     });
@@ -1395,21 +1398,15 @@ export function useHotPlexRuntime({
                 queueMicrotask(() => scheduleQueueDrainRef.current());
             }
 
-            // User-friendly mapping for specific terminal errors
-            const errorMessage = mapErrorToMessage(
-                data?.code,
-                data?.message,
-            );
-
             // Add error message to thread
             setMessages((prev) => [
                 ...prev,
                 {
                     id: `error-${Date.now()}`,
                     role: "assistant",
-                    parts: [{ type: "text", text: `⚠️ ${errorMessage}` }],
+                    parts: [{ type: "text", text: errorNotice.text }],
                     createdAt: new Date(),
-                    status: "error",
+                    status: errorNotice.status,
                 },
             ]);
         };

--- a/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { BrowserHotPlexClient } from "./browser-client";
 import { AEP_VERSION, ErrorCode, EventKind, WorkerType } from "./constants";
 import type { Envelope } from "./types";
+import { logger } from "@/lib/logger";
 
 afterEach(() => {
     vi.useRealTimers();
@@ -160,6 +161,8 @@ describe("BrowserHotPlexClient connection handoff", () => {
 
     it("does not recursively reconnect when init reports a missing session", async () => {
         vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+        const error = vi.spyOn(logger, "error").mockImplementation(() => undefined);
         const client = new BrowserHotPlexClient({
             url: "ws://127.0.0.1:8888/ws",
             workerType: WorkerType.CodexCLI,
@@ -188,6 +191,12 @@ describe("BrowserHotPlexClient connection handoff", () => {
         expect(ControlledWebSocket.instances).toHaveLength(1);
         expect(client.connected).toBe(false);
         expect(client.connecting).toBe(false);
+        expect(warn).toHaveBeenCalledWith(
+            "BrowserClient",
+            "Handshake session unavailable",
+            { message: "session not found" },
+        );
+        expect(error).not.toHaveBeenCalled();
 
         client.disconnect();
         socket.finishClose();
@@ -216,6 +225,47 @@ describe("BrowserHotPlexClient connection handoff", () => {
         await Promise.resolve();
         expect(client.connected).toBe(false);
         expect(client.connecting).toBe(false);
+
+        client.disconnect();
+        socket.finishClose();
+    });
+
+    it("logs an authentication handshake rejection as a warning", async () => {
+        vi.stubGlobal("WebSocket", ControlledWebSocket);
+        const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+        const error = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+        const client = new BrowserHotPlexClient({
+            url: "ws://127.0.0.1:8888/ws",
+            workerType: WorkerType.CodexCLI,
+        });
+
+        const connect = client.connect("session-auth-required");
+        void connect.catch(() => undefined);
+        await Promise.resolve();
+        const socket = ControlledWebSocket.instances[0];
+        socket.open();
+        socket.message({
+            ...initAck("session-auth-required"),
+            event: {
+                type: EventKind.InitAck,
+                data: {
+                    state: "idle",
+                    error: "authentication required",
+                    code: ErrorCode.AuthRequired,
+                },
+            },
+        });
+
+        await Promise.resolve();
+        expect(warn).toHaveBeenCalledWith(
+            "BrowserClient",
+            "Handshake rejected",
+            {
+                code: ErrorCode.AuthRequired,
+                message: "authentication required",
+            },
+        );
+        expect(error).not.toHaveBeenCalled();
 
         client.disconnect();
         socket.finishClose();

--- a/webchat/lib/ai-sdk-transport/client/browser-client.ts
+++ b/webchat/lib/ai-sdk-transport/client/browser-client.ts
@@ -57,6 +57,7 @@ import {
   isInitAck,
   newEventId,
 } from './envelope';
+import { isExpectedClientError } from './error-policy';
 
 // ============================================================================
 // Event Types
@@ -452,7 +453,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
           this.shouldReconnect = false;
           this._stopHeartbeat();
           this._clearReconnectTimer();
-          logger.error('BrowserClient', 'Handshake session not found', { message: errorMsg });
+          logger.warn('BrowserClient', 'Handshake session unavailable', { message: errorMsg });
           this.emit('error', {
             code: ErrorCode.SessionNotFound,
             message: errorMsg,
@@ -520,7 +521,17 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
           return;
         }
 
-        logger.error('BrowserClient', 'Handshake error', { message: errorMsg });
+        if (isExpectedClientError(ackData.code)) {
+          logger.warn('BrowserClient', 'Handshake rejected', {
+            code: ackData.code,
+            message: errorMsg,
+          });
+        } else {
+          logger.error('BrowserClient', 'Handshake error', {
+            code: ackData.code,
+            message: errorMsg,
+          });
+        }
         this.emit('error', {
           code: ackData.code || ErrorCode.InternalError,
           message: errorMsg
@@ -538,7 +549,7 @@ export class BrowserHotPlexClient extends EventEmitter<BrowserClientEvents> {
         this.shouldReconnect = false;
         this._stopHeartbeat();
         this._clearReconnectTimer();
-        logger.error('BrowserClient', 'Handshake returned deleted session', { message: errorMsg });
+        logger.warn('BrowserClient', 'Handshake session unavailable', { message: errorMsg });
         this.emit('error', {
           code: ErrorCode.SessionNotFound,
           message: errorMsg,

--- a/webchat/lib/ai-sdk-transport/client/constants.ts
+++ b/webchat/lib/ai-sdk-transport/client/constants.ts
@@ -89,6 +89,8 @@ export const ErrorCode = {
   WorkerOutputLimit: 'WORKER_OUTPUT_LIMIT',
   TurnTimeout: 'TURN_TIMEOUT',
   ResumeRetry: 'RESUME_RETRY',
+  NotSupported: 'NOT_SUPPORTED',
+  OperatorAbandoned: 'OPERATOR_ABANDONED',
 } as const;
 
 export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];

--- a/webchat/lib/ai-sdk-transport/client/error-policy.test.ts
+++ b/webchat/lib/ai-sdk-transport/client/error-policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { ErrorCode } from "./constants";
+import { isExpectedClientError } from "./error-policy";
+
+describe("isExpectedClientError", () => {
+    it.each([
+        ErrorCode.InvalidMessage,
+        ErrorCode.SessionNotFound,
+        ErrorCode.SessionExpired,
+        ErrorCode.SessionTerminated,
+        ErrorCode.SessionInvalidated,
+        ErrorCode.SessionBusy,
+        ErrorCode.SessionAlreadyConnected,
+        ErrorCode.Unauthorized,
+        ErrorCode.AuthRequired,
+        ErrorCode.VersionMismatch,
+        ErrorCode.ConfigInvalid,
+        ErrorCode.RateLimited,
+        ErrorCode.GatewayOverload,
+        ErrorCode.ExecutionTimeout,
+        ErrorCode.ReconnectRequired,
+        ErrorCode.ResumeRetry,
+        ErrorCode.NotSupported,
+        ErrorCode.OperatorAbandoned,
+    ])("classifies %s as an expected client-visible outcome", (code) => {
+        expect(isExpectedClientError(code)).toBe(true);
+    });
+
+    it.each([
+        ErrorCode.WorkerStartFailed,
+        ErrorCode.WorkerCrash,
+        ErrorCode.WorkerTimeout,
+        ErrorCode.WorkerOOM,
+        ErrorCode.WorkerSIGKILL,
+        ErrorCode.InternalError,
+        ErrorCode.ProtocolViolation,
+        ErrorCode.WorkerOutputLimit,
+        ErrorCode.TurnTimeout,
+    ])("keeps %s classified as a genuine runtime fault", (code) => {
+        expect(isExpectedClientError(code)).toBe(false);
+    });
+
+    it("does not downgrade unknown error codes", () => {
+        expect(isExpectedClientError("UNKNOWN_ERROR")).toBe(false);
+        expect(isExpectedClientError(undefined)).toBe(false);
+    });
+});

--- a/webchat/lib/ai-sdk-transport/client/error-policy.ts
+++ b/webchat/lib/ai-sdk-transport/client/error-policy.ts
@@ -1,0 +1,29 @@
+import { ErrorCode } from "./constants";
+
+// These codes describe expected lifecycle, authentication, validation, or
+// capacity outcomes that the UI can explain and recover from. They remain
+// observable as warnings without triggering Next.js's console-error overlay.
+const EXPECTED_CLIENT_ERROR_CODES = new Set<string>([
+    ErrorCode.InvalidMessage,
+    ErrorCode.SessionNotFound,
+    ErrorCode.SessionExpired,
+    ErrorCode.SessionTerminated,
+    ErrorCode.SessionInvalidated,
+    ErrorCode.SessionBusy,
+    ErrorCode.SessionAlreadyConnected,
+    ErrorCode.Unauthorized,
+    ErrorCode.AuthRequired,
+    ErrorCode.VersionMismatch,
+    ErrorCode.ConfigInvalid,
+    ErrorCode.RateLimited,
+    ErrorCode.GatewayOverload,
+    ErrorCode.ExecutionTimeout,
+    ErrorCode.ReconnectRequired,
+    ErrorCode.ResumeRetry,
+    ErrorCode.NotSupported,
+    ErrorCode.OperatorAbandoned,
+]);
+
+export function isExpectedClientError(code: string | undefined): boolean {
+    return code !== undefined && EXPECTED_CLIENT_ERROR_CODES.has(code);
+}


### PR DESCRIPTION
## Summary

- serialize same-session stop and input acceptance with a bounded fixed-stripe gate, then release admission at the exact provider acceptance boundary instead of waiting for a full ACP/OCS turn
- quarantine late run events, retry/replay side effects, and crash fallbacks after cancellation commits; emit `stopped_by_user` only after teardown and forwarder quiescence
- use ACP JSON-RPC write completion, OpenCode `prompt_async`, and OpenCode native-command `state(running)` as two-phase dispatch acknowledgements
- propagate Codex interrupt/unsubscribe deadlines without consuming the one-second forwarder-settle budget
- require exact `(session, worker_run, execution)` matching for detached-run stop idempotence when the execution ledger is enabled

## Behavior and safety

- failed provider cancellation rolls back the stop claim and preserves an accepted input's real error; successful cancellation absorbs the adapter's expected cancellation result
- LLM retry releases its event admission after provider acceptance, so an already-dispatched retry cannot block stop for the whole turn
- teardown failure uses `Kill` fallback; quiescence timeout fails closed without emitting a false success terminal
- Codex and OpenCode release only the stopped session wrapper and preserve sibling sessions on their shared services
- no AEP/SDK, WebChat production, migration, configuration, or `worker.Worker` main-interface change

## Regression coverage

- blocking Input vs stop admission, including successful and failed stop outcomes
- retry Input vs stop event barrier
- ACP prompt acceptance before its blocking response
- OpenCode async prompt and blocking native-command acceptance
- Codex interrupt/unsubscribe context propagation and deadline budget
- stale detached stop claim vs a newer execution

## Verification

- `make quality` — formatting, lint, and full repository `go test -race -count=1 -shuffle=on`
- `make docs-lint`
- `make build`
- focused RED→GREEN regression tests for dispatch, retry, Codex deadline, and stale claims
- pre-push gate — formatting, vet, module verification, lint, build, and tests: 6 passed, 0 failed

## Rollback

The change has no wire or storage migration. Reverting the two implementation commits restores the previous soft-stop behavior.

Closes #971
