### PR TITLE
fix: preserve failed terminal errors

### DIFF
--- a/docs/superpowers/plans/2026-08-31-terminal-failure-classification.md
+++ b/docs/superpowers/plans/2026-08-31-terminal-failure-classification.md
@@ -1,0 +1,172 @@
+# Terminal Failure Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent failed and stopped turns from being shown as an empty successful Agent reply while preserving the true error and legitimate empty-success fallback.
+
+**Architecture:** Resolve a worker terminal outcome before emitting user-visible fallbacks. The Bridge keeps a separate real-content signal for retry decisions and only synthesizes success fallbacks for successful Done events. Feishu uses Done metadata to avoid converting a user stop into an empty-success warning.
+
+**Tech Stack:** Go, testify/require, existing Gateway Hub and Feishu streaming-card tests.
+
+**Spec:** User-approved terminal failure analysis from 2026-08-31.
+
+## Global Constraints
+
+- Preserve the AEP `DoneData` wire format and existing event ordering guarantees.
+- Keep `fc.turnText` history backfill, but never use synthesized text as real worker output.
+- Use table-driven/testify tests with `t.Parallel()` where safe; no sleeps for asynchronous assertions.
+- Do not change service configuration, credentials, or runtime state.
+
+---
+
+### Task 1: Bridge terminal-outcome regression coverage
+
+**Files:**
+
+- Modify: `internal/gateway/bridge_forward_fallback_test.go`
+- Modify: `internal/gateway/bridge_forward.go`
+
+**Interfaces:**
+
+- Consumes: `processForwardedEvent(env, worker, forwardOpts, forwardContext)`.
+- Produces: failed `Error → Done{Success:false}` turns display the real error once and never call the empty-success fallback; successful empty turns still synthesize the retryable warning.
+
+- [x] **Step 1: Write failing tests**
+
+```go
+// Error followed by Done(false), with retry disabled, must emit Error and no
+// events.Message containing messaging.FormatEmptySuccess().
+// Done(false) without Error must not emit the empty-success warning.
+```
+
+- [x] **Step 2: Run the focused Gateway test to verify failure**
+
+Run: `go test ./internal/gateway -run TestBridge_FailedDone -count=1`
+
+Expected: FAIL because `maybeSendDoneFallback` currently emits the empty-success message and the terminal fence drops the buffered Error.
+
+- [x] **Step 3: Implement terminal classification before side effects**
+
+```go
+done, isDone := asDoneData(env.Event.Data)
+failed := isDone && !done.Success
+// Do not synthesize success text for failed Done events.
+// Decide retry before terminal emission; when no retry is selected, send the
+// buffered Error as the single user-visible failure terminal.
+```
+
+- [x] **Step 4: Re-run focused Gateway tests**
+
+Run: `go test ./internal/gateway -run 'TestBridge_FailedDone|TestMaybeSendDoneFallback' -count=1 -race -shuffle=on`
+
+Expected: PASS.
+
+### Task 2: Preserve real content semantics
+
+**Files:**
+
+- Modify: `internal/gateway/bridge_forward.go`
+- Modify: `internal/gateway/bridge_forward_fallback_test.go`
+
+**Interfaces:**
+
+- Consumes: `extractMessageContent(env)` and `forwardContext.turnText`.
+- Produces: typed `MessageData` and pointer payloads count as real assistant content; synthesized fallback text cannot change retry eligibility.
+
+- [x] **Step 1: Write failing tests**
+
+```go
+// A typed events.MessageData{Content: "answer"} followed by Done(true)
+// emits only the answer, not FormatEmptySuccess().
+```
+
+- [x] **Step 2: Run the focused test to verify failure**
+
+Run: `go test ./internal/gateway -run TestExtractMessageContent_MessageData -count=1`
+
+Expected: FAIL because `extractMessageContent` only accepts `MessageDeltaData` and maps.
+
+- [x] **Step 3: Implement type-complete extraction and independent real-content state**
+
+```go
+case events.MessageData:
+    return d.Content
+case *events.MessageData:
+    if d != nil { return d.Content }
+case *events.MessageDeltaData:
+    if d != nil { return d.Content }
+```
+
+- [x] **Step 4: Re-run focused Gateway tests**
+
+Run: `go test ./internal/gateway -run 'TestBridge_FailedDone|TestExtractMessageContent|TestMaybeSendDoneFallback' -count=1 -race -shuffle=on`
+
+Expected: PASS.
+
+### Task 3: Feishu terminal semantics
+
+**Files:**
+
+- Modify: `internal/messaging/feishu/conn.go`
+- Modify: `internal/messaging/feishu/streaming_empty_success_test.go`
+
+**Interfaces:**
+
+- Consumes: `events.DoneData.Reason` and an active `StreamingCardController` placeholder.
+- Produces: `stopped_by_user` closes the stream without the empty-success warning; genuine successful empty turns retain the retryable warning.
+
+- [x] **Step 1: Write a failing stopped-turn test**
+
+```go
+// Feed DoneData{Reason: "stopped_by_user"} to a connection with an empty
+// active placeholder and assert the final content does not contain
+// "未收到可展示".
+```
+
+- [x] **Step 2: Run the focused Feishu test to verify failure**
+
+Run: `go test ./internal/messaging/feishu -run Test.*Stopped -count=1`
+
+Expected: FAIL because `handleDone` closes the active placeholder through the generic empty-success backstop.
+
+- [x] **Step 3: Pass a non-success terminal result to the close path**
+
+```go
+// On stopped_by_user, clear the placeholder before Close so Close does not
+// synthesize a successful-empty response.
+```
+
+- [x] **Step 4: Re-run focused Feishu tests**
+
+Run: `go test ./internal/messaging/feishu -run 'Test.*Stopped|TestStreamingCardController_Close_PlaceholderEmptySuccess' -count=1 -race -shuffle=on`
+
+Expected: PASS.
+
+### Task 4: Final verification and review
+
+**Files:**
+
+- Verify: `internal/gateway/bridge_forward.go`
+- Verify: `internal/messaging/feishu/conn.go`
+
+- [x] **Step 1: Format changed Go files**
+
+Run: `gofmt -w internal/gateway/bridge_forward.go internal/gateway/bridge_forward_fallback_test.go internal/messaging/feishu/conn.go internal/messaging/feishu/streaming_empty_success_test.go`
+
+- [x] **Step 2: Run package suites**
+
+Run: `go test ./internal/gateway ./internal/messaging/feishu -count=1 -race -shuffle=on`
+
+Expected: PASS.
+
+- [x] **Step 3: Run repository quality gate**
+
+Run: `make quality`
+
+Expected: PASS.
+
+- [x] **Step 4: Inspect the final diff and commit one focused bug-fix change**
+
+Run: `git diff --check && git diff --staged && git status --short`
+
+Expected: only the four implementation/test files and this plan; no credentials or generated artifacts.

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -53,8 +53,11 @@ type forwardContext struct {
 	// terminalSent fences duplicate Done/Error events from a worker stream and
 	// lets the exit path suppress a second synthetic error. It is atomic because
 	// the turn-timeout callback and the forwarder goroutine can race.
-	terminalSent   atomic.Bool
-	turnText       strings.Builder
+	terminalSent atomic.Bool
+	turnText     strings.Builder
+	// hasRealText tracks worker-produced assistant text independently from
+	// synthetic fallback text appended to turnText for history.
+	hasRealText    bool
 	lastError      *events.ErrorData
 	pendingError   *events.Envelope
 	turnTimerFired atomic.Bool
@@ -520,16 +523,67 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	b.accumulateStats(env, w, opts, fc)
 
 	terminalStatus := ""
+	doneData, isDone := asDoneData(env.Event.Data)
+	shouldRetry := false
+	retryAttempt := 0
+	deferRuntimeFinish := env.Event.Type == events.Done && isDone && !doneData.Success && fc.pendingError != nil
 	// Done processing: mark received.
 	if env.Event.Type == events.Done {
 		fc.doneReceived = true
 		b.resetCrashLoop(sessionID)
 		b.maybeTransitionIdleAfterDone(sessionID, fc)
-		b.finishRuntimeOnDone(sessionID, fc, env)
+		if !deferRuntimeFinish {
+			b.finishRuntimeOnDone(sessionID, fc, env)
+		}
 		terminalStatus = "completed"
-		if done, ok := asDoneData(env.Event.Data); ok && !done.Success {
+		if isDone && !doneData.Success {
 			terminalStatus = "failed"
 		}
+		if isDone && !doneData.Success && b.retryCtrl != nil && (!opts.resumed || fc.hasRealText) {
+			shouldRetry, retryAttempt = b.retryCtrl.ShouldRetry(context.TODO(), sessionID, fc.lastError)
+		}
+	}
+
+	if shouldRetry {
+		if deferRuntimeFinish {
+			b.finishRuntimeOnDone(sessionID, fc, env)
+		}
+		fc.pendingError = nil
+		fc.reopenTerminal()
+		// Pre-register cancel channel before launching goroutine to close
+		// the race window where CancelRetry can't find the channel.
+		cancelCh := make(chan struct{})
+		b.retryCancelMu.Lock()
+		b.retryCancel[sessionID] = cancelCh
+		b.retryCancelMu.Unlock()
+		// Run autoRetry asynchronously so forwardEvents continues reading
+		// from recvCh. This prevents the goroutine from blocking during
+		// the backoff period — if the worker crashes, the for-range loop
+		// detects recvCh closure immediately instead of waiting for the
+		// backoff timer to expire. The goroutine uses shutdownCtx so it
+		// cancels promptly during bridge shutdown.
+		go b.autoRetry(b.shutdownCtx, w, sessionID, retryAttempt, cancelCh, fc.lifecycle)
+		fc.turnText.Reset()
+		fc.hasRealText = false
+		if b.collector != nil {
+			b.collector.ResetSession(sessionID)
+		}
+		fc.lastError = nil
+		return // continue — retry produces new events on recv
+	}
+
+	if env.Event.Type == events.Done && isDone && !doneData.Success && fc.pendingError != nil {
+		// A failed turn with a worker Error has one user-visible terminal: the
+		// Error. The Done already owns the bridge fence, so sending it first
+		// would otherwise make flushPendingError discard the real error.
+		b.sendPendingError(fc)
+		b.captureForwardedEvent(env, deltaContent, reasoningContent, fc)
+		b.finishRuntimeOnDone(sessionID, fc, env)
+		b.finishTurnTTFT(sessionID, terminalStatus)
+		fc.turnText.Reset()
+		fc.hasRealText = false
+		fc.lastError = nil
+		return
 	}
 
 	if err := b.hub.SendToSession(context.Background(), env); err != nil {
@@ -541,32 +595,8 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	// Flush buffered error on non-Done events.
 	b.flushPendingError(fc, true)
 
-	// LLM retry: check after Done is forwarded.
-	if env.Event.Type == events.Done && b.retryCtrl != nil && (!opts.resumed || fc.turnText.Len() > 0) {
-		if shouldRetry, attempt := b.retryCtrl.ShouldRetry(context.TODO(), sessionID, fc.lastError); shouldRetry {
-			fc.pendingError = nil
-			fc.reopenTerminal()
-			// Pre-register cancel channel before launching goroutine to close
-			// the race window where CancelRetry can't find the channel.
-			cancelCh := make(chan struct{})
-			b.retryCancelMu.Lock()
-			b.retryCancel[sessionID] = cancelCh
-			b.retryCancelMu.Unlock()
-			// Run autoRetry asynchronously so forwardEvents continues reading
-			// from recvCh. This prevents the goroutine from blocking during
-			// the backoff period — if the worker crashes, the for-range loop
-			// detects recvCh closure immediately instead of waiting for the
-			// backoff timer to expire. The goroutine uses shutdownCtx so it
-			// cancels promptly during bridge shutdown.
-			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh, fc.lifecycle)
-			fc.turnText.Reset()
-			if b.collector != nil {
-				b.collector.ResetSession(sessionID)
-			}
-			fc.lastError = nil
-			return // continue — retry produces new events on recv
-		}
-		b.flushPendingError(fc, false)
+	if env.Event.Type == events.Done && b.retryCtrl != nil && (!isDone || doneData.Success) {
+		fc.pendingError = nil
 		b.retryCtrl.RecordSuccess(sessionID)
 		fc.lastError = nil
 	}
@@ -576,6 +606,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		// the retry decision confirms this is the terminal worker attempt.
 		b.finishTurnTTFT(sessionID, terminalStatus)
 		fc.turnText.Reset()
+		fc.hasRealText = false
 		// Do NOT reset fc.turnStartTime here. The previous code did
 		// `fc.turnStartTime = time.Now()` at Done, which started the NEXT turn's
 		// clock at this Done — so inter-turn idle was billed to the next turn.
@@ -704,6 +735,7 @@ func (b *Bridge) extractTurnContent(env *events.Envelope, fc *forwardContext) (d
 	case events.MessageDelta, events.Message:
 		if content := extractMessageContent(env); content != "" {
 			fc.turnText.WriteString(content)
+			fc.hasRealText = true
 			if env.Event.Type == events.MessageDelta {
 				deltaContent = content
 			}
@@ -748,6 +780,7 @@ func (b *Bridge) handleInternalReset(env *events.Envelope, sessionID string, fc 
 	}
 	acc.TurnCount.Store(0)
 	fc.turnText.Reset()
+	fc.hasRealText = false
 }
 
 // accumulateStats tracks tool calls and per-turn stats on done events.
@@ -776,8 +809,10 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 			fc.turnTimer.Stop()
 		}
 		acc := b.getOrInitAccum(sessionID, opts.workDir, fc.startTime)
+		success := false
 		if dd, ok := asDoneData(env.Event.Data); ok {
 			acc.mergePerTurnStats(dd)
+			success = dd.Success
 		}
 		acc.TurnCount.Add(1)
 		// Turn duration: prefer the input-path start stamp so the timer covers
@@ -799,7 +834,7 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 		}
 
 		b.injectSessionStats(env, acc)
-		b.maybeSendDoneFallback(sessionID, acc, fc)
+		b.maybeSendDoneFallback(sessionID, acc, fc, success)
 		b.captureAssistantTurn(sessionID, env.Seq, acc, fc.turnText.String(),
 			fc.sessOwner, fc.sessPlatform, env.Timestamp)
 		acc.resetPerTurn()
@@ -829,7 +864,10 @@ func (b *Bridge) accumulateStats(env *events.Envelope, w worker.Worker, opts for
 // fallback text so the turns table records it (history/replay shows the
 // fallback instead of an empty assistant turn). Also persists to the events
 // table via captureEvent so WS event replay surfaces it too.
-func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator, fc *forwardContext) {
+func (b *Bridge) maybeSendDoneFallback(sessionID string, acc *sessionAccumulator, fc *forwardContext, success bool) {
+	if !success {
+		return
+	}
 	if fc.turnText.Len() > 0 {
 		return // state 1: real assistant content
 	}
@@ -916,8 +954,9 @@ func (b *Bridge) captureForwardedEvent(env *events.Envelope, deltaContent, reaso
 }
 
 // flushPendingError sends the buffered error event to the client.
-// skipOnDone controls whether to suppress the flush when the current event is Done
-// (used in the main forwarding loop to defer error delivery past retry decision).
+// skipOnDone controls whether to suppress the flush when the current event is Done.
+// Failed Done events with a buffered error are resolved explicitly before the
+// Done can be sent, so this helper remains for non-terminal stream events.
 func (b *Bridge) flushPendingError(fc *forwardContext, skipOnDone bool) {
 	if fc.pendingError == nil {
 		return
@@ -927,6 +966,16 @@ func (b *Bridge) flushPendingError(fc *forwardContext, skipOnDone bool) {
 	}
 	if !fc.claimTerminal() {
 		fc.pendingError = nil
+		return
+	}
+	b.sendPendingError(fc)
+}
+
+// sendPendingError delivers a buffered worker error without claiming the
+// terminal fence. Callers use it when another terminal event already claimed
+// the fence but must remain hidden from the client.
+func (b *Bridge) sendPendingError(fc *forwardContext) {
+	if fc.pendingError == nil {
 		return
 	}
 	if err := b.hub.SendToSession(context.Background(), fc.pendingError); err != nil {
@@ -1458,8 +1507,19 @@ func extractInputContent(data any) string {
 func extractMessageContent(env *events.Envelope) string {
 	switch env.Event.Type {
 	case events.Message, events.MessageDelta:
-		if d, ok := env.Event.Data.(events.MessageDeltaData); ok {
+		switch d := env.Event.Data.(type) {
+		case events.MessageData:
 			return d.Content
+		case *events.MessageData:
+			if d != nil {
+				return d.Content
+			}
+		case events.MessageDeltaData:
+			return d.Content
+		case *events.MessageDeltaData:
+			if d != nil {
+				return d.Content
+			}
 		}
 		if m, ok := env.Event.Data.(map[string]any); ok {
 			if content, ok := m["content"].(string); ok {

--- a/internal/gateway/bridge_forward_fallback_test.go
+++ b/internal/gateway/bridge_forward_fallback_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 
@@ -205,6 +206,140 @@ func TestBridge_ProcessForwardedEventSendsExactlyOneTerminal(t *testing.T) {
 	require.Nil(t, tryReadEnvelope(t, server), "duplicate Done must be suppressed")
 }
 
+func TestBridge_FailedDoneForwardsWorkerErrorWithoutEmptySuccessFallback(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	const sessionID = "failed-done-error"
+	h.JoinSession(sessionID, newConn(h, conn, sessionID, nil))
+	b := NewBridge(BridgeDeps{
+		Log:       slog.Default(),
+		Hub:       h,
+		RetryCtrl: NewLLMRetryController(config.AutoRetryConfig{Enabled: false}, slog.Default()),
+	})
+	fw := &mockBridgeWorker{workerType: worker.TypeCodexCLI}
+	fc := &forwardContext{sessionID: sessionID, workerType: worker.TypeCodexCLI, firstEvent: true}
+
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error,
+		events.ErrorData{Code: events.ErrCodeRateLimited, Message: "rate limit exceeded"}), fw, forwardOpts{}, fc)
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
+		events.DoneData{Success: false}), fw, forwardOpts{}, fc)
+
+	terminal := tryReadEnvelope(t, server)
+	require.NotNil(t, terminal)
+	require.Equal(t, events.Error, terminal.Event.Type)
+	data, ok := terminal.Event.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "rate limit exceeded", data["message"])
+	require.Nil(t, tryReadEnvelope(t, server), "failed turn must not emit a success fallback or a second terminal")
+}
+
+func TestBridge_RetryableFailedDoneDoesNotEmitTerminalBeforeRetry(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	const sessionID = "retryable-failed-done"
+	h.JoinSession(sessionID, newConn(h, conn, sessionID, nil))
+	retryCtrl := NewLLMRetryController(config.AutoRetryConfig{
+		Enabled:    true,
+		MaxRetries: 1,
+		BaseDelay:  time.Hour,
+		MaxDelay:   time.Hour,
+		RetryInput: "continue",
+	}, slog.Default())
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h, RetryCtrl: retryCtrl})
+	b.shutdownCancel()
+	fw := &mockBridgeWorker{workerType: worker.TypeCodexCLI}
+	fc := &forwardContext{sessionID: sessionID, workerType: worker.TypeCodexCLI, firstEvent: true}
+
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error,
+		events.ErrorData{Code: events.ErrCodeRateLimited, Message: "rate limit exceeded"}), fw, forwardOpts{}, fc)
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
+		events.DoneData{Success: false}), fw, forwardOpts{}, fc)
+
+	require.Nil(t, tryReadEnvelope(t, server), "retryable failure must not emit a terminal before retry output")
+}
+
+func TestBridge_FailedDoneWithoutErrorDoesNotEmitEmptySuccessFallback(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	const sessionID = "failed-done-no-error"
+	h.JoinSession(sessionID, newConn(h, conn, sessionID, nil))
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+	fw := &mockBridgeWorker{workerType: worker.TypeCodexCLI}
+	fc := &forwardContext{sessionID: sessionID, workerType: worker.TypeCodexCLI, firstEvent: true}
+
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
+		events.DoneData{Success: false}), fw, forwardOpts{}, fc)
+
+	terminal := tryReadEnvelope(t, server)
+	require.NotNil(t, terminal)
+	require.Equal(t, events.Done, terminal.Event.Type)
+	require.Nil(t, tryReadEnvelope(t, server), "failed turn must not emit an empty-success fallback")
+}
+
+func TestBridge_CompleteMessageDataCountsAsRealReply(t *testing.T) {
+	t.Parallel()
+	h := newTestHub(t)
+	conn, server := newTestWSConnPair(t)
+	t.Cleanup(func() { _ = conn.Close(); _ = server.Close() })
+	const sessionID = "typed-complete-message"
+	h.JoinSession(sessionID, newConn(h, conn, sessionID, nil))
+	b := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+	fw := &mockBridgeWorker{workerType: worker.TypeCodexCLI}
+	fc := &forwardContext{sessionID: sessionID, workerType: worker.TypeCodexCLI, firstEvent: true}
+
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Message,
+		events.MessageData{Role: "assistant", Content: "complete answer"}), fw, forwardOpts{}, fc)
+	b.processForwardedEvent(events.NewEnvelope(aep.NewID(), sessionID, 0, events.Done,
+		events.DoneData{Success: true}), fw, forwardOpts{}, fc)
+
+	message := tryReadEnvelope(t, server)
+	require.NotNil(t, message)
+	require.Equal(t, events.Message, message.Event.Type)
+	done := tryReadEnvelope(t, server)
+	require.NotNil(t, done)
+	require.Equal(t, events.Done, done.Event.Type)
+	require.Nil(t, tryReadEnvelope(t, server), "complete typed messages must not trigger an empty-success fallback")
+}
+
+func TestExtractMessageContent_TypedPayloads(t *testing.T) {
+	t.Parallel()
+
+	message := &events.MessageData{Content: "complete message"}
+	delta := &events.MessageDeltaData{Content: "message delta"}
+	for _, tt := range []struct {
+		name string
+		env  *events.Envelope
+		want string
+	}{
+		{
+			name: "message_data_value",
+			env:  events.NewEnvelope(aep.NewID(), "s1", 0, events.Message, events.MessageData{Content: "complete value"}),
+			want: "complete value",
+		},
+		{
+			name: "message_data_pointer",
+			env:  events.NewEnvelope(aep.NewID(), "s1", 0, events.Message, message),
+			want: "complete message",
+		},
+		{
+			name: "message_delta_pointer",
+			env:  events.NewEnvelope(aep.NewID(), "s1", 0, events.MessageDelta, delta),
+			want: "message delta",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, extractMessageContent(tt.env))
+		})
+	}
+}
+
 func TestBridge_CompleteMessageStartsNextTurnAfterTerminal(t *testing.T) {
 	t.Parallel()
 	h := newTestHub(t)
@@ -295,7 +430,7 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		acc.ToolCallCount.Store(3)
 		acc.ToolNames = map[string]int{"Bash": 2, "Read": 1}
 
-		b.maybeSendDoneFallback("s1", acc, fc)
+		b.maybeSendDoneFallback("s1", acc, fc, true)
 
 		env := tryReadEnvelope(t, server)
 		require.NotNil(t, env, "expected a fallback Message envelope")
@@ -314,7 +449,7 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		acc.ToolCallCount.Store(3)
 		fc.turnText.WriteString("real reply text")
 
-		b.maybeSendDoneFallback("s1", acc, fc)
+		b.maybeSendDoneFallback("s1", acc, fc, true)
 
 		require.Nil(t, tryReadEnvelope(t, server), "no fallback expected when turn has text")
 	})
@@ -325,7 +460,7 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		// No text AND no tool calls → empty-success integrity failure. The turn
 		// must NOT end silently leaving a placeholder; emit a retryable terminal
 		// (Turn-Integrity Fix C, invariant I-5).
-		b.maybeSendDoneFallback("s1", acc, fc)
+		b.maybeSendDoneFallback("s1", acc, fc, true)
 
 		env := tryReadEnvelope(t, server)
 		require.NotNil(t, env, "empty-success must emit a terminal Message")
@@ -342,7 +477,7 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		b, acc, fc, server := setup(t, platformWebChat)
 		// WebChat is skipped for tool-only fallbacks, but empty-success still
 		// needs an explicit terminal so the assistant turn is not left blank.
-		b.maybeSendDoneFallback("s1", acc, fc)
+		b.maybeSendDoneFallback("s1", acc, fc, true)
 
 		env := tryReadEnvelope(t, server)
 		require.NotNil(t, env, "webchat empty-success must emit a terminal Message, not a blank assistant turn")
@@ -354,8 +489,17 @@ func TestMaybeSendDoneFallback(t *testing.T) {
 		b, acc, fc, server := setup(t, platformWebChat)
 		acc.ToolCallCount.Store(3)
 		// Tool-only turn on webchat: UI renders the tool list independently, no fallback.
-		b.maybeSendDoneFallback("s1", acc, fc)
+		b.maybeSendDoneFallback("s1", acc, fc, true)
 
 		require.Nil(t, tryReadEnvelope(t, server), "no tool-only fallback expected for webchat")
+	})
+
+	t.Run("skipped_for_failed_tool_only", func(t *testing.T) {
+		t.Parallel()
+		b, acc, fc, server := setup(t, "feishu")
+		acc.ToolCallCount.Store(3)
+		b.maybeSendDoneFallback("s1", acc, fc, false)
+
+		require.Nil(t, tryReadEnvelope(t, server), "failed tool-only turns must not emit a success summary")
 	})
 }

--- a/internal/messaging/feishu/adapter_flow_test.go
+++ b/internal/messaging/feishu/adapter_flow_test.go
@@ -233,6 +233,50 @@ func TestAdapterFlow_WriteCtx_DoneEvent_WithStreamCtrl(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAdapterFlow_WriteCtx_StoppedDoneReplacesEmptyPlaceholder(t *testing.T) {
+	t.Parallel()
+	a := newTestAdapter(t)
+	conn := NewFeishuConn(a, "chat123", "", "")
+	ctrl := newTestStreamingCtrl()
+	require.True(t, ctrl.transition(PhaseCreating))
+	require.True(t, ctrl.transition(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.placeholder = "正在处理"
+	ctrl.lastFlushed = ctrl.placeholder
+	ctrl.cardKitOK = false
+	ctrl.streamingActive = false
+	ctrl.mu.Unlock()
+	conn.EnableStreaming(ctrl)
+
+	env := events.NewEnvelope("stopped-done", "sess-stopped", 0, events.Done,
+		events.DoneData{Reason: "stopped_by_user"})
+	require.NoError(t, conn.WriteCtx(context.Background(), env))
+	require.Equal(t, "⏹️ 本轮已停止。", ctrl.Content())
+	require.Equal(t, PhaseCompleted, ctrl.getPhase())
+}
+
+func TestAdapterFlow_WriteCtx_FailedDoneReplacesEmptyPlaceholder(t *testing.T) {
+	t.Parallel()
+	a := newTestAdapter(t)
+	conn := NewFeishuConn(a, "chat123", "", "")
+	ctrl := newTestStreamingCtrl()
+	require.True(t, ctrl.transition(PhaseCreating))
+	require.True(t, ctrl.transition(PhaseStreaming))
+	ctrl.mu.Lock()
+	ctrl.placeholder = "正在处理"
+	ctrl.lastFlushed = ctrl.placeholder
+	ctrl.cardKitOK = false
+	ctrl.streamingActive = false
+	ctrl.mu.Unlock()
+	conn.EnableStreaming(ctrl)
+
+	env := events.NewEnvelope("failed-done", "sess-failed", 0, events.Done,
+		events.DoneData{Success: false})
+	require.NoError(t, conn.WriteCtx(context.Background(), env))
+	require.Equal(t, "⚠️ 本轮执行失败，请重试。", ctrl.Content())
+	require.Equal(t, PhaseCompleted, ctrl.getPhase())
+}
+
 func TestAdapterFlow_WriteCtx_ErrorEvent_WithStreamCtrl(t *testing.T) {
 	t.Parallel()
 	a := newTestAdapter(t)

--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -351,6 +351,14 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 	var closeErr error
 	if streamCtrl != nil && streamCtrl.IsCreated() {
 		streamCtrl.SetCloseMeta(d)
+		if done, ok := events.DecodeAs[events.DoneData](env.Event.Data); ok {
+			switch {
+			case done.Reason == "stopped_by_user":
+				streamCtrl.SetTerminalContent("⏹️ 本轮已停止。")
+			case !done.Success:
+				streamCtrl.SetTerminalContent("⚠️ 本轮执行失败，请重试。")
+			}
+		}
 		closeErr = streamCtrl.Close(terminalCtx)
 		if closeErr != nil {
 			closeErr = c.handleTerminalDeliveryError(terminalCtx, closeErr)


### PR DESCRIPTION
## Summary

- classify failed `Done` events before sending empty-success fallbacks
- forward a buffered Worker `Error` as the sole terminal result when retry is not selected
- make retry eligibility depend on real Worker text, including complete `MessageData` payloads
- distinguish stopped and failed Feishu streaming-card terminal states
- add Bridge and Feishu regression coverage

Fixes #982.

## Verification

- `rtk proxy make quality`
- `rtk proxy go test -race -shuffle=on -count=1 ./internal/gateway ./internal/messaging/feishu`
- pre-push quality gate (format, vet, module verification, lint, build, tests)
- `git diff --check`